### PR TITLE
[CIR][Lowering] Support no-proto functions lowering

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -325,6 +325,14 @@ public:
                                                       llvmSrcVal);
       return mlir::success();
     }
+    case mlir::cir::CastKind::bitcast: {
+      auto dstTy = castOp.getType();
+      auto llvmSrcVal = adaptor.getOperands().front();
+      auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::BitcastOp>(castOp, llvmDstTy,
+                                                         llvmSrcVal);
+      return mlir::success();
+    }
     default:
       llvm_unreachable("NYI");
     }
@@ -1153,6 +1161,14 @@ mlir::LLVMTypeConverter prepareTypeConverter(mlir::MLIRContext *ctx) {
   converter.addConversion([&](mlir::cir::IntType type) -> mlir::Type {
     // LLVM doesn't work with signed types, so we drop the CIR signs here.
     return mlir::IntegerType::get(type.getContext(), type.getWidth());
+  });
+  converter.addConversion([&](mlir::cir::FuncType type) -> mlir::Type {
+    auto result = converter.convertType(type.getResult(0));
+    llvm::SmallVector<mlir::Type> arguments;
+    if (converter.convertTypes(type.getInputs(), arguments).failed())
+      llvm_unreachable("Failed to convert function type parameters");
+    auto varArg = type.isVarArg();
+    return mlir::LLVM::LLVMFunctionType::get(result, arguments, varArg);
   });
   converter.addConversion([&](mlir::cir::StructType type) -> mlir::Type {
     llvm::SmallVector<mlir::Type> llvmMembers;

--- a/clang/test/CIR/Lowering/func.cir
+++ b/clang/test/CIR/Lowering/func.cir
@@ -1,0 +1,18 @@
+// RUN: cir-tool %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck %s -check-prefix=MLIR --input-file=%t.mlir
+
+!s32i = !cir.int<s, 32>
+module attributes {cir.lang = #cir.lang<c17>} {
+  cir.func private @noProto3(...) -> !s32i
+  // MLIR: llvm.func @noProto3(...) -> i32
+  cir.func @test3(%arg0: !s32i) {
+    %3 = cir.get_global @noProto3 : cir.ptr <!cir.func<!s32i (...)>>
+    // MLIR: %[[#FN_PTR:]] = llvm.mlir.addressof @noProto3 : !llvm.ptr<func<i32 (...)>>
+    %4 = cir.cast(bitcast, %3 : !cir.ptr<!cir.func<!s32i (...)>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
+    // MLIR: %[[#FUNC:]] = llvm.bitcast %[[#FN_PTR]] : !llvm.ptr<func<i32 (...)>> to !llvm.ptr<func<i32 (i32)>>
+    %5 = cir.call %4(%arg0) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
+    // MLIR: %{{.+}} = llvm.call %[[#FUNC]](%{{.+}}) : !llvm.ptr<func<i32 (i32)>>, (i32) -> i32
+    cir.return
+  }
+}
+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123
* #130
* #122
* #120

Lowers bitcasts and function types to LLVM Dialect. These are required
to represent indirect call generated by no-proto functions.