### PR TITLE
[ClR] Set optnone attribute for functions.

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -26,6 +26,14 @@ class CIR_Attr<string name, string attrMnemonic, list<Trait> traits = []>
   let mnemonic = attrMnemonic;
 }
 
+class CIRUnitAttr<string name, string attrMnemonic, list<Trait> traits = []>
+    : CIR_Attr<name, attrMnemonic, traits> {
+  let returnType = "bool";
+  let defaultValue = "false";
+  let valueType = NoneType;
+  let isOptional = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // LangAttr
 //===----------------------------------------------------------------------===//
@@ -438,6 +446,10 @@ def InlineAttr : CIR_Attr<"Inline", "inline"> {
     bool isAlwaysInline() const { return getValue() == InlineKind::AlwaysInline; };
     bool isInlineHint() const { return getValue() == InlineKind::InlineHint; };
   }];
+}
+
+def OptNoneAttr : CIRUnitAttr<"OptNone", "optnone"> {
+  let storageType = [{ OptNoneAttr }];
 }
 
 #endif // MLIR_CIR_DIALECT_CIR_ATTRS

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1905,7 +1905,26 @@ void CIRGenModule::setExtraAttributesForFunc(FuncOp f,
                                              mlir::cir::InlineKind::NoInline);
       attrs.set(attr.getMnemonic(), attr);
     }
+  }
 
+  // Track whether we need to add the optnone attribute,
+  // starting with the default for this optimization level.
+  bool ShouldAddOptNone =
+      !codeGenOpts.DisableO0ImplyOptNone && codeGenOpts.OptimizationLevel == 0;
+  if (FD) {
+    ShouldAddOptNone &= !FD->hasAttr<MinSizeAttr>();
+    ShouldAddOptNone &= !FD->hasAttr<AlwaysInlineAttr>();
+    ShouldAddOptNone |= FD->hasAttr<OptimizeNoneAttr>();
+  }
+
+  if (ShouldAddOptNone) {
+    auto optNoneAttr = mlir::cir::OptNoneAttr::get(builder.getContext());
+    attrs.set(optNoneAttr.getMnemonic(), optNoneAttr);
+
+    // OptimizeNone implies noinline; we should not be inlining such functions.
+    auto noInlineAttr = mlir::cir::InlineAttr::get(
+        builder.getContext(), mlir::cir::InlineKind::NoInline);
+    attrs.set(noInlineAttr.getMnemonic(), noInlineAttr);
   }
 
   f.setExtraAttrsAttr(mlir::cir::ExtraFuncAttributesAttr::get(

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerAttrToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerAttrToLLVMIR.cpp
@@ -67,6 +67,8 @@ public:
             llvmFunc->addFnAttr(llvm::Attribute::InlineHint);
           else
             llvm_unreachable("Unknown inline kind");
+        } else if (attr.getValue().dyn_cast<mlir::cir::OptNoneAttr>()) {
+          llvmFunc->addFnAttr(llvm::Attribute::OptimizeNone);
         }
       }
     }

--- a/clang/test/CIR/CodeGen/optnone.cpp
+++ b/clang/test/CIR/CodeGen/optnone.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -O0 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR-O0
+// RUN: %clang_cc1 -O0 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM-O0
+
+// RUN: %clang_cc1 -O2 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t2.cir
+// RUN: FileCheck --input-file=%t2.cir %s -check-prefix=CIR-O2
+// RUN: %clang_cc1 -O2 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o %t2.ll
+// RUN: FileCheck --input-file=%t2.ll %s -check-prefix=LLVM-O2
+
+int s0(int a, int b) {
+  int x = a + b;
+  if (x > 0)
+    x = 0;
+  else
+    x = 1;
+  return x;
+}
+
+// CIR-O0:   cir.func @_Z2s0ii(%arg0:{{.*}}, %arg1:{{.*}} -> {{.*}} extra( {inline = #cir.inline<no>, optnone = #cir.optnone} )
+// CIR-O2-NOT:   cir.func @_Z2s0ii(%arg0:{{.*}}, %arg1:{{.*}} -> {{.*}} optnone
+
+// LLVM-O0: define i32 @_Z2s0ii(i32 %0, i32 %1) #[[#ATTR:]]
+// LLVM-O0: attributes #[[#ATTR]] = { noinline optnone }
+// LLVM-O2-NOT: attributes #[[#]] = { noinline optnone }


### PR DESCRIPTION
Summary:
Setting the Optnone attribute for CIR functions and progating it all the way down to LLVM IR for those not supposed to be optimized.