### PR TITLE
[CIR][Bugfix] Use llvm types when creating a LLVM::CallOp

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -383,7 +383,7 @@ public:
   matchAndRewrite(mlir::cir::CallOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
-        op, op.getResultTypes(), op.getCalleeAttr(), op.getArgOperands());
+        op, op.getResultTypes(), op.getCalleeAttr(), adaptor.getOperands());
     return mlir::LogicalResult::success();
   }
 };

--- a/clang/test/CIR/Lowering/call.cir
+++ b/clang/test/CIR/Lowering/call.cir
@@ -9,7 +9,6 @@ module {
     cir.call @a() : () -> ()
     cir.return
   }
-}
 
 //      MLIR: llvm.func @a() {
 // MLIR-NEXT:   llvm.return
@@ -26,3 +25,12 @@ module {
 // LLVM-NEXT:   call void @a()
 // LLVM-NEXT:   ret void
 // LLVM-NEXT: }
+
+  cir.func @callee(!cir.ptr<i32>) -> () attributes {sym_visibility = "private"}
+  cir.func @caller(%arg0: !cir.ptr<i32>) -> () {
+    cir.call @callee(%arg0) : (!cir.ptr<i32>) -> ()
+    // MLIR: llvm.call @callee(%arg0) : (!llvm.ptr<i32>) -> ()
+    cir.return
+  }
+
+} // end module


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

