### PR TITLE
Compile a "Hello, world!" C program

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -111,7 +111,11 @@ public:
         Builder.getFloatAttr(Ty, E->getValue()));
   }
   mlir::Value VisitCharacterLiteral(const CharacterLiteral *E) {
-    llvm_unreachable("NYI");
+    mlir::Type Ty = CGF.getCIRType(E->getType());
+    auto newOp = Builder.create<mlir::cir::ConstantOp>(
+        CGF.getLoc(E->getExprLoc()), Ty,
+        Builder.getIntegerAttr(Ty, E->getValue()));
+    return newOp;
   }
   mlir::Value VisitObjCBoolLiteralExpr(const ObjCBoolLiteralExpr *E) {
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -346,47 +346,51 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
       ResultType = ::mlir::cir::BoolType::get(Builder.getContext());
       break;
 
+    // Signed types.
+    case BuiltinType::Accum:
     case BuiltinType::Char_S:
-    case BuiltinType::Char_U:
-    case BuiltinType::SChar:
-    case BuiltinType::UChar:
-    case BuiltinType::Short:
-    case BuiltinType::UShort:
+    case BuiltinType::Fract:
     case BuiltinType::Int:
-    case BuiltinType::UInt:
     case BuiltinType::Long:
-    case BuiltinType::ULong:
+    case BuiltinType::LongAccum:
+    case BuiltinType::LongFract:
     case BuiltinType::LongLong:
-    case BuiltinType::ULongLong:
+    case BuiltinType::SChar:
+    case BuiltinType::Short:
+    case BuiltinType::ShortAccum:
+    case BuiltinType::ShortFract:
     case BuiltinType::WChar_S:
-    case BuiltinType::WChar_U:
-    case BuiltinType::Char8:
+    // Saturated signed types.
+    case BuiltinType::SatAccum:
+    case BuiltinType::SatFract:
+    case BuiltinType::SatLongAccum:
+    case BuiltinType::SatLongFract:
+    case BuiltinType::SatShortAccum:
+    case BuiltinType::SatShortFract:
+    // Unsigned types.
     case BuiltinType::Char16:
     case BuiltinType::Char32:
-    case BuiltinType::ShortAccum:
-    case BuiltinType::Accum:
-    case BuiltinType::LongAccum:
-    case BuiltinType::UShortAccum:
+    case BuiltinType::Char8:
+    case BuiltinType::Char_U:
     case BuiltinType::UAccum:
-    case BuiltinType::ULongAccum:
-    case BuiltinType::ShortFract:
-    case BuiltinType::Fract:
-    case BuiltinType::LongFract:
-    case BuiltinType::UShortFract:
+    case BuiltinType::UChar:
     case BuiltinType::UFract:
+    case BuiltinType::UInt:
+    case BuiltinType::ULong:
+    case BuiltinType::ULongAccum:
     case BuiltinType::ULongFract:
-    case BuiltinType::SatShortAccum:
-    case BuiltinType::SatAccum:
-    case BuiltinType::SatLongAccum:
-    case BuiltinType::SatUShortAccum:
+    case BuiltinType::ULongLong:
+    case BuiltinType::UShort:
+    case BuiltinType::UShortAccum:
+    case BuiltinType::UShortFract:
+    case BuiltinType::WChar_U:
+    // Saturated unsigned types.
     case BuiltinType::SatUAccum:
-    case BuiltinType::SatULongAccum:
-    case BuiltinType::SatShortFract:
-    case BuiltinType::SatFract:
-    case BuiltinType::SatLongFract:
-    case BuiltinType::SatUShortFract:
     case BuiltinType::SatUFract:
+    case BuiltinType::SatULongAccum:
     case BuiltinType::SatULongFract:
+    case BuiltinType::SatUShortAccum:
+    case BuiltinType::SatUShortFract:
       // FIXME: break this in s/u and also pass signed param.
       ResultType =
           Builder.getIntegerType(static_cast<unsigned>(Context.getTypeSize(T)));

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -193,6 +193,30 @@ public:
           mlir::cir::CmpOpKind::ne, src, zero);
       break;
     }
+    case mlir::cir::CastKind::integral: {
+      auto oldSourceType =
+          castOp->getOperands().front().getType().cast<mlir::IntegerType>();
+      auto sourceValue = adaptor.getOperands().front();
+      auto sourceType = sourceValue.getType().cast<mlir::IntegerType>();
+      auto targetType = getTypeConverter()
+                            ->convertType(castOp.getResult().getType())
+                            .cast<mlir::IntegerType>();
+
+      // Target integer is smaller: truncate source value.
+      if (targetType.getWidth() < sourceType.getWidth()) {
+        rewriter.replaceOpWithNewOp<mlir::LLVM::TruncOp>(castOp, targetType,
+                                                         sourceValue);
+      } else {
+        // FIXME: CIR codegen does not distiguishes singned/unsinged types.
+        if (oldSourceType.isUnsigned())
+          rewriter.replaceOpWithNewOp<mlir::LLVM::ZExtOp>(castOp, targetType,
+                                                          sourceValue);
+        else
+          rewriter.replaceOpWithNewOp<mlir::LLVM::SExtOp>(castOp, targetType,
+                                                          sourceValue);
+      }
+      break;
+    }
     default:
       llvm_unreachable("NYI");
     }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -25,6 +25,8 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
