### PR TITLE
[CIR] Enable -fclangir-direct-lowering by default.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2273,10 +2273,10 @@ def fclangir_lifetime_check : Flag<["-"], "fclangir-lifetime-check">,
   Flags<[CoreOption, CC1Option]>, Group<f_Group>,
   Alias<fclangir_lifetime_check_EQ>, AliasArgs<["history=invalid,null"]>,
   HelpText<"Run lifetime checker">;
-def fclangir_direct_lowering : Flag<["-"], "fclangir-direct-lowering">,
-  Flags<[CoreOption, CC1Option]>, Group<f_Group>,
-  HelpText<"Lower directly from ClangIR to LLVM">,
-  MarshallingInfoFlag<FrontendOpts<"ClangIRDirectLowering">>;
+defm clangir_direct_lowering : BoolFOption<"clangir-direct-lowering",
+  FrontendOpts<"ClangIRDirectLowering">, DefaultTrue,
+  PosFlag<SetTrue, [CoreOption, CC1Option], "Lower directly from ClangIR to LLVM">,
+  NegFlag<SetFalse, [CoreOption, CC1Option],  "Lower through MLIR to LLVM">>;
 
 def flto_EQ : Joined<["-"], "flto=">, Flags<[CoreOption, CC1Option, FC1Option, FlangOption]>, Group<f_Group>,
   HelpText<"Set LTO mode">, Values<"thin,full">;
@@ -3556,7 +3556,7 @@ def mthreads : Joined<["-"], "mthreads">, Group<m_Group>, Flags<[NoXarchOption]>
 def mguard_EQ : Joined<["-"], "mguard=">, Group<m_Group>, Flags<[NoXarchOption]>,
   HelpText<"Enable or disable Control Flow Guard checks and guard tables emission">,
   Values<"none,cf,cf-nochecks">;
-def mcpu_EQ : Joined<["-"], "mcpu=">, Group<m_Group>, 
+def mcpu_EQ : Joined<["-"], "mcpu=">, Group<m_Group>,
   HelpText<"For a list of available CPUs for the target use '-mcpu=help'">;
 def mmcu_EQ : Joined<["-"], "mmcu=">, Group<m_Group>;
 def msim : Flag<["-"], "msim">, Group<m_Group>;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -32,6 +32,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -1096,9 +1097,9 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule,
   if (theModule.verify().failed())
     report_fatal_error("Verification of the final LLVMIR dialect failed!");
 
+  mlir::registerBuiltinDialectTranslation(*mlirCtx);
   mlir::registerLLVMDialectTranslation(*mlirCtx);
 
-  LLVMContext llvmContext;
   auto llvmModule = mlir::translateModuleToLLVMIR(theModule, llvmCtx);
 
   if (!llvmModule)

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -565,7 +565,6 @@ lowerFromCIRToMLIRToLLVMIR(mlir::ModuleOp theModule,
   mlir::registerBuiltinDialectTranslation(*mlirCtx);
   mlir::registerLLVMDialectTranslation(*mlirCtx);
 
-  LLVMContext llvmContext;
   auto llvmModule = mlir::translateModuleToLLVMIR(theModule, llvmCtx);
 
   if (!llvmModule)

--- a/clang/test/CIR/cc1.c
+++ b/clang/test/CIR/cc1.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
@@ -24,4 +24,3 @@ void foo() {}
 //      ASM: retq
 
 // OBJ: 0: c3 retq
-

--- a/clang/test/CIR/driver.c
+++ b/clang/test/CIR/driver.c
@@ -1,7 +1,11 @@
-// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir-enable -S -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir-enable -S -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir-enable -fclangir-direct-lowering -S -emit-cir %s -o %t1.cir
+// RUN: FileCheck --input-file=%t1.cir %s -check-prefix=CIR
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir-enable -fno-clangir-direct-lowering -S -emit-cir %s -o %t2.cir
+// RUN: FileCheck --input-file=%t2.cir %s -check-prefix=CIR
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir-enable -fclangir-direct-lowering -S -emit-llvm %s -o %t1.ll
+// RUN: FileCheck --input-file=%t1.ll %s -check-prefix=LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir-enable -fno-clangir-direct-lowering -S -emit-llvm %s -o %t2.ll
+// RUN: FileCheck --input-file=%t2.ll %s -check-prefix=LLVM
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir-enable -c %s -o %t.o
 // RUN: llvm-objdump -d %t.o | FileCheck %s -check-prefix=OBJ
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir-enable -clangir-disable-passes -S -emit-cir %s -o %t.cir


### PR DESCRIPTION
Summary:
This change turns on direct lowering from CIR to LLVM IR by default. A missing API call to register the builtin LLVM dialtect is added, otherwise an error `cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: builtin.module` is hit during llvm IR conversion.  A test is also tweaked.