### PR TITLE
[CIR][CIRGen][Lowering] Support float unary not op

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -50,13 +50,14 @@ def CK_PtrToBoolean : I32EnumAttrCase<"ptr_to_bool", 6>;
 def CK_FloatToIntegral : I32EnumAttrCase<"float_to_int", 7>;
 def CK_IntegralToPointer : I32EnumAttrCase<"int_to_ptr", 8>;
 def CK_PointerToIntegral : I32EnumAttrCase<"ptr_to_int", 9>;
+def CK_FloatToBoolean : I32EnumAttrCase<"float_to_bool", 10>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
     "cast kind",
     [CK_IntegralToBoolean, CK_ArrayToPointerDecay, CK_IntegralCast,
      CK_BitCast, CK_FloatingCast, CK_PtrToBoolean, CK_FloatToIntegral,
-     CK_IntegralToPointer, CK_PointerToIntegral]> {
+     CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean]> {
   let cppNamespace = "::mlir::cir";
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -809,6 +809,12 @@ public:
                                  E->getExprLoc());
   }
 
+  mlir::Value buildFloatToBoolConversion(mlir::Value src, mlir::Location loc) {
+    auto boolTy = Builder.getBoolTy();
+    return Builder.create<mlir::cir::CastOp>(
+        loc, boolTy, mlir::cir::CastKind::float_to_bool, src);
+  }
+
   mlir::Value buildIntToBoolConversion(mlir::Value srcVal, mlir::Location loc) {
     // Because of the type rules of C, we often end up computing a
     // logical value, then zero extending it to int, then wanting it
@@ -827,7 +833,7 @@ public:
     assert(SrcType.isCanonical() && "EmitScalarConversion strips typedefs");
 
     if (SrcType->isRealFloatingType())
-      assert(0 && "not implemented");
+      return buildFloatToBoolConversion(Src, loc);
 
     if (auto *MPT = llvm::dyn_cast<MemberPointerType>(SrcType))
       assert(0 && "not implemented");
@@ -1180,7 +1186,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
   case CK_PointerToBoolean:
     return buildPointerToBoolConversion(Visit(E), E->getType());
   case CK_FloatingToBoolean:
-    llvm_unreachable("NYI");
+    return buildFloatToBoolConversion(Visit(E), CGF.getLoc(E->getExprLoc()));
   case CK_MemberPointerToBoolean:
     llvm_unreachable("NYI");
   case CK_FloatingComplexToReal:

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -315,6 +315,13 @@ LogicalResult CastOp::verify() {
       return emitOpError() << "requires integer for result";
     return success();
   }
+  case cir::CastKind::float_to_bool: {
+    if (!srcType.isa<mlir::FloatType>())
+      return emitOpError() << "requires float for source";
+    if (!resType.isa<mlir::cir::BoolType>())
+      return emitOpError() << "requires !cir.bool for result";
+    return success();
+  }
   }
 
   llvm_unreachable("Unknown CastOp kind?");

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -271,6 +271,24 @@ public:
                                                           llvmSrcVal);
       return mlir::success();
     }
+    case mlir::cir::CastKind::float_to_bool: {
+      auto dstTy = castOp.getType().cast<mlir::cir::BoolType>();
+      auto llvmSrcVal = adaptor.getOperands().front();
+      auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+      auto kind = mlir::LLVM::FCmpPredicate::une;
+      
+      // Check if float is not equal to zero.
+      auto zeroFloat = rewriter.create<mlir::LLVM::ConstantOp>(
+          castOp.getLoc(), llvmSrcVal.getType(),
+          mlir::FloatAttr::get(llvmSrcVal.getType(), 0.0));
+      
+      // Extend comparison result to either bool (C++) or int (C).
+      mlir::Value cmpResult = rewriter.create<mlir::LLVM::FCmpOp>(
+          castOp.getLoc(), kind, llvmSrcVal, zeroFloat);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::ZExtOp>(castOp, llvmDstTy,
+                                                      cmpResult);
+      return mlir::success();
+    }
     default:
       llvm_unreachable("NYI");
     }
@@ -901,6 +919,21 @@ public:
       }
       default:
         op.emitError() << "Floating point unary lowering ot implemented";
+        return mlir::failure();
+      }
+    }
+
+    // Boolean unary operations.
+    if (type.isa<mlir::cir::BoolType>()) {
+      switch (op.getKind()) {
+      case mlir::cir::UnaryOpKind::Not:
+        rewriter.replaceOpWithNewOp<mlir::LLVM::XOrOp>(
+            op, llvmType, adaptor.getInput(),
+            rewriter.create<mlir::LLVM::ConstantOp>(
+                op.getLoc(), llvmType, mlir::IntegerAttr::get(llvmType, 1)));
+        return mlir::success();
+      default:
+        op.emitError() << "Unary operator not implemented for bool type";
         return mlir::failure();
       }
     }

