### PR TITLE
[CIR][CIRGen][Lowering] Support C values unary negation

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -51,13 +51,15 @@ def CK_FloatToIntegral : I32EnumAttrCase<"float_to_int", 7>;
 def CK_IntegralToPointer : I32EnumAttrCase<"int_to_ptr", 8>;
 def CK_PointerToIntegral : I32EnumAttrCase<"ptr_to_int", 9>;
 def CK_FloatToBoolean : I32EnumAttrCase<"float_to_bool", 10>;
+def CK_BooleanToIntegral : I32EnumAttrCase<"bool_to_int", 11>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
     "cast kind",
     [CK_IntegralToBoolean, CK_ArrayToPointerDecay, CK_IntegralCast,
      CK_BitCast, CK_FloatingCast, CK_PtrToBoolean, CK_FloatToIntegral,
-     CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean]> {
+     CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean,
+     CK_BooleanToIntegral]> {
   let cppNamespace = "::mlir::cir";
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -379,6 +379,10 @@ public:
       return src;
     llvm_unreachable("NYI");
   }
+
+  mlir::Value createBoolToInt(mlir::Value src, mlir::Type newTy) {
+    return createCast(mlir::cir::CastKind::bool_to_int, src, newTy);
+  }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1293,8 +1293,12 @@ mlir::Value ScalarExprEmitter::VisitUnaryLNot(const UnaryOperator *E) {
 
   // ZExt result to the expr type.
   auto dstTy = ConvertType(E->getType());
-  assert(boolVal.getType() == dstTy && "NYI");
-  return boolVal;
+  if (dstTy.isa<mlir::cir::IntType>())
+    return Builder.createBoolToInt(boolVal, dstTy);
+  if (dstTy.isa<mlir::cir::BoolType>())
+    return boolVal;
+
+  llvm_unreachable("destination type for negation unary operator is NYI");
 }
 
 mlir::Value ScalarExprEmitter::buildScalarCast(

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -12,6 +12,7 @@
 
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
+#include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -320,6 +321,13 @@ LogicalResult CastOp::verify() {
       return emitOpError() << "requires float for source";
     if (!resType.isa<mlir::cir::BoolType>())
       return emitOpError() << "requires !cir.bool for result";
+    return success();
+  }
+  case cir::CastKind::bool_to_int: {
+    if (!srcType.isa<mlir::cir::BoolType>())
+      return emitOpError() << "requires !cir.bool for source";
+    if (!resType.isa<mlir::cir::IntType>())
+      return emitOpError() << "requires !cir.int for result";
     return success();
   }
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -289,6 +289,14 @@ public:
                                                       cmpResult);
       return mlir::success();
     }
+    case mlir::cir::CastKind::bool_to_int: {
+      auto dstTy = castOp.getType().cast<mlir::cir::IntType>();
+      auto llvmSrcVal = adaptor.getOperands().front();
+      auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::ZExtOp>(castOp, llvmDstTy,
+                                                      llvmSrcVal);
+      return mlir::success();
+    }
     default:
       llvm_unreachable("NYI");
     }

--- a/clang/test/CIR/CodeGen/unary.c
+++ b/clang/test/CIR/CodeGen/unary.c
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -Wno-unused-value -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void valueNegation(int i, short s, long l, float f, double d) {
+// CHECK: cir.func @valueNegation(
+  !i;
+  // CHECK: %[[#INT:]] = cir.load %{{[0-9]+}} : cir.ptr <!s32i>, !s32i
+  // CHECK: %[[#INT_TO_BOOL:]] = cir.cast(int_to_bool, %[[#INT]] : !s32i), !cir.bool
+  // CHECK: = cir.unary(not, %[[#INT_TO_BOOL]]) : !cir.bool, !cir.bool
+  !s;
+  // CHECK: %[[#SHORT:]] = cir.load %{{[0-9]+}} : cir.ptr <!s16i>, !s16i
+  // CHECK: %[[#SHORT_TO_BOOL:]] = cir.cast(int_to_bool, %[[#SHORT]] : !s16i), !cir.bool
+  // CHECK: = cir.unary(not, %[[#SHORT_TO_BOOL]]) : !cir.bool, !cir.bool
+  !l;
+  // CHECK: %[[#LONG:]] = cir.load %{{[0-9]+}} : cir.ptr <!s64i>, !s64i
+  // CHECK: %[[#LONG_TO_BOOL:]] = cir.cast(int_to_bool, %[[#LONG]] : !s64i), !cir.bool
+  // CHECK: = cir.unary(not, %[[#LONG_TO_BOOL]]) : !cir.bool, !cir.bool
+  !f;
+  // CHECK: %[[#FLOAT:]] = cir.load %{{[0-9]+}} : cir.ptr <f32>, f32
+  // CHECK: %[[#FLOAT_TO_BOOL:]] = cir.cast(float_to_bool, %[[#FLOAT]] : f32), !cir.bool
+  // CHECK: %[[#FLOAT_NOT:]] = cir.unary(not, %[[#FLOAT_TO_BOOL]]) : !cir.bool, !cir.bool
+  // CHECK: = cir.cast(bool_to_int, %[[#FLOAT_NOT]] : !cir.bool), !s32i
+  !d;
+  // CHECK: %[[#DOUBLE:]] = cir.load %{{[0-9]+}} : cir.ptr <f64>, f64
+  // CHECK: %[[#DOUBLE_TO_BOOL:]] = cir.cast(float_to_bool, %[[#DOUBLE]] : f64), !cir.bool
+  // CHECK: %[[#DOUBLE_NOT:]] = cir.unary(not, %[[#DOUBLE_TO_BOOL]]) : !cir.bool, !cir.bool
+  // CHECK: = cir.cast(bool_to_int, %[[#DOUBLE_NOT]] : !cir.bool), !s32i
+}

