### PR TITLE
[CIR] Fix invalid alias name for dialect's struct types

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1126,9 +1126,9 @@ def StructElementAddr : CIR_Op<"struct_element_addr"> {
 
     Example:
     ```mlir
-    !22struct2EBar22 = type !cir.struct<"struct.Bar", i32, i8>
+    !ty_22struct2EBar22 = type !cir.struct<"struct.Bar", i32, i8>
     ...
-    %0 = cir.alloca !22struct2EBar22, cir.ptr <!22struct2EBar22>
+    %0 = cir.alloca !ty_22struct2EBar22, cir.ptr <!ty_22struct2EBar22>
     ...
     %1 = cir.struct_element_addr %0, "Bar.a"
     %2 = cir.load %1 : cir.ptr <int>, int

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -41,7 +41,7 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
 
   AliasResult getAlias(Type type, raw_ostream &os) const final {
     if (auto structType = type.dyn_cast<StructType>()) {
-      os << structType.getTypeName();
+      os << "ty_" << structType.getTypeName();
       return AliasResult::OverridableAlias;
     }
 

--- a/clang/test/CIR/CodeGen/String.cpp
+++ b/clang/test/CIR/CodeGen/String.cpp
@@ -18,20 +18,20 @@ void test() {
 }
 
 //      CHECK: cir.func linkonce_odr @_ZN6StringC2Ev
-// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!22class2EString22>
+// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22class2EString22>
 // CHECK-NEXT:   cir.store %arg0, %0
 // CHECK-NEXT:   %1 = cir.load %0
 // CHECK-NEXT:   %2 = "cir.struct_element_addr"(%0) {member_name = "storage"}
 // CHECK-NEXT:   %3 = cir.cst(#cir.null : !cir.ptr<i8>) : !cir.ptr<i8>
 // CHECK-NEXT:   cir.store %3, %2 : !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>
-// CHECK-NEXT:   %4 = "cir.struct_element_addr"(%0) {member_name = "size"} : (!cir.ptr<!cir.ptr<!22class2EString22>>) -> !cir.ptr<i64>
+// CHECK-NEXT:   %4 = "cir.struct_element_addr"(%0) {member_name = "size"} : (!cir.ptr<!cir.ptr<!ty_22class2EString22>>) -> !cir.ptr<i64>
 // CHECK-NEXT:   %5 = cir.cst(0 : i32) : i32
 // CHECK-NEXT:   %6 = cir.cast(integral, %5 : i32), i64
 // CHECK-NEXT:   cir.store %6, %4 : i64, cir.ptr <i64>
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }
 //      CHECK: cir.func linkonce_odr @_ZN6StringC2Ei
-// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!22class2EString22>
+// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22class2EString22>
 // CHECK-NEXT:   %1 = cir.alloca i32, cir.ptr <i32>, ["size", init]
 // CHECK-NEXT:   cir.store %arg0, %0
 // CHECK-NEXT:   cir.store %arg1, %1
@@ -39,7 +39,7 @@ void test() {
 // CHECK-NEXT:   %3 = "cir.struct_element_addr"(%0) {member_name = "storage"}
 // CHECK-NEXT:   %4 = cir.cst(#cir.null : !cir.ptr<i8>)
 // CHECK-NEXT:   cir.store %4, %3
-// CHECK-NEXT:   %5 = "cir.struct_element_addr"(%0) {member_name = "size"} : (!cir.ptr<!cir.ptr<!22class2EString22>>) -> !cir.ptr<i64>
+// CHECK-NEXT:   %5 = "cir.struct_element_addr"(%0) {member_name = "size"} : (!cir.ptr<!cir.ptr<!ty_22class2EString22>>) -> !cir.ptr<i64>
 // CHECK-NEXT:   %6 = cir.load %1 : cir.ptr <i32>, i32
 // CHECK-NEXT:   %7 = cir.cast(integral, %6 : i32), i64
 // CHECK-NEXT:   cir.store %7, %5 : i64, cir.ptr <i64>
@@ -47,27 +47,27 @@ void test() {
 // CHECK-NEXT: }
 
 //      CHECK: cir.func linkonce_odr @_ZN6StringC2EPKc
-// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!22class2EString22>, cir.ptr <!cir.ptr<!22class2EString22>>, ["this", init] {alignment = 8 : i64}
+// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22class2EString22>, cir.ptr <!cir.ptr<!ty_22class2EString22>>, ["this", init] {alignment = 8 : i64}
 // CHECK-NEXT:   %1 = cir.alloca !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>, ["s", init] {alignment = 8 : i64}
-// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!22class2EString22>, cir.ptr <!cir.ptr<!22class2EString22>>
+// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!ty_22class2EString22>, cir.ptr <!cir.ptr<!ty_22class2EString22>>
 // CHECK-NEXT:   cir.store %arg1, %1 : !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>
-// CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!22class2EString22>>, !cir.ptr<!22class2EString22>
-// CHECK-NEXT:   %3 = "cir.struct_element_addr"(%0) {member_name = "storage"} : (!cir.ptr<!cir.ptr<!22class2EString22>>) -> !cir.ptr<!cir.ptr<i8>>
+// CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22class2EString22>>, !cir.ptr<!ty_22class2EString22>
+// CHECK-NEXT:   %3 = "cir.struct_element_addr"(%0) {member_name = "storage"} : (!cir.ptr<!cir.ptr<!ty_22class2EString22>>) -> !cir.ptr<!cir.ptr<i8>>
 // CHECK-NEXT:   %4 = cir.cst(#cir.null : !cir.ptr<i8>) : !cir.ptr<i8>
 // CHECK-NEXT:   cir.store %4, %3 : !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>
 // CHECK-NEXT:   cir.return
 
 //      CHECK: cir.func linkonce_odr @_ZN6StringC1EPKc
-// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!22class2EString22>, cir.ptr <!cir.ptr<!22class2EString22>>, ["this", init] {alignment = 8 : i64}
+// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22class2EString22>, cir.ptr <!cir.ptr<!ty_22class2EString22>>, ["this", init] {alignment = 8 : i64}
 // CHECK-NEXT:   %1 = cir.alloca !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>, ["s", init] {alignment = 8 : i64}
-// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!22class2EString22>, cir.ptr <!cir.ptr<!22class2EString22>>
+// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!ty_22class2EString22>, cir.ptr <!cir.ptr<!ty_22class2EString22>>
 // CHECK-NEXT:   cir.store %arg1, %1 : !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>
-// CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!22class2EString22>>, !cir.ptr<!22class2EString22>
+// CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22class2EString22>>, !cir.ptr<!ty_22class2EString22>
 // CHECK-NEXT:   %3 = cir.load %1 : cir.ptr <!cir.ptr<i8>>, !cir.ptr<i8>
-// CHECK-NEXT:   cir.call @_ZN6StringC2EPKc(%2, %3) : (!cir.ptr<!22class2EString22>, !cir.ptr<i8>) -> ()
+// CHECK-NEXT:   cir.call @_ZN6StringC2EPKc(%2, %3) : (!cir.ptr<!ty_22class2EString22>, !cir.ptr<i8>) -> ()
 // CHECK-NEXT:   cir.return
 
 // CHECK: cir.func @_Z4testv() {
-// CHECK:   cir.call @_ZN6StringC1Ev(%0) : (!cir.ptr<!22class2EString22>) -> ()
-// CHECK:   cir.call @_ZN6StringC1Ei(%1, %3) : (!cir.ptr<!22class2EString22>, i32) -> ()
-// CHECK:   cir.call @_ZN6StringC1EPKc(%2, %5) : (!cir.ptr<!22class2EString22>, !cir.ptr<i8>) -> ()
+// CHECK:   cir.call @_ZN6StringC1Ev(%0) : (!cir.ptr<!ty_22class2EString22>) -> ()
+// CHECK:   cir.call @_ZN6StringC1Ei(%1, %3) : (!cir.ptr<!ty_22class2EString22>, i32) -> ()
+// CHECK:   cir.call @_ZN6StringC1EPKc(%2, %5) : (!cir.ptr<!ty_22class2EString22>, !cir.ptr<i8>) -> ()

--- a/clang/test/CIR/CodeGen/assign-operator.cpp
+++ b/clang/test/CIR/CodeGen/assign-operator.cpp
@@ -12,13 +12,13 @@ struct String {
   // StringView::StringView(String const&)
   //
   // CHECK: cir.func linkonce_odr @_ZN10StringViewC2ERK6String
-  // CHECK:   %0 = cir.alloca !cir.ptr<!22struct2EStringView22>, cir.ptr <!cir.ptr<!22struct2EStringView22>>, ["this", init] {alignment = 8 : i64}
-  // CHECK:   %1 = cir.alloca !cir.ptr<!22struct2EString22>, cir.ptr <!cir.ptr<!22struct2EString22>>, ["s", init] {alignment = 8 : i64}
-  // CHECK:   cir.store %arg0, %0 : !cir.ptr<!22struct2EStringView22>
-  // CHECK:   cir.store %arg1, %1 : !cir.ptr<!22struct2EString22>
-  // CHECK:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!22struct2EStringView22>>
+  // CHECK:   %0 = cir.alloca !cir.ptr<!ty_22struct2EStringView22>, cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>, ["this", init] {alignment = 8 : i64}
+  // CHECK:   %1 = cir.alloca !cir.ptr<!ty_22struct2EString22>, cir.ptr <!cir.ptr<!ty_22struct2EString22>>, ["s", init] {alignment = 8 : i64}
+  // CHECK:   cir.store %arg0, %0 : !cir.ptr<!ty_22struct2EStringView22>
+  // CHECK:   cir.store %arg1, %1 : !cir.ptr<!ty_22struct2EString22>
+  // CHECK:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>
   // CHECK:   %3 = "cir.struct_element_addr"(%0) {member_name = "size"}
-  // CHECK:   %4 = cir.load %1 : cir.ptr <!cir.ptr<!22struct2EString22>>
+  // CHECK:   %4 = cir.load %1 : cir.ptr <!cir.ptr<!ty_22struct2EString22>>
   // CHECK:   %5 = "cir.struct_element_addr"(%0) {member_name = "size"}
   // CHECK:   %6 = cir.load %5 : cir.ptr <i64>, i64
   // CHECK:   cir.store %6, %3 : i64, cir.ptr <i64>
@@ -26,25 +26,25 @@ struct String {
   // CHECK: }
 
   // DISABLE: cir.func linkonce_odr @_ZN10StringViewC2ERK6String
-  // DISABLE-NEXT:   %0 = cir.alloca !cir.ptr<!22struct2EStringView22>, cir.ptr <!cir.ptr<!22struct2EStringView22>>, ["this", init] {alignment = 8 : i64}
+  // DISABLE-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22struct2EStringView22>, cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>, ["this", init] {alignment = 8 : i64}
 
   // StringView::operator=(StringView&&)
   //
   // CHECK: cir.func linkonce_odr @_ZN10StringViewaSEOS_
-  // CHECK:   %0 = cir.alloca !cir.ptr<!22struct2EStringView22>, cir.ptr <!cir.ptr<!22struct2EStringView22>>, ["this", init] {alignment = 8 : i64}
-  // CHECK:   %1 = cir.alloca !cir.ptr<!22struct2EStringView22>, cir.ptr <!cir.ptr<!22struct2EStringView22>>, ["", init] {alignment = 8 : i64}
-  // CHECK:   %2 = cir.alloca !cir.ptr<!22struct2EStringView22>, cir.ptr <!cir.ptr<!22struct2EStringView22>>, ["__retval"] {alignment = 8 : i64}
-  // CHECK:   cir.store %arg0, %0 : !cir.ptr<!22struct2EStringView22>
-  // CHECK:   cir.store %arg1, %1 : !cir.ptr<!22struct2EStringView22>
-  // CHECK:   %3 = cir.load deref %0 : cir.ptr <!cir.ptr<!22struct2EStringView22>>
-  // CHECK:   %4 = cir.load %1 : cir.ptr <!cir.ptr<!22struct2EStringView22>>
+  // CHECK:   %0 = cir.alloca !cir.ptr<!ty_22struct2EStringView22>, cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>, ["this", init] {alignment = 8 : i64}
+  // CHECK:   %1 = cir.alloca !cir.ptr<!ty_22struct2EStringView22>, cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>, ["", init] {alignment = 8 : i64}
+  // CHECK:   %2 = cir.alloca !cir.ptr<!ty_22struct2EStringView22>, cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>, ["__retval"] {alignment = 8 : i64}
+  // CHECK:   cir.store %arg0, %0 : !cir.ptr<!ty_22struct2EStringView22>
+  // CHECK:   cir.store %arg1, %1 : !cir.ptr<!ty_22struct2EStringView22>
+  // CHECK:   %3 = cir.load deref %0 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>
+  // CHECK:   %4 = cir.load %1 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>
   // CHECK:   %5 = "cir.struct_element_addr"(%0) {member_name = "size"}
   // CHECK:   %6 = cir.load %5 : cir.ptr <i64>, i64
   // CHECK:   %7 = "cir.struct_element_addr"(%0) {member_name = "size"}
   // CHECK:   cir.store %6, %7 : i64, cir.ptr <i64>
-  // CHECK:   cir.store %3, %2 : !cir.ptr<!22struct2EStringView22>
-  // CHECK:   %8 = cir.load %2 : cir.ptr <!cir.ptr<!22struct2EStringView22>>
-  // CHECK:   cir.return %8 : !cir.ptr<!22struct2EStringView22>
+  // CHECK:   cir.store %3, %2 : !cir.ptr<!ty_22struct2EStringView22>
+  // CHECK:   %8 = cir.load %2 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>
+  // CHECK:   cir.return %8 : !cir.ptr<!ty_22struct2EStringView22>
   // CHECK: }
 
   // DISABLE: cir.func @_ZN10StringViewaSEOS_
@@ -68,16 +68,16 @@ int main() {
 
 // CHECK: cir.func @main() -> i32 {
 // CHECK:     %0 = cir.alloca i32, cir.ptr <i32>, ["__retval"] {alignment = 4 : i64}
-// CHECK:     %1 = cir.alloca !22struct2EStringView22, cir.ptr <!22struct2EStringView22>, ["sv"] {alignment = 8 : i64}
-// CHECK:     cir.call @_ZN10StringViewC2Ev(%1) : (!cir.ptr<!22struct2EStringView22>) -> ()
+// CHECK:     %1 = cir.alloca !ty_22struct2EStringView22, cir.ptr <!ty_22struct2EStringView22>, ["sv"] {alignment = 8 : i64}
+// CHECK:     cir.call @_ZN10StringViewC2Ev(%1) : (!cir.ptr<!ty_22struct2EStringView22>) -> ()
 // CHECK:     cir.scope {
-// CHECK:       %3 = cir.alloca !22struct2EString22, cir.ptr <!22struct2EString22>, ["s"] {alignment = 8 : i64}
-// CHECK:       %4 = cir.alloca !22struct2EStringView22, cir.ptr <!22struct2EStringView22>, ["ref.tmp"] {alignment = 8 : i64}
+// CHECK:       %3 = cir.alloca !ty_22struct2EString22, cir.ptr <!ty_22struct2EString22>, ["s"] {alignment = 8 : i64}
+// CHECK:       %4 = cir.alloca !ty_22struct2EStringView22, cir.ptr <!ty_22struct2EStringView22>, ["ref.tmp"] {alignment = 8 : i64}
 // CHECK:       %5 = cir.get_global @".str" : cir.ptr <!cir.array<i8 x 3>>
 // CHECK:       %6 = cir.cast(array_to_ptrdecay, %5 : !cir.ptr<!cir.array<i8 x 3>>), !cir.ptr<i8>
-// CHECK:       cir.call @_ZN6StringC2EPKc(%3, %6) : (!cir.ptr<!22struct2EString22>, !cir.ptr<i8>) -> ()
-// CHECK:       cir.call @_ZN10StringViewC2ERK6String(%4, %3) : (!cir.ptr<!22struct2EStringView22>, !cir.ptr<!22struct2EString22>) -> ()
-// CHECK:       %7 = cir.call @_ZN10StringViewaSEOS_(%1, %4) : (!cir.ptr<!22struct2EStringView22>, !cir.ptr<!22struct2EStringView22>) -> !cir.ptr<!22struct2EStringView22>
+// CHECK:       cir.call @_ZN6StringC2EPKc(%3, %6) : (!cir.ptr<!ty_22struct2EString22>, !cir.ptr<i8>) -> ()
+// CHECK:       cir.call @_ZN10StringViewC2ERK6String(%4, %3) : (!cir.ptr<!ty_22struct2EStringView22>, !cir.ptr<!ty_22struct2EString22>) -> ()
+// CHECK:       %7 = cir.call @_ZN10StringViewaSEOS_(%1, %4) : (!cir.ptr<!ty_22struct2EStringView22>, !cir.ptr<!ty_22struct2EStringView22>) -> !cir.ptr<!ty_22struct2EStringView22>
 // CHECK:     }
 // CHECK:     %2 = cir.load %0 : cir.ptr <i32>, i32
 // CHECK:     cir.return %2 : i32

--- a/clang/test/CIR/CodeGen/ctor-alias.cpp
+++ b/clang/test/CIR/CodeGen/ctor-alias.cpp
@@ -9,18 +9,18 @@ void t() {
 }
 
 //      CHECK: cir.func linkonce_odr @_ZN11DummyStringC2EPKc
-// CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!22struct2EDummyString22>, cir.ptr <!cir.ptr<!22struct2EDummyString22>>, ["this", init] {alignment = 8 : i64}
+// CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!ty_22struct2EDummyString22>, cir.ptr <!cir.ptr<!ty_22struct2EDummyString22>>, ["this", init] {alignment = 8 : i64}
 // CHECK-NEXT:     %1 = cir.alloca !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>, ["s", init] {alignment = 8 : i64}
-// CHECK-NEXT:     cir.store %arg0, %0 : !cir.ptr<!22struct2EDummyString22>, cir.ptr <!cir.ptr<!22struct2EDummyString22>>
+// CHECK-NEXT:     cir.store %arg0, %0 : !cir.ptr<!ty_22struct2EDummyString22>, cir.ptr <!cir.ptr<!ty_22struct2EDummyString22>>
 // CHECK-NEXT:     cir.store %arg1, %1 : !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>
-// CHECK-NEXT:     %2 = cir.load %0 : cir.ptr <!cir.ptr<!22struct2EDummyString22>>, !cir.ptr<!22struct2EDummyString22>
+// CHECK-NEXT:     %2 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22struct2EDummyString22>>, !cir.ptr<!ty_22struct2EDummyString22>
 // CHECK-NEXT:     cir.return
 
 // CHECK-NOT: cir.fun @_ZN11DummyStringC1EPKc
 
 //      CHECK:   cir.func @_Z1tv
-// CHECK-NEXT:     %0 = cir.alloca !22struct2EDummyString22, cir.ptr <!22struct2EDummyString22>, ["s4"] {alignment = 1 : i64}
+// CHECK-NEXT:     %0 = cir.alloca !ty_22struct2EDummyString22, cir.ptr <!ty_22struct2EDummyString22>, ["s4"] {alignment = 1 : i64}
 // CHECK-NEXT:     %1 = cir.get_global @".str" : cir.ptr <!cir.array<i8 x 5>>
 // CHECK-NEXT:     %2 = cir.cast(array_to_ptrdecay, %1 : !cir.ptr<!cir.array<i8 x 5>>), !cir.ptr<i8>
-// CHECK-NEXT:     cir.call @_ZN11DummyStringC2EPKc(%0, %2) : (!cir.ptr<!22struct2EDummyString22>, !cir.ptr<i8>) -> ()
+// CHECK-NEXT:     cir.call @_ZN11DummyStringC2EPKc(%0, %2) : (!cir.ptr<!ty_22struct2EDummyString22>, !cir.ptr<i8>) -> ()
 // CHECK-NEXT:     cir.return

--- a/clang/test/CIR/CodeGen/ctor-member-lvalue-to-rvalue.cpp
+++ b/clang/test/CIR/CodeGen/ctor-member-lvalue-to-rvalue.cpp
@@ -6,8 +6,8 @@ struct String {
   long size;
   String(const String &s) : size{s.size} {}
 // CHECK: cir.func linkonce_odr @_ZN6StringC2ERKS_
-// CHECK:     %0 = cir.alloca !cir.ptr<!22struct2EString22>, cir.ptr <!cir.ptr<!22struct2EString22>>, ["this", init] {alignment = 8 : i64}
-// CHECK:     %1 = cir.alloca !cir.ptr<!22struct2EString22>, cir.ptr <!cir.ptr<!22struct2EString22>>, ["s", init] {alignment = 8 : i64}
+// CHECK:     %0 = cir.alloca !cir.ptr<!ty_22struct2EString22>, cir.ptr <!cir.ptr<!ty_22struct2EString22>>, ["this", init] {alignment = 8 : i64}
+// CHECK:     %1 = cir.alloca !cir.ptr<!ty_22struct2EString22>, cir.ptr <!cir.ptr<!ty_22struct2EString22>>, ["s", init] {alignment = 8 : i64}
 // CHECK:     cir.store %arg0, %0
 // CHECK:     cir.store %arg1, %1
 // CHECK:     %2 = cir.load %0
@@ -28,10 +28,10 @@ void foo() {
   // FIXME: s1 shouldn't be uninitialized.
 
   //  cir.func @_Z3foov() {
-  //   %0 = cir.alloca !22struct2EString22, cir.ptr <!22struct2EString22>, ["s"] {alignment = 8 : i64}
-  //   %1 = cir.alloca !22struct2EString22, cir.ptr <!22struct2EString22>, ["s1"] {alignment = 8 : i64}
-  //   cir.call @_ZN6StringC2Ev(%0) : (!cir.ptr<!22struct2EString22>) -> ()
-  //   cir.call @_ZN6StringC2ERKS_(%1, %0) : (!cir.ptr<!22struct2EString22>, !cir.ptr<!22struct2EString22>) -> ()
+  //   %0 = cir.alloca !ty_22struct2EString22, cir.ptr <!ty_22struct2EString22>, ["s"] {alignment = 8 : i64}
+  //   %1 = cir.alloca !ty_22struct2EString22, cir.ptr <!ty_22struct2EString22>, ["s1"] {alignment = 8 : i64}
+  //   cir.call @_ZN6StringC2Ev(%0) : (!cir.ptr<!ty_22struct2EString22>) -> ()
+  //   cir.call @_ZN6StringC2ERKS_(%1, %0) : (!cir.ptr<!ty_22struct2EString22>, !cir.ptr<!ty_22struct2EString22>) -> ()
   //   cir.return
   // }
 }

--- a/clang/test/CIR/CodeGen/ctor.cpp
+++ b/clang/test/CIR/CodeGen/ctor.cpp
@@ -11,22 +11,22 @@ void baz() {
   Struk s;
 }
 
-// CHECK: !22struct2EStruk22 = !cir.struct<"struct.Struk", i32>
+// CHECK: !ty_22struct2EStruk22 = !cir.struct<"struct.Struk", i32>
 
-// CHECK:   cir.func linkonce_odr @_ZN5StrukC2Ev(%arg0: !cir.ptr<!22struct2EStruk22>
-// CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!22struct2EStruk22>, cir.ptr <!cir.ptr<!22struct2EStruk22>>, ["this", init] {alignment = 8 : i64}
-// CHECK-NEXT:     cir.store %arg0, %0 : !cir.ptr<!22struct2EStruk22>, cir.ptr <!cir.ptr<!22struct2EStruk22>>
-// CHECK-NEXT:     %1 = cir.load %0 : cir.ptr <!cir.ptr<!22struct2EStruk22>>, !cir.ptr<!22struct2EStruk22>
+// CHECK:   cir.func linkonce_odr @_ZN5StrukC2Ev(%arg0: !cir.ptr<!ty_22struct2EStruk22>
+// CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!ty_22struct2EStruk22>, cir.ptr <!cir.ptr<!ty_22struct2EStruk22>>, ["this", init] {alignment = 8 : i64}
+// CHECK-NEXT:     cir.store %arg0, %0 : !cir.ptr<!ty_22struct2EStruk22>, cir.ptr <!cir.ptr<!ty_22struct2EStruk22>>
+// CHECK-NEXT:     %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22struct2EStruk22>>, !cir.ptr<!ty_22struct2EStruk22>
 // CHECK-NEXT:     cir.return
 
-// CHECK:   cir.func linkonce_odr @_ZN5StrukC1Ev(%arg0: !cir.ptr<!22struct2EStruk22>
-// CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!22struct2EStruk22>, cir.ptr <!cir.ptr<!22struct2EStruk22>>, ["this", init] {alignment = 8 : i64}
-// CHECK-NEXT:     cir.store %arg0, %0 : !cir.ptr<!22struct2EStruk22>, cir.ptr <!cir.ptr<!22struct2EStruk22>>
-// CHECK-NEXT:     %1 = cir.load %0 : cir.ptr <!cir.ptr<!22struct2EStruk22>>, !cir.ptr<!22struct2EStruk22>
-// CHECK-NEXT:     cir.call @_ZN5StrukC2Ev(%1) : (!cir.ptr<!22struct2EStruk22>) -> ()
+// CHECK:   cir.func linkonce_odr @_ZN5StrukC1Ev(%arg0: !cir.ptr<!ty_22struct2EStruk22>
+// CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!ty_22struct2EStruk22>, cir.ptr <!cir.ptr<!ty_22struct2EStruk22>>, ["this", init] {alignment = 8 : i64}
+// CHECK-NEXT:     cir.store %arg0, %0 : !cir.ptr<!ty_22struct2EStruk22>, cir.ptr <!cir.ptr<!ty_22struct2EStruk22>>
+// CHECK-NEXT:     %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22struct2EStruk22>>, !cir.ptr<!ty_22struct2EStruk22>
+// CHECK-NEXT:     cir.call @_ZN5StrukC2Ev(%1) : (!cir.ptr<!ty_22struct2EStruk22>) -> ()
 // CHECK-NEXT:     cir.return
 
 // CHECK:   cir.func @_Z3bazv()
-// CHECK-NEXT:     %0 = cir.alloca !22struct2EStruk22, cir.ptr <!22struct2EStruk22>, ["s"] {alignment = 4 : i64}
-// CHECK-NEXT:     cir.call @_ZN5StrukC1Ev(%0) : (!cir.ptr<!22struct2EStruk22>) -> ()
+// CHECK-NEXT:     %0 = cir.alloca !ty_22struct2EStruk22, cir.ptr <!ty_22struct2EStruk22>, ["s"] {alignment = 4 : i64}
+// CHECK-NEXT:     cir.call @_ZN5StrukC1Ev(%0) : (!cir.ptr<!ty_22struct2EStruk22>) -> ()
 // CHECK-NEXT:     cir.return

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -5,7 +5,7 @@ void fn() {
   auto a = [](){};
 }
 
-//      CHECK: !22class2Eanon22 = !cir.struct<"class.anon", i8>
+//      CHECK: !ty_22class2Eanon22 = !cir.struct<"class.anon", i8>
 // CHECK-NEXT: module
 // CHECK-NEXT:   cir.func @_Z2fnv()
-// CHECK-NEXT:     %0 = cir.alloca !22class2Eanon22, cir.ptr <!22class2Eanon22>, ["a"]
+// CHECK-NEXT:     %0 = cir.alloca !ty_22class2Eanon22, cir.ptr <!ty_22class2Eanon22>, ["a"]

--- a/clang/test/CIR/CodeGen/lvalue-refs.cpp
+++ b/clang/test/CIR/CodeGen/lvalue-refs.cpp
@@ -6,8 +6,8 @@ struct String {
 
 void split(String &S) {}
 
-// CHECK: cir.func @_Z5splitR6String(%arg0: !cir.ptr<!22struct2EString22>
-// CHECK:     %0 = cir.alloca !cir.ptr<!22struct2EString22>, cir.ptr <!cir.ptr<!22struct2EString22>>, ["S", init]
+// CHECK: cir.func @_Z5splitR6String(%arg0: !cir.ptr<!ty_22struct2EString22>
+// CHECK:     %0 = cir.alloca !cir.ptr<!ty_22struct2EString22>, cir.ptr <!cir.ptr<!ty_22struct2EString22>>, ["S", init]
 
 void foo() {
   String s;
@@ -15,5 +15,5 @@ void foo() {
 }
 
 // CHECK: cir.func @_Z3foov() {
-// CHECK:     %0 = cir.alloca !22struct2EString22, cir.ptr <!22struct2EString22>, ["s"]
-// CHECK:     cir.call @_Z5splitR6String(%0) : (!cir.ptr<!22struct2EString22>) -> ()
+// CHECK:     %0 = cir.alloca !ty_22struct2EString22, cir.ptr <!ty_22struct2EString22>, ["s"]
+// CHECK:     cir.call @_Z5splitR6String(%0) : (!cir.ptr<!ty_22struct2EString22>) -> ()

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -17,12 +17,12 @@ void baz() {
   struct Foo f;
 }
 
-//      CHECK: !22struct2EBar22 = !cir.struct<"struct.Bar", i32, i8>
-// CHECK-NEXT: !22struct2EFoo22 = !cir.struct<"struct.Foo", i32, i8, !cir.struct<"struct.Bar", i32, i8>>
+//      CHECK: !ty_22struct2EBar22 = !cir.struct<"struct.Bar", i32, i8>
+// CHECK-NEXT: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo", i32, i8, !cir.struct<"struct.Bar", i32, i8>>
 // CHECK-NEXT: module  {
 // CHECK-NEXT:   cir.func @baz() {
-// CHECK-NEXT:     %0 = cir.alloca !22struct2EBar22, cir.ptr <!22struct2EBar22>, ["b"] {alignment = 4 : i64}
-// CHECK-NEXT:     %1 = cir.alloca !22struct2EFoo22, cir.ptr <!22struct2EFoo22>, ["f"] {alignment = 4 : i64}
+// CHECK-NEXT:     %0 = cir.alloca !ty_22struct2EBar22, cir.ptr <!ty_22struct2EBar22>, ["b"] {alignment = 4 : i64}
+// CHECK-NEXT:     %1 = cir.alloca !ty_22struct2EFoo22, cir.ptr <!ty_22struct2EFoo22>, ["f"] {alignment = 4 : i64}
 // CHECK-NEXT:     cir.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -23,32 +23,32 @@ void baz() {
   Foo f;
 }
 
-//      CHECK: !22struct2EBar22 = !cir.struct<"struct.Bar", i32, i8>
-// CHECK-NEXT: !22struct2EFoo22 = !cir.struct<"struct.Foo", i32, i8, !cir.struct<"struct.Bar", i32, i8>>
+//      CHECK: !ty_22struct2EBar22 = !cir.struct<"struct.Bar", i32, i8>
+// CHECK-NEXT: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo", i32, i8, !cir.struct<"struct.Bar", i32, i8>>
 
-//      CHECK: cir.func linkonce_odr @_ZN3Bar6methodEv(%arg0: !cir.ptr<!22struct2EBar22>
-// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!22struct2EBar22>, cir.ptr <!cir.ptr<!22struct2EBar22>>, ["this", init] {alignment = 8 : i64}
-// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!22struct2EBar22>, cir.ptr <!cir.ptr<!22struct2EBar22>>
-// CHECK-NEXT:   %1 = cir.load %0 : cir.ptr <!cir.ptr<!22struct2EBar22>>, !cir.ptr<!22struct2EBar22>
+//      CHECK: cir.func linkonce_odr @_ZN3Bar6methodEv(%arg0: !cir.ptr<!ty_22struct2EBar22>
+// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22struct2EBar22>, cir.ptr <!cir.ptr<!ty_22struct2EBar22>>, ["this", init] {alignment = 8 : i64}
+// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!ty_22struct2EBar22>, cir.ptr <!cir.ptr<!ty_22struct2EBar22>>
+// CHECK-NEXT:   %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22struct2EBar22>>, !cir.ptr<!ty_22struct2EBar22>
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }
 
-//      CHECK: cir.func linkonce_odr @_ZN3Bar7method2Ei(%arg0: !cir.ptr<!22struct2EBar22> {{.*}}, %arg1: i32
-// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!22struct2EBar22>, cir.ptr <!cir.ptr<!22struct2EBar22>>, ["this", init] {alignment = 8 : i64}
+//      CHECK: cir.func linkonce_odr @_ZN3Bar7method2Ei(%arg0: !cir.ptr<!ty_22struct2EBar22> {{.*}}, %arg1: i32
+// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22struct2EBar22>, cir.ptr <!cir.ptr<!ty_22struct2EBar22>>, ["this", init] {alignment = 8 : i64}
 // CHECK-NEXT:   %1 = cir.alloca i32, cir.ptr <i32>, ["a", init] {alignment = 4 : i64}
-// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!22struct2EBar22>, cir.ptr <!cir.ptr<!22struct2EBar22>>
+// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!ty_22struct2EBar22>, cir.ptr <!cir.ptr<!ty_22struct2EBar22>>
 // CHECK-NEXT:   cir.store %arg1, %1 : i32, cir.ptr <i32>
-// CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!22struct2EBar22>>, !cir.ptr<!22struct2EBar22>
+// CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22struct2EBar22>>, !cir.ptr<!ty_22struct2EBar22>
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }
 
-//      CHECK: cir.func linkonce_odr @_ZN3Bar7method3Ei(%arg0: !cir.ptr<!22struct2EBar22> {{.*}}, %arg1: i32
-// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!22struct2EBar22>, cir.ptr <!cir.ptr<!22struct2EBar22>>, ["this", init] {alignment = 8 : i64}
+//      CHECK: cir.func linkonce_odr @_ZN3Bar7method3Ei(%arg0: !cir.ptr<!ty_22struct2EBar22> {{.*}}, %arg1: i32
+// CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22struct2EBar22>, cir.ptr <!cir.ptr<!ty_22struct2EBar22>>, ["this", init] {alignment = 8 : i64}
 // CHECK-NEXT:   %1 = cir.alloca i32, cir.ptr <i32>, ["a", init] {alignment = 4 : i64}
 // CHECK-NEXT:   %2 = cir.alloca i32, cir.ptr <i32>, ["__retval"] {alignment = 4 : i64}
-// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!22struct2EBar22>, cir.ptr <!cir.ptr<!22struct2EBar22>>
+// CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!ty_22struct2EBar22>, cir.ptr <!cir.ptr<!ty_22struct2EBar22>>
 // CHECK-NEXT:   cir.store %arg1, %1 : i32, cir.ptr <i32>
-// CHECK-NEXT:   %3 = cir.load %0 : cir.ptr <!cir.ptr<!22struct2EBar22>>, !cir.ptr<!22struct2EBar22>
+// CHECK-NEXT:   %3 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22struct2EBar22>>, !cir.ptr<!ty_22struct2EBar22>
 // CHECK-NEXT:   %4 = cir.load %1 : cir.ptr <i32>, i32
 // CHECK-NEXT:   cir.store %4, %2 : i32, cir.ptr <i32>
 // CHECK-NEXT:   %5 = cir.load %2 : cir.ptr <i32>, i32
@@ -56,14 +56,14 @@ void baz() {
 // CHECK-NEXT: }
 
 //      CHECK: cir.func @_Z3bazv()
-// CHECK-NEXT:   %0 = cir.alloca !22struct2EBar22, cir.ptr <!22struct2EBar22>, ["b"] {alignment = 4 : i64}
+// CHECK-NEXT:   %0 = cir.alloca !ty_22struct2EBar22, cir.ptr <!ty_22struct2EBar22>, ["b"] {alignment = 4 : i64}
 // CHECK-NEXT:   %1 = cir.alloca i32, cir.ptr <i32>, ["result", init] {alignment = 4 : i64}
-// CHECK-NEXT:   %2 = cir.alloca !22struct2EFoo22, cir.ptr <!22struct2EFoo22>, ["f"] {alignment = 4 : i64}
-// CHECK-NEXT:   cir.call @_ZN3Bar6methodEv(%0) : (!cir.ptr<!22struct2EBar22>) -> ()
+// CHECK-NEXT:   %2 = cir.alloca !ty_22struct2EFoo22, cir.ptr <!ty_22struct2EFoo22>, ["f"] {alignment = 4 : i64}
+// CHECK-NEXT:   cir.call @_ZN3Bar6methodEv(%0) : (!cir.ptr<!ty_22struct2EBar22>) -> ()
 // CHECK-NEXT:   %3 = cir.cst(4 : i32) : i32
-// CHECK-NEXT:   cir.call @_ZN3Bar7method2Ei(%0, %3) : (!cir.ptr<!22struct2EBar22>, i32) -> ()
+// CHECK-NEXT:   cir.call @_ZN3Bar7method2Ei(%0, %3) : (!cir.ptr<!ty_22struct2EBar22>, i32) -> ()
 // CHECK-NEXT:   %4 = cir.cst(4 : i32) : i32
-// CHECK-NEXT:   %5 = cir.call @_ZN3Bar7method3Ei(%0, %4) : (!cir.ptr<!22struct2EBar22>, i32) -> i32
+// CHECK-NEXT:   %5 = cir.call @_ZN3Bar7method3Ei(%0, %4) : (!cir.ptr<!ty_22struct2EBar22>, i32) -> i32
 // CHECK-NEXT:   cir.store %5, %1 : i32, cir.ptr <i32>
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }


### PR DESCRIPTION
For those types, the mangled name started with a number which is not a valid start character for alias types in MLIR.  Prefix these aliases with "ty_".

Relates to llvm/clangir#9.
