### PR TITLE
[CIR][CIRGen] Implement tentative definitions

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -89,6 +89,7 @@ public:
   void HandleTagDeclDefinition(clang::TagDecl *D) override;
   void HandleTagDeclRequiredDefinition(const clang::TagDecl *D) override;
   void HandleCXXStaticMemberVarInstantiation(clang::VarDecl *D) override;
+  void CompleteTentativeDefinition(clang::VarDecl *D) override;
 
   mlir::ModuleOp getModule();
   std::unique_ptr<mlir::MLIRContext> takeContext() {

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -24,6 +24,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/FloatingPointMode.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace cir {
 
@@ -142,6 +143,23 @@ public:
   mlir::cir::TypeInfoAttr getTypeInfo(mlir::ArrayAttr fieldsAttr) {
     auto anonStruct = getAnonConstStruct(fieldsAttr);
     return mlir::cir::TypeInfoAttr::get(anonStruct.getType(), anonStruct);
+  }
+
+  mlir::TypedAttr getZeroInitAttr(mlir::Type ty) {
+    if (ty.isa<mlir::cir::IntType>())
+      return mlir::cir::IntAttr::get(ty, 0);
+    if (ty.isa<mlir::FloatType>())
+      return mlir::FloatAttr::get(ty, 0.0);
+    if (auto arrTy = ty.dyn_cast<mlir::cir::ArrayType>()) {
+      // FIXME(cir): We should have a proper zero initializer CIR instead of
+      // manually pumping zeros into the array.
+      auto values = llvm::SmallVector<mlir::Attribute, 4>();
+      auto zero = getZeroInitAttr(arrTy.getEltType());
+      for (unsigned i = 0, e = arrTy.getSize(); i < e; ++i)
+        values.push_back(zero);
+      return getConstArray(mlir::ArrayAttr::get(getContext(), values), arrTy);
+    }
+    llvm_unreachable("Zero initializer for given type is NYI");
   }
 
   //

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -485,7 +485,10 @@ LValue CIRGenFunction::buildDeclRefLValue(const DeclRefExpr *E) {
 
   if (const auto *VD = dyn_cast<VarDecl>(ND)) {
     // Global Named registers access via intrinsics only
-    assert(VD->getStorageClass() != SC_Register && "not implemented");
+    if (VD->getStorageClass() == SC_Register &&
+        VD->hasAttr<AsmLabelAttr>() && !VD->isLocalVarDecl())
+        llvm_unreachable("NYI");
+
     assert(E->isNonOdrUse() != NOUR_Constant && "not implemented");
 
     // Check for captured variables.

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -764,7 +764,7 @@ void CIRGenModule::buildGlobalVarDefinition(const clang::VarDecl *D,
     // exists. A use may still exists, however, so we still may need
     // to do a RAUW.
     assert(!ASTTy->isIncompleteType() && "Unexpected incomplete type");
-    assert(0 && "not implemented");
+    Init = builder.getZeroInitAttr(getCIRType(D->getType()));
   } else {
     initializedGlobalDecl = GlobalDecl(D);
     emitter.emplace(*this);
@@ -1599,6 +1599,34 @@ StringRef CIRGenModule::getMangledName(GlobalDecl GD) {
 
   auto Result = Manglings.insert(std::make_pair(MangledName, GD));
   return MangledDeclNames[CanonicalGD] = Result.first->first();
+}
+
+void CIRGenModule::buildTentativeDefinition(const VarDecl *D) {
+  assert(!D->getInit() && "Cannot emit definite definitions here!");
+
+  StringRef MangledName = getMangledName(D);
+  auto *GV = getGlobalValue(MangledName);
+
+  // TODO(cir): either remove or embelish this assert.
+  if (GV)
+    assert(isa<mlir::cir::GlobalOp>(GV) &&
+           "tentative definition can only be built from a cir.global_op");
+
+  // We already have a definition, not declaration, with the same mangled name.
+  // Emitting of declaration is not required (and actually overwrites emitted
+  // definition).
+  if (GV && !dyn_cast<mlir::cir::GlobalOp>(GV).isDeclaration())
+    return;
+
+  // If we have not seen a reference to this variable yet, place it into the
+  // deferred declarations table to be emitted if needed later.
+  if (!MustBeEmitted(D) && !GV) {
+    DeferredDecls[MangledName] = D;
+    return;
+  }
+
+  // The tentative definition is the only definition.
+  buildGlobalVarDefinition(D);
 }
 
 void CIRGenModule::setGlobalVisibility(mlir::Operation *GV,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -445,6 +445,8 @@ public:
 
   llvm::StringRef getMangledName(clang::GlobalDecl GD);
 
+  void buildTentativeDefinition(const VarDecl *D);
+
   // Make sure that this type is translated.
   void UpdateCompletedType(const clang::TagDecl *TD);
 

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -181,3 +181,10 @@ void CIRGenerator::HandleCXXStaticMemberVarInstantiation(VarDecl *D) {
 
   CGM->HandleCXXStaticMemberVarInstantiation(D);
 }
+
+void CIRGenerator::CompleteTentativeDefinition(VarDecl *D) {
+  if (Diags.hasErrorOccurred())
+    return;
+
+  CGM->buildTentativeDefinition(D);
+}

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -300,7 +300,7 @@ public:
   }
 
   void CompleteTentativeDefinition(VarDecl *D) override {
-    llvm_unreachable("NYI");
+    gen->CompleteTentativeDefinition(D);
   }
 
   void CompleteExternalDeclaration(VarDecl *D) override {

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -13,3 +13,23 @@ int filler_sint[4] = {1, 2}; // Ensure missing elements are zero-initialized.
 // CHECK: cir.global external @filler_sint = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.array<!s32i x 4>
 int excess_sint[2] = {1, 2, 3, 4}; // Ensure excess elements are ignored.
 // CHECK: cir.global external @excess_sint = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>
+
+// Tentative definition is just a declaration.
+int tentativeB;
+int tentativeB = 1;
+// CHECK: cir.global external @tentativeB = #cir.int<1> : !s32i
+
+// Tentative incomplete definition is just a declaration.
+int tentativeE[];
+int tentativeE[2] = {1, 2};
+// CHECK: cir.global external @tentativeE = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>
+
+// TODO: test tentatives with internal linkage.
+
+// Tentative definition is THE definition. Should be zero-initialized.
+int tentativeA;
+float tentativeC;
+int tentativeD[];
+// CHECK: cir.global external @tentativeA = #cir.int<0> : !s32i
+// CHECK: cir.global external @tentativeC = 0.000000e+00 : f32
+// CHECK: cir.global external @tentativeD = #cir.const_array<[#cir.int<0> : !s32i]> : !cir.array<!s32i x 1>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127
* #126
* __->__ #125
* #124

Only external tentative definitions were added.

A method to easily create initialization attributes for distinct types
was added as well.