### PR TITLE
[CIR] Add -fcir-output for writing clang IR output to a file

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -322,6 +322,8 @@ def err_drv_incompatible_omp_arch : Error<"OpenMP target architecture '%0' point
 def err_drv_omp_host_ir_file_not_found : Error<
   "provided host compiler IR file '%0' is required to generate code for OpenMP "
   "target regions but cannot be found">;
+def err_drv_cir_multiple_input : Error<
+  "clangir (cir) generation requires exactly one input source file">;
 def err_drv_omp_host_target_not_supported : Error<
   "target '%0' is not a supported OpenMP host target">;
 def err_drv_expecting_fopenmp_with_fopenmp_targets : Error<

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -459,6 +459,9 @@ public:
   /// host code generation.
   std::string OMPHostIRFile;
 
+  /// Name of the CIR file to output to disk.
+  std::string CIRFile;
+
   /// The user provided compilation unit ID, if non-empty. This is used to
   /// externalize static variables which is needed to support accessing static
   /// device variables in host code for single source offloading languages

--- a/clang/include/clang/CIR/CIRBuilder.h
+++ b/clang/include/clang/CIR/CIRBuilder.h
@@ -14,6 +14,7 @@
 #ifndef CLANG_CIRBUILDER_H_
 #define CLANG_CIRBUILDER_H_
 
+#include "llvm/Support/ToolOutputFile.h"
 #include <memory>
 
 namespace mlir {
@@ -42,6 +43,7 @@ public:
 private:
   std::unique_ptr<mlir::MLIRContext> mlirCtx;
   std::unique_ptr<CIRBuildImpl> builder;
+  std::unique_ptr<llvm::ToolOutputFile> cirOut;
   clang::ASTContext &astCtx;
 };
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1436,6 +1436,12 @@ defm cir_warnings : BoolFOption<"cir-warnings",
   LangOpts<"CIRWarnings">, DefaultFalse,
   PosFlag<SetTrue, [CC1Option], "Use">, NegFlag<SetFalse, [], "Don't use">,
   BothFlags<[CoreOption], " CIR to emit (analysis based) warnings">>;
+def fcir_output_EQ : Joined<["-"], "fcir-output=">,
+  Group<f_Group>, HelpText<"Write clang IR (cir) to output file">,
+  Flags<[CC1Option, CoreOption]>, MarshallingInfoString<LangOpts<"CIRFile">>,
+  MetaVarName<"<file>">;
+def fcir_output : Flag<["-"], "fcir-output">,
+  Group<f_Group>, Flags<[CC1Option, CoreOption]>;
 
 defm addrsig : BoolFOption<"addrsig",
   CodeGenOpts<"Addrsig">, DefaultFalse,

--- a/clang/include/clang/Sema/AnalysisBasedWarnings.h
+++ b/clang/include/clang/Sema/AnalysisBasedWarnings.h
@@ -19,14 +19,14 @@
 namespace clang {
 
 class BlockExpr;
-class CIRBasedWarnings;
 class Decl;
 class FunctionDecl;
 class QualType;
 class Sema;
 
 namespace sema {
-  class FunctionScopeInfo;
+class CIRBasedWarnings;
+class FunctionScopeInfo;
 }
 
 namespace sema {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -9851,7 +9851,7 @@ public:
   threadSafety::BeforeSet *ThreadSafetyDeclCache;
 
   /// Worker object for performing CIR based warnings.
-  sema::CIRBasedWarnings CIRWarnings;
+  std::unique_ptr<sema::CIRBasedWarnings> CIRWarnings;
 
   /// An entity for which implicit template instantiation is required.
   ///

--- a/clang/lib/CIR/CIRBuilder.cpp
+++ b/clang/lib/CIR/CIRBuilder.cpp
@@ -47,6 +47,8 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <numeric>
 
@@ -64,7 +66,6 @@ using llvm::SmallVector;
 using llvm::StringRef;
 using llvm::Twine;
 
-CIRContext::~CIRContext() {}
 CIRContext::CIRContext(clang::ASTContext &AC) : astCtx(AC) { Init(); }
 
 CIRCodeGenFunction::CIRCodeGenFunction() = default;
@@ -505,10 +506,28 @@ public:
 };
 } // namespace cir
 
