### PR TITLE
[CIR] Implement more of CheckAggExprForMemSetUse()

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -299,6 +299,11 @@ static void CheckAggExprForMemSetUse(AggValueSlot &Slot, const Expr *E,
         return;
     }
 
+  // If the type is 16-bytes or smaller, prefer individual stores over memset.
+  CharUnits Size = Slot.getPreferredSize(CGF.getContext(), E->getType());
+  if (Size <= CharUnits::fromQuantity(16))
+    return;
+
   llvm_unreachable("NYI");
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenValue.h
+++ b/clang/lib/CIR/CodeGen/CIRGenValue.h
@@ -364,6 +364,14 @@ public:
   bool isSanitizerChecked() const { return SanitizerCheckedFlag; }
 
   IsZeroed_t isZeroed() const { return IsZeroed_t(ZeroedFlag); }
+
+  /// Get the preferred size to use when storing a value to this slot. This
+  /// is the type size unless that might overlap another object, in which
+  /// case it's the dsize.
+  clang::CharUnits getPreferredSize(clang::ASTContext &Ctx, clang::QualType Type) {
+    return mayOverlap() ? Ctx.getTypeInfoDataSizeInChars(Type).Width
+                        : Ctx.getTypeSizeInChars(Type);
+  }
 };
 
 } // namespace cir

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
 void fn() {
   auto a = [](){};


### PR DESCRIPTION
Implement another early return so the empty lambda also bail for this optimization -- in particular not performing it for small types.

Fixes llvm/clangir#6.
