### PR TITLE
[CIR] Use source path for the CIR module name and propagate it to LLV…

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -155,6 +155,13 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
   }
   theModule->setAttr("cir.sob",
                      mlir::cir::SignedOverflowBehaviorAttr::get(&context, sob));
+  // Set the module name to be the name of the main file.
+  auto MainFileID = astctx.getSourceManager().getMainFileID();
+  const FileEntry &MainFile =
+      *astctx.getSourceManager().getFileEntryForID(MainFileID);
+  auto Path = MainFile.tryGetRealPathName();
+  if (!Path.empty())
+    theModule.setSymName(Path);
 }
 
 CIRGenModule::~CIRGenModule() {}

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1103,7 +1103,9 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule,
   mlir::registerBuiltinDialectTranslation(*mlirCtx);
   mlir::registerLLVMDialectTranslation(*mlirCtx);
 
-  auto llvmModule = mlir::translateModuleToLLVMIR(theModule, llvmCtx);
+  auto ModuleName = theModule.getName();
+  auto llvmModule = mlir::translateModuleToLLVMIR(
+      theModule, llvmCtx, ModuleName ? *ModuleName : "CIRToLLVMModule");
 
   if (!llvmModule)
     report_fatal_error("Lowering from LLVMIR dialect to llvm IR failed!");

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -8,7 +8,7 @@ int foo(int i) {
   return i;
 }
 
-//      CHECK: module attributes {
+//      CHECK: module @"{{.*}}basic.c" attributes {
 // CHECK-NEXT: cir.func @foo(%arg0: !s32i loc({{.*}})) -> !s32i {
 // CHECK-NEXT: %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK-NEXT: %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/dlti.c
+++ b/clang/test/CIR/CodeGen/dlti.c
@@ -3,7 +3,7 @@
 
 void foo() {}
 
-//      CHECK: module attributes {
+//      CHECK: module @"{{.*}}dlti.c" attributes {
 // CHECK-DAG:   cir.sob = #cir.signed_overflow_behavior<undefined>
 // CHECK-DAG:   dlti.dl_spec =
 // CHECK-DAG:   #dlti.dl_spec<

