### PR TITLE
[CIR][Bugfix] Mark Builtin dialect as illegal when lowering to LLVM

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1020,7 +1020,8 @@ void ConvertCIRToLLVMPass::runOnOperation() {
                     >();
   // clang-format on
   target.addLegalDialect<mlir::LLVM::LLVMDialect>();
-  target.addIllegalDialect<mlir::cir::CIRDialect, mlir::func::FuncDialect>();
+  target.addIllegalDialect<mlir::BuiltinDialect, mlir::cir::CIRDialect,
+                           mlir::func::FuncDialect>();
 
   getOperation()->removeAttr("cir.sob");
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

