### PR TITLE
[test][MLIR] Fix attribute getter

### DIFF
--- a/mlir/test/mlir-tblgen/op-attribute.td
+++ b/mlir/test/mlir-tblgen/op-attribute.td
@@ -512,4 +512,4 @@ def StructAttrOp : NS_Op<"struct_attr_op", []> {
   );
 }
 
-// DECL: dialect_2::MyStruct potatoes();
+// DECL: dialect_2::MyStruct getPotatoes();


### PR DESCRIPTION
As per https://discourse.llvm.org/t/psa-the-default-accessor-naming-has-been-flipped-to-prefixed/65111
