### PR TITLE
[CIR][CIRGen][Lowering] Add integral to FP casts

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -52,6 +52,7 @@ def CK_IntegralToPointer : I32EnumAttrCase<"int_to_ptr", 8>;
 def CK_PointerToIntegral : I32EnumAttrCase<"ptr_to_int", 9>;
 def CK_FloatToBoolean : I32EnumAttrCase<"float_to_bool", 10>;
 def CK_BooleanToIntegral : I32EnumAttrCase<"bool_to_int", 11>;
+def CK_IntegralToFloat : I32EnumAttrCase<"int_to_float", 12>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
@@ -59,7 +60,7 @@ def CastKind : I32EnumAttr<
     [CK_IntegralToBoolean, CK_ArrayToPointerDecay, CK_IntegralCast,
      CK_BitCast, CK_FloatingCast, CK_PtrToBoolean, CK_FloatToIntegral,
      CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean,
-     CK_BooleanToIntegral]> {
+     CK_BooleanToIntegral, CK_IntegralToFloat]> {
   let cppNamespace = "::mlir::cir";
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/FunctionImplementation.h"
@@ -330,6 +331,12 @@ LogicalResult CastOp::verify() {
       return emitOpError() << "requires !cir.int for result";
     return success();
   }
+  case cir::CastKind::int_to_float:
+    if (!srcType.isa<mlir::cir::IntType>())
+      return emitOpError() << "requires !cir.int for source";
+    if (!resType.isa<mlir::FloatType>())
+      return emitOpError() << "requires !cir.float for result";
+    return success();
   }
 
   llvm_unreachable("Unknown CastOp kind?");

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -325,6 +325,18 @@ public:
                                                       llvmSrcVal);
       return mlir::success();
     }
+    case mlir::cir::CastKind::int_to_float: {
+      auto dstTy = castOp.getType();
+      auto llvmSrcVal = adaptor.getOperands().front();
+      auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+      if (castOp.getSrc().getType().cast<mlir::cir::IntType>().isSigned())
+        rewriter.replaceOpWithNewOp<mlir::LLVM::SIToFPOp>(castOp, llvmDstTy,
+                                                          llvmSrcVal);
+      else
+        rewriter.replaceOpWithNewOp<mlir::LLVM::UIToFPOp>(castOp, llvmDstTy,
+                                                          llvmSrcVal);
+      return mlir::success();
+    }
     default:
       llvm_unreachable("NYI");
     }

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -47,6 +47,12 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4) {
   // CHECK: %[[TMP2:[0-9]+]] = cir.cast(int_to_ptr, %[[TMP]] : !u64i), !cir.ptr<!u8i>
   // CHECK: %{{[0-9]+}} = cir.cast(ptr_to_int, %[[TMP2]] : !cir.ptr<!u8i>), !s64i
 
+  float sitofp = (float)x2; // Signed integer to floating point
+  // CHECK: %{{.+}} = cir.cast(int_to_float, %{{[0-9]+}} : !s32i), f32
+
+  float uitofp = (float)x1; // Unsigned integer to floating point
+  // CHECK: %{{.+}} = cir.cast(int_to_float, %{{[0-9]+}} : !u32i), f32
+
   return 0;
 }
 

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -68,6 +68,10 @@ module {
     // MLIR: %[[TMP2:[0-9]+]] = llvm.inttoptr %[[TMP]] : i64 to !llvm.ptr<i8>
     %24 = cir.cast(ptr_to_int, %23 : !cir.ptr<!u8i>), !s32i
     // MLIR: %{{[0-9]+}} = llvm.ptrtoint %[[TMP2]] : !llvm.ptr<i8> to i32
+    %25 = cir.cast(int_to_float, %arg1 : !s32i), f32
+    // MLIR: %{{.+}} = llvm.sitofp %{{.+}} : i32 to f32
+    %26 = cir.cast(int_to_float, %arg0 : !u32i), f32
+    // MLIR: %{{.+}} = llvm.uitofp %{{.+}} : i32 to f32
     %18 = cir.const(#cir.int<0> : !s32i) : !s32i
     cir.store %18, %2 : !s32i, cir.ptr <!s32i>
     %19 = cir.load %2 : cir.ptr <!s32i>, !s32i


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127
* #126
* #125
* __->__ #124

Lowering of these casts is done by mapping them to LLVM's SIToFP and
UIToFP casts. Sign interpretation is deferred from CodeGen to the
lowering stage.