@@ -38,6 +40,8 @@
 #include "clang/CIR/Passes.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
+#include <optional>
 
 using namespace cir;
 using namespace llvm;
@@ -500,6 +504,168 @@ public:
   }
 };
 
+template <typename T>
+mlir::DenseElementsAttr
+convertToDenseElementsAttr(mlir::cir::ConstArrayAttr attr) {
+  auto type = attr.getType().cast<mlir::cir::ArrayType>().getEltType();
+  auto values = llvm::SmallVector<T, 8>{};
+  for (auto element : attr.getValue().cast<mlir::ArrayAttr>())
+    values.push_back(element.cast<mlir::IntegerAttr>().getInt());
+  return mlir::DenseElementsAttr::get(
+      mlir::RankedTensorType::get({(int64_t)values.size()}, type),
+      llvm::ArrayRef(values));
+}
+
+std::optional<mlir::Attribute>
+lowerConstArrayAttr(mlir::cir::ConstArrayAttr constArr) {
+
+  // Ensure ConstArrayAttr has a type.
+  auto typedConstArr = constArr.dyn_cast<mlir::TypedAttr>();
+  assert(typedConstArr && "cir::ConstArrayAttr is not a mlir::TypedAttr");
+
+  // Ensure ConstArrayAttr type is a ArrayType.
+  auto cirArrayType = typedConstArr.getType().dyn_cast<mlir::cir::ArrayType>();
+  assert(cirArrayType && "cir::ConstArrayAttr is not a cir::ArrayType");
+
+  // Is a ConstArrayAttr with an cir::ArrayType: fetch element type.
+  auto type = cirArrayType.getEltType();
+
+  if (type.isInteger(8))
+    return convertToDenseElementsAttr<int8_t>(constArr);
+  if (type.isInteger(16))
+    return convertToDenseElementsAttr<int16_t>(constArr);
+  if (type.isInteger(32))
+    return convertToDenseElementsAttr<int32_t>(constArr);
+  if (type.isInteger(64))
+    return convertToDenseElementsAttr<int64_t>(constArr);
+
+  return std::nullopt;
+}
+
+mlir::LLVM::Linkage convertLinkage(mlir::cir::GlobalLinkageKind linkage) {
+  using CIR = mlir::cir::GlobalLinkageKind;
+  using LLVM = mlir::LLVM::Linkage;
+
+  switch (linkage) {
+  case CIR::AvailableExternallyLinkage:
+    return LLVM::AvailableExternally;
+  case CIR::CommonLinkage:
+    return LLVM::Common;
+  case CIR::ExternalLinkage:
+    return LLVM::External;
+  case CIR::ExternalWeakLinkage:
+    return LLVM::ExternWeak;
+  case CIR::InternalLinkage:
+    return LLVM::Internal;
+  case CIR::LinkOnceAnyLinkage:
+    return LLVM::Linkonce;
+  case CIR::LinkOnceODRLinkage:
+    return LLVM::LinkonceODR;
+  case CIR::PrivateLinkage:
+    return LLVM::Private;
+  case CIR::WeakAnyLinkage:
+    return LLVM::Weak;
+  case CIR::WeakODRLinkage:
+    return LLVM::WeakODR;
+  };
+}
+
+class CIRGetGlobalOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::GetGlobalOp> {
+public:
+  using OpConversionPattern<mlir::cir::GetGlobalOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::GetGlobalOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto type = getTypeConverter()->convertType(op.getType());
+    auto symbol = op.getName();
+    rewriter.replaceOpWithNewOp<mlir::LLVM::AddressOfOp>(op, type, symbol);
+    return mlir::success();
+  }
+};
+
+class CIRGlobalOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::GlobalOp> {
+public:
+  using OpConversionPattern<mlir::cir::GlobalOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::GlobalOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+
+    // Fetch required values to create LLVM op.
+    auto type = getTypeConverter()->convertType(op.getSymType());
+    auto isConst = op.getConstant();
+    auto linkage = convertLinkage(op.getLinkage());
+    auto symbol = op.getSymName();
+    auto init = op.getInitialValue();
+
+    // Check for missing funcionalities.
+    if (!init.has_value()) {
+      op.emitError() << "uninitialized globals are not yet supported.";
+      return mlir::failure();
+    }
+
+    // Initializer is a constant array: convert it to a compatible llvm init.
+    if (auto constArr = init.value().dyn_cast<mlir::cir::ConstArrayAttr>()) {
+      if (auto attr = constArr.getValue().dyn_cast<mlir::StringAttr>()) {
+        init = rewriter.getStringAttr(attr.getValue());
+      } else if (auto attr = constArr.getValue().dyn_cast<mlir::ArrayAttr>()) {
+        if (!(init = lowerConstArrayAttr(constArr))) {
+          op.emitError()
+              << "unsupported lowering for #cir.const_array with element type "
+              << type;
+          return mlir::failure();
+        }
+      } else {
+        op.emitError()
+            << "unsupported lowering for #cir.const_array with value "
+            << constArr.getValue();
+        return mlir::failure();
+      }
+    } else if (llvm::isa<mlir::IntegerAttr, mlir::FloatAttr>(init.value())) {
+      // Nothing to do since LLVM already supports these types as initializers.
+    }
+    // Initializer is a global: load global value in initializer block.
+    else if (auto attr = init.value().dyn_cast<mlir::FlatSymbolRefAttr>()) {
+      auto newGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
+          op, type, isConst, linkage, symbol, mlir::Attribute());
+      mlir::OpBuilder::InsertionGuard guard(rewriter);
+
+      // Create initializer block.
+      auto *newBlock = new mlir::Block();
+      newGlobalOp.getRegion().push_back(newBlock);
+
+      // Fetch global used as initializer.
+      auto sourceSymbol =
+          dyn_cast<mlir::LLVM::GlobalOp>(mlir::SymbolTable::lookupSymbolIn(
+              op->getParentOfType<mlir::ModuleOp>(), attr.getValue()));
+
+      // Load and return the initializer value.
+      rewriter.setInsertionPointToEnd(newBlock);
+      auto addressOfOp = rewriter.create<mlir::LLVM::AddressOfOp>(
+          op->getLoc(),
+          mlir::LLVM::LLVMPointerType::get(sourceSymbol.getType()),
+          sourceSymbol.getSymName());
+      llvm::SmallVector<mlir::LLVM::GEPArg> offset{0};
+      auto gepOp = rewriter.create<mlir::LLVM::GEPOp>(
+          op->getLoc(), type, addressOfOp.getResult(), offset);
+      rewriter.create<mlir::LLVM::ReturnOp>(op->getLoc(), gepOp.getResult());
+
+      return mlir::success();
+    } else {
+      op.emitError() << "usupported initializer '" << init.value() << "'";
+      return mlir::failure();
+    }
+
+    // Rewrite op.
+    rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
+        op, type, isConst, linkage, symbol, init.value());
+    return mlir::success();
+  }
+};
+
 class CIRUnaryOpLowering
     : public mlir::OpConversionPattern<mlir::cir::UnaryOp> {
 public:
@@ -830,7 +996,8 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                CIRPtrStrideOpLowering, CIRCallLowering, CIRUnaryOpLowering,
                CIRBinOpLowering, CIRLoadLowering, CIRConstantLowering,
                CIRStoreLowering, CIRAllocaLowering, CIRFuncLowering,
-               CIRScopeOpLowering, CIRCastOpLowering, CIRIfLowering>(
+               CIRScopeOpLowering, CIRCastOpLowering, CIRIfLowering,
+               CIRGlobalOpLowering, CIRGetGlobalOpLowering>(
       converter, patterns.getContext());
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -184,6 +184,15 @@ public:
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto src = adaptor.getSrc();
     switch (castOp.getKind()) {
+    case mlir::cir::CastKind::array_to_ptrdecay: {
+      auto sourceValue = adaptor.getOperands().front();
+      auto targetType =
+          getTypeConverter()->convertType(castOp->getResult(0).getType());
+      auto offset = llvm::SmallVector<mlir::LLVM::GEPArg>{0};
+      rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(castOp, targetType,
+                                                     sourceValue, offset);
+      break;
+    }
     case mlir::cir::CastKind::int_to_bool: {
       auto zero = rewriter.create<mlir::cir::ConstantOp>(
           src.getLoc(), src.getType(),

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1051,7 +1051,8 @@ void ConvertCIRToLLVMPass::runOnOperation() {
                     >();
   // clang-format on
   target.addLegalDialect<mlir::LLVM::LLVMDialect>();
-  target.addIllegalDialect<mlir::cir::CIRDialect, mlir::func::FuncDialect>();
+  target.addIllegalDialect<mlir::BuiltinDialect, mlir::cir::CIRDialect,
+                           mlir::func::FuncDialect>();
 
   getOperation()->removeAttr("cir.sob");
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -37,6 +37,7 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Passes.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallVector.h"
 
 using namespace cir;
 using namespace llvm;
@@ -382,9 +383,15 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::CallOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
+    llvm::SmallVector<mlir::Type, 8> llvmResults;
+    auto cirResults = op.getResultTypes();
+
+    if (getTypeConverter()->convertTypes(cirResults, llvmResults).failed())
+      return mlir::failure();
+
     rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
-        op, op.getResultTypes(), op.getCalleeAttr(), op.getArgOperands());
-    return mlir::LogicalResult::success();
+        op, llvmResults, op.getCalleeAttr(), adaptor.getOperands());
+    return mlir::success();
   }
 };
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4608,6 +4608,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       Args.hasArg(options::OPT_emit_cir))
     CmdArgs.push_back("-fclangir-enable");
 
+  if (Args.hasArg(options::OPT_fclangir_direct_lowering))
+    CmdArgs.push_back("-fclangir-direct-lowering");
+
   if (Args.hasArg(options::OPT_clangir_disable_passes))
     CmdArgs.push_back("-clangir-disable-passes");
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2830,6 +2830,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_fclangir_enable) || Args.hasArg(OPT_emit_cir))
     Opts.UseClangIRPipeline = true;
 
