### PR TITLE
[CIR] Clean up include_directories for subdirectories.

### DIFF
--- a/clang/lib/CIR/CMakeLists.txt
+++ b/clang/lib/CIR/CMakeLists.txt
@@ -1,3 +1,6 @@
+include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
+include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
+
 add_subdirectory(Dialect)
 add_subdirectory(CodeGen)
 add_subdirectory(FrontendAction)

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -4,9 +4,6 @@ set(
   Support
 )
 
-include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
-include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
-
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_clang_library(clangCIR

--- a/clang/lib/CIR/Dialect/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/CMakeLists.txt
@@ -1,5 +1,2 @@
-include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
-include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
-
 add_subdirectory(IR)
 add_subdirectory(Transforms)

--- a/clang/lib/CIR/FrontendAction/CMakeLists.txt
+++ b/clang/lib/CIR/FrontendAction/CMakeLists.txt
@@ -3,9 +3,6 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-include_directories( ${LLVM_MAIN_SRC_DIR}/../mlir/include )
-include_directories( ${CMAKE_BINARY_DIR}/tools/mlir/include )
-
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_clang_library(clangCIRFrontendAction

--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -3,9 +3,6 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-include_directories( ${LLVM_MAIN_SRC_DIR}/../mlir/include )
-include_directories( ${CMAKE_BINARY_DIR}/tools/mlir/include )
-
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_clang_library(clangCIRLoweringDirectToLLVM

--- a/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
@@ -3,9 +3,6 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-include_directories( ${LLVM_MAIN_SRC_DIR}/../mlir/include )
-include_directories( ${CMAKE_BINARY_DIR}/tools/mlir/include )
-
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_clang_library(clangCIRLoweringThroughMLIR


### PR DESCRIPTION
Summary:
It looks like we can just set up the MLIR include_directories paths in the outermost dirctory of CIR instead of specifying them in each of the subdirectory.