### PR TITLE
[clang] Fix for broken clang build

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprCst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCst.cpp
@@ -1153,6 +1153,12 @@ mlir::Attribute ConstantEmitter::tryEmitAbstractForMemory(const APValue &value,
   return (C ? emitForMemory(C, destType) : nullptr);
 }
 
+mlir::TypedAttr ConstantEmitter::tryEmitPrivateForMemory(const Expr *E,
+                                                         QualType destType) {
+  assert(0 && "not implemented");
+  return nullptr;
+}
+
 mlir::Attribute ConstantEmitter::tryEmitPrivateForMemory(const APValue &value,
                                                          QualType destType) {
   auto nonMemoryDestType = getNonMemoryType(CGM, destType);
@@ -1236,6 +1242,11 @@ buildArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
   // We have mixed types. Use a packed struct.
   assert(0 && "NYE");
   return {};
+}
+
+mlir::TypedAttr ConstantEmitter::tryEmitPrivate(const Expr *E, QualType T) {
+  assert(0 && "not implemented");
+  return nullptr;
 }
 
 mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -53,7 +53,7 @@ std::string CIRGenTypes::getRecordTypeName(const clang::RecordDecl *recordDecl,
     if (recordDecl->getDeclContext())
       recordDecl->printQualifiedName(outStream, policy);
     else
-      recordDecl->DeclaratorDecl::printName(outStream);
+      recordDecl->printName(outStream, policy);
   } else if (auto *typedefNameDecl = recordDecl->getTypedefNameForAnonDecl()) {
     if (typedefNameDecl->getDeclContext())
       typedefNameDecl->printQualifiedName(outStream, policy);


### PR DESCRIPTION
Summary: The following compilation command is broken:
```
ninja clang
```
It will produce the following output
```
.../clangir/clang/lib/CIR/CodeGen/CIRGenTypes.cpp: In member function ‘std::__cxx11::string cir::CIRGenTypes::getRecordTypeName(const clang::RecordDecl*, llvm::StringRef)’:
.../clangir/clang/lib/CIR/CodeGen/CIRGenTypes.cpp:56:35: error: ‘clang::DeclaratorDecl’ is not a base of ‘const clang::RecordDecl’
       recordDecl->DeclaratorDecl::printName(outStream);
```

Test Plan:
```
ninja clang
```

