### PR TITLE
[CIR] Restrict FuncType to exactly one return type

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1458,7 +1458,9 @@ def FuncOp : CIR_Op<"func", [
     /// Returns the results types that the callable region produces when
     /// executed.
     ArrayRef<Type> getCallableResults() {
-      return getFunctionType().getResults();
+      if (::llvm::isa<cir::VoidType>(getFunctionType().getReturnType()))
+        return {};
+      return getFunctionType().getReturnTypes();
     }
 
     /// Returns the argument attributes for all callable region arguments or
@@ -1477,7 +1479,7 @@ def FuncOp : CIR_Op<"func", [
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
     /// Returns the result types of this function.
-    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getReturnTypes(); }
 
     /// Hook for OpTrait::FunctionOpInterfaceTrait, called after verifying that
     /// the 'type' attribute is present and checks if it holds a function type.
@@ -1527,14 +1529,16 @@ def CallOp : CIR_Op<"call",
     OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
       $_state.addOperands(operands);
       $_state.addAttribute("callee", SymbolRefAttr::get(callee));
-      $_state.addTypes(callee.getFunctionType().getResults());
+      if (!callee.getFunctionType().isVoid())
+        $_state.addTypes(callee.getFunctionType().getReturnType());
     }]>,
     OpBuilder<(ins "Value":$ind_target,
                "FuncType":$fn_type,
                CArg<"ValueRange", "{}">:$operands), [{
       $_state.addOperands(ValueRange{ind_target});
       $_state.addOperands(operands);
-      $_state.addTypes(fn_type.getResults());
+      if (!fn_type.isVoid())
+        $_state.addTypes(fn_type.getReturnType());
     }]>];
 
   let extraClassDeclaration = [{

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -184,18 +184,19 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
     ```
   }];
 
-  let parameters = (ins ArrayRefParameter<"Type">:$inputs,
-                        ArrayRefParameter<"Type">:$results, "bool":$varArg);
+  let parameters = (ins ArrayRefParameter<"Type">:$inputs, "Type":$returnType,
+                        "bool":$varArg);
   let assemblyFormat = [{
-    `<` $results ` ` `(` custom<FuncTypeArgs>($inputs, $varArg) `>`
+    `<` $returnType ` ` `(` custom<FuncTypeArgs>($inputs, $varArg) `>`
   }];
 
   let skipDefaultBuilders = 1;
 
   let builders = [
-    TypeBuilder<(ins CArg<"TypeRange">:$inputs, CArg<"TypeRange">:$results,
-                 CArg<"bool", "false">:$isVarArg), [{
-      return $_get($_ctxt, llvm::to_vector(inputs), llvm::to_vector(results), isVarArg);
+    TypeBuilderWithInferredContext<(ins
+      "ArrayRef<Type>":$inputs, "Type":$returnType,
+      CArg<"bool", "false">:$isVarArg), [{
+      return $_get(returnType.getContext(), inputs, returnType, isVarArg);
     }]>
   ];
 
@@ -211,11 +212,12 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
     /// Returns the number of arguments to the function.
     unsigned getNumInputs() const { return getInputs().size(); }
 
-    /// Returns the `i`th result operand type. Asserts if out of bounds.
-    Type getResult(unsigned i) const { return getResults()[i]; }
+    /// Returns the result type of the function as an ArrayRef, enabling better
+    /// integration with generic MLIR utilities.
+    ArrayRef<Type> getReturnTypes() const;
 
-    /// Returns the number of results to the function.
-    unsigned getNumResults() const { return getResults().size(); }
+    /// Returns whether the function is returns void.
+    bool isVoid() const;
 
     /// Returns a clone of this function type with the given argument
     /// and result types.

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -180,8 +180,7 @@ public:
   mlir::Type getVirtualFnPtrType(bool isVarArg = false) {
     // FIXME: replay LLVM codegen for now, perhaps add a vtable ptr special
     // type so it's a bit more clear and C++ idiomatic.
-    auto fnTy =
-        mlir::cir::FuncType::get(getContext(), {}, {getUInt32Ty()}, isVarArg);
+    auto fnTy = mlir::cir::FuncType::get({}, getUInt32Ty(), isVarArg);
     assert(!UnimplementedFeature::isVarArg());
     return getPointerTo(getPointerTo(fnTy));
   }

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -21,6 +21,7 @@
 #include "clang/AST/GlobalDecl.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -255,9 +256,9 @@ mlir::cir::FuncType CIRGenTypes::GetFunctionType(const CIRGenFunctionInfo &FI) {
   (void)Erased;
   assert(Erased && "Not in set?");
 
-  return mlir::cir::FuncType::get(&getMLIRContext(), ArgTypes,
-                                  (resultType ? resultType : mlir::TypeRange{}),
-                                  FI.isVariadic());
+  return mlir::cir::FuncType::get(
+      ArgTypes, (resultType ? resultType : Builder.getVoidTy()),
+      FI.isVariadic());
 }
 
 mlir::cir::FuncType CIRGenTypes::GetFunctionTypeForVTable(GlobalDecl GD) {

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -170,9 +170,8 @@ mlir::cir::CallOp CIRGenFunction::buildCoroIDBuiltinCall(mlir::Location loc,
   if (!builtin) {
     fnOp = CGM.createCIRFunction(
         loc, CGM.builtinCoroId,
-        builder.getType<mlir::cir::FuncType>(
-            mlir::TypeRange{int32Ty, VoidPtrTy, VoidPtrTy, VoidPtrTy},
-            mlir::TypeRange{int32Ty}),
+        mlir::cir::FuncType::get({int32Ty, VoidPtrTy, VoidPtrTy, VoidPtrTy},
+                                 int32Ty),
         /*FD=*/nullptr);
     assert(fnOp && "should always succeed");
     fnOp.setBuiltinAttr(mlir::UnitAttr::get(builder.getContext()));
@@ -196,8 +195,7 @@ CIRGenFunction::buildCoroAllocBuiltinCall(mlir::Location loc) {
   if (!builtin) {
     fnOp = CGM.createCIRFunction(
         loc, CGM.builtinCoroAlloc,
-        builder.getType<mlir::cir::FuncType>(mlir::TypeRange{int32Ty},
-                                             mlir::TypeRange{boolTy}),
+        mlir::cir::FuncType::get({int32Ty}, boolTy),
         /*FD=*/nullptr);
     assert(fnOp && "should always succeed");
     fnOp.setBuiltinAttr(mlir::UnitAttr::get(builder.getContext()));
@@ -218,8 +216,8 @@ CIRGenFunction::buildCoroBeginBuiltinCall(mlir::Location loc,
   if (!builtin) {
     fnOp = CGM.createCIRFunction(
         loc, CGM.builtinCoroBegin,
-        builder.getType<mlir::cir::FuncType>(
-            mlir::TypeRange{int32Ty, VoidPtrTy}, mlir::TypeRange{VoidPtrTy}),
+        mlir::cir::FuncType::get({int32Ty, VoidPtrTy},
+                                 VoidPtrTy),
         /*FD=*/nullptr);
     assert(fnOp && "should always succeed");
     fnOp.setBuiltinAttr(mlir::UnitAttr::get(builder.getContext()));
@@ -240,8 +238,7 @@ mlir::cir::CallOp CIRGenFunction::buildCoroEndBuiltinCall(mlir::Location loc,
   if (!builtin) {
     fnOp = CGM.createCIRFunction(
         loc, CGM.builtinCoroEnd,
-        builder.getType<mlir::cir::FuncType>(mlir::TypeRange{VoidPtrTy, boolTy},
-                                             mlir::TypeRange{boolTy}),
+        mlir::cir::FuncType::get({VoidPtrTy, boolTy}, boolTy),
         /*FD=*/nullptr);
     assert(fnOp && "should always succeed");
     fnOp.setBuiltinAttr(mlir::UnitAttr::get(builder.getContext()));

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -345,28 +345,16 @@ static mlir::LogicalResult checkReturnAndFunction(ReturnOp op,
   if (op.getNumOperands() > 1)
     return op.emitOpError() << "expects at most 1 return operand";
 
-  // The operand number and types must match the function signature.
-  const auto &results = function.getFunctionType().getResults();
-  if (op.getNumOperands() != results.size())
-    return op.emitOpError()
-           << "does not return the same number of values ("
-           << op.getNumOperands() << ") as the enclosing function ("
-           << results.size() << ")";
+  // Ensure returned type matches the function signature.
+  auto expectedTy = function.getFunctionType().getReturnType();
+  auto actualTy =
+      (op.getNumOperands() == 0 ? mlir::cir::VoidType::get(op.getContext())
+                                : op.getOperand(0).getType());
+  if (actualTy != expectedTy)
+    return op.emitOpError() << "returns " << actualTy
+                            << " but enclosing function returns " << expectedTy;
 
-  // If the operation does not have an input, we are done.
-  if (!op.hasOperand())
-    return mlir::success();
-
-  auto inputType = *op.operand_type_begin();
-  auto resultType = results.front();
-
-  // Check that the result type of the function matches the operand type.
-  if (inputType == resultType)
-    return mlir::success();
-
-  return op.emitError() << "type of return operand (" << inputType
-                        << ") doesn't match function result type ("
-                        << resultType << ")";
+  return mlir::success();
 }
 
 mlir::LogicalResult ReturnOp::verify() {
@@ -1320,9 +1308,8 @@ LogicalResult cir::VTableAddrPointOp::verify() {
     return success();
 
   auto resultType = getAddr().getType();
-  auto fnTy = mlir::cir::FuncType::get(
-      getContext(), {},
-      {mlir::cir::IntType::get(getContext(), 32, /*isSigned=*/false)});
+  auto intTy = mlir::cir::IntType::get(getContext(), 32, /*isSigned=*/false);
+  auto fnTy = mlir::cir::FuncType::get({}, intTy);
 
   auto resTy = mlir::cir::PointerType::get(
       getContext(), mlir::cir::PointerType::get(getContext(), fnTy));
@@ -1416,10 +1403,17 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
   for (auto &arg : arguments)
     argTypes.push_back(arg.type);
 
+  if (resultTypes.size() > 1)
+    return parser.emitError(loc, "functions only supports zero or one results");
+
+  // Fetch return type or set it to void if empty/ommited.
+  mlir::Type returnType =
+      (resultTypes.empty() ? mlir::cir::VoidType::get(builder.getContext())
+                           : resultTypes.front());
+
   // Build the function type.
   auto fnType = mlir::cir::FuncType::getChecked(
-      parser.getEncodedSourceLoc(loc), parser.getContext(),
-      mlir::TypeRange(argTypes), mlir::TypeRange(resultTypes), isVariadic);
+      parser.getEncodedSourceLoc(loc), argTypes, returnType, isVariadic);
   if (!fnType)
     return failure();
   state.addAttribute(getFunctionTypeAttrName(state.name),
@@ -1513,8 +1507,14 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
   // Print function name, signature, and control.
   p.printSymbolName(getSymName());
   auto fnType = getFunctionType();
-  function_interface_impl::printFunctionSignature(
-      p, *this, fnType.getInputs(), fnType.isVarArg(), fnType.getResults());
+  SmallVector<Type, 1> resultTypes;
+  if (!fnType.isVoid())
+    function_interface_impl::printFunctionSignature(
+        p, *this, fnType.getInputs(), fnType.isVarArg(),
+        fnType.getReturnTypes());
+  else
+    function_interface_impl::printFunctionSignature(
+        p, *this, fnType.getInputs(), fnType.isVarArg(), {});
   function_interface_impl::printFunctionAttributes(
       p, *this,
       {getSymVisibilityAttrName(), getAliaseeAttrName(),
@@ -1543,8 +1543,6 @@ LogicalResult cir::FuncOp::verifyType() {
   if (!type.isa<cir::FuncType>())
     return emitOpError("requires '" + getFunctionTypeAttrName().str() +
                        "' attribute of function type");
-  if (getFunctionType().getNumResults() > 1)
-    return emitOpError("cannot have more than one result");
   return success();
 }
 
@@ -1624,16 +1622,20 @@ cir::CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
              << fnType.getInput(i) << ", but provided "
              << getOperand(i).getType() << " for operand number " << i;
 
-  if (fnType.getNumResults() != getNumResults())
+  // Void function must not return any results.
+  if (fnType.isVoid() && getNumResults() != 0)
+    return emitOpError("callee returns void but call has results");
+
+  // Non-void function calls must return exactly one result.
+  if (!fnType.isVoid() && getNumResults() != 1)
     return emitOpError("incorrect number of results for callee");
 
-  for (unsigned i = 0, e = fnType.getNumResults(); i != e; ++i)
-    if (getResult(i).getType() != fnType.getResult(i)) {
-      auto diag = emitOpError("result type mismatch at index ") << i;
-      diag.attachNote() << "      op result types: " << getResultTypes();
-      diag.attachNote() << "function result types: " << fnType.getResults();
-      return diag;
-    }
+  // Parent function and return value types must match.
+  if (!fnType.isVoid() && getResultTypes().front() != fnType.getReturnType()) {
+    return emitOpError("result type mismatch: expected ")
+           << fnType.getReturnType() << ", but provided "
+           << getResult(0).getType();
+  }
 
   return success();
 }

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Support/LogicalResult.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -409,17 +410,16 @@ IntType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
 
 mlir::LogicalResult
 FuncType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
-                 llvm::ArrayRef<mlir::Type> inputs,
-                 llvm::ArrayRef<mlir::Type> results, bool varArg) {
-  if (results.size() > 1)
-    return emitError() << "functions only supports 0 or 1 results";
+                 llvm::ArrayRef<mlir::Type> inputs, mlir::Type result,
+                 bool varArg) {
   if (varArg && inputs.empty())
     return emitError() << "functions must have at least one non-variadic input";
   return mlir::success();
 }
 
 FuncType FuncType::clone(TypeRange inputs, TypeRange results) const {
-  return get(getContext(), results, inputs, isVarArg());
+  assert(results.size() == 1 && "expected exactly one result type");
+  return get(llvm::to_vector(inputs), results[0], isVarArg());
 }
 
 static mlir::ParseResult
@@ -460,6 +460,12 @@ static void printFuncTypeArgs(mlir::AsmPrinter &p,
   }
   p << ')';
 }
+
+llvm::ArrayRef<mlir::Type> FuncType::getReturnTypes() const {
+  return static_cast<detail::FuncTypeStorage *>(getImpl())->returnType;
+}
+
+bool FuncType::isVoid() const { return getReturnType().isa<VoidType>(); }
 
 //===----------------------------------------------------------------------===//
 // CIR Dialect

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -670,12 +670,8 @@ public:
       signatureConversion.addInputs(argType.index(), convertedType);
     }
 
-    mlir::Type resultType;
-    if (fnType.getNumResults() == 1) {
-      resultType = getTypeConverter()->convertType(fnType.getResult(0));
-      if (!resultType)
-        return mlir::failure();
-    }
+    mlir::Type resultType =
+        getTypeConverter()->convertType(fnType.getReturnType());
 
     // Create the LLVM function operation.
     auto llvmFnTy = mlir::LLVM::LLVMFunctionType::get(
@@ -1163,6 +1159,9 @@ mlir::LLVMTypeConverter prepareTypeConverter(mlir::MLIRContext *ctx) {
     if (llvmStruct.setBody(llvmMembers, /*isPacked=*/type.getPacked()).failed())
       llvm_unreachable("Failed to set body of struct");
     return llvmStruct;
+  });
+  converter.addConversion([&](mlir::cir::VoidType type) -> mlir::Type {
+    return mlir::LLVM::LLVMVoidType::get(type.getContext());
   });
 
   return converter;

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
 #include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
@@ -35,6 +36,7 @@
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Passes.h"
 #include "llvm/ADT/Sequence.h"
 
@@ -190,13 +192,8 @@ public:
       signatureConversion.addInputs(argType.index(), convertedType);
     }
 
-    mlir::Type resultType;
-    if (fnType.getNumResults() == 1) {
-      resultType = getTypeConverter()->convertType(fnType.getResult(0));
-      if (!resultType)
-        return mlir::failure();
-    }
-
+    mlir::Type resultType =
+        getTypeConverter()->convertType(fnType.getReturnType());
     auto fn = rewriter.create<mlir::func::FuncOp>(
         op.getLoc(), op.getName(),
         rewriter.getFunctionType(signatureConversion.getConvertedTypes(),
@@ -520,6 +517,8 @@ static mlir::TypeConverter prepareTypeConverter() {
       [&](mlir::IntegerType type) -> mlir::Type { return type; });
   converter.addConversion(
       [&](mlir::FloatType type) -> mlir::Type { return type; });
+  converter.addConversion(
+      [&](mlir::cir::VoidType type) -> mlir::Type { return {}; });
 
   return converter;
 }

--- a/clang/test/CIR/IR/func.cir
+++ b/clang/test/CIR/IR/func.cir
@@ -27,6 +27,16 @@ module {
     %1 = cir.alloca !cir.ptr<!cir.func<!s32i (!s32i, ...)>>, cir.ptr <!cir.ptr<!cir.func<!s32i (!s32i, ...)>>>, ["fn", init] {alignment = 8 : i64}
     cir.return
   }
+
+  // Should parse void return types.
+  cir.func @parse_explicit_void_func() -> !cir.void {
+    cir.return
+  }
+
+  // Should parse omitted void return type.
+  cir.func @parse_func_type_with_omitted_void() {
+    cir.return
+  }
 }
 
 // CHECK: cir.func @l0()

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -377,7 +377,7 @@ module {
 // -----
 
 module {
-  // expected-error@+1 {{functions only supports 0 or 1 results}}
+  // expected-error@+1 {{functions only supports zero or one results}}
   cir.func @variadic() -> (!cir.int<s, 32>, !cir.int<s, 32>)
 }
 
@@ -389,5 +389,36 @@ module {
     // expected-error@+1 {{'cir.call' op too few operands for callee}}
     %1 = cir.call @variadic(%0) : (!cir.int<s, 32>) -> !cir.int<s, 32>
     cir.return %1 : !cir.int<s, 32>
+  }
+}
+
+// -----
+
+module {
+  cir.func private @test() -> !cir.void
+  cir.func @invalid_call() {
+    // expected-error@+1 {{'cir.call' op callee returns void but call has results}}
+    %1 = cir.call @test() : () -> (!cir.int<s, 32>)
+    cir.return
+  }
+}
+
+// -----
+
+module {
+  cir.func private @test() -> !cir.int<u, 8>
+  cir.func @invalid_call() {
+    // expected-error@+1 {{'cir.call' op result type mismatch: expected '!cir.int<u, 8>', but provided '!cir.int<s, 32>'}}
+    %1 = cir.call @test() : () -> (!cir.int<s, 32>)
+    cir.return
+  }
+}
+
+// -----
+
+module {
+  cir.func @invalid_return_type(%0 : !cir.int<u, 64>) -> !cir.int<s, 32> {
+    // expected-error@+1 {{'cir.return' op returns '!cir.int<u, 64>' but enclosing function returns '!cir.int<s, 32>'}}
+    cir.return %0 : !cir.int<u, 64>
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #118
* #117

Updates FuncType table gen definition to restrict the number of return
types to exactly one.

Patches FuncOp, CallOp, and codegen builders to work with the new
function type definition.

Empty results in FuncType builders are replaced by void types.

Void function definitions can be parsed in three different ways:
  - No return type specified: the return type is implicitly void
  - Return type specified as void: the return type is explicitly void
  - Return type specified as empty: the return type is implicitly void

Some verification checks are removed since they are now implicitly
checked.

Added lowering for void types in both direct and indirect lowering.