### PR TITLE
Default bash on macOS (v. 3.x) doesn't support `|&` syntax

### DIFF
--- a/mlir/test/mlir-cpu-runner/invalid.mlir
+++ b/mlir/test/mlir-cpu-runner/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: not mlir-cpu-runner --no-implicit-module %s |& FileCheck %s
+// RUN: not mlir-cpu-runner --no-implicit-module %s 2>&1 | FileCheck %s
 
 // CHECK: Error: top-level op must be a symbol table.
 llvm.func @main()

--- a/mlir/test/mlir-reduce/invalid.mlir
+++ b/mlir/test/mlir-reduce/invalid.mlir
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
-// RUN: not mlir-reduce -opt-reduction-pass --no-implicit-module %s |& FileCheck %s --check-prefix=CHECK-PASS
-// RUN: not mlir-reduce -reduction-tree --no-implicit-module %s |& FileCheck %s --check-prefix=CHECK-TREE
+// RUN: not mlir-reduce -opt-reduction-pass --no-implicit-module %s 2>&1 | FileCheck %s --check-prefix=CHECK-PASS
+// RUN: not mlir-reduce -reduction-tree --no-implicit-module %s 2>&1 | FileCheck %s --check-prefix=CHECK-TREE
 
 // The reduction passes are currently restricted to 'builtin.module'.
 // CHECK-PASS: error: Can't add pass '{{.+}}' restricted to 'builtin.module' on a PassManager intended to run on 'func.func'


### PR DESCRIPTION
This PR fixes two tests on macOS:

```
  MLIR :: mlir-reduce/invalid.mlir
  MLIR :: mlir-cpu-runner/invalid.mlir
```

Default bash on macOS is outdated:

```bash
> bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin21)
Copyright (C) 2007 Free Software Foundation, Inc.
```

So it fails at `|&` redirect:

```
-- Testing: 1 tests, 1 workers --
FAIL: MLIR :: mlir-reduce/invalid.mlir (1 of 1)
******************** TEST 'MLIR :: mlir-reduce/invalid.mlir' FAILED ********************
Script:
--
: 'RUN: at line 2';   /opt/LLVM/clangir/llvm/cmake-build-debug/bin/not /opt/LLVM/clangir/llvm/cmake-build-debug/bin/mlir-reduce -opt-reduction-pass --no-implicit-module /opt/LLVM/clangir/mlir/test/mlir-reduce/invalid.mlir 2>&1 | /opt/LLVM/clangir/llvm/cmake-build-debug/bin/FileCheck /opt/LLVM/clangir/mlir/test/mlir-reduce/invalid.mlir --check-prefix=CHECK-PASS
: 'RUN: at line 3';   /opt/LLVM/clangir/llvm/cmake-build-debug/bin/not /opt/LLVM/clangir/llvm/cmake-build-debug/bin/mlir-reduce -reduction-tree --no-implicit-module /opt/LLVM/clangir/mlir/test/mlir-reduce/invalid.mlir |& /opt/LLVM/clangir/llvm/cmake-build-debug/bin/FileCheck /opt/LLVM/clangir/mlir/test/mlir-reduce/invalid.mlir --check-prefix=CHECK-TREE
--
Exit Code: 2

Command Output (stderr):
--
/opt/LLVM/clangir/llvm/cmake-build-debug/tools/mlir/test/mlir-reduce/Output/invalid.mlir.script: line 2: syntax error near unexpected token `&'
/opt/LLVM/clangir/llvm/cmake-build-debug/tools/mlir/test/mlir-reduce/Output/invalid.mlir.script: line 2: `{ : 'RUN: at line 3';   /opt/LLVM/clangir/llvm/cmake-build-debug/bin/not /opt/LLVM/clangir/llvm/cmake-build-debug/bin/mlir-reduce -reduction-tree --no-implicit-module /opt/LLVM/clangir/mlir/test/mlir-reduce/invalid.mlir |& /opt/LLVM/clangir/llvm/cmake-build-debug/bin/FileCheck /opt/LLVM/clangir/mlir/test/mlir-reduce/invalid.mlir --check-prefix=CHECK-TREE; }'
```