--- a/clang/test/CIR/Lowering/unary-not.cir
+++ b/clang/test/CIR/Lowering/unary-not.cir
@@ -45,4 +45,38 @@ module {
         // MLIR: = llvm.xor %[[#D_ZEXT]], %[[#D_ONE]]  : i8
         cir.return
     }
+
+    cir.func @CStyleValueNegation(%arg0: !s32i, %arg1: f32) {
+    // MLIR: llvm.func @CStyleValueNegation
+        %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+        %3 = cir.alloca f32, cir.ptr <f32>, ["f", init] {alignment = 4 : i64}
+        cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+        cir.store %arg1, %3 : f32, cir.ptr <f32>
+
+        %5 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %6 = cir.cast(int_to_bool, %5 : !s32i), !cir.bool
+        %7 = cir.unary(not, %6) : !cir.bool, !cir.bool
+        %8 = cir.cast(bool_to_int, %7 : !cir.bool), !s32i
+        // MLIR: %[[#INT:]] = llvm.load %{{.+}} : !llvm.ptr<i32>
+        // MLIR: %[[#IZERO:]] = llvm.mlir.constant(0 : i32) : i32
+        // MLIR: %[[#ICMP:]] = llvm.icmp "ne" %[[#INT]], %[[#IZERO]] : i32
+        // MLIR: %[[#IEXT:]] = llvm.zext %[[#ICMP]] : i1 to i8
+        // MLIR: %[[#IONE:]] = llvm.mlir.constant(1 : i8) : i8
+        // MLIR: %[[#IXOR:]] = llvm.xor %[[#IEXT]], %[[#IONE]]  : i8
+        // MLIR: = llvm.zext %[[#IXOR]] : i8 to i32
+
+        %17 = cir.load %3 : cir.ptr <f32>, f32
+        %18 = cir.cast(float_to_bool, %17 : f32), !cir.bool
+        %19 = cir.unary(not, %18) : !cir.bool, !cir.bool
+        %20 = cir.cast(bool_to_int, %19 : !cir.bool), !s32i
+        // MLIR: %[[#FLOAT:]] = llvm.load %{{.+}} : !llvm.ptr<f32>
+        // MLIR: %[[#FZERO:]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
+        // MLIR: %[[#FCMP:]] = llvm.fcmp "une" %[[#FLOAT]], %[[#FZERO]] : f32
+        // MLIR: %[[#FEXT:]] = llvm.zext %[[#FCMP]] : i1 to i8
+        // MLIR: %[[#FONE:]] = llvm.mlir.constant(1 : i8) : i8
+        // MLIR: %[[#FXOR:]] = llvm.xor %[[#FEXT]], %[[#FONE]]  : i8
+        // MLIR: = llvm.zext %[[#FXOR]] : i8 to i32
+
+        cir.return
+    }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #110
* #109
* #108
* #107

In C, value negation implicitly casts to int, in C++, it casts to bool.
This patch adds support for the C-specific scenario.

Since both C and C++ share code gen paths for unary negation, the C
cases are handled by casting the boolean type that is already generated
for the C++ cases to an int. The following additions were made:

 - Added C style unary negation test case.
 - Updated CIR cast to support bool_to_int conversions.
 - Lowering bool_to_int conversion as a ZExt operation.