### PR TITLE
[CIR][Lowering] Lower float plus and minus unary ops

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -33,8 +33,10 @@
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
@@ -825,47 +827,69 @@ public:
   matchAndRewrite(mlir::cir::UnaryOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Type type = op.getInput().getType();
-    assert(type.isa<mlir::cir::IntType>() && "operand type not supported yet");
 
     auto llvmInType = adaptor.getInput().getType();
     auto llvmType = getTypeConverter()->convertType(op.getType());
 
-    switch (op.getKind()) {
-    case mlir::cir::UnaryOpKind::Inc: {
-      auto One = rewriter.create<mlir::LLVM::ConstantOp>(
-          op.getLoc(), llvmInType, mlir::IntegerAttr::get(llvmInType, 1));
-      rewriter.replaceOpWithNewOp<mlir::LLVM::AddOp>(op, llvmType,
-                                                     adaptor.getInput(), One);
-      break;
-    }
-    case mlir::cir::UnaryOpKind::Dec: {
-      auto One = rewriter.create<mlir::LLVM::ConstantOp>(
-          op.getLoc(), llvmInType, mlir::IntegerAttr::get(llvmInType, 1));
-      rewriter.replaceOpWithNewOp<mlir::LLVM::SubOp>(op, llvmType,
-                                                     adaptor.getInput(), One);
-      break;
-    }
-    case mlir::cir::UnaryOpKind::Plus: {
-      rewriter.replaceOp(op, adaptor.getInput());
-      break;
-    }
-    case mlir::cir::UnaryOpKind::Minus: {
-      auto Zero = rewriter.create<mlir::LLVM::ConstantOp>(
-          op.getLoc(), llvmInType, mlir::IntegerAttr::get(llvmInType, 0));
-      rewriter.replaceOpWithNewOp<mlir::LLVM::SubOp>(op, llvmType, Zero,
-                                                     adaptor.getInput());
-      break;
-    }
-    case mlir::cir::UnaryOpKind::Not: {
-      auto MinusOne = rewriter.create<mlir::LLVM::ConstantOp>(
-          op.getLoc(), llvmType, mlir::IntegerAttr::get(llvmType, -1));
-      rewriter.replaceOpWithNewOp<mlir::LLVM::XOrOp>(op, llvmType, MinusOne,
-                                                     adaptor.getInput());
-      break;
-    }
+    // Integer unary operations.
+    if (type.isa<mlir::cir::IntType>()) {
+      switch (op.getKind()) {
+      case mlir::cir::UnaryOpKind::Inc: {
+        auto One = rewriter.create<mlir::LLVM::ConstantOp>(
+            op.getLoc(), llvmInType, mlir::IntegerAttr::get(llvmInType, 1));
+        rewriter.replaceOpWithNewOp<mlir::LLVM::AddOp>(op, llvmType,
+                                                       adaptor.getInput(), One);
+        return mlir::success();
+      }
+      case mlir::cir::UnaryOpKind::Dec: {
+        auto One = rewriter.create<mlir::LLVM::ConstantOp>(
+            op.getLoc(), llvmInType, mlir::IntegerAttr::get(llvmInType, 1));
+        rewriter.replaceOpWithNewOp<mlir::LLVM::SubOp>(op, llvmType,
+                                                       adaptor.getInput(), One);
+        return mlir::success();
+      }
+      case mlir::cir::UnaryOpKind::Plus: {
+        rewriter.replaceOp(op, adaptor.getInput());
+        return mlir::success();
+      }
+      case mlir::cir::UnaryOpKind::Minus: {
+        auto Zero = rewriter.create<mlir::LLVM::ConstantOp>(
+            op.getLoc(), llvmInType, mlir::IntegerAttr::get(llvmInType, 0));
+        rewriter.replaceOpWithNewOp<mlir::LLVM::SubOp>(op, llvmType, Zero,
+                                                       adaptor.getInput());
+        return mlir::success();
+      }
+      case mlir::cir::UnaryOpKind::Not: {
+        auto MinusOne = rewriter.create<mlir::LLVM::ConstantOp>(
+            op.getLoc(), llvmType, mlir::IntegerAttr::get(llvmType, -1));
+        rewriter.replaceOpWithNewOp<mlir::LLVM::XOrOp>(op, llvmType, MinusOne,
+                                                       adaptor.getInput());
+        return mlir::success();
+      }
+      }
     }
 
-    return mlir::LogicalResult::success();
+    // Floating point unary operations.
+    if (type.isa<mlir::FloatType>()) {
+      switch (op.getKind()) {
+      case mlir::cir::UnaryOpKind::Plus:
+        rewriter.replaceOp(op, adaptor.getInput());
+        return mlir::success();
+      case mlir::cir::UnaryOpKind::Minus: {
+        auto negOneAttr = mlir::FloatAttr::get(llvmInType, -1.0);
+        auto negOneConst = rewriter.create<mlir::LLVM::ConstantOp>(
+            op.getLoc(), llvmInType, negOneAttr);
+        rewriter.replaceOpWithNewOp<mlir::LLVM::FMulOp>(
+            op, llvmType, negOneConst, adaptor.getInput());
+        return mlir::success();
+      }
+      default:
+        op.emitError() << "Floating point unary lowering ot implemented";
+        return mlir::failure();
+      }
+    }
+
+    return op.emitError() << "Unary operation has unsupported type: " << type;
   }
 };
 

--- a/clang/test/CIR/CodeGen/unary.cpp
+++ b/clang/test/CIR/CodeGen/unary.cpp
@@ -152,3 +152,15 @@ int *inc_p(int *i) {
 // CHECK:   %[[#i_inc:]] = cir.load %0 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK:   %[[#inc_const:]] = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK:   = cir.ptr_stride(%[[#i_inc]] : !cir.ptr<!s32i>, %[[#inc_const]] : !s32i), !cir.ptr<!s32i>
+
+void floats(float f) {
+// CHECK: cir.func @{{.+}}floats{{.+}}
+  +f; // CHECK: %{{[0-9]+}} = cir.unary(plus, %{{[0-9]+}}) : f32, f32
+  -f; // CHECK: %{{[0-9]+}} = cir.unary(minus, %{{[0-9]+}}) : f32, f32
+}
+
+void doubles(double d) {
+// CHECK: cir.func @{{.+}}doubles{{.+}}
+  +d; // CHECK: %{{[0-9]+}} = cir.unary(plus, %{{[0-9]+}}) : f64, f64
+  -d; // CHECK: %{{[0-9]+}} = cir.unary(minus, %{{[0-9]+}}) : f64, f64
+}

--- a/clang/test/CIR/Lowering/unary-plus-minus.cir
+++ b/clang/test/CIR/Lowering/unary-plus-minus.cir
@@ -18,7 +18,6 @@ module {
     cir.store %6, %1 : !s32i, cir.ptr <!s32i>
     cir.return
   }
-}
 
 // MLIR: %[[#INPUT_PLUS:]] = llvm.load
 // MLIR: llvm.store %[[#INPUT_PLUS]]
@@ -27,3 +26,21 @@ module {
 // MLIR: llvm.sub %[[ZERO]], %[[#INPUT_MINUS]]
 
 // LLVM: = sub i32 0, %[[#]]
+
+
+  cir.func @floatingPoints(%arg0: f64) {
+  // MLIR: llvm.func @floatingPoints(%arg0: f64) {
+    %0 = cir.alloca f64, cir.ptr <f64>, ["X", init] {alignment = 8 : i64}
+    cir.store %arg0, %0 : f64, cir.ptr <f64>
+    %1 = cir.load %0 : cir.ptr <f64>, f64
+    %2 = cir.unary(plus, %1) : f64, f64
+    // MLIR: llvm.store %arg0, %[[#F_PLUS:]] : !llvm.ptr<f64>
+    // MLIR: %{{[0-9]}} = llvm.load %[[#F_PLUS]] : !llvm.ptr<f64>
+    %3 = cir.load %0 : cir.ptr <f64>, f64
+    %4 = cir.unary(minus, %3) : f64, f64
+    // MLIR: %[[#F_MINUS:]] = llvm.load %{{[0-9]}} : !llvm.ptr<f64>
+    // MLIR: %[[#F_NEG_ONE:]] = llvm.mlir.constant(-1.000000e+00 : f64) : f64
+    // MLIR: %5 = llvm.fmul %[[#F_NEG_ONE]], %[[#F_MINUS]]  : f64
+    cir.return
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #110
* #109
* #108
* __->__ #107

Lower plus and minus unary operators when applied to float types.