### PR TITLE
[CIR][CodeGen] Handle init list size mismatch

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCstEmitter.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCstEmitter.h
@@ -109,6 +109,9 @@ public:
   mlir::Attribute tryEmitPrivate(const APValue &value, QualType T);
   mlir::Attribute tryEmitPrivateForMemory(const APValue &value, QualType T);
 
+  mlir::Attribute tryEmitAbstract(const Expr *E, QualType destType);
+  mlir::Attribute tryEmitAbstractForMemory(const Expr *E, QualType destType);
+
   mlir::Attribute tryEmitAbstract(const APValue &value, QualType destType);
   mlir::Attribute tryEmitAbstractForMemory(const APValue &value,
                                            QualType destType);

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -9,3 +9,7 @@ char string[] = "whatnow";
 // CHECK: cir.global external @string = #cir.const_array<"whatnow\00" : !cir.array<i8 x 8>> : !cir.array<i8 x 8>
 int sint[] = {123, 456, 789};
 // CHECK: cir.global external @sint = #cir.const_array<[123 : i32, 456 : i32, 789 : i32] : !cir.array<i32 x 3>> : !cir.array<i32 x 3>
+int filler_sint[4] = {1, 2}; // Ensure missing elements are zero-initialized.
+// CHECK: cir.global external @filler_sint = #cir.const_array<[1 : i32, 2 : i32, 0 : i32, 0 : i32] : !cir.array<i32 x 4>> : !cir.array<i32 x 4>
+int excess_sint[2] = {1, 2, 3, 4}; // Ensure excess elements are ignored.
+// CHECK: cir.global external @excess_sint = #cir.const_array<[1 : i32, 2 : i32] : !cir.array<i32 x 2>> : !cir.array<i32 x 2>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #66
* #65
* #64
* #63

Initializer lists can have more or fewer elements than the destination
the array can hold, and the compiler will deal with it.
This patch handles handle these scenarios.