### PR TITLE
[CIR][NFC] Add stdarg builtin CIR Ops

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1661,4 +1661,44 @@ def AwaitOp : CIR_Op<"await",
   let hasVerifier = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// VAStartOp
+//===----------------------------------------------------------------------===//
+
+def VAStartOp : CIR_Op<"vastart">, Arguments<(ins CIR_PointerType:$arg_list)> {
+  let summary = "Starts a variable argument list";
+  let assemblyFormat = "$arg_list attr-dict `:` type(operands)";
+}
+
+//===----------------------------------------------------------------------===//
+// VAEndOp
+//===----------------------------------------------------------------------===//
+
+def VAEndOp : CIR_Op<"vaend">, Arguments<(ins CIR_PointerType:$arg_list)> {
+  let summary = "Ends a variable argument list";
+  let assemblyFormat = "$arg_list attr-dict `:` type(operands)";
+}
+
+//===----------------------------------------------------------------------===//
+// VACopyOp
+//===----------------------------------------------------------------------===//
+
+def VACopyOp : CIR_Op<"vacopy">,
+               Arguments<(ins CIR_PointerType:$dst_list,
+                              CIR_PointerType:$src_list)> {
+  let summary = "Copies a variable argument list";
+  let assemblyFormat = "$src_list `to` $dst_list attr-dict `:` type(operands)";
+}
+
+//===----------------------------------------------------------------------===//
+// VAArgOp
+//===----------------------------------------------------------------------===//
+
+def VAArgOp : CIR_Op<"vaarg">,
+              Results<(outs AnyType:$result)>,
+              Arguments<(ins CIR_PointerType:$arg_list)> {
+  let summary = "Fetches next variadic element as a given type";
+  let assemblyFormat = "$arg_list attr-dict `:` functional-type(operands, $result)";
+}
+
 #endif // MLIR_CIR_DIALECT_CIR_OPS


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Adds custom CIR operations to represent builtin calls from the stdarg
header. These include `va_start`, `va_end`, `va_copy`, and `va_arg`.