### PR TITLE
[CIR][Codegen][NFC] Move buildArrayConstant to CIRGenExprConst namespace

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -14,6 +14,8 @@
 #include "CIRGenCstEmitter.h"
 #include "CIRGenFunction.h"
 #include "CIRGenModule.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -32,6 +34,12 @@ using namespace cir;
 
 namespace {
 class ConstExprEmitter;
+
+static mlir::Attribute
+buildArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
+                   mlir::Type CommonElementType, unsigned ArrayBound,
+                   SmallVectorImpl<mlir::TypedAttr> &Elements,
+                   mlir::TypedAttr Filler);
 
 struct ConstantAggregateBuilderUtils {
   CIRGenModule &CGM;
@@ -830,6 +838,68 @@ public:
   mlir::Type ConvertType(QualType T) { return CGM.getTypes().ConvertType(T); }
 };
 
+static mlir::Attribute
+buildArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
+                   mlir::Type CommonElementType, unsigned ArrayBound,
+                   SmallVectorImpl<mlir::TypedAttr> &Elements,
+                   mlir::TypedAttr Filler) {
+  auto &builder = CGM.getBuilder();
+  auto isNullValue = [&](mlir::Attribute f) {
+    // TODO(cir): introduce char type in CIR and check for that instead.
+    auto intVal = f.dyn_cast_or_null<mlir::IntegerAttr>();
+    assert(intVal && "not implemented");
+    if (intVal.getInt() == 0)
+      return true;
+    return false;
+  };
+
+  // Figure out how long the initial prefix of non-zero elements is.
+  unsigned NonzeroLength = ArrayBound;
+  if (Elements.size() < NonzeroLength && isNullValue(Filler))
+    NonzeroLength = Elements.size();
+  if (NonzeroLength == Elements.size()) {
+    while (NonzeroLength > 0 && isNullValue(Elements[NonzeroLength - 1]))
+      --NonzeroLength;
+  }
+
+  if (NonzeroLength == 0)
+    assert(0 && "NYE");
+
+  // Add a zeroinitializer array filler if we have lots of trailing zeroes.
+  unsigned TrailingZeroes = ArrayBound - NonzeroLength;
+  if (TrailingZeroes >= 8) {
+    assert(0 && "NYE");
+    assert(Elements.size() >= NonzeroLength &&
+           "missing initializer for non-zero element");
+
+    // TODO(cir): If all the elements had the same type up to the trailing
+    // zeroes, emit a struct of two arrays (the nonzero data and the
+    // zeroinitializer). Use DesiredType to get the element type.
+  } else if (Elements.size() != ArrayBound) {
+    // Otherwise pad to the right size with the filler if necessary.
+    Elements.resize(ArrayBound, Filler);
+    if (Filler.getType() != CommonElementType)
+      CommonElementType = {};
+  }
+
+  // If all elements have the same type, just emit an array constant.
+  if (CommonElementType) {
+    SmallVector<mlir::Attribute, 4> Eles;
+    Eles.reserve(Elements.size());
+    for (auto const &Element : Elements)
+      Eles.push_back(Element);
+
+    return builder.getConstArray(
+        mlir::ArrayAttr::get(builder.getContext(), Eles),
+        mlir::cir::ArrayType::get(builder.getContext(), CommonElementType,
+                                  ArrayBound));
+  }
+
+  // We have mixed types. Use a packed struct.
+  assert(0 && "NYE");
+  return {};
+}
+
 } // end anonymous namespace.
 
 //===----------------------------------------------------------------------===//
@@ -1181,68 +1251,6 @@ mlir::Attribute ConstantEmitter::emitForMemory(CIRGenModule &CGM,
   }
 
   return C;
-}
-
-static mlir::Attribute
-buildArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
-                   mlir::Type CommonElementType, unsigned ArrayBound,
-                   SmallVectorImpl<mlir::TypedAttr> &Elements,
-                   mlir::TypedAttr Filler) {
-  auto &builder = CGM.getBuilder();
-  auto isNullValue = [&](mlir::Attribute f) {
-    // TODO(cir): introduce char type in CIR and check for that instead.
-    auto intVal = f.dyn_cast_or_null<mlir::IntegerAttr>();
-    assert(intVal && "not implemented");
-    if (intVal.getInt() == 0)
-      return true;
-    return false;
-  };
-
-  // Figure out how long the initial prefix of non-zero elements is.
-  unsigned NonzeroLength = ArrayBound;
-  if (Elements.size() < NonzeroLength && isNullValue(Filler))
-    NonzeroLength = Elements.size();
-  if (NonzeroLength == Elements.size()) {
-    while (NonzeroLength > 0 && isNullValue(Elements[NonzeroLength - 1]))
-      --NonzeroLength;
-  }
-
-  if (NonzeroLength == 0)
-    assert(0 && "NYE");
-
-  // Add a zeroinitializer array filler if we have lots of trailing zeroes.
-  unsigned TrailingZeroes = ArrayBound - NonzeroLength;
-  if (TrailingZeroes >= 8) {
-    assert(0 && "NYE");
-    assert(Elements.size() >= NonzeroLength &&
-           "missing initializer for non-zero element");
-
-    // TODO(cir): If all the elements had the same type up to the trailing
-    // zeroes, emit a struct of two arrays (the nonzero data and the
-    // zeroinitializer). Use DesiredType to get the element type.
-  } else if (Elements.size() != ArrayBound) {
-    // Otherwise pad to the right size with the filler if necessary.
-    Elements.resize(ArrayBound, Filler);
-    if (Filler.getType() != CommonElementType)
-      CommonElementType = {};
-  }
-
-  // If all elements have the same type, just emit an array constant.
-  if (CommonElementType) {
-    SmallVector<mlir::Attribute, 4> Eles;
-    Eles.reserve(Elements.size());
-    for (auto const &Element : Elements)
-      Eles.push_back(Element);
-
-    return builder.getConstArray(
-        mlir::ArrayAttr::get(builder.getContext(), Eles),
-        mlir::cir::ArrayType::get(builder.getContext(), CommonElementType,
-                                  ArrayBound));
-  }
-
-  // We have mixed types. Use a packed struct.
-  assert(0 && "NYE");
-  return {};
 }
 
 mlir::TypedAttr ConstantEmitter::tryEmitPrivate(const Expr *E, QualType T) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #66
* #65
* #64
* __->__ #63

The buildArrayConstant method is only used when generating code for some
constant expression in the AST. To ensure encapsulation, this patch
moves the method to the CIRGenExprConst anonymous namespace, ensuring
any (and only) expression constant visitors have access to it.