+  if (Args.hasArg(OPT_fclangir_direct_lowering))
+    Opts.ClangIRDirectLowering = true;
+
   if (Args.hasArg(OPT_clangir_disable_passes))
     Opts.ClangIRDisablePasses = true;
 

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -58,7 +58,7 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
   if (UseCIR && !IsImplementedCIROutput)
     llvm::report_fatal_error("-fclangir-enable currently only works with "
                              "-emit-cir, -emit-cir-only, -emit-mlir, "
-                             "-emit-llvm and -S");
+                             "-emit-llvm, -emit-obj, and -S");
   if (!UseCIR && EmitsCIR)
     llvm::report_fatal_error(
         "-emit-cir and -emit-cir-only only valid when using -fclangir-enable");

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -14,3 +14,26 @@ unsigned char cxxstaticcast_0(unsigned int x) {
 // CHECK:    %4 = cir.load %1 : cir.ptr <i8>, i8
 // CHECK:    cir.return %4 : i8
 // CHECK:  }
+
+
+int cStyleCasts_0(unsigned x1, int x2) {
+// CHECK: cir.func @_{{.*}}cStyleCasts_0{{.*}}
+
+  char a = (char)x1; // truncate
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : i32), i8
+
+  short b = (short)x2; // truncate with sign
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : i32), i16
+
+  long long c = (long long)x1; // zero extend
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : i32), i64
+
+  long long d = (long long)x2; // sign extend
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : i32), i64
+
+  int arr[3];
+  int* e = (int*)arr; // explicit pointer decay
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %{{[0-9]+}} : !cir.ptr<!cir.array<i32 x 3>>), !cir.ptr<i32>
+
+  return 0;
+}

