### PR TITLE
[NFC] deprecated on makeArrayRef.

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprCst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCst.cpp
@@ -248,8 +248,8 @@ void ConstantAggregateBuilder::condense(CharUnits Offset,
   }
 
   mlir::Attribute Replacement = buildFrom(
-      CGM, makeArrayRef(Elems).slice(First, Length),
-      makeArrayRef(Offsets).slice(First, Length), Offset, getSize(DesiredTy),
+      CGM, ArrayRef(Elems).slice(First, Length),
+      ArrayRef(Offsets).slice(First, Length), Offset, getSize(DesiredTy),
       /*known to have natural layout=*/false, DesiredTy, false);
   replace(Elems, First, Last, {Replacement});
   replace(Offsets, First, Last, {Offset});

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -282,7 +282,7 @@ void CIRGenFunction::LexicalScopeGuard::cleanup() {
     if (CGF.FnRetCIRTy.has_value()) {
       // If there's anything to return, load it first.
       auto val = builder.create<LoadOp>(loc, *CGF.FnRetCIRTy, *CGF.FnRetAlloca);
-      return builder.create<ReturnOp>(loc, llvm::makeArrayRef(val.getResult()));
+      return builder.create<ReturnOp>(loc, llvm::ArrayRef(val.getResult()));
     }
     return builder.create<ReturnOp>(loc);
   };

--- a/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
@@ -431,7 +431,7 @@ public:
   llvm::ArrayRef<ExtParameterInfo> getExtParameterInfos() const {
     if (!HasExtParameterInfos)
       return {};
-    return llvm::makeArrayRef(getExtParameterInfosBuffer(), NumArgs);
+    return llvm::ArrayRef(getExtParameterInfosBuffer(), NumArgs);
   }
   ExtParameterInfo getExtParameterInfo(unsigned argIndex) const {
     assert(argIndex <= NumArgs);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -71,7 +71,6 @@ using llvm::ArrayRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::makeArrayRef;
 using llvm::SmallVector;
 using llvm::StringRef;
 


### PR DESCRIPTION
 Just replace llvm::makeArrayRef with llvm::ArrayRef and silence these warnings on build.

