### PR TITLE
[CIR] Fix parsing of CIR dialect's struct type

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -76,9 +76,12 @@ Type StructType::parse(mlir::AsmParser &parser) {
   if (parser.parseString(&typeName))
     return Type();
   llvm::SmallVector<Type> members;
-  Type nextMember;
-  while (mlir::succeeded(parser.parseType(nextMember)))
+  while (mlir::succeeded(parser.parseOptionalComma())) {
+    Type nextMember;
+    if (parser.parseType(nextMember))
+      return Type();
     members.push_back(nextMember);
+  }
   if (parser.parseGreater())
     return Type();
   return get(parser.getContext(), members, typeName);

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -1,0 +1,11 @@
+// RUN: cir-tool %s | cir-tool | FileCheck %s
+
+module  {
+  cir.func @structs() {
+    %0 = cir.alloca !cir.ptr<!cir.struct<"S", i8, i16, i32>>, cir.ptr <!cir.ptr<!cir.struct<"S", i8, i16, i32>>>, ["s", init]
+    cir.return
+  }
+}
+
+// CHECK: cir.func @structs() {
+// CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!cir.struct<"S", i8, i16, i32>>, cir.ptr <!cir.ptr<!cir.struct<"S", i8, i16, i32>>>, ["s", init]


### PR DESCRIPTION
The parsing function wasn't considering the commas separating the types
inside the angle brackets, that are used by printing.


Related to llvm/clangir#9.