--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -75,3 +75,34 @@ int use_func() { return func<int>(); }
 // CHECK-NEXT:    %2 = cir.load %0 : cir.ptr <i32>, i32
 // CHECK-NEXT:    cir.return %2 : i32
 // CHECK-NEXT:  }
+
+
+char string[] = "whatnow";
+// CHECK: cir.global external @string = #cir.const_array<[119 : i8, 104 : i8, 97 : i8, 116 : i8, 110 : i8, 111 : i8, 119 : i8, 0 : i8] : !cir.array<i8 x 8>> : !cir.array<i8 x 8>
+unsigned uint[] = {255};
+// CHECK: cir.global external @uint = #cir.const_array<[255 : i32] : !cir.array<i32 x 1>> : !cir.array<i32 x 1>
+short sshort[] = {11111, 22222};
+// CHECK: cir.global external @sshort = #cir.const_array<[11111 : i16, 22222 : i16] : !cir.array<i16 x 2>> : !cir.array<i16 x 2>
+int sint[] = {123, 456, 789};
+// CHECK: cir.global external @sint = #cir.const_array<[123 : i32, 456 : i32, 789 : i32] : !cir.array<i32 x 3>> : !cir.array<i32 x 3>
+long long ll[] = {999999999, 0, 0, 0};
+// CHECK: cir.global external @ll = #cir.const_array<[999999999, 0, 0, 0] : !cir.array<i64 x 4>> : !cir.array<i64 x 4>
+
+void get_globals() {
+  // CHECK: cir.func @_Z11get_globalsv()
+  char *s = string;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @string : cir.ptr <!cir.array<i8 x 8>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i8 x 8>>), !cir.ptr<i8>
+  unsigned *u = uint;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @uint : cir.ptr <!cir.array<i32 x 1>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i32 x 1>>), !cir.ptr<i32>
+  short *ss = sshort;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @sshort : cir.ptr <!cir.array<i16 x 2>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i16 x 2>>), !cir.ptr<i16>
+  int *si = sint;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @sint : cir.ptr <!cir.array<i32 x 3>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i32 x 3>>), !cir.ptr<i32>
+  long long *l = ll;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @ll : cir.ptr <!cir.array<i64 x 4>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i64 x 4>>), !cir.ptr<i64>
+}