--- a/clang/test/CIR/CodeGen/sourcelocation.cpp
+++ b/clang/test/CIR/CodeGen/sourcelocation.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 int s0(int a, int b) {
   int x = a + b;
@@ -10,64 +12,68 @@ int s0(int a, int b) {
   return x;
 }
 
-// CHECK: #loc3 = loc("{{.*}}sourcelocation.cpp":4:8)
-// CHECK: #loc4 = loc("{{.*}}sourcelocation.cpp":4:12)
-// CHECK: #loc5 = loc("{{.*}}sourcelocation.cpp":4:15)
-// CHECK: #loc6 = loc("{{.*}}sourcelocation.cpp":4:19)
-// CHECK: #loc21 = loc(fused[#loc3, #loc4])
-// CHECK: #loc22 = loc(fused[#loc5, #loc6])
-// CHECK: module attributes {cir.sob = #cir.signed_overflow_behavior<undefined>
-// CHECK:   cir.func @_Z2s0ii(%arg0: !s32i loc(fused[#loc3, #loc4]), %arg1: !s32i loc(fused[#loc5, #loc6])) -> !s32i {
-// CHECK:     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64} loc(#loc21)
-// CHECK:     %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["b", init] {alignment = 4 : i64} loc(#loc22)
-// CHECK:     %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64} loc(#loc2)
-// CHECK:     %3 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64} loc(#loc23)
-// CHECK:     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i> loc(#loc9)
-// CHECK:     cir.store %arg1, %1 : !s32i, cir.ptr <!s32i> loc(#loc9)
-// CHECK:     %4 = cir.load %0 : cir.ptr <!s32i>, !s32i loc(#loc10)
-// CHECK:     %5 = cir.load %1 : cir.ptr <!s32i>, !s32i loc(#loc8)
-// CHECK:     %6 = cir.binop(add, %4, %5) : !s32i loc(#loc24)
-// CHECK:     cir.store %6, %3 : !s32i, cir.ptr <!s32i> loc(#loc23)
-// CHECK:     cir.scope {
-// CHECK:       %9 = cir.load %3 : cir.ptr <!s32i>, !s32i loc(#loc13)
-// CHECK:       %10 = cir.const(#cir.int<0> : !s32i) : !s32i loc(#loc14)
-// CHECK:       %11 = cir.cmp(gt, %9, %10) : !s32i, !cir.bool loc(#loc26)
-// CHECK:       cir.if %11 {
-// CHECK:         %12 = cir.const(#cir.int<0> : !s32i) : !s32i loc(#loc16)
-// CHECK:         cir.store %12, %3 : !s32i, cir.ptr <!s32i> loc(#loc28)
-// CHECK:       } else {
-// CHECK:         %12 = cir.const(#cir.int<1> : !s32i) : !s32i loc(#loc12)
-// CHECK:         cir.store %12, %3 : !s32i, cir.ptr <!s32i> loc(#loc29)
-// CHECK:       } loc(#loc27)
-// CHECK:     } loc(#loc25)
-// CHECK:     %7 = cir.load %3 : cir.ptr <!s32i>, !s32i loc(#loc18)
-// CHECK:     cir.store %7, %2 : !s32i, cir.ptr <!s32i> loc(#loc30)
-// CHECK:     %8 = cir.load %2 : cir.ptr <!s32i>, !s32i loc(#loc30)
-// CHECK:     cir.return %8 : !s32i loc(#loc30)
-// CHECK:   } loc(#loc20)
-// CHECK: } loc(#loc)
-// CHECK: #loc = loc(unknown)
-// CHECK: #loc1 = loc("{{.*}}sourcelocation.cpp":4:1)
-// CHECK: #loc2 = loc("{{.*}}sourcelocation.cpp":11:1)
-// CHECK: #loc7 = loc("{{.*}}sourcelocation.cpp":5:3)
-// CHECK: #loc8 = loc("{{.*}}sourcelocation.cpp":5:15)
-// CHECK: #loc9 = loc("{{.*}}sourcelocation.cpp":4:22)
-// CHECK: #loc10 = loc("{{.*}}sourcelocation.cpp":5:11)
-// CHECK: #loc11 = loc("{{.*}}sourcelocation.cpp":6:3)
-// CHECK: #loc12 = loc("{{.*}}sourcelocation.cpp":9:9)
-// CHECK: #loc13 = loc("{{.*}}sourcelocation.cpp":6:7)
-// CHECK: #loc14 = loc("{{.*}}sourcelocation.cpp":6:11)
-// CHECK: #loc15 = loc("{{.*}}sourcelocation.cpp":7:5)
-// CHECK: #loc16 = loc("{{.*}}sourcelocation.cpp":7:9)
-// CHECK: #loc17 = loc("{{.*}}sourcelocation.cpp":9:5)
-// CHECK: #loc18 = loc("{{.*}}sourcelocation.cpp":10:10)
-// CHECK: #loc19 = loc("{{.*}}sourcelocation.cpp":10:3)
-// CHECK: #loc20 = loc(fused[#loc1, #loc2])
-// CHECK: #loc23 = loc(fused[#loc7, #loc8])
-// CHECK: #loc24 = loc(fused[#loc10, #loc8])
-// CHECK: #loc25 = loc(fused[#loc11, #loc12])
-// CHECK: #loc26 = loc(fused[#loc13, #loc14])
-// CHECK: #loc27 = loc(fused[#loc15, #loc16, #loc17, #loc12])
-// CHECK: #loc28 = loc(fused[#loc15, #loc16])
-// CHECK: #loc29 = loc(fused[#loc17, #loc12])
-// CHECK: #loc30 = loc(fused[#loc19, #loc18])
+// CIR: #loc3 = loc("{{.*}}sourcelocation.cpp":6:8)
+// CIR: #loc4 = loc("{{.*}}sourcelocation.cpp":6:12)
+// CIR: #loc5 = loc("{{.*}}sourcelocation.cpp":6:15)
+// CIR: #loc6 = loc("{{.*}}sourcelocation.cpp":6:19)
+// CIR: #loc21 = loc(fused[#loc3, #loc4])
+// CIR: #loc22 = loc(fused[#loc5, #loc6])
+// CIR: module @"{{.*}}sourcelocation.cpp" attributes {cir.sob = #cir.signed_overflow_behavior<undefined>
+// CIR:   cir.func @_Z2s0ii(%arg0: !s32i loc(fused[#loc3, #loc4]), %arg1: !s32i loc(fused[#loc5, #loc6])) -> !s32i {
+// CIR:     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64} loc(#loc21)
+// CIR:     %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["b", init] {alignment = 4 : i64} loc(#loc22)
+// CIR:     %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64} loc(#loc2)
+// CIR:     %3 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64} loc(#loc23)
+// CIR:     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i> loc(#loc9)
+// CIR:     cir.store %arg1, %1 : !s32i, cir.ptr <!s32i> loc(#loc9)
+// CIR:     %4 = cir.load %0 : cir.ptr <!s32i>, !s32i loc(#loc10)
+// CIR:     %5 = cir.load %1 : cir.ptr <!s32i>, !s32i loc(#loc8)
+// CIR:     %6 = cir.binop(add, %4, %5) : !s32i loc(#loc24)
+// CIR:     cir.store %6, %3 : !s32i, cir.ptr <!s32i> loc(#loc23)
+// CIR:     cir.scope {
+// CIR:       %9 = cir.load %3 : cir.ptr <!s32i>, !s32i loc(#loc13)
+// CIR:       %10 = cir.const(#cir.int<0> : !s32i) : !s32i loc(#loc14)
+// CIR:       %11 = cir.cmp(gt, %9, %10) : !s32i, !cir.bool loc(#loc26)
+// CIR:       cir.if %11 {
+// CIR:         %12 = cir.const(#cir.int<0> : !s32i) : !s32i loc(#loc16)
+// CIR:         cir.store %12, %3 : !s32i, cir.ptr <!s32i> loc(#loc28)
+// CIR:       } else {
+// CIR:         %12 = cir.const(#cir.int<1> : !s32i) : !s32i loc(#loc12)
+// CIR:         cir.store %12, %3 : !s32i, cir.ptr <!s32i> loc(#loc29)
+// CIR:       } loc(#loc27)
+// CIR:     } loc(#loc25)
+// CIR:     %7 = cir.load %3 : cir.ptr <!s32i>, !s32i loc(#loc18)
+// CIR:     cir.store %7, %2 : !s32i, cir.ptr <!s32i> loc(#loc30)
+// CIR:     %8 = cir.load %2 : cir.ptr <!s32i>, !s32i loc(#loc30)
+// CIR:     cir.return %8 : !s32i loc(#loc30)
+// CIR:   } loc(#loc20)
+// CIR: } loc(#loc)
+// CIR: #loc = loc(unknown)
+// CIR: #loc1 = loc("{{.*}}sourcelocation.cpp":6:1)
+// CIR: #loc2 = loc("{{.*}}sourcelocation.cpp":13:1)
+// CIR: #loc7 = loc("{{.*}}sourcelocation.cpp":7:3)
+// CIR: #loc8 = loc("{{.*}}sourcelocation.cpp":7:15)
+// CIR: #loc9 = loc("{{.*}}sourcelocation.cpp":6:22)
+// CIR: #loc10 = loc("{{.*}}sourcelocation.cpp":7:11)
+// CIR: #loc11 = loc("{{.*}}sourcelocation.cpp":8:3)
+// CIR: #loc12 = loc("{{.*}}sourcelocation.cpp":11:9)
+// CIR: #loc13 = loc("{{.*}}sourcelocation.cpp":8:7)
+// CIR: #loc14 = loc("{{.*}}sourcelocation.cpp":8:11)
+// CIR: #loc15 = loc("{{.*}}sourcelocation.cpp":9:5)
+// CIR: #loc16 = loc("{{.*}}sourcelocation.cpp":9:9)
+// CIR: #loc17 = loc("{{.*}}sourcelocation.cpp":11:5)
+// CIR: #loc18 = loc("{{.*}}sourcelocation.cpp":12:10)
+// CIR: #loc19 = loc("{{.*}}sourcelocation.cpp":12:3)
+// CIR: #loc20 = loc(fused[#loc1, #loc2])
+// CIR: #loc23 = loc(fused[#loc7, #loc8])
+// CIR: #loc24 = loc(fused[#loc10, #loc8])
+// CIR: #loc25 = loc(fused[#loc11, #loc12])
+// CIR: #loc26 = loc(fused[#loc13, #loc14])
+// CIR: #loc27 = loc(fused[#loc15, #loc16, #loc17, #loc12])
+// CIR: #loc28 = loc(fused[#loc15, #loc16])
+// CIR: #loc29 = loc(fused[#loc17, #loc12])
+// CIR: #loc30 = loc(fused[#loc19, #loc18])
+
+
+// LLVM: ModuleID = '{{.*}}sourcelocation.cpp'
+// LLVM: source_filename = "{{.*}}sourcelocation.cpp"


### PR DESCRIPTION
…M IR.

Summary:
Previously the CIR module doesn't have a name and a fake name "LLVMDialectModule" is used for the resuliting LLVM module. I'm changing it to use the source path, which matches the default behavior.