### PR TITLE
[CIR] Enabling debug loc to be progatated into LLVM.

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -155,13 +155,19 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
   }
   theModule->setAttr("cir.sob",
                      mlir::cir::SignedOverflowBehaviorAttr::get(&context, sob));
-  // Set the module name to be the name of the main file.
+  // Set the module name to be the name of the main file. TranslationUnitDecl
+  // often contains invalid source locations and isn't a reliable source for the
+  // module location.
   auto MainFileID = astctx.getSourceManager().getMainFileID();
   const FileEntry &MainFile =
       *astctx.getSourceManager().getFileEntryForID(MainFileID);
   auto Path = MainFile.tryGetRealPathName();
-  if (!Path.empty())
+  if (!Path.empty()) {
     theModule.setSymName(Path);
+    theModule->setLoc(mlir::FileLineColLoc::get(&context, Path,
+                                                /*line=*/0,
+                                                /*col=*/0));
+  }
 }
 
 CIRGenModule::~CIRGenModule() {}

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
 #include "mlir/IR/Attributes.h"
@@ -512,8 +513,16 @@ public:
         resultType ? resultType : mlir::LLVM::LLVMVoidType::get(getContext()),
         signatureConversion.getConvertedTypes(),
         /*isVarArg=*/fnType.isVarArg());
-    auto fn = rewriter.create<mlir::LLVM::LLVMFuncOp>(op.getLoc(), op.getName(),
-                                                      llvmFnTy);
+    // LLVMFuncOp expects a single FileLine Location instead of a fused
+    // location.
+    auto Loc = op.getLoc();
+    if (Loc.isa<mlir::FusedLoc>()) {
+      auto FusedLoc = Loc.cast<mlir::FusedLoc>();
+      Loc = FusedLoc.getLocations()[0];
+    }
+    assert(Loc.isa<mlir::FileLineColLoc>() && "expected single location here");
+    auto fn =
+        rewriter.create<mlir::LLVM::LLVMFuncOp>(Loc, op.getName(), llvmFnTy);
 
     rewriter.inlineRegionBefore(op.getBody(), fn.getBody(), fn.end());
     if (failed(rewriter.convertRegionTypes(&fn.getBody(), *typeConverter,
@@ -1090,6 +1099,12 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule,
   mlir::PassManager pm(mlirCtx.get());
 
   pm.addPass(createConvertCIRToLLVMPass());
+
+  // This is necessary to have line tables emitted and basic
+  // debugger working. In the future we will add proper debug information
+  // emission directly from our frontend.
+  pm.addNestedPass<mlir::LLVM::LLVMFuncOp>(
+      mlir::LLVM::createDIScopeForLLVMFuncOpPass());
 
   auto result = !mlir::failed(pm.run(theModule));
   if (!result)

--- a/clang/test/CIR/CodeGen/sourcelocation.cpp
+++ b/clang/test/CIR/CodeGen/sourcelocation.cpp
@@ -48,7 +48,7 @@ int s0(int a, int b) {
 // CIR:     cir.return %8 : !s32i loc(#loc30)
 // CIR:   } loc(#loc20)
 // CIR: } loc(#loc)
-// CIR: #loc = loc(unknown)
+// CIR: #loc = loc("{{.*}}sourcelocation.cpp":0:0)
 // CIR: #loc1 = loc("{{.*}}sourcelocation.cpp":6:1)
 // CIR: #loc2 = loc("{{.*}}sourcelocation.cpp":13:1)
 // CIR: #loc7 = loc("{{.*}}sourcelocation.cpp":7:3)
@@ -77,3 +77,14 @@ int s0(int a, int b) {
 
 // LLVM: ModuleID = '{{.*}}sourcelocation.cpp'
 // LLVM: source_filename = "{{.*}}sourcelocation.cpp"
+// LLVM: define i32 @_Z2s0ii(i32 %0, i32 %1) !dbg ![[#SP:]]
+// LLVM:  %3 = alloca i32, i64 1, align 4, !dbg ![[#LOC1:]]
+
+
+// LLVM: !llvm.module.flags = !{!0}
+// LLVM: !llvm.dbg.cu = !{!1}
+// LLVM: !0 = !{i32 2, !"Debug Info Version", i32 3}
+// LLVM: !1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "MLIR", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+// LLVM: !2 = !DIFile(filename: "sourcelocation.cpp", directory: "{{.*}}clang/test/CIR/CodeGen")
+// LLVM: ![[#SP]] = distinct !DISubprogram(name: "_Z2s0ii", linkageName: "_Z2s0ii", scope: !2, file: !2, line: 6, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !1)
+// LLVM: ![[#LOC1]] = !DILocation(line: 6, scope: ![[#SP]])


### PR DESCRIPTION
Summary:

As titled. To achieve that I have to update the loc attribute of a func op from using a fused range loc to a single file/loc, since the MLIR builtin support doesn't seem to allow fused locs when converted to LLVM (https://github.com/llvm/clangir/blob/main/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp#L27)