### PR TITLE
[CIR][Lowering] Lower CIR global operations

### DIFF
--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -75,3 +75,34 @@ int use_func() { return func<int>(); }
 // CHECK-NEXT:    %2 = cir.load %0 : cir.ptr <i32>, i32
 // CHECK-NEXT:    cir.return %2 : i32
 // CHECK-NEXT:  }
+
+
+char string[] = "whatnow";
+// CHECK: cir.global external @string = #cir.const_array<[119 : i8, 104 : i8, 97 : i8, 116 : i8, 110 : i8, 111 : i8, 119 : i8, 0 : i8] : !cir.array<i8 x 8>> : !cir.array<i8 x 8>
+unsigned uint[] = {255};
+// CHECK: cir.global external @uint = #cir.const_array<[255 : i32] : !cir.array<i32 x 1>> : !cir.array<i32 x 1>
+short sshort[] = {11111, 22222};
+// CHECK: cir.global external @sshort = #cir.const_array<[11111 : i16, 22222 : i16] : !cir.array<i16 x 2>> : !cir.array<i16 x 2>
+int sint[] = {123, 456, 789};
+// CHECK: cir.global external @sint = #cir.const_array<[123 : i32, 456 : i32, 789 : i32] : !cir.array<i32 x 3>> : !cir.array<i32 x 3>
+long long ll[] = {999999999, 0, 0, 0};
+// CHECK: cir.global external @ll = #cir.const_array<[999999999, 0, 0, 0] : !cir.array<i64 x 4>> : !cir.array<i64 x 4>
+
+void get_globals() {
+  // CHECK: cir.func @_Z11get_globalsv()
+  char *s = string;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @string : cir.ptr <!cir.array<i8 x 8>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i8 x 8>>), !cir.ptr<i8>
+  unsigned *u = uint;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @uint : cir.ptr <!cir.array<i32 x 1>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i32 x 1>>), !cir.ptr<i32>
+  short *ss = sshort;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @sshort : cir.ptr <!cir.array<i16 x 2>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i16 x 2>>), !cir.ptr<i16>
+  int *si = sint;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @sint : cir.ptr <!cir.array<i32 x 3>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i32 x 3>>), !cir.ptr<i32>
+  long long *l = ll;
+  // CHECK: %[[RES:[0-9]+]] = cir.get_global @ll : cir.ptr <!cir.array<i64 x 4>>
+  // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %[[RES]] : !cir.ptr<!cir.array<i64 x 4>>), !cir.ptr<i64>
+}

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -1,0 +1,108 @@
+// RUN: cir-tool %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-tool %s -cir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
+module {
+  cir.global external @a = 3 : i32
+  cir.global external @c = 2 : i64
+  cir.global external @y = 3.400000e+00 : f32
+  cir.global external @w = 4.300000e+00 : f64
+  cir.global external @x = 51 : i8
+  cir.global external @rgb = #cir.const_array<[0 : i8, -23 : i8, 33 : i8] : !cir.array<i8 x 3>> : !cir.array<i8 x 3>
+  cir.global external @alpha = #cir.const_array<[97 : i8, 98 : i8, 99 : i8, 0 : i8] : !cir.array<i8 x 4>> : !cir.array<i8 x 4>
+  cir.global "private" constant internal @".str" = #cir.const_array<"example\00" : !cir.array<i8 x 8>> : !cir.array<i8 x 8> {alignment = 1 : i64}
+  cir.global external @s = @".str": !cir.ptr<i8>
+  // MLIR: llvm.mlir.global internal constant @".str"("example\00") {addr_space = 0 : i32}
+  // MLIR: llvm.mlir.global external @s() {addr_space = 0 : i32} : !llvm.ptr<i8> {
+  // MLIR:   %0 = llvm.mlir.addressof @".str" : !llvm.ptr<array<8 x i8>>
+  // MLIR:   %1 = llvm.getelementptr %0[0] : (!llvm.ptr<array<8 x i8>>) -> !llvm.ptr<i8>
+  // MLIR:   llvm.return %1 : !llvm.ptr<i8>
+  // MLIR: }
+  // LLVM: @.str = internal constant [8 x i8] c"example\00"
+  // LLVM: @s = global ptr @.str
+  cir.global "private" constant internal @".str1" = #cir.const_array<"example1\00" : !cir.array<i8 x 9>> : !cir.array<i8 x 9> {alignment = 1 : i64}
+  cir.global external @s1 = @".str1": !cir.ptr<i8>
+  cir.global external @s2 = @".str": !cir.ptr<i8>
+  cir.func @_Z10use_globalv() {
+    %0 = cir.alloca i32, cir.ptr <i32>, ["li", init] {alignment = 4 : i64}
+    %1 = cir.get_global @a : cir.ptr <i32>
+    %2 = cir.load %1 : cir.ptr <i32>, i32
+    cir.store %2, %0 : i32, cir.ptr <i32>
+    cir.return
+  }
+  cir.func @_Z17use_global_stringv() {
+    %0 = cir.alloca i8, cir.ptr <i8>, ["c", init] {alignment = 1 : i64}
+    %1 = cir.get_global @s2 : cir.ptr <!cir.ptr<i8>>
+    %2 = cir.load %1 : cir.ptr <!cir.ptr<i8>>, !cir.ptr<i8>
+    %3 = cir.const(0 : i32) : i32
+    %4 = cir.ptr_stride(%2 : !cir.ptr<i8>, %3 : i32), !cir.ptr<i8>
+    %5 = cir.load %4 : cir.ptr <i8>, i8
+    cir.store %5, %0 : i8, cir.ptr <i8>
+    cir.return
+  }
+  cir.func linkonce_odr @_Z4funcIiET_v() -> i32 {
+    %0 = cir.alloca i32, cir.ptr <i32>, ["__retval"] {alignment = 4 : i64}
+    %1 = cir.const(0 : i32) : i32
+    cir.store %1, %0 : i32, cir.ptr <i32>
+    %2 = cir.load %0 : cir.ptr <i32>, i32
+    cir.return %2 : i32
+  }
+  cir.func @_Z8use_funcv() -> i32 {
+    %0 = cir.alloca i32, cir.ptr <i32>, ["__retval"] {alignment = 4 : i64}
+    %1 = cir.call @_Z4funcIiET_v() : () -> i32
+    cir.store %1, %0 : i32, cir.ptr <i32>
+    %2 = cir.load %0 : cir.ptr <i32>, i32
+    cir.return %2 : i32
+  }
+  cir.global external @string = #cir.const_array<[119 : i8, 104 : i8, 97 : i8, 116 : i8, 110 : i8, 111 : i8, 119 : i8, 0 : i8] : !cir.array<i8 x 8>> : !cir.array<i8 x 8>
+  // MLIR: llvm.mlir.global external @string(dense<[119, 104, 97, 116, 110, 111, 119, 0]> : tensor<8xi8>) {addr_space = 0 : i32} : !llvm.array<8 x i8>
+  // LLVM: @string = global [8 x i8] c"whatnow\00"
+  cir.global external @uint = #cir.const_array<[255 : i32] : !cir.array<i32 x 1>> : !cir.array<i32 x 1>
+  // MLIR: llvm.mlir.global external @uint(dense<255> : tensor<1xi32>) {addr_space = 0 : i32} : !llvm.array<1 x i32>
+  // LLVM: @uint = global [1 x i32] [i32 255]
+  cir.global external @sshort = #cir.const_array<[11111 : i16, 22222 : i16] : !cir.array<i16 x 2>> : !cir.array<i16 x 2>
+  // MLIR: llvm.mlir.global external @sshort(dense<[11111, 22222]> : tensor<2xi16>) {addr_space = 0 : i32} : !llvm.array<2 x i16>
+  // LLVM: @sshort = global [2 x i16] [i16 11111, i16 22222]
+  cir.global external @sint = #cir.const_array<[123 : i32, 456 : i32, 789 : i32] : !cir.array<i32 x 3>> : !cir.array<i32 x 3>
+  // MLIR: llvm.mlir.global external @sint(dense<[123, 456, 789]> : tensor<3xi32>) {addr_space = 0 : i32} : !llvm.array<3 x i32>
+  // LLVM: @sint = global [3 x i32] [i32 123, i32 456, i32 789]
+  cir.global external @ll = #cir.const_array<[999999999, 0, 0, 0] : !cir.array<i64 x 4>> : !cir.array<i64 x 4>
+  // MLIR: llvm.mlir.global external @ll(dense<[999999999, 0, 0, 0]> : tensor<4xi64>) {addr_space = 0 : i32} : !llvm.array<4 x i64>
+  // LLVM: @ll = global [4 x i64] [i64 999999999, i64 0, i64 0, i64 0]
+  cir.func @_Z11get_globalsv() {
+    %0 = cir.alloca !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>, ["s", init] {alignment = 8 : i64}
+    %1 = cir.alloca !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>, ["u", init] {alignment = 8 : i64}
+    %2 = cir.alloca !cir.ptr<i16>, cir.ptr <!cir.ptr<i16>>, ["ss", init] {alignment = 8 : i64}
+    %3 = cir.alloca !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>, ["si", init] {alignment = 8 : i64}
+    %4 = cir.alloca !cir.ptr<i64>, cir.ptr <!cir.ptr<i64>>, ["l", init] {alignment = 8 : i64}
+    %5 = cir.get_global @string : cir.ptr <!cir.array<i8 x 8>>
+    %6 = cir.cast(array_to_ptrdecay, %5 : !cir.ptr<!cir.array<i8 x 8>>), !cir.ptr<i8>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @string : !llvm.ptr<array<8 x i8>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<8 x i8>>) -> !llvm.ptr<i8>
+    // LLVM: store ptr @string, ptr %{{[0-9]+}}
+    cir.store %6, %0 : !cir.ptr<i8>, cir.ptr <!cir.ptr<i8>>
+    %7 = cir.get_global @uint : cir.ptr <!cir.array<i32 x 1>>
+    %8 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<i32 x 1>>), !cir.ptr<i32>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @uint : !llvm.ptr<array<1 x i32>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<1 x i32>>) -> !llvm.ptr<i32>
+    // LLVM: store ptr @uint, ptr %{{[0-9]+}}
+    cir.store %8, %1 : !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>
+    %9 = cir.get_global @sshort : cir.ptr <!cir.array<i16 x 2>>
+    %10 = cir.cast(array_to_ptrdecay, %9 : !cir.ptr<!cir.array<i16 x 2>>), !cir.ptr<i16>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sshort : !llvm.ptr<array<2 x i16>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<2 x i16>>) -> !llvm.ptr<i16>
+    // LLVM: store ptr @sshort, ptr %{{[0-9]+}}
+    cir.store %10, %2 : !cir.ptr<i16>, cir.ptr <!cir.ptr<i16>>
+    %11 = cir.get_global @sint : cir.ptr <!cir.array<i32 x 3>>
+    %12 = cir.cast(array_to_ptrdecay, %11 : !cir.ptr<!cir.array<i32 x 3>>), !cir.ptr<i32>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sint : !llvm.ptr<array<3 x i32>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<3 x i32>>) -> !llvm.ptr<i32>
+    // LLVM: store ptr @sint, ptr %{{[0-9]+}}
+    cir.store %12, %3 : !cir.ptr<i32>, cir.ptr <!cir.ptr<i32>>
+    %13 = cir.get_global @ll : cir.ptr <!cir.array<i64 x 4>>
+    %14 = cir.cast(array_to_ptrdecay, %13 : !cir.ptr<!cir.array<i64 x 4>>), !cir.ptr<i64>
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @ll : !llvm.ptr<array<4 x i64>>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<4 x i64>>) -> !llvm.ptr<i64>
+    // LLVM: store ptr @ll, ptr %{{[0-9]+}}
+    cir.store %14, %4 : !cir.ptr<i64>, cir.ptr <!cir.ptr<i64>>
+    cir.return
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

- Map between CIR and LLVM linkage types
 - Convert CIR's constant arrays to tensors
 - Increment code gen tests for globals
 - Add lowering tests for globals