+CIRContext::~CIRContext() {
+  if (cirOut) {
+    // FIXME: pick a more verbose level.
+    builder->getModule()->print(cirOut->os());
+    cirOut->keep();
+  }
+}
+
 void CIRContext::Init() {
+  using namespace llvm;
+
   mlirCtx = std::make_unique<mlir::MLIRContext>();
   mlirCtx->getOrLoadDialect<mlir::cir::CIRDialect>();
   builder = std::make_unique<CIRBuildImpl>(*mlirCtx.get(), astCtx);
+
+  std::error_code EC;
+  StringRef outFile = astCtx.getLangOpts().CIRFile;
+  if (outFile.empty())
+    return;
+  cirOut = std::make_unique<ToolOutputFile>(outFile, EC, sys::fs::OF_None);
+  if (EC)
+    report_fatal_error("Failed to open " + outFile + ": " + EC.message());
 }
 
 bool CIRContext::EmitFunction(const FunctionDecl *FD) {
@@ -519,6 +538,5 @@ bool CIRContext::EmitFunction(const FunctionDecl *FD) {
   // FIXME: currently checked after emitting every function, should
   // only run when the consumer of the context shutdowns.
   builder->verifyModule();
-  builder->getModule().dump();
   return true;
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7397,6 +7397,28 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       Input.getInputArg().renderAsInput(Args, CmdArgs);
   }
 
+  if (Arg *A = Args.getLastArg(options::OPT_fcir_output_EQ,
+                               options::OPT_fcir_output)) {
+    if (A->getOption().matches(options::OPT_fcir_output_EQ)) {
+      StringRef Value = A->getValue();
+      CmdArgs.push_back(Args.MakeArgString("-fcir-output=" + Value));
+    } else {
+      std::string OutFile;
+      for (const InputInfo &Input : FrontendInputs) {
+        if (!Input.isFilename())
+          continue;
+        OutFile = Input.getFilename();
+        OutFile.append(".cir");
+        StringRef Value = OutFile;
+        CmdArgs.push_back(Args.MakeArgString("-fcir-output=" + Value));
+        break;
+      }
+
+      if (OutFile.empty())
+        D.Diag(diag::err_drv_cir_multiple_input);
+    }
+  }
+
   if (D.CC1Main && !D.CCGenDiagnostics) {
     // Invoke the CC1 directly in this process
     C.addCommand(std::make_unique<CC1Command>(

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3870,6 +3870,9 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
           << Opts.OMPHostIRFile;
   }
 
+  if (Arg *A = Args.getLastArg(options::OPT_fcir_output_EQ))
+    Opts.CIRFile = A->getValue();
+
   // Set CUDA mode for OpenMP target NVPTX/AMDGCN if specified in options
   Opts.OpenMPCUDAMode = Opts.OpenMPIsDevice && (T.isNVPTX() || T.isAMDGCN()) &&
                         Args.hasArg(options::OPT_fopenmp_cuda_mode);

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -218,9 +218,8 @@ Sema::Sema(Preprocessor &pp, ASTContext &ctxt, ASTConsumer &consumer,
       InNonInstantiationSFINAEContext(false), NonInstantiationEntries(0),
       ArgumentPackSubstitutionIndex(-1), CurrentInstantiationScope(nullptr),
       DisableTypoCorrection(false), TyposCorrected(0), AnalysisWarnings(*this),
-      ThreadSafetyDeclCache(nullptr), CIRWarnings(*this),
-      VarDataSharingAttributesStack(nullptr), CurScope(nullptr),
-      Ident_super(nullptr), Ident___float128(nullptr) {
+      ThreadSafetyDeclCache(nullptr), VarDataSharingAttributesStack(nullptr),
+      CurScope(nullptr), Ident_super(nullptr), Ident___float128(nullptr) {
   assert(pp.TUKind == TUKind);
   TUScope = nullptr;
   isConstantEvaluatedOverride = false;
@@ -250,6 +249,8 @@ Sema::Sema(Preprocessor &pp, ASTContext &ctxt, ASTConsumer &consumer,
 
   std::unique_ptr<sema::SemaPPCallbacks> Callbacks =
       std::make_unique<sema::SemaPPCallbacks>();
+  CIRWarnings = std::make_unique<sema::CIRBasedWarnings>(*this);
+
   SemaPPCallbackHandler = Callbacks.get();
   PP.addPPCallbacks(std::move(Callbacks));
   SemaPPCallbackHandler->set(*this);
@@ -569,7 +570,7 @@ void Sema::PrintStats() const {
 
   BumpAlloc.PrintStats();
   if (LangOpts.CIRWarnings)
-    CIRWarnings.PrintStats();
+    CIRWarnings->PrintStats();
   else
     AnalysisWarnings.PrintStats();
 }
@@ -1438,6 +1439,11 @@ void Sema::ActOnEndOfTranslationUnit() {
 
   if (!PP.isIncrementalProcessingEnabled())
     TUScope = nullptr;
+
+  // Clean up CIR based warnings and write out files to disk (if any).
+  // FIXME: this is where globals should be emitted prior to CIR output.
+  if (getLangOpts().CIRWarnings)
+    CIRWarnings.reset();
 }
 
 
@@ -2260,7 +2266,7 @@ Sema::PopFunctionScopeInfo(const AnalysisBasedWarnings::Policy *WP,
   // are the same as for analysis-based one, but this is not emitting
   // anything just yet.
   if (WP && D && LangOpts.CIRWarnings)
-    CIRWarnings.IssueWarnings(*WP, Scope.get(), D, BlockType);
+    CIRWarnings->IssueWarnings(*WP, Scope.get(), D, BlockType);
 
   // Issue any analysis-based warnings.
   if (WP && D)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Two modes available:
- `-fcir-output` creates a new file with suffixed with .cir on top of the source file.
- `-fcir-output=<file>` uses user provided file path.

Currently only supported when the driver takes a single source input.