--- a/clang/test/CIR/CodeGen/literals.c
+++ b/clang/test/CIR/CodeGen/literals.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fclangir-enable -emit-cir %s -o - | FileCheck %s
+
+int literals(void) {
+    char a = 'a'; // char literals are int in C
+    // CHECK: %[[RES:[0-9]+]] = cir.const(97 : i32) : i32
+    // CHECK: %{{[0-9]+}} = cir.cast(integral, %[[RES]] : i32), i8
+
+    return 0;
+}

--- a/clang/test/CIR/CodeGen/literals.cpp
+++ b/clang/test/CIR/CodeGen/literals.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -fclangir-enable -emit-cir %s -o - | FileCheck %s
+
+int literals() {
+    char a = 'a'; // char literals have char type in C++
+    // CHECK:  %{{[0-9]+}} = cir.const(97 : i8) : i8
+
+    return 0;
+}

--- a/clang/test/CIR/Executables/hello.c
+++ b/clang/test/CIR/Executables/hello.c
@@ -1,0 +1,9 @@
+// RUN: %clang -fclangir-enable -fclangir-direct-lowering -o %t %s
+// RUN: %t | FileCheck %s
+int printf(const char *format);
+
+int main (void) {
+    printf ("Hello, world!\n");
+    // CHECK: Hello, world!
+    return 0;
+}

--- a/clang/test/CIR/Lowering/call.cir
+++ b/clang/test/CIR/Lowering/call.cir
@@ -9,7 +9,6 @@ module {
     cir.call @a() : () -> ()
     cir.return
   }
-}
 
 //      MLIR: llvm.func @a() {
 // MLIR-NEXT:   llvm.return
@@ -26,3 +25,15 @@ module {
 // LLVM-NEXT:   call void @a()
 // LLVM-NEXT:   ret void
 // LLVM-NEXT: }
+
+  // check operands and results type lowering
+  cir.func @callee(!cir.ptr<i32>) -> !cir.ptr<i32> attributes {sym_visibility = "private"}
+  // MLIR: llvm.func @callee(!llvm.ptr<i32>) -> !llvm.ptr<i32>
+  cir.func @caller(%arg0: !cir.ptr<i32>) -> !cir.ptr<i32> {
+  // MLIR: llvm.func @caller(%arg0: !llvm.ptr<i32>) -> !llvm.ptr<i32>
+    %0 = cir.call @callee(%arg0) : (!cir.ptr<i32>) -> !cir.ptr<i32>
+    // MLIR: %{{[0-9]+}} = llvm.call @callee(%arg0) : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
+    cir.return %0 : !cir.ptr<i32>
+  }
+
+} // end module

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -6,16 +6,13 @@ module {
     %4 = cir.cast(int_to_bool, %arg0 : i32), !cir.bool
     cir.return %arg0 : i32
   }
-}
 
-//      MLIR: module {
-// MLIR-NEXT:  llvm.func @foo(%arg0: i32) -> i32 {
+//      MLIR:  llvm.func @foo(%arg0: i32) -> i32 {
 // MLIR-NEXT:    [[v0:%[0-9]]] = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:    [[v1:%[0-9]]] = llvm.icmp "ne" %arg0, %0 : i32
 // MLIR-NEXT:    [[v2:%[0-9]]] = llvm.zext %1 : i1 to i8
 // MLIR-NEXT:    llvm.return %arg0 : i32
 // MLIR-NEXT:  }
-// MLIR-NEXT:}
 
 
 //      LLVM: define i32 @foo(i32 %0) {
