### PR TITLE
[CIR][Lowering] Add support for signed comparisons

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -211,7 +211,7 @@ public:
           mlir::cir::IntAttr::get(castOp.getSrc().getType(), 0));
       rewriter.replaceOpWithNewOp<mlir::cir::CmpOp>(
           castOp, mlir::cir::BoolType::get(getContext()),
-          mlir::cir::CmpOpKind::ne, src, zero);
+          mlir::cir::CmpOpKind::ne, castOp.getSrc(), zero);
       break;
     }
     case mlir::cir::CastKind::integral: {
@@ -889,8 +889,8 @@ class CIRCmpOpLowering : public mlir::OpConversionPattern<mlir::cir::CmpOp> {
 public:
   using OpConversionPattern<mlir::cir::CmpOp>::OpConversionPattern;
 
-  mlir::LLVM::ICmpPredicate
-  convertToICmpPredicate(mlir::cir::CmpOpKind kind) const {
+  mlir::LLVM::ICmpPredicate convertToICmpPredicate(mlir::cir::CmpOpKind kind,
+                                                   bool isSigned) const {
     using CIR = mlir::cir::CmpOpKind;
     using LLVMICmp = mlir::LLVM::ICmpPredicate;
 
@@ -900,13 +900,13 @@ public:
     case CIR::ne:
       return LLVMICmp::ne;
     case CIR::lt:
-      return LLVMICmp::ult;
+      return (isSigned ? LLVMICmp::slt : LLVMICmp::ult);
     case CIR::le:
-      return LLVMICmp::ule;
+      return (isSigned ? LLVMICmp::sle : LLVMICmp::ule);
     case CIR::gt:
-      return LLVMICmp::ugt;
+      return (isSigned ? LLVMICmp::sgt : LLVMICmp::ugt);
     case CIR::ge:
-      return LLVMICmp::uge;
+      return (isSigned ? LLVMICmp::sge : LLVMICmp::uge);
     }
     llvm_unreachable("Unknown CmpOpKind");
   }
@@ -936,12 +936,12 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::CmpOp cmpOp, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto type = adaptor.getLhs().getType();
+    auto type = cmpOp.getLhs().getType();
     mlir::Value llResult;
 
     // Lower to LLVM comparison op.
-    if (auto intTy = type.dyn_cast<mlir::IntegerType>()) {
-      auto kind = convertToICmpPredicate(cmpOp.getKind());
+    if (auto intTy = type.dyn_cast<mlir::cir::IntType>()) {
+      auto kind = convertToICmpPredicate(cmpOp.getKind(), intTy.isSigned());
       llResult = rewriter.create<mlir::LLVM::ICmpOp>(
           cmpOp.getLoc(), kind, adaptor.getLhs(), adaptor.getRhs());
     } else if (type.isa<mlir::FloatType>()) {

--- a/clang/test/CIR/Lowering/cmp.cir
+++ b/clang/test/CIR/Lowering/cmp.cir
@@ -1,31 +1,31 @@
 // RUN: cir-tool %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-tool %s -cir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
-
+!s32i = !cir.int<s, 32>
 module {
   cir.func @foo() {
-    %0 = cir.alloca i32, cir.ptr <i32>, ["a"] {alignment = 4 : i64}
-    %1 = cir.alloca i32, cir.ptr <i32>, ["b"] {alignment = 4 : i64}
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a"] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["b"] {alignment = 4 : i64}
     %2 = cir.alloca f32, cir.ptr <f32>, ["c"] {alignment = 4 : i64}
     %3 = cir.alloca f32, cir.ptr <f32>, ["d"] {alignment = 4 : i64}
     %4 = cir.alloca !cir.bool, cir.ptr <!cir.bool>, ["e"] {alignment = 1 : i64}
-    %5 = cir.load %0 : cir.ptr <i32>, i32
-    %6 = cir.load %1 : cir.ptr <i32>, i32
-    %7 = cir.cmp(gt, %5, %6) : i32, !cir.bool
-    %8 = cir.load %0 : cir.ptr <i32>, i32
-    %9 = cir.load %1 : cir.ptr <i32>, i32
-    %10 = cir.cmp(eq, %8, %9) : i32, !cir.bool
-    %11 = cir.load %0 : cir.ptr <i32>, i32
-    %12 = cir.load %1 : cir.ptr <i32>, i32
-    %13 = cir.cmp(lt, %11, %12) : i32, !cir.bool
-    %14 = cir.load %0 : cir.ptr <i32>, i32
-    %15 = cir.load %1 : cir.ptr <i32>, i32
-    %16 = cir.cmp(ge, %14, %15) : i32, !cir.bool
-    %17 = cir.load %0 : cir.ptr <i32>, i32
-    %18 = cir.load %1 : cir.ptr <i32>, i32
-    %19 = cir.cmp(ne, %17, %18) : i32, !cir.bool
-    %20 = cir.load %0 : cir.ptr <i32>, i32
-    %21 = cir.load %1 : cir.ptr <i32>, i32
-    %22 = cir.cmp(le, %20, %21) : i32, !cir.bool
+    %5 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %7 = cir.cmp(gt, %5, %6) : !s32i, !cir.bool
+    %8 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %9 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %10 = cir.cmp(eq, %8, %9) : !s32i, !cir.bool
+    %11 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %12 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %13 = cir.cmp(lt, %11, %12) : !s32i, !cir.bool
+    %14 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %15 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %16 = cir.cmp(ge, %14, %15) : !s32i, !cir.bool
+    %17 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %18 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %19 = cir.cmp(ne, %17, %18) : !s32i, !cir.bool
+    %20 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %21 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %22 = cir.cmp(le, %20, %21) : !s32i, !cir.bool
     %23 = cir.load %2 : cir.ptr <f32>, f32
     %24 = cir.load %3 : cir.ptr <f32>, f32
     %25 = cir.cmp(gt, %23, %24) : f32, !cir.bool
@@ -48,12 +48,12 @@ module {
   }
 }
 
-// MLIR: = llvm.icmp "ugt"
+// MLIR: = llvm.icmp "sgt"
 // MLIR: = llvm.icmp "eq"
-// MLIR: = llvm.icmp "ult"
-// MLIR: = llvm.icmp "uge"
+// MLIR: = llvm.icmp "slt"
+// MLIR: = llvm.icmp "sge"
 // MLIR: = llvm.icmp "ne"
-// MLIR: = llvm.icmp "ule"
+// MLIR: = llvm.icmp "sle"
 // MLIR: = llvm.fcmp "ugt"
 // MLIR: = llvm.fcmp "ueq"
 // MLIR: = llvm.fcmp "ult"
@@ -61,12 +61,12 @@ module {
 // MLIR: = llvm.fcmp "une"
 // MLIR: = llvm.fcmp "ule"
 
-// LLVM: icmp ugt i32
+// LLVM: icmp sgt i32
 // LLVM: icmp eq i32
-// LLVM: icmp ult i32
-// LLVM: icmp uge i32
+// LLVM: icmp slt i32
+// LLVM: icmp sge i32
 // LLVM: icmp ne i32
-// LLVM: icmp ule i32
+// LLVM: icmp sle i32
 // LLVM: fcmp ugt float
 // LLVM: fcmp ueq float
 // LLVM: fcmp ult float

--- a/clang/test/CIR/Lowering/dot.cir
+++ b/clang/test/CIR/Lowering/dot.cir
@@ -83,7 +83,7 @@ module {
 // MLIR-NEXT:   ^bb2:  // 2 preds: ^bb1, ^bb6
 // MLIR-NEXT:     %14 = llvm.load %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     %15 = llvm.load %5 : !llvm.ptr<i32>
-// MLIR-NEXT:     %16 = llvm.icmp "ult" %14, %15 : i32
+// MLIR-NEXT:     %16 = llvm.icmp "slt" %14, %15 : i32
 // MLIR-NEXT:     %17 = llvm.zext %16 : i1 to i32
 // MLIR-NEXT:     %18 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:     %19 = llvm.icmp "ne" %17, %18 : i32
@@ -144,7 +144,7 @@ module {
 //  LLVM-NEXT: 11:                                               ; preds = %24, %9
 //  LLVM-NEXT:   %12 = load i32, ptr %10, align 4
 //  LLVM-NEXT:   %13 = load i32, ptr %6, align 4
-//  LLVM-NEXT:   %14 = icmp ult i32 %12, %13
+//  LLVM-NEXT:   %14 = icmp slt i32 %12, %13
 //  LLVM-NEXT:   %15 = zext i1 %14 to i32
 //  LLVM-NEXT:   %16 = icmp ne i32 %15, 0
 //  LLVM-NEXT:   %17 = zext i1 %16 to i8

--- a/clang/test/CIR/Lowering/for.cir
+++ b/clang/test/CIR/Lowering/for.cir
@@ -39,7 +39,7 @@ module {
 // MLIR-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb5
 // MLIR-NEXT:     %3 = llvm.load %1 : !llvm.ptr<i32>
 // MLIR-NEXT:     %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:     %5 = llvm.icmp "ult" %3, %4 : i32
+// MLIR-NEXT:     %5 = llvm.icmp "slt" %3, %4 : i32
 // MLIR-NEXT:     %6 = llvm.zext %5 : i1 to i32
 // MLIR-NEXT:     %7 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:     %8 = llvm.icmp "ne" %6, %7 : i32
@@ -70,7 +70,7 @@ module {
 // LLVM-EMPTY:
 //  LLVM-NEXT: 2:
 //  LLVM-NEXT:   %3 = load i32, ptr %1, align 4
-//  LLVM-NEXT:   %4 = icmp ult i32 %3, 10
+//  LLVM-NEXT:   %4 = icmp slt i32 %3, 10
 //  LLVM-NEXT:   %5 = zext i1 %4 to i32
 //  LLVM-NEXT:   %6 = icmp ne i32 %5, 0
 //  LLVM-NEXT:   %7 = zext i1 %6 to i8


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #106
* #105
* #104
* #102
* #101
* #100

Updates CIR's CmpOp lowering to use CIR's custom cir::IntType, allowing
it to handle signed comparisons.