### PR TITLE
[CIR][CodeGen] Emit array initialization

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -24,6 +24,7 @@
 #include "clang/Basic/Builtins.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
 
 using namespace clang;
@@ -771,6 +772,11 @@ public:
     SmallVector<mlir::TypedAttr, 16> Elts;
     Elts.reserve(NumElements);
 
+    // Emit array filler, if there is one.
+    if (Expr *filler = ILE->getArrayFiller()) {
+      llvm_unreachable("NYI");
+    }
+
     // Emit initializer elements as MLIR attributes and check for common type.
     mlir::Type CommonElementType;
     for (unsigned i = 0; i != NumInitableElts; ++i) {
@@ -1294,7 +1300,7 @@ mlir::TypedAttr ConstantEmitter::tryEmitPrivate(const Expr *E, QualType T) {
   bool Success;
 
   // TODO: Implement the missing functionalities below.
-  assert(!T->isReferenceType() && "can't emit a reference type constant");
+  assert(!T->isReferenceType() && "NYI");
 
   // NOTE: Not all constant expressions can be emited by the ConstExprEmitter.
   //       So we have to fold/evaluate the expression in some cases.

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -7,3 +7,5 @@
 
 char string[] = "whatnow";
 // CHECK: cir.global external @string = #cir.const_array<"whatnow\00" : !cir.array<i8 x 8>> : !cir.array<i8 x 8>
+int sint[] = {123, 456, 789};
+// CHECK: cir.global external @sint = #cir.const_array<[123 : i32, 456 : i32, 789 : i32] : !cir.array<i32 x 3>> : !cir.array<i32 x 3>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #66
* __->__ #65
* #64
* #63

Implement InitListExpr visitor to emit a cir.const_array attribute.
As a dependency, also implemented methods tryEmitPrivate and
tryEmitForMemory, to both handle emission failures and emissions of
elements not in memory.