@@ -23,3 +20,38 @@ module {
 // LLVM-NEXT:   %3 = zext i1 %2 to i8
 // LLVM-NEXT:   ret i32 %0
 // LLVM-NEXT: }
+
+  cir.func @cStyleCasts(%arg0: i32, %arg1: i32) -> i32 {
+    // MLIR: llvm.func @cStyleCasts(%arg0: i32, %arg1: i32) -> i32 {
+    %0 = cir.alloca i32, cir.ptr <i32>, ["x1", init] {alignment = 4 : i64}
+    %1 = cir.alloca i32, cir.ptr <i32>, ["x2", init] {alignment = 4 : i64}
+    %2 = cir.alloca i32, cir.ptr <i32>, ["__retval"] {alignment = 4 : i64}
+    %3 = cir.alloca i8, cir.ptr <i8>, ["a", init] {alignment = 1 : i64}
+    %4 = cir.alloca i16, cir.ptr <i16>, ["b", init] {alignment = 2 : i64}
+    %5 = cir.alloca i64, cir.ptr <i64>, ["c", init] {alignment = 8 : i64}
+    %6 = cir.alloca i64, cir.ptr <i64>, ["d", init] {alignment = 8 : i64}
+    cir.store %arg0, %0 : i32, cir.ptr <i32>
+    cir.store %arg1, %1 : i32, cir.ptr <i32>
+    %7 = cir.load %0 : cir.ptr <i32>, i32
+    %8 = cir.cast(integral, %7 : i32), i8
+    // MLIR: %{{[0-9]+}} = llvm.trunc %{{[0-9]+}} : i32 to i8
+    cir.store %8, %3 : i8, cir.ptr <i8>
+    %9 = cir.load %1 : cir.ptr <i32>, i32
+    %10 = cir.cast(integral, %9 : i32), i16
+    // MLIR: %{{[0-9]+}} = llvm.trunc %{{[0-9]+}} : i32 to i16
+    cir.store %10, %4 : i16, cir.ptr <i16>
+    %11 = cir.load %0 : cir.ptr <i32>, i32
+    %12 = cir.cast(integral, %11 : i32), i64
+    // FIXME: this should be a zext, but we don't distinguish signed/unsigned
+    // MLIR: %{{[0-9]+}} = llvm.sext %{{[0-9]+}} : i32 to i64
+    cir.store %12, %5 : i64, cir.ptr <i64>
+    %13 = cir.load %1 : cir.ptr <i32>, i32
+    %14 = cir.cast(integral, %13 : i32), i64
+    // MLIR: %{{[0-9]+}} = llvm.sext %{{[0-9]+}} : i32 to i64
+    cir.store %14, %6 : i64, cir.ptr <i64>
+    %15 = cir.const(0 : i32) : i32
+    cir.store %15, %2 : i32, cir.ptr <i32>
+    %16 = cir.load %2 : cir.ptr <i32>, i32
+    cir.return %16 : i32
+  }
+}

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -30,6 +30,8 @@ module {
     %4 = cir.alloca i16, cir.ptr <i16>, ["b", init] {alignment = 2 : i64}
     %5 = cir.alloca i64, cir.ptr <i64>, ["c", init] {alignment = 8 : i64}
     %6 = cir.alloca i64, cir.ptr <i64>, ["d", init] {alignment = 8 : i64}
+    %17 = cir.alloca !cir.array<i32 x 3>, cir.ptr <!cir.array<i32 x 3>>, ["arr"] {alignment = 4 : i64}
+    %18 = cir.alloca !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>, ["e", init] {alignment = 8 : i64}
     cir.store %arg0, %0 : i32, cir.ptr <i32>
     cir.store %arg1, %1 : i32, cir.ptr <i32>
     %7 = cir.load %0 : cir.ptr <i32>, i32
@@ -49,6 +51,9 @@ module {
     %14 = cir.cast(integral, %13 : i32), i64
     // MLIR: %{{[0-9]+}} = llvm.sext %{{[0-9]+}} : i32 to i64
     cir.store %14, %6 : i64, cir.ptr <i64>
+    %19 = cir.cast(array_to_ptrdecay, %17 : !cir.ptr<!cir.array<i32 x 3>>), !cir.ptr<i32>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr<array<3 x i32>>) -> !llvm.ptr<i32>
+    cir.store %19, %18 : !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>
     %15 = cir.const(0 : i32) : i32
     cir.store %15, %2 : i32, cir.ptr <i32>
     %16 = cir.load %2 : cir.ptr <i32>, i32

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -1,0 +1,108 @@
+// RUN: cir-tool %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-tool %s -cir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
+module {
+  cir.global external @a = 3 : i32
+  cir.global external @c = 2 : i64
+  cir.global external @y = 3.400000e+00 : f32
+  cir.global external @w = 4.300000e+00 : f64
+  cir.global external @x = 51 : i8
+  cir.global external @rgb = #cir.const_array<[0 : i8, -23 : i8, 33 : i8] : !cir.array<i8 x 3>> : !cir.array<i8 x 3>
+  cir.global external @alpha = #cir.const_array<[97 : i8, 98 : i8, 99 : i8, 0 : i8] : !cir.array<i8 x 4>> : !cir.array<i8 x 4>
+  cir.global "private" constant internal @".str" = #cir.const_array<"example\00" : !cir.array<i8 x 8>> : !cir.array<i8 x 8> {alignment = 1 : i64}
+  cir.global external @s = @".str": !cir.ptr<i8>
+  // MLIR: llvm.mlir.global internal constant @".str"("example\00") {addr_space = 0 : i32}
+  // MLIR: llvm.mlir.global external @s() {addr_space = 0 : i32} : !llvm.ptr<i8> {
+  // MLIR:   %0 = llvm.mlir.addressof @".str" : !llvm.ptr<array<8 x i8>>
+  // MLIR:   %1 = llvm.getelementptr %0[0] : (!llvm.ptr<array<8 x i8>>) -> !llvm.ptr<i8>
+  // MLIR:   llvm.return %1 : !llvm.ptr<i8>
+  // MLIR: }
+  // LLVM: @.str = internal constant [8 x i8] c"example\00"
+  // LLVM: @s = global ptr @.str
+  cir.global "private" constant internal @".str1" = #cir.const_array<"example1\00" : !cir.array<i8 x 9>> : !cir.array<i8 x 9> {alignment = 1 : i64}
+  cir.global external @s1 = @".str1": !cir.ptr<i8>
+  cir.global external @s2 = @".str": !cir.ptr<i8>
+  cir.func @_Z10use_globalv() {
+    %0 = cir.alloca i32, cir.ptr <i32>, ["li", init] {alignment = 4 : i64}
+    %1 = cir.get_global @a : cir.ptr <i32>
+    %2 = cir.load %1 : cir.ptr <i32>, i32
+    cir.store %2, %0 : i32, cir.ptr <i32>
+    cir.return
+  }
+  cir.func @_Z17use_global_stringv() {
+    %0 = cir.alloca i8, cir.ptr <i8>, ["c", init] {alignment = 1 : i64}
+    %1 = cir.get_global @s2 : cir.ptr <!cir.ptr<i8>>
+    %2 = cir.load %1 : cir.ptr <!cir.ptr<i8>>, !cir.ptr<i8>
+    %3 = cir.const(0 : i32) : i32
+    %4 = cir.ptr_stride(%2 : !cir.ptr<i8>, %3 : i32), !cir.ptr<i8>
+    %5 = cir.load %4 : cir.ptr <i8>, i8
+    cir.store %5, %0 : i8, cir.ptr <i8>
+    cir.return
+  }
+  cir.func linkonce_odr @_Z4funcIiET_v() -> i32 {
+    %0 = cir.alloca i32, cir.ptr <i32>, ["__retval"] {alignment = 4 : i64}
+    %1 = cir.const(0 : i32) : i32
+    cir.store %1, %0 : i32, cir.ptr <i32>
+    %2 = cir.load %0 : cir.ptr <i32>, i32
+    cir.return %2 : i32
+  }
+  cir.func @_Z8use_funcv() -> i32 {
+    %0 = cir.alloca i32, cir.ptr <i32>, ["__retval"] {alignment = 4 : i64}
+    %1 = cir.call @_Z4funcIiET_v() : () -> i32
+    cir.store %1, %0 : i32, cir.ptr <i32>
+    %2 = cir.load %0 : cir.ptr <i32>, i32
+    cir.return %2 : i32
+  }
+  cir.global external @string = #cir.const_array<[119 : i8, 104 : i8, 97 : i8, 116 : i8, 110 : i8, 111 : i8, 119 : i8, 0 : i8] : !cir.array<i8 x 8>> : !cir.array<i8 x 8>
+  // MLIR: llvm.mlir.global external @string(dense<[119, 104, 97, 116, 110, 111, 119, 0]> : tensor<8xi8>) {addr_space = 0 : i32} : !llvm.array<8 x i8>
+  // LLVM: @string = global [8 x i8] c"whatnow\00"
+  cir.global external @uint = #cir.const_array<[255 : i32] : !cir.array<i32 x 1>> : !cir.array<i32 x 1>
+  // MLIR: llvm.mlir.global external @uint(dense<255> : tensor<1xi32>) {addr_space = 0 : i32} : !llvm.array<1 x i32>
+  // LLVM: @uint = global [1 x i32] [i32 255]
+  cir.global external @sshort = #cir.const_array<[11111 : i16, 22222 : i16] : !cir.array<i16 x 2>> : !cir.array<i16 x 2>
+  // MLIR: llvm.mlir.global external @sshort(dense<[11111, 22222]> : tensor<2xi16>) {addr_space = 0 : i32} : !llvm.array<2 x i16>
+  // LLVM: @sshort = global [2 x i16] [i16 11111, i16 22222]
+  cir.global external @sint = #cir.const_array<[123 : i32, 456 : i32, 789 : i32] : !cir.array<i32 x 3>> : !cir.array<i32 x 3>
+  // MLIR: llvm.mlir.global external @sint(dense<[123, 456, 789]> : tensor<3xi32>) {addr_space = 0 : i32} : !llvm.array<3 x i32>
+  // LLVM: @sint = global [3 x i32] [i32 123, i32 456, i32 789]
+  cir.global external @ll = #cir.const_array<[999999999, 0, 0, 0] : !cir.array<i64 x 4>> : !cir.array<i64 x 4>
+  // MLIR: llvm.mlir.global external @ll(dense<[999999999, 0, 0, 0]> : tensor<4xi64>) {addr_space = 0 : i32} : !llvm.array<4 x i64>
+  // LLVM: @ll = global [4 x i64] [i64 999999999, i64 0, i64 0, i64 0]
+  cir.func @_Z11get_globalsv() {
+    %0 = cir.alloca !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>, ["s", init] {alignment = 8 : i64}
+    %1 = cir.alloca !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>, ["u", init] {alignment = 8 : i64}
+    %2 = cir.alloca !cir.ptr<i16>, cir.ptr <!cir.ptr<i16>>, ["ss", init] {alignment = 8 : i64}
+    %3 = cir.alloca !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>, ["si", init] {alignment = 8 : i64}
+    %4 = cir.alloca !cir.ptr<i64>, cir.ptr <!cir.ptr<i64>>, ["l", init] {alignment = 8 : i64}
+    %5 = cir.get_global @string : cir.ptr <!cir.array<i8 x 8>>
+    %6 = cir.cast(array_to_ptrdecay, %5 : !cir.ptr<!cir.array<i8 x 8>>), !cir.ptr<i8>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @string : !llvm.ptr<array<8 x i8>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<8 x i8>>) -> !llvm.ptr<i8>
+    // LLVM: store ptr @string, ptr %{{[0-9]+}}
+    cir.store %6, %0 : !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>
+    %7 = cir.get_global @uint : cir.ptr <!cir.array<i32 x 1>>
+    %8 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<i32 x 1>>), !cir.ptr<i32>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @uint : !llvm.ptr<array<1 x i32>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<1 x i32>>) -> !llvm.ptr<i32>
+    // LLVM: store ptr @uint, ptr %{{[0-9]+}}
+    cir.store %8, %1 : !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>
+    %9 = cir.get_global @sshort : cir.ptr <!cir.array<i16 x 2>>
+    %10 = cir.cast(array_to_ptrdecay, %9 : !cir.ptr<!cir.array<i16 x 2>>), !cir.ptr<i16>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sshort : !llvm.ptr<array<2 x i16>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<2 x i16>>) -> !llvm.ptr<i16>
+    // LLVM: store ptr @sshort, ptr %{{[0-9]+}}
+    cir.store %10, %2 : !cir.ptr<i16>, cir.ptr <!cir.ptr<i16>>
+    %11 = cir.get_global @sint : cir.ptr <!cir.array<i32 x 3>>
+    %12 = cir.cast(array_to_ptrdecay, %11 : !cir.ptr<!cir.array<i32 x 3>>), !cir.ptr<i32>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sint : !llvm.ptr<array<3 x i32>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<3 x i32>>) -> !llvm.ptr<i32>
+    // LLVM: store ptr @sint, ptr %{{[0-9]+}}
+    cir.store %12, %3 : !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>
+    %13 = cir.get_global @ll : cir.ptr <!cir.array<i64 x 4>>
+    %14 = cir.cast(array_to_ptrdecay, %13 : !cir.ptr<!cir.array<i64 x 4>>), !cir.ptr<i64>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @ll : !llvm.ptr<array<4 x i64>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<4 x i64>>) -> !llvm.ptr<i64>
+    // LLVM: store ptr @ll, ptr %{{[0-9]+}}
+    cir.store %14, %4 : !cir.ptr<i64>, cir.ptr <!cir.ptr<i64>>
+    cir.return
+  }
+}

