### PR TITLE
[CIR] Add simple test for ClangIR codegen

### DIFF
--- a/clang/lib/CIR/CIRBuilder.cpp
+++ b/clang/lib/CIR/CIRBuilder.cpp
@@ -518,6 +518,7 @@ void CIRContext::Init() {
   using namespace llvm;
 
   mlirCtx = std::make_unique<mlir::MLIRContext>();
+  mlirCtx->getOrLoadDialect<mlir::func::FuncDialect>();
   mlirCtx->getOrLoadDialect<mlir::cir::CIRDialect>();
   builder = std::make_unique<CIRBuildImpl>(*mlirCtx.get(), astCtx);
 

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -1,1 +1,12 @@
-// RUN: true
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fsyntax-only -fcir-warnings %s -fcir-output=%t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+int foo(int i) {
+  return i;
+}
+
+//      CHECK: module  {
+// CHECK-NEXT:   func @foo(%arg0: i32) -> i32 {
+// CHECK-NEXT:     cir.return %arg0 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

- Codegen of ClangIR out of clang AST, ClangIR down to anything else isn't
yet implemented.
- Right now -fcir-warnings -fcir-output must be used, in the future
we should add an independent codegen flag and use it to drive tests such
as these.