### PR TITLE
[CIR][LowerToMLIR] Fix lowering signless integer type on DIV, REM, SHR ops

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -542,7 +542,7 @@ public:
     case mlir::cir::BinOpKind::Div:
       if (type.isa<mlir::IntegerType>()) {
         if (type.isSignlessInteger())
-          rewriter.replaceOpWithNewOp<mlir::LLVM::SDivOp>(
+          rewriter.replaceOpWithNewOp<mlir::LLVM::UDivOp>(
               op, op.getType(), op.getLhs(), op.getRhs());
         else
           llvm_unreachable("integer type not supported in CIR yet");
@@ -553,7 +553,7 @@ public:
     case mlir::cir::BinOpKind::Rem:
       if (type.isa<mlir::IntegerType>()) {
         if (type.isSignlessInteger())
-          rewriter.replaceOpWithNewOp<mlir::LLVM::SRemOp>(
+          rewriter.replaceOpWithNewOp<mlir::LLVM::URemOp>(
               op, op.getType(), op.getLhs(), op.getRhs());
         else
           llvm_unreachable("integer type not supported in CIR yet");
@@ -579,7 +579,7 @@ public:
       break;
     case mlir::cir::BinOpKind::Shr:
       if (type.isSignlessInteger())
-        rewriter.replaceOpWithNewOp<mlir::LLVM::AShrOp>(
+        rewriter.replaceOpWithNewOp<mlir::LLVM::LShrOp>(
             op, op.getType(), op.getLhs(), op.getRhs());
       else
         llvm_unreachable("integer type not supported in CIR yet");

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -295,7 +295,7 @@ public:
     case mlir::cir::BinOpKind::Div:
       if (type.isa<mlir::IntegerType>()) {
         if (type.isSignlessInteger())
-          rewriter.replaceOpWithNewOp<mlir::arith::DivSIOp>(
+          rewriter.replaceOpWithNewOp<mlir::arith::DivUIOp>(
               op, op.getType(), op.getLhs(), op.getRhs());
         else
           llvm_unreachable("integer type not supported in CIR yet");
@@ -306,7 +306,7 @@ public:
     case mlir::cir::BinOpKind::Rem:
       if (type.isa<mlir::IntegerType>()) {
         if (type.isSignlessInteger())
-          rewriter.replaceOpWithNewOp<mlir::arith::RemSIOp>(
+          rewriter.replaceOpWithNewOp<mlir::arith::RemUIOp>(
               op, op.getType(), op.getLhs(), op.getRhs());
         else
           llvm_unreachable("integer type not supported in CIR yet");
@@ -332,7 +332,7 @@ public:
       break;
     case mlir::cir::BinOpKind::Shr:
       if (type.isSignlessInteger())
-        rewriter.replaceOpWithNewOp<mlir::arith::ShRSIOp>(
+        rewriter.replaceOpWithNewOp<mlir::arith::ShRUIOp>(
             op, op.getType(), op.getLhs(), op.getRhs());
       else
         llvm_unreachable("integer type not supported in CIR yet");

--- a/clang/test/CIR/Lowering/ThroughMLIR/binop-unsigned-int.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/binop-unsigned-int.cir
@@ -53,22 +53,22 @@ module {
 }
 
 // MLIR: = arith.muli
-// MLIR: = arith.divsi
-// MLIR: = arith.remsi
+// MLIR: = arith.divui
+// MLIR: = arith.remui
 // MLIR: = arith.addi
 // MLIR: = arith.subi
-// MLIR: = arith.shrsi
+// MLIR: = arith.shrui
 // MLIR: = arith.shli
 // MLIR: = arith.andi
 // MLIR: = arith.xori
 // MLIR: = arith.ori
 
 // LLVM: = mul i32
-// LLVM: = sdiv i32
-// LLVM: = srem i32
+// LLVM: = udiv i32
+// LLVM: = urem i32
 // LLVM: = add i32
 // LLVM: = sub i32
-// LLVM: = ashr i32
+// LLVM: = lshr i32
 // LLVM: = shl i32
 // LLVM: = and i32
 // LLVM: = xor i32

--- a/clang/test/CIR/Lowering/binop-unsigned-int.cir
+++ b/clang/test/CIR/Lowering/binop-unsigned-int.cir
@@ -53,22 +53,22 @@ module {
 }
 
 // MLIR: = llvm.mul
-// MLIR: = llvm.sdiv
-// MLIR: = llvm.srem
+// MLIR: = llvm.udiv
+// MLIR: = llvm.urem
 // MLIR: = llvm.add
 // MLIR: = llvm.sub
-// MLIR: = llvm.ashr
+// MLIR: = llvm.lshr
 // MLIR: = llvm.shl
 // MLIR: = llvm.and
 // MLIR: = llvm.xor
 // MLIR: = llvm.or
 
 // LLVM: = mul i32
-// LLVM: = sdiv i32
-// LLVM: = srem i32
+// LLVM: = udiv i32
+// LLVM: = urem i32
 // LLVM: = add i32
 // LLVM: = sub i32
-// LLVM: = ashr i32
+// LLVM: = lshr i32
 // LLVM: = shl i32
 // LLVM: = and i32
 // LLVM: = xor i32


### PR DESCRIPTION

 Fix lower cir to mlir with signed, signless integer type on
DIV, REM, SHR operations. But now on .c -> .cir -> .llvm, it will
generate unsigned operation at end, no matter the given type 'int'
or 'unsigned'. Need more fix.

---------------------

I just change the code https://github.com/llvm/clangir/blob/90e6ee2819b1a7515ff3cad78de43dbb98f8053a/clang/test/CIR/CodeGen/binop.cpp#L4-L5

with `int` to `unsigned`, run with clang -emit-cir , then cir-tool -cir-to-mlir.
They both get mlir operation with unsigned. I guess it may need some process on CIRGen to fix it next.