--- a/clang/test/CIR/CodeGen/unary.cpp
+++ b/clang/test/CIR/CodeGen/unary.cpp
@@ -161,6 +161,10 @@ void floats(float f) {
   --f; // CHECK: = cir.unary(dec, %{{[0-9]+}}) : f32, f32
   f++; // CHECK: = cir.unary(inc, %{{[0-9]+}}) : f32, f32
   f--; // CHECK: = cir.unary(dec, %{{[0-9]+}}) : f32, f32
+
+  !f;
+  // CHECK: %[[#F_BOOL:]] = cir.cast(float_to_bool, %{{[0-9]+}} : f32), !cir.bool
+  // CHECK: = cir.unary(not, %[[#F_BOOL]]) : !cir.bool, !cir.bool
 }
 
 void doubles(double d) {
@@ -171,4 +175,8 @@ void doubles(double d) {
   --d; // CHECK: = cir.unary(dec, %{{[0-9]+}}) : f64, f64
   d++; // CHECK: = cir.unary(inc, %{{[0-9]+}}) : f64, f64
   d--; // CHECK: = cir.unary(dec, %{{[0-9]+}}) : f64, f64
+
+  !d;
+  // CHECK: %[[#D_BOOL:]] = cir.cast(float_to_bool, %{{[0-9]+}} : f64), !cir.bool
+  // CHECK: = cir.unary(not, %[[#D_BOOL]]) : !cir.bool, !cir.bool
 }

--- a/clang/test/CIR/Lowering/unary-not.cir
+++ b/clang/test/CIR/Lowering/unary-not.cir
@@ -13,10 +13,36 @@ module {
         %5 = cir.load %0 : cir.ptr <!s32i>, !s32i
         cir.return %5 : !s32i
     }
-}
 
 // MLIR: = llvm.load
 // MLIR: = llvm.mlir.constant(-1 : i32)
 // MLIR: = llvm.xor
 
 // LLVM: = xor i32 -1, %[[#]]
+
+
+    cir.func @floatingPoint(%arg0: f32, %arg1: f64) {
+    // MLIR: llvm.func @floatingPoint
+        %0 = cir.alloca f32, cir.ptr <f32>, ["f", init] {alignment = 4 : i64}
+        %1 = cir.alloca f64, cir.ptr <f64>, ["d", init] {alignment = 8 : i64}
+        cir.store %arg0, %0 : f32, cir.ptr <f32>
+        cir.store %arg1, %1 : f64, cir.ptr <f64>
+        %2 = cir.load %0 : cir.ptr <f32>, f32
+        %3 = cir.cast(float_to_bool, %2 : f32), !cir.bool
+        // MLIR: %[[#F_ZERO:]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
+        // MLIR: %[[#F_BOOL:]] = llvm.fcmp "une" %{{.+}}, %[[#F_ZERO]] : f32
+        // MLIR: %[[#F_ZEXT:]] = llvm.zext %[[#F_BOOL]] : i1 to i8
+        %4 = cir.unary(not, %3) : !cir.bool, !cir.bool
+        // MLIR: %[[#F_ONE:]] = llvm.mlir.constant(1 : i8) : i8
+        // MLIR: = llvm.xor %[[#F_ZEXT]], %[[#F_ONE]]  : i8
+        %5 = cir.load %1 : cir.ptr <f64>, f64
+        %6 = cir.cast(float_to_bool, %5 : f64), !cir.bool
+        // MLIR: %[[#D_ZERO:]] = llvm.mlir.constant(0.000000e+00 : f64) : f64
+        // MLIR: %[[#D_BOOL:]] = llvm.fcmp "une" %{{.+}}, %[[#D_ZERO]] : f64
+        // MLIR: %[[#D_ZEXT:]] = llvm.zext %[[#D_BOOL]] : i1 to i8
+        %7 = cir.unary(not, %6) : !cir.bool, !cir.bool
+        // MLIR: %[[#D_ONE:]] = llvm.mlir.constant(1 : i8) : i8
+        // MLIR: = llvm.xor %[[#D_ZEXT]], %[[#D_ONE]]  : i8
+        cir.return
+    }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Adds new cir.cast op float-to-bool kind, including its codegen and
lowering as well.