### PR TITLE
[CIR][CIRGen][NFC] Fix circular include dependency

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_CLANG_LIB_CIR_CIRGENRECORDLAYOUT_H
 #define LLVM_CLANG_LIB_CIR_CIRGENRECORDLAYOUT_H
 
-#include "CIRGenTypes.h"
-
 #include "clang/AST/Decl.h"
 
 #include "clang/CIR/Dialect/IR/CIRTypes.h"


### PR DESCRIPTION
`CIRGenTypes.h` This file seems to include `CIRGenRecordLayout.h`, these two files have circular dependencies.