### PR TITLE
[CIR][CIRGen] Allow no-proto declarations in CIR

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -413,8 +413,6 @@ FuncType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
                  llvm::ArrayRef<mlir::Type> results, bool varArg) {
   if (results.size() > 1)
     return emitError() << "functions only supports 0 or 1 results";
-  if (varArg && inputs.empty())
-    return emitError() << "functions must have at least one non-variadic input";
   return mlir::success();
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #123
* #130
* #122
* __->__ #121
* #120

A no-prototype declaration in CIR is represented by a function that can
take any number of arguments, which is required to bypass function
parameters type checking in CIR. This is enabled only on C standards.