### PR TITLE
[CIR][CIRGen][Lowering] Implement CIR void type

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -456,7 +456,7 @@ def TernaryOp : CIR_Op<"ternary",
   let arguments = (ins CIR_BoolType:$cond);
   let regions = (region SizedRegion<1>:$trueRegion,
                         SizedRegion<1>:$falseRegion);
-  let results = (outs AnyType:$result);
+  let results = (outs Optional<AnyType>:$result);
 
   let skipDefaultBuilders = 1;
   let builders = [
@@ -473,7 +473,7 @@ def TernaryOp : CIR_Op<"ternary",
     `(` $cond `,`
       `true` $trueRegion `,`
       `false` $falseRegion
-    `)` `:` type($result) attr-dict
+    `)` `:` functional-type(operands, results) attr-dict
   }];
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -224,10 +224,21 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Void type
+//===----------------------------------------------------------------------===//
+
+def CIR_VoidType : CIR_Type<"Void", "void"> {
+  let summary = "CIR void type";
+  let description = [{
+    The `!cir.void` type represents the C/C++ `void` type.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // One type to bind them all
 //===----------------------------------------------------------------------===//
 
 def CIR_AnyCIRType : AnyTypeOf<[CIR_PointerType, CIR_BoolType, CIR_StructType,
-                                CIR_ArrayType, CIR_FuncType]>;
+                                CIR_ArrayType, CIR_FuncType, CIR_VoidType]>;
 
 #endif // MLIR_CIR_DIALECT_CIR_TYPES

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -148,6 +148,8 @@ public:
   // Type helpers
   // ------------
   //
+  mlir::Type getVoidTy() { return typeCache.VoidTy; }
+
   mlir::Type getSInt8Ty() { return typeCache.SInt8Ty; }
   mlir::Type getSInt16Ty() { return typeCache.SInt16Ty; }
   mlir::Type getSInt32Ty() { return typeCache.SInt32Ty; }
@@ -195,6 +197,10 @@ public:
                                       unsigned addressSpace = 0) {
     assert(!UnimplementedFeature::addressSpace() && "NYI");
     return mlir::cir::PointerType::get(getContext(), ty);
+  }
+
+  mlir::cir::PointerType getVoidPtrTy(unsigned AddrSpace = 0) {
+    return typeCache.VoidPtrTy;
   }
 
   //
@@ -402,6 +408,10 @@ public:
 
   mlir::Value createBoolToInt(mlir::Value src, mlir::Type newTy) {
     return createCast(mlir::cir::CastKind::bool_to_int, src, newTy);
+  }
+
+  mlir::Value createBitcast(mlir::Value src, mlir::Type newTy) {
+    return createCast(mlir::cir::CastKind::bitcast, src, newTy);
   }
 };
 

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -395,13 +395,15 @@ RValue CIRGenFunction::buildCall(const CIRGenFunctionInfo &CallInfo,
                "swift NYI");
 
         // We might have to widen integers, but we should never truncate.
-        assert(ArgInfo.getCoerceToType() == V.getType() && "widening NYI");
+        if (ArgInfo.getCoerceToType() != V.getType() &&
+            V.getType().isa<mlir::cir::IntType>())
+          llvm_unreachable("NYI");
 
         // If the argument doesn't match, perform a bitcast to coerce it. This
         // can happen due to trivial type mismatches.
         if (FirstCIRArg < CIRFuncTy.getNumInputs() &&
             V.getType() != CIRFuncTy.getInput(FirstCIRArg))
-          assert(false && "Shouldn't have to bitcast anything yet");
+          V = builder.createBitcast(V, CIRFuncTy.getInput(FirstCIRArg));
 
         CIRCallArgs[FirstCIRArg] = V;
         break;

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -13,6 +13,7 @@
 #include "CIRGenFunction.h"
 #include "clang/AST/StmtCXX.h"
 #include "clang/AST/StmtVisitor.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "llvm/ADT/ScopeExit.h"
 
 using namespace clang;
@@ -158,7 +159,6 @@ static mlir::LogicalResult buildBodyAndFallthrough(
 
 mlir::cir::CallOp CIRGenFunction::buildCoroIDBuiltinCall(mlir::Location loc,
                                                          mlir::Value nullPtr) {
-  auto int8PtrTy = builder.getUInt8PtrTy();
   auto int32Ty = builder.getUInt32Ty();
 
   auto &TI = CGM.getASTContext().getTargetInfo();
@@ -171,7 +171,7 @@ mlir::cir::CallOp CIRGenFunction::buildCoroIDBuiltinCall(mlir::Location loc,
     fnOp = CGM.createCIRFunction(
         loc, CGM.builtinCoroId,
         builder.getType<mlir::cir::FuncType>(
-            mlir::TypeRange{int32Ty, int8PtrTy, int8PtrTy, int8PtrTy},
+            mlir::TypeRange{int32Ty, VoidPtrTy, VoidPtrTy, VoidPtrTy},
             mlir::TypeRange{int32Ty}),
         /*FD=*/nullptr);
     assert(fnOp && "should always succeed");
@@ -211,7 +211,6 @@ CIRGenFunction::buildCoroAllocBuiltinCall(mlir::Location loc) {
 mlir::cir::CallOp
 CIRGenFunction::buildCoroBeginBuiltinCall(mlir::Location loc,
                                           mlir::Value coroframeAddr) {
-  auto int8PtrTy = builder.getUInt8PtrTy();
   auto int32Ty = builder.getUInt32Ty();
   mlir::Operation *builtin = CGM.getGlobalValue(CGM.builtinCoroBegin);
 
@@ -220,7 +219,7 @@ CIRGenFunction::buildCoroBeginBuiltinCall(mlir::Location loc,
     fnOp = CGM.createCIRFunction(
         loc, CGM.builtinCoroBegin,
         builder.getType<mlir::cir::FuncType>(
-            mlir::TypeRange{int32Ty, int8PtrTy}, mlir::TypeRange{int8PtrTy}),
+            mlir::TypeRange{int32Ty, VoidPtrTy}, mlir::TypeRange{VoidPtrTy}),
         /*FD=*/nullptr);
     assert(fnOp && "should always succeed");
     fnOp.setBuiltinAttr(mlir::UnitAttr::get(builder.getContext()));
@@ -234,7 +233,6 @@ CIRGenFunction::buildCoroBeginBuiltinCall(mlir::Location loc,
 
 mlir::cir::CallOp CIRGenFunction::buildCoroEndBuiltinCall(mlir::Location loc,
                                                           mlir::Value nullPtr) {
-  auto int8PtrTy = builder.getUInt8PtrTy();
   auto boolTy = builder.getBoolTy();
   mlir::Operation *builtin = CGM.getGlobalValue(CGM.builtinCoroEnd);
 
@@ -242,7 +240,7 @@ mlir::cir::CallOp CIRGenFunction::buildCoroEndBuiltinCall(mlir::Location loc,
   if (!builtin) {
     fnOp = CGM.createCIRFunction(
         loc, CGM.builtinCoroEnd,
-        builder.getType<mlir::cir::FuncType>(mlir::TypeRange{int8PtrTy, boolTy},
+        builder.getType<mlir::cir::FuncType>(mlir::TypeRange{VoidPtrTy, boolTy},
                                              mlir::TypeRange{boolTy}),
         /*FD=*/nullptr);
     assert(fnOp && "should always succeed");
@@ -257,7 +255,7 @@ mlir::cir::CallOp CIRGenFunction::buildCoroEndBuiltinCall(mlir::Location loc,
 mlir::LogicalResult
 CIRGenFunction::buildCoroutineBody(const CoroutineBodyStmt &S) {
   auto openCurlyLoc = getLoc(S.getBeginLoc());
-  auto nullPtrCst = builder.getNullPtr(builder.getUInt8PtrTy(), openCurlyLoc);
+  auto nullPtrCst = builder.getNullPtr(VoidPtrTy, openCurlyLoc);
 
   CurFn.setCoroutineAttr(mlir::UnitAttr::get(builder.getContext()));
   auto coroId = buildCoroIDBuiltinCall(openCurlyLoc, nullPtrCst);
@@ -276,7 +274,9 @@ CIRGenFunction::buildCoroutineBody(const CoroutineBodyStmt &S) {
                        /*ArraySize=*/nullptr);
 
   auto storeAddr = coroFrame.getPointer();
-  builder.create<mlir::cir::StoreOp>(openCurlyLoc, nullPtrCst, storeAddr);
+  auto coroPtrTy = storeAddr.getType().dyn_cast<mlir::cir::PointerType>();
+  auto temp = builder.createBitcast(nullPtrCst, coroPtrTy.getPointee());
+  builder.create<mlir::cir::StoreOp>(openCurlyLoc, temp, storeAddr);
   builder.create<mlir::cir::IfOp>(openCurlyLoc, coroAlloc.getResult(0),
                                   /*withElseRegion=*/false,
                                   /*thenBuilder=*/

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -313,7 +313,7 @@ void CIRGenFunction::LexicalScopeGuard::cleanup() {
     // If we are on a coroutine, add the coro_end builtin call.
     if (CGF.CurFn.getCoroutine())
       CGF.buildCoroEndBuiltinCall(
-          loc, builder.getNullPtr(builder.getUInt8PtrTy(), loc));
+          loc, builder.getNullPtr(builder.getVoidPtrTy(), loc));
 
     if (CGF.FnRetCIRTy.has_value()) {
       // If there's anything to return, load it first.

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -115,7 +115,10 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
   UInt64Ty =
       ::mlir::cir::IntType::get(builder.getContext(), 64, /*isSigned=*/false);
 
-  VoidTy = UInt8Ty;
+  VoidTy = ::mlir::cir::VoidType::get(builder.getContext());
+
+  // Initialize CIR pointer types cache.
+  VoidPtrTy = ::mlir::cir::PointerType::get(builder.getContext(), VoidTy);
 
   // TODO: HalfTy
   // TODO: BFloatTy

--- a/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
@@ -50,10 +50,8 @@ struct CIRGenTypeCache {
   };
 
   /// void* in address space 0
-  union {
-    mlir::cir::PointerType VoidPtrTy;
-    mlir::cir::PointerType UInt8PtrTy;
-  };
+  mlir::cir::PointerType VoidPtrTy;
+  mlir::cir::PointerType UInt8PtrTy;
 
   /// void** in address space 0
   union {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -690,9 +690,10 @@ void TernaryOp::build(OpBuilder &builder, OperationState &result, Value cond,
   falseBuilder(builder, result.location);
 
   auto yield = dyn_cast<YieldOp>(block->getTerminator());
-  assert((yield && yield.getNumOperands() == 1) &&
-         "expected cir.yield terminator with one operand");
-  result.addTypes(TypeRange{yield.getOperand(0).getType()});
+  assert((yield && yield.getNumOperands() <= 1) &&
+         "expected zero or one result type");
+  if (yield.getNumOperands() == 1)
+    result.addTypes(TypeRange{yield.getOperandTypes().front()});
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -66,14 +66,14 @@ void yo() {
 // CHECK: cir.func @_Z2yov() {
 // CHECK:   %0 = cir.alloca !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>, ["ext"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.alloca !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>, ["ext2", init] {alignment = 8 : i64}
-// CHECK:   %2 = cir.const(#cir.const_struct<{#cir.int<1000070000> : !u32i,#cir.null : !cir.ptr<!u8i>,#cir.int<0> : !u64i}> : !ty_22struct2EYo22) : !ty_22struct2EYo22
+// CHECK:   %2 = cir.const(#cir.const_struct<{#cir.int<1000070000> : !u32i,#cir.null : !cir.ptr<!cir.void>,#cir.int<0> : !u64i}> : !ty_22struct2EYo22) : !ty_22struct2EYo22
 // CHECK:   cir.store %2, %0 : !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>
 // CHECK:   %3 = "cir.struct_element_addr"(%1) {member_name = "type"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u32i>
 // CHECK:   %4 = cir.const(#cir.int<1000066001> : !u32i) : !u32i
 // CHECK:   cir.store %4, %3 : !u32i, cir.ptr <!u32i>
-// CHECK:   %5 = "cir.struct_element_addr"(%1) {member_name = "next"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!cir.ptr<!u8i>>
-// CHECK:   %6 = cir.cast(bitcast, %0 : !cir.ptr<!ty_22struct2EYo22>), !cir.ptr<!u8i>
-// CHECK:   cir.store %6, %5 : !cir.ptr<!u8i>, cir.ptr <!cir.ptr<!u8i>>
+// CHECK:   %5 = "cir.struct_element_addr"(%1) {member_name = "next"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!cir.ptr<!cir.void>>
+// CHECK:   %6 = cir.cast(bitcast, %0 : !cir.ptr<!ty_22struct2EYo22>), !cir.ptr<!cir.void>
+// CHECK:   cir.store %6, %5 : !cir.ptr<!cir.void>, cir.ptr <!cir.ptr<!cir.void>>
 // CHECK:   %7 = "cir.struct_element_addr"(%1) {member_name = "createFlags"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u64i>
 // CHECK:   %8 = cir.const(#cir.int<0> : !u64i) : !u64i
 // CHECK:   cir.store %8, %7 : !u64i, cir.ptr <!u64i>

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -44,8 +44,8 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4) {
 
   long l = (long)(void*)x4; // Must sign extend before casting to pointer
   // CHECK: %[[TMP:[0-9]+]] = cir.cast(integral, %{{[0-9]+}} : !s16i), !u64i
-  // CHECK: %[[TMP2:[0-9]+]] = cir.cast(int_to_ptr, %[[TMP]] : !u64i), !cir.ptr<!u8i>
-  // CHECK: %{{[0-9]+}} = cir.cast(ptr_to_int, %[[TMP2]] : !cir.ptr<!u8i>), !s64i
+  // CHECK: %[[TMP2:[0-9]+]] = cir.cast(int_to_ptr, %[[TMP]] : !u64i), !cir.ptr<!cir.void>
+  // CHECK: %{{[0-9]+}} = cir.cast(ptr_to_int, %[[TMP2]] : !cir.ptr<!cir.void>), !s64i
 
   return 0;
 }
@@ -55,22 +55,22 @@ bool cptr(void *d) {
   return x;
 }
 
-// CHECK: cir.func @_Z4cptrPv(%arg0: !cir.ptr<!u8i>
-// CHECK:   %0 = cir.alloca !cir.ptr<!u8i>, cir.ptr <!cir.ptr<!u8i>>, ["d", init] {alignment = 8 : i64}
+// CHECK: cir.func @_Z4cptrPv(%arg0: !cir.ptr<!cir.void>
+// CHECK:   %0 = cir.alloca !cir.ptr<!cir.void>, cir.ptr <!cir.ptr<!cir.void>>, ["d", init] {alignment = 8 : i64}
 
-// CHECK:   %3 = cir.load %0 : cir.ptr <!cir.ptr<!u8i>>, !cir.ptr<!u8i>
-// CHECK:   %4 = cir.cast(ptr_to_bool, %3 : !cir.ptr<!u8i>), !cir.bool
+// CHECK:   %3 = cir.load %0 : cir.ptr <!cir.ptr<!cir.void>>, !cir.ptr<!cir.void>
+// CHECK:   %4 = cir.cast(ptr_to_bool, %3 : !cir.ptr<!cir.void>), !cir.bool
 
 void call_cptr(void *d) {
   if (!cptr(d)) {
   }
 }
 
-// CHECK: cir.func @_Z9call_cptrPv(%arg0: !cir.ptr<!u8i>
-// CHECK:   %0 = cir.alloca !cir.ptr<!u8i>, cir.ptr <!cir.ptr<!u8i>>, ["d", init] {alignment = 8 : i64}
+// CHECK: cir.func @_Z9call_cptrPv(%arg0: !cir.ptr<!cir.void>
+// CHECK:   %0 = cir.alloca !cir.ptr<!cir.void>, cir.ptr <!cir.ptr<!cir.void>>, ["d", init] {alignment = 8 : i64}
 
 // CHECK:   cir.scope {
-// CHECK:     %1 = cir.load %0 : cir.ptr <!cir.ptr<!u8i>>, !cir.ptr<!u8i>
-// CHECK:     %2 = cir.call @_Z4cptrPv(%1) : (!cir.ptr<!u8i>) -> !cir.bool
+// CHECK:     %1 = cir.load %0 : cir.ptr <!cir.ptr<!cir.void>>, !cir.ptr<!cir.void>
+// CHECK:     %2 = cir.call @_Z4cptrPv(%1) : (!cir.ptr<!cir.void>) -> !cir.bool
 // CHECK:     %3 = cir.unary(not, %2) : !cir.bool, !cir.bool
 // CHECK:     cir.if %3 {

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -137,10 +137,10 @@ co_invoke_fn co_invoke;
 // CHECK: module {{.*}} {
 // CHECK-NEXT: cir.global external @_ZN5folly4coro9co_invokeE = #cir.zero : !ty_22struct2Efolly3A3Acoro3A3Aco_invoke_fn22
 
-// CHECK: cir.func builtin private @__builtin_coro_id(!u32i, !cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>) -> !u32i
+// CHECK: cir.func builtin private @__builtin_coro_id(!u32i, !cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.ptr<!cir.void>) -> !u32i
 // CHECK: cir.func builtin private @__builtin_coro_alloc(!u32i) -> !cir.bool
 // CHECK: cir.func builtin private @__builtin_coro_size() -> !u64i
-// CHECK: cir.func builtin private @__builtin_coro_begin(!u32i, !cir.ptr<!u8i>) -> !cir.ptr<!u8i>
+// CHECK: cir.func builtin private @__builtin_coro_begin(!u32i, !cir.ptr<!cir.void>) -> !cir.ptr<!cir.void>
 
 using VoidTask = folly::coro::Task<void>;
 
@@ -153,12 +153,12 @@ VoidTask silly_task() {
 // Allocate promise.
 
 // CHECK: %[[#VoidTaskAddr:]] = cir.alloca ![[VoidTask]], {{.*}}, ["__retval"]
-// CHECK: %[[#SavedFrameAddr:]] = cir.alloca !cir.ptr<!u8i>, cir.ptr <!cir.ptr<!u8i>>, ["__coro_frame_addr"] {alignment = 8 : i64}
+// CHECK: %[[#SavedFrameAddr:]] = cir.alloca !cir.ptr<!cir.void>, cir.ptr <!cir.ptr<!cir.void>>, ["__coro_frame_addr"] {alignment = 8 : i64}
 // CHECK: %[[#VoidPromisseAddr:]] = cir.alloca ![[VoidPromisse]], {{.*}}, ["__promise"]
 
 // Get coroutine id with __builtin_coro_id.
 
-// CHECK: %[[#NullPtr:]] = cir.const(#cir.null : !cir.ptr<!u8i>) : !cir.ptr<!u8i>
+// CHECK: %[[#NullPtr:]] = cir.const(#cir.null : !cir.ptr<!cir.void>) : !cir.ptr<!cir.void>
 // CHECK: %[[#Align:]] = cir.const(#cir.int<16> : !u32i) : !u32i
 // CHECK: %[[#CoroId:]] = cir.call @__builtin_coro_id(%[[#Align]], %[[#NullPtr]], %[[#NullPtr]], %[[#NullPtr]])
 
@@ -166,13 +166,13 @@ VoidTask silly_task() {
 // call __builtin_coro_begin for the final coroutine frame address.
 
 // CHECK: %[[#ShouldAlloc:]] = cir.call @__builtin_coro_alloc(%[[#CoroId]]) : (!u32i) -> !cir.bool
-// CHECK: cir.store %[[#NullPtr]], %[[#SavedFrameAddr]] : !cir.ptr<!u8i>, cir.ptr <!cir.ptr<!u8i>>
+// CHECK: cir.store %[[#NullPtr]], %[[#SavedFrameAddr]] : !cir.ptr<!cir.void>, cir.ptr <!cir.ptr<!cir.void>>
 // CHECK: cir.if %[[#ShouldAlloc]] {
 // CHECK:   %[[#CoroSize:]] = cir.call @__builtin_coro_size() : () -> !u64i
-// CHECK:   %[[#AllocAddr:]] = cir.call @_Znwm(%[[#CoroSize]]) : (!u64i) -> !cir.ptr<!u8i>
-// CHECK:   cir.store %[[#AllocAddr]], %[[#SavedFrameAddr]] : !cir.ptr<!u8i>, cir.ptr <!cir.ptr<!u8i>>
+// CHECK:   %[[#AllocAddr:]] = cir.call @_Znwm(%[[#CoroSize]]) : (!u64i) -> !cir.ptr<!cir.void>
+// CHECK:   cir.store %[[#AllocAddr]], %[[#SavedFrameAddr]] : !cir.ptr<!cir.void>, cir.ptr <!cir.ptr<!cir.void>>
 // CHECK: }
-// CHECK: %[[#Load0:]] = cir.load %[[#SavedFrameAddr]] : cir.ptr <!cir.ptr<!u8i>>, !cir.ptr<!u8i>
+// CHECK: %[[#Load0:]] = cir.load %[[#SavedFrameAddr]] : cir.ptr <!cir.ptr<!cir.void>>, !cir.ptr<!cir.void>
 // CHECK: %[[#CoroFrameAddr:]] = cir.call @__builtin_coro_begin(%[[#CoroId]], %[[#Load0]])
 
 // Call promise.get_return_object() to retrieve the task object.
@@ -264,7 +264,7 @@ VoidTask silly_task() {
 
 // Call builtin coro end and return
 
-// CHECK-NEXT: %[[#CoroEndArg0:]] = cir.const(#cir.null : !cir.ptr<!u8i>)
+// CHECK-NEXT: %[[#CoroEndArg0:]] = cir.const(#cir.null : !cir.ptr<!cir.void>)
 // CHECK-NEXT: %[[#CoroEndArg1:]] = cir.const(#false) : !cir.bool
 // CHECK-NEXT: = cir.call @__builtin_coro_end(%[[#CoroEndArg0]], %[[#CoroEndArg1]])
 

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -55,7 +55,7 @@ public:
 // CHECK:   cir.func private @_ZN1BD2Ev(!cir.ptr<![[ClassB]]>)
 
 // operator delete(void*) declaration
-// CHECK:   cir.func private @_ZdlPv(!cir.ptr<!u8i>)
+// CHECK:   cir.func private @_ZdlPv(!cir.ptr<!cir.void>)
 
 // B dtor => @B::~B() #2
 // Calls dtor #1
@@ -66,8 +66,8 @@ public:
 // CHECK:     cir.store %arg0, %0 : !cir.ptr<![[ClassB]]>, cir.ptr <!cir.ptr<![[ClassB]]>>
 // CHECK:     %1 = cir.load %0 : cir.ptr <!cir.ptr<![[ClassB]]>>, !cir.ptr<![[ClassB]]>
 // CHECK:     cir.call @_ZN1BD2Ev(%1) : (!cir.ptr<![[ClassB]]>) -> ()
-// CHECK:     %2 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassB]]>), !cir.ptr<!u8i>
-// CHECK:     cir.call @_ZdlPv(%2) : (!cir.ptr<!u8i>) -> ()
+// CHECK:     %2 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassB]]>), !cir.ptr<!cir.void>
+// CHECK:     cir.call @_ZdlPv(%2) : (!cir.ptr<!cir.void>) -> ()
 // CHECK:     cir.return
 // CHECK:   }
 

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -20,8 +20,8 @@ void m(int a, int b) {
 // CHECK:   cir.store %arg1, %1 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK:   cir.scope {
 // CHECK:     %4 = cir.const(#cir.int<1> : !u64i) : !u64i
-// CHECK:     %5 = cir.call @_Znwm(%4) : (!u64i) -> !cir.ptr<!u8i>
-// CHECK:     %6 = cir.cast(bitcast, %5 : !cir.ptr<!u8i>), !cir.ptr<!ty_22struct2ES22>
+// CHECK:     %5 = cir.call @_Znwm(%4) : (!u64i) -> !cir.ptr<!cir.void>
+// CHECK:     %6 = cir.cast(bitcast, %5 : !cir.ptr<!cir.void>), !cir.ptr<!ty_22struct2ES22>
 // CHECK:     %7 = cir.load %0 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK:     %8 = cir.load %7 : cir.ptr <!s32i>, !s32i
 // CHECK:     %9 = cir.load %1 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -21,7 +21,7 @@ void init(unsigned numImages) {
   }
 }
 
-// CHECK: !ty_22struct2Etriple22 = !cir.struct<"struct.triple", !u32i, !cir.ptr<!u8i>, !u32i>
+// CHECK: !ty_22struct2Etriple22 = !cir.struct<"struct.triple", !u32i, !cir.ptr<!cir.void>, !u32i>
 // CHECK: !ty_22class2Estd3A3Avector22 = !cir.struct<"class.std::vector", !cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>>
 // CHECK: !ty_22struct2E__vector_iterator22 = !cir.struct<"struct.__vector_iterator", !cir.ptr<!ty_22struct2Etriple22>>
 
@@ -64,7 +64,7 @@ void init(unsigned numImages) {
 // CHECK:         %15 = "cir.struct_element_addr"(%13) {member_name = "type"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!u32i>
 // CHECK:         %16 = cir.const(#cir.int<1000024002> : !u32i) : !u32i
 // CHECK:         cir.store %16, %15 : !u32i, cir.ptr <!u32i>
-// CHECK:         %17 = "cir.struct_element_addr"(%13) {member_name = "next"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!cir.ptr<!u8i>>
+// CHECK:         %17 = "cir.struct_element_addr"(%13) {member_name = "next"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!cir.ptr<!cir.void>>
 // CHECK:         %18 = "cir.struct_element_addr"(%13) {member_name = "image"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!u32i>
 // CHECK:         %19 = cir.load %7 : cir.ptr <!cir.ptr<!ty_22struct2Etriple22>>, !cir.ptr<!ty_22struct2Etriple22>
 // CHECK:         %20 = cir.call @_ZN6tripleaSEOS_(%19, %13) : (!cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!ty_22struct2Etriple22>

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -29,10 +29,10 @@ void yoyo(incomplete *i) {}
 //      CHECK: !ty_22struct2Eincomplete22 = !cir.struct<"struct.incomplete", incomplete
 //      CHECK: !ty_22struct2EBar22 = !cir.struct<"struct.Bar", !s32i, !s8i>
 
-//      CHECK: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo", !s32i, !s8i, !ty_22struct2EBar22>
-//      CHECK: !ty_22struct2EMandalore22 = !cir.struct<"struct.Mandalore", !u32i, !cir.ptr<!u8i>, !s32i, #cir.recdecl.ast>
+//      CHECK: !ty_22struct2EMandalore22 = !cir.struct<"struct.Mandalore", !u32i, !cir.ptr<!cir.void>, !s32i, #cir.recdecl.ast>
 //      CHECK: !ty_22class2EAdv22 = !cir.struct<"class.Adv", !ty_22struct2EMandalore22>
-//      CHECK: !ty_22struct2EEntry22 = !cir.struct<"struct.Entry", !cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!u8i>)>>>
+//      CHECK: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo", !s32i, !s8i, !ty_22struct2EBar22>
+//      CHECK: !ty_22struct2EEntry22 = !cir.struct<"struct.Entry", !cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!cir.void>)>>>
 
 //      CHECK: cir.func linkonce_odr @_ZN3Bar6methodEv(%arg0: !cir.ptr<!ty_22struct2EBar22>
 // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22struct2EBar22>, cir.ptr <!cir.ptr<!ty_22struct2EBar22>>, ["this", init] {alignment = 8 : i64}
@@ -102,9 +102,9 @@ void m() { Adv C; }
 // CHECK:     %3 = "cir.struct_element_addr"(%2) {member_name = "w"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!u32i>
 // CHECK:     %4 = cir.const(#cir.int<1000024001> : !u32i) : !u32i
 // CHECK:     cir.store %4, %3 : !u32i, cir.ptr <!u32i>
-// CHECK:     %5 = "cir.struct_element_addr"(%2) {member_name = "n"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!cir.ptr<!u8i>>
-// CHECK:     %6 = cir.const(#cir.null : !cir.ptr<!u8i>) : !cir.ptr<!u8i>
-// CHECK:     cir.store %6, %5 : !cir.ptr<!u8i>, cir.ptr <!cir.ptr<!u8i>>
+// CHECK:     %5 = "cir.struct_element_addr"(%2) {member_name = "n"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!cir.ptr<!cir.void>>
+// CHECK:     %6 = cir.const(#cir.null : !cir.ptr<!cir.void>) : !cir.ptr<!cir.void>
+// CHECK:     cir.store %6, %5 : !cir.ptr<!cir.void>, cir.ptr <!cir.ptr<!cir.void>>
 // CHECK:     %7 = "cir.struct_element_addr"(%2) {member_name = "d"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!s32i>
 // CHECK:     %8 = cir.const(#cir.int<0> : !s32i) : !s32i
 // CHECK:     cir.store %8, %7 : !s32i, cir.ptr <!s32i>
@@ -147,4 +147,4 @@ void ppp() { Entry x; }
 
 // CHECK: cir.func linkonce_odr @_ZN5EntryC2Ev(%arg0: !cir.ptr<!ty_22struct2EEntry22>
 
-// CHECK: = "cir.struct_element_addr"(%1) {member_name = "procAddr"} : (!cir.ptr<!ty_22struct2EEntry22>) -> !cir.ptr<!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!u8i>)>>>
+// CHECK: = "cir.struct_element_addr"(%1) {member_name = "procAddr"} : (!cir.ptr<!ty_22struct2EEntry22>) -> !cir.ptr<!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!cir.void>)>>>

--- a/clang/test/CIR/CodeGen/ternary.cpp
+++ b/clang/test/CIR/CodeGen/ternary.cpp
@@ -18,7 +18,7 @@ int x(int y) {
 // CHECK:     }, false {
 // CHECK:       %7 = cir.const(#cir.int<5> : !s32i) : !s32i
 // CHECK:       cir.yield %7 : !s32i
-// CHECK:     }) : !s32i
+// CHECK:     }) : (!cir.bool) -> !s32i
 // CHECK:     cir.store %5, %1 : !s32i, cir.ptr <!s32i>
 // CHECK:     %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
 // CHECK:     cir.return %6 : !s32i
@@ -43,16 +43,14 @@ void m(APIType api) {
 // CHECK:    %3 = cir.const(#cir.int<0> : !u32i) : !u32i
 // CHECK:    %4 = cir.cast(integral, %3 : !u32i), !s32i
 // CHECK:    %5 = cir.cmp(eq, %2, %4) : !s32i, !cir.bool
-// CHECK:    %6 = cir.ternary(%5, true {
-// CHECK:      %7 = cir.const(#cir.int<0> : !s32i) : !s32i
-// CHECK:      %8 = cir.const(#cir.int<0> : !u8i) : !u8i
-// CHECK:      cir.yield %8 : !u8i
+// CHECK:    cir.ternary(%5, true {
+// CHECK:      %6 = cir.const(#cir.int<0> : !s32i) : !s32i
+// CHECK:      cir.yield
 // CHECK:    }, false {
-// CHECK:      %7 = cir.get_global @".str" : cir.ptr <!cir.array<!s8i x 7>>
-// CHECK:      %8 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<!s8i x 7>>), !cir.ptr<!s8i>
-// CHECK:      cir.call @_Z3obaPKc(%8) : (!cir.ptr<!s8i>) -> ()
-// CHECK:      %9 = cir.const(#cir.int<0> : !u8i) : !u8i
-// CHECK:      cir.yield %9 : !u8i
-// CHECK:    }) : !u8i
+// CHECK:      %6 = cir.get_global @".str" : cir.ptr <!cir.array<!s8i x 7>>
+// CHECK:      %7 = cir.cast(array_to_ptrdecay, %6 : !cir.ptr<!cir.array<!s8i x 7>>), !cir.ptr<!s8i>
+// CHECK:      cir.call @_Z3obaPKc(%7) : (!cir.ptr<!s8i>) -> ()
+// CHECK:      cir.yield
+// CHECK:    }) : (!cir.bool) -> ()
 // CHECK:    cir.return
 // CHECK:  }

--- a/clang/test/CIR/IR/ternary.cir
+++ b/clang/test/CIR/IR/ternary.cir
@@ -9,7 +9,7 @@ module  {
     }, false {
       %b = cir.const(#cir.int<1> : !u32i) : !u32i
       cir.yield %b : !u32i
-    }) : !u32i
+    }) : (!cir.bool) -> !u32i
     cir.return %0 : !u32i
   }
 }
@@ -23,7 +23,7 @@ module  {
 // CHECK:   }, false {
 // CHECK:     %1 = cir.const(#cir.int<1> : !u32i) : !u32i
 // CHECK:     cir.yield %1 : !u32i
-// CHECK:   }) : !u32i
+// CHECK:   }) : (!cir.bool) -> !u32i
 // CHECK:   cir.return %0 : !u32i
 // CHECK: }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #118
* __->__ #117

Implements a custom `!cir.void` type to represent absence of value and
support for void pointers (`!cir.ptr<!cir.void>`).

The `VoidPtrTy` and `UInt8PtrTy` type cache variables no longer share a
union, as they cannot be considered the same in terms of CIR types
(`!cir.ptr<u8i>` is not equivalent to `!cir.ptr<!cir.void>`).

Due to this pointer differentiation, improper occurrences of
`!cir.int<u, 8>` is replaced with `!cir.void` where applicable.
This was mostly done in coroutine-related builtin calls.

Return values for `cir.ternary` operations are now optional allowing
`!cir.void` return types. Consequentially, `!cir.yield` operations with
no operands are allowed within ternary regions.