### PR TITLE
[CIR][BugFix] Allow implicit value type in const_array parser

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1800,18 +1800,18 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
 
   // ArrayAttrrs have per-element type, not the type of the array...
   if (resultVal->dyn_cast<ArrayAttr>()) {
-    // Parse literal ':'
-    if (parser.parseColon())
-      return {};
-
-    // Parse variable 'type'
-    resultTy = ::mlir::FieldParser<::mlir::Type>::parse(parser);
-    if (failed(resultTy)) {
-      parser.emitError(
-          parser.getCurrentLocation(),
-          "failed to parse ConstArrayAttr parameter 'type' which is "
-          "to be a `::mlir::Type`");
-      return {};
+    // Array has implicit type: infer from const array type.
+    if (parser.parseOptionalColon().failed()) {
+      resultTy = type;
+    } else { // Array has explicit type: parse it.
+      resultTy = ::mlir::FieldParser<::mlir::Type>::parse(parser);
+      if (failed(resultTy)) {
+        parser.emitError(
+            parser.getCurrentLocation(),
+            "failed to parse ConstArrayAttr parameter 'type' which is "
+            "to be a `::mlir::Type`");
+        return {};
+      }
     }
   } else {
     assert(resultVal->isa<TypedAttr>() && "IDK");

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -6,7 +6,7 @@ module {
   cir.global external @y = 3.400000e+00 : f32
   cir.global external @w = 4.300000e+00 : f64
   cir.global external @x = 51 : i8
-  cir.global external @rgb = #cir.const_array<[0 : i8, -23 : i8, 33 : i8] : !cir.array<i8 x 3>> : !cir.array<i8 x 3>
+  cir.global external @rgb = #cir.const_array<[0 : i8, -23 : i8, 33 : i8]> : !cir.array<i8 x 3> // Implicit array type
   cir.global external @alpha = #cir.const_array<[97 : i8, 98 : i8, 99 : i8, 0 : i8] : !cir.array<i8 x 4>> : !cir.array<i8 x 4>
   cir.global "private" constant internal @".str" = #cir.const_array<"example\00" : !cir.array<i8 x 8>> : !cir.array<i8 x 8> {alignment = 1 : i64}
   cir.global external @s = @".str": !cir.ptr<i8>


### PR DESCRIPTION
Fixes parsing for const_arrays with values (ArrayAttribute) with omitted types. In this case, it infers the value's type from the const_array type.