--- a/clang/tools/cir-tool/cir-tool.cpp
+++ b/clang/tools/cir-tool/cir-tool.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -28,7 +29,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   registry.insert<mlir::BuiltinDialect, mlir::arith::ArithDialect,
                   mlir::cir::CIRDialect, mlir::memref::MemRefDialect,
-                  mlir::LLVM::LLVMDialect>();
+                  mlir::LLVM::LLVMDialect, mlir::DLTIDialect>();
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return cir::createConvertMLIRToLLVMPass();


### PR DESCRIPTION
## What?

Add a series of functionalities and bug fixes to easily compile a simple "Hello world!" C program.

## Why?

Most programs will require some standard library to compile. Printf is specially used for correctness. This is meant to be a first step to testing Clang IR against some benchmarks and other "real-world" programs.

## How?

Additions:

 - Add code gen visitor for character literals.
 - Implement pointer decay casts to convert char arrays to char pointers.
 - Implement direct lowering conversion patterns for both `cir.get_global` and `cir.global` operations.
 - Test compiling a `hello.c` program using `clang -fclangir-enable -fclangir-direct-lowering`.
 
Bug fixes:

 - Use converted LLVM types when generating `llvm.call` operations instead of CIR types.
 - Fix `-fclangir-direct-lowering` flag being ignored (indirect lowering seems to be broken in some cases).
 - Also marked DLTI as legal and Builtin as illegal in the LLVM conversion target.