### PR TITLE
[CIR] Enable per-pass IR printing

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -42,7 +42,7 @@ mlir::LogicalResult runCIRToCIRPasses(mlir::ModuleOp theModule,
   // need to run this right before dialect emission.
   pm.addPass(mlir::createDropASTPass());
   pm.enableVerifier(enableVerifier);
-
+  (void)mlir::applyPassManagerCLOptions(pm);
   return pm.run(theModule);
 }
 } // namespace cir

--- a/clang/lib/FrontendTool/CMakeLists.txt
+++ b/clang/lib/FrontendTool/CMakeLists.txt
@@ -16,8 +16,10 @@ if(CLANG_ENABLE_CIR)
   list(APPEND link_libs
     clangCIRFrontendAction
     MLIRIR
+    MLIRPass
     )
   include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
+  include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 endif()
 
 if(CLANG_ENABLE_ARCMT)

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -34,6 +34,7 @@
 
 #if CLANG_ENABLE_CIR
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/PassManager.h"
 #include "clang/CIRFrontendAction/CIRGenAction.h"
 #endif
 
@@ -308,6 +309,7 @@ bool ExecuteCompilerInvocation(CompilerInstance *Clang) {
 #if CLANG_ENABLE_CIR
   if (!Clang->getFrontendOpts().MLIRArgs.empty()) {
     mlir::registerMLIRContextCLOptions();
+    mlir::registerPassManagerCLOptions();
     unsigned NumArgs = Clang->getFrontendOpts().MLIRArgs.size();
     auto Args = std::make_unique<const char *[]>(NumArgs + 2);
     Args[0] = "ClangIR (MLIR option parsing)";

--- a/clang/test/CIR/CodeGen/mlirprint.c
+++ b/clang/test/CIR/CodeGen/mlirprint.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.ll 2>&1 | FileCheck %s
+
+int foo() {
+  int i = 3;
+  return i;
+}
+
+
+// CHECK: IR Dump After MergeCleanups (cir-merge-cleanups)
+// cir.func @foo() -> !s32i
+// CHECK: IR Dump After DropAST (cir-drop-ast)
+// cir.func @foo() -> !s32i


### PR DESCRIPTION
Summary:
Adding support to print IR after each pass. Example usage: -mmlir --mlir-print-ir-after-all
```

// -----// IR Dump After MergeCleanups (cir-merge-cleanups) //----- // !s32i = !cir.int<s, 32>
module @"/home/hoy/src/clangir/clang/test/CIR/CodeGen/mlirargs.c" attributes {cir.sob = #cir.signed_overflow_behavior<undefined>, dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f128, dense<128> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f80, dense<128> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi32>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi32>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi32>>, #dlti.dl_entry<i64, dense<64> : vector<2xi32>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i32>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"} {
  cir.func @f3() -> !s32i attributes {ast = #cir.fndecl.ast} {
    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] ast #cir.vardecl.ast {alignment = 4 : i64}
    %2 = cir.const(#cir.int<3> : !s32i) : !s32i
    cir.store %2, %1 : !s32i, cir.ptr <!s32i>
    %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
    cir.store %3, %0 : !s32i, cir.ptr <!s32i>
    %4 = cir.load %0 : cir.ptr <!s32i>, !s32i
    cir.return %4 : !s32i
  }
}

// -----// IR Dump After DropAST (cir-drop-ast) //----- // !s32i = !cir.int<s, 32>
module @"/home/hoy/src/clangir/clang/test/CIR/CodeGen/mlirargs.c" attributes {cir.sob = #cir.signed_overflow_behavior<undefined>, dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f128, dense<128> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f80, dense<128> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi32>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi32>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi32>>, #dlti.dl_entry<i64, dense<64> : vector<2xi32>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i32>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"} {
  cir.func @f3() -> !s32i {
    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
    %2 = cir.const(#cir.int<3> : !s32i) : !s32i
    cir.store %2, %1 : !s32i, cir.ptr <!s32i>
    %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
    cir.store %3, %0 : !s32i, cir.ptr <!s32i>
    %4 = cir.load %0 : cir.ptr <!s32i>, !s32i
    cir.return %4 : !s32i
  }
}
```