### PR TITLE
Move MLIR before clang for in the list of external projects

### DIFF
--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -41,11 +41,10 @@ add_llvm_tool_subdirectory(llvm-profdata)
 
 # Projects supported via LLVM_EXTERNAL_*_SOURCE_DIR need to be explicitly
 # specified.
+add_llvm_external_project(mlir)
 add_llvm_external_project(clang)
 add_llvm_external_project(lld)
 add_llvm_external_project(lldb)
-add_llvm_external_project(mlir)
-# Flang depends on mlir, so place it afterward
 add_llvm_external_project(flang)
 add_llvm_external_project(bolt)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

clang now depends on MLIR and thus we need to include it first for it's
dependencies to be added properly.