### PR TITLE
[CIR][Codegen] Emit string literals

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -821,8 +821,7 @@ public:
 
   mlir::Attribute VisitStringLiteral(StringLiteral *E, QualType T) {
     // This is a string literal initializing an array in an initializer.
-    assert(0 && "not implemented");
-    return {};
+    return CGM.getConstantArrayFromStringLiteral(E);
   }
 
   mlir::Attribute VisitObjCEncodeExpr(ObjCEncodeExpr *E, QualType T) {
@@ -1205,8 +1204,17 @@ mlir::Attribute ConstantEmitter::tryEmitPrivateForVarInit(const VarDecl &D) {
   if (destType->isReferenceType())
     return {};
 
-  assert(0 && "not implemented");
-  return {};
+  // Evaluation failed and not a reference type: ensure initializer exists.
+  const Expr *E = D.getInit();
+  assert(E && "No initializer to emit");
+
+  // Initializer exists: emit it "manually" through visitors.
+  auto nonMemoryDestType = getNonMemoryType(CGM, destType);
+  auto C =
+      ConstExprEmitter(*this).Visit(const_cast<Expr *>(E), nonMemoryDestType);
+
+  // Return either the initializer attribute or a null attribute on failure.
+  return (C ? emitForMemory(C, destType) : nullptr);
 }
 
 mlir::Attribute ConstantEmitter::tryEmitAbstract(const APValue &value,

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -1,0 +1,9 @@
+// There seems to be some differences in how constant expressions are evaluated
+// in C vs C++. This causees the code gen for C initialized globals to be a
+// bit different from the C++ version. This test ensures that these differences
+// are accounted for.
+
+// RUN: %clang_cc1 -emit-cir %s -o - | FileCheck %s
+
+char string[] = "whatnow";
+// CHECK: cir.global external @string = #cir.const_array<"whatnow\00" : !cir.array<i8 x 8>> : !cir.array<i8 x 8>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #66
* #65
* __->__ #64
* #63

When emitting variable initializers, if the initializer's evaluation
fails, CodeGen will fall back to regular visitors for the emission.
String literals are then emitted as a constant array of bytes.
This fixes issues with C constant expression initializers that fail
to be evaluated.