### PR TITLE
[CIR][Lowering] Lower inc/dec float and double types

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -17,9 +17,12 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cstdint>
 
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
 
 using namespace cir;
@@ -338,7 +341,15 @@ public:
     } else if (type->isVectorType()) {
       llvm_unreachable("no vector inc/dec yet");
     } else if (type->isRealFloatingType()) {
-      llvm_unreachable("no float inc/dec yet");
+      auto isFloatOrDouble = type->isSpecificBuiltinType(BuiltinType::Float) ||
+                             type->isSpecificBuiltinType(BuiltinType::Double);
+      assert(isFloatOrDouble && "NYI");
+
+      // Create the inc/dec operation.
+      auto kind =
+          (isInc ? mlir::cir::UnaryOpKind::Inc : mlir::cir::UnaryOpKind::Dec);
+      value = buildUnaryOp(E, kind, input);
+
     } else if (type->isFixedPointType()) {
       llvm_unreachable("no fixed point inc/dec yet");
     } else {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -872,6 +872,22 @@ public:
     // Floating point unary operations.
     if (type.isa<mlir::FloatType>()) {
       switch (op.getKind()) {
+      case mlir::cir::UnaryOpKind::Inc: {
+        auto oneAttr = rewriter.getFloatAttr(llvmInType, 1.0);
+        auto oneConst = rewriter.create<mlir::LLVM::ConstantOp>(
+            op.getLoc(), llvmInType, oneAttr);
+        rewriter.replaceOpWithNewOp<mlir::LLVM::FAddOp>(op, llvmType, oneConst,
+                                                        adaptor.getInput());
+        return mlir::success();
+      }
+      case mlir::cir::UnaryOpKind::Dec: {
+        auto negOneAttr = rewriter.getFloatAttr(llvmInType, -1.0);
+        auto negOneConst = rewriter.create<mlir::LLVM::ConstantOp>(
+            op.getLoc(), llvmInType, negOneAttr);
+        rewriter.replaceOpWithNewOp<mlir::LLVM::FSubOp>(
+            op, llvmType, negOneConst, adaptor.getInput());
+        return mlir::success();
+      }
       case mlir::cir::UnaryOpKind::Plus:
         rewriter.replaceOp(op, adaptor.getInput());
         return mlir::success();

--- a/clang/test/CIR/CodeGen/unary.cpp
+++ b/clang/test/CIR/CodeGen/unary.cpp
@@ -157,10 +157,18 @@ void floats(float f) {
 // CHECK: cir.func @{{.+}}floats{{.+}}
   +f; // CHECK: %{{[0-9]+}} = cir.unary(plus, %{{[0-9]+}}) : f32, f32
   -f; // CHECK: %{{[0-9]+}} = cir.unary(minus, %{{[0-9]+}}) : f32, f32
+  ++f; // CHECK: = cir.unary(inc, %{{[0-9]+}}) : f32, f32
+  --f; // CHECK: = cir.unary(dec, %{{[0-9]+}}) : f32, f32
+  f++; // CHECK: = cir.unary(inc, %{{[0-9]+}}) : f32, f32
+  f--; // CHECK: = cir.unary(dec, %{{[0-9]+}}) : f32, f32
 }
 
 void doubles(double d) {
 // CHECK: cir.func @{{.+}}doubles{{.+}}
   +d; // CHECK: %{{[0-9]+}} = cir.unary(plus, %{{[0-9]+}}) : f64, f64
   -d; // CHECK: %{{[0-9]+}} = cir.unary(minus, %{{[0-9]+}}) : f64, f64
+  ++d; // CHECK: = cir.unary(inc, %{{[0-9]+}}) : f64, f64
+  --d; // CHECK: = cir.unary(dec, %{{[0-9]+}}) : f64, f64
+  d++; // CHECK: = cir.unary(inc, %{{[0-9]+}}) : f64, f64
+  d--; // CHECK: = cir.unary(dec, %{{[0-9]+}}) : f64, f64
 }

--- a/clang/test/CIR/Lowering/unary-inc-dec.cir
+++ b/clang/test/CIR/Lowering/unary-inc-dec.cir
@@ -18,7 +18,6 @@ module {
     cir.store %6, %1 : !s32i, cir.ptr <!s32i>
     cir.return
   }
-}
 
 // MLIR: = llvm.mlir.constant(1 : i32)
 // MLIR: = llvm.add
@@ -27,3 +26,38 @@ module {
 
 // LLVM: = add i32 %[[#]], 1
 // LLVM: = sub i32 %[[#]], 1
+
+  cir.func @floatingPoint(%arg0: f32, %arg1: f64) {
+  // MLIR: llvm.func @floatingPoint
+    %0 = cir.alloca f32, cir.ptr <f32>, ["f", init] {alignment = 4 : i64}
+    %1 = cir.alloca f64, cir.ptr <f64>, ["d", init] {alignment = 8 : i64}
+    cir.store %arg0, %0 : f32, cir.ptr <f32>
+    cir.store %arg1, %1 : f64, cir.ptr <f64>
+
+    %2 = cir.load %0 : cir.ptr <f32>, f32
+    %3 = cir.unary(inc, %2) : f32, f32
+    cir.store %3, %0 : f32, cir.ptr <f32>
+    // MLIR: %[[#F_ONE:]] = llvm.mlir.constant(1.000000e+00 : f32) : f32
+    // MLIR: = llvm.fadd %[[#F_ONE]], %{{[0-9]+}}  : f32
+
+    %4 = cir.load %0 : cir.ptr <f32>, f32
+    %5 = cir.unary(dec, %4) : f32, f32
+    cir.store %5, %0 : f32, cir.ptr <f32>
+    // MLIR: %[[#D_ONE:]] = llvm.mlir.constant(-1.000000e+00 : f32) : f32
+    // MLIR: = llvm.fsub %[[#D_ONE]], %{{[0-9]+}}  : f32
+
+    %6 = cir.load %1 : cir.ptr <f64>, f64
+    %7 = cir.unary(inc, %6) : f64, f64
+    cir.store %7, %1 : f64, cir.ptr <f64>
+    // MLIR: %[[#D_ONE:]] = llvm.mlir.constant(1.000000e+00 : f64) : f64
+    // MLIR: = llvm.fadd %[[#D_ONE]], %{{[0-9]+}}  : f64
+    
+    %8 = cir.load %1 : cir.ptr <f64>, f64
+    %9 = cir.unary(dec, %8) : f64, f64
+    cir.store %9, %1 : f64, cir.ptr <f64>
+    // MLIR: %[[#D_ONE:]] = llvm.mlir.constant(-1.000000e+00 : f64) : f64
+    // MLIR: = llvm.fsub %[[#D_ONE]], %{{[0-9]+}}  : f64
+
+    cir.return
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Implement lowering for inc/dec float and double types. Also adds a
small bit of codegen that was missing for this lowering to work.