### PR TITLE
[CIR][Lowering] Lower FP to integral casts

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -337,6 +337,18 @@ public:
                                                           llvmSrcVal);
       return mlir::success();
     }
+    case mlir::cir::CastKind::float_to_int: {
+      auto dstTy = castOp.getType();
+      auto llvmSrcVal = adaptor.getOperands().front();
+      auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+      if (castOp.getResult().getType().cast<mlir::cir::IntType>().isSigned())
+        rewriter.replaceOpWithNewOp<mlir::LLVM::FPToSIOp>(castOp, llvmDstTy,
+                                                          llvmSrcVal);
+      else
+        rewriter.replaceOpWithNewOp<mlir::LLVM::FPToUIOp>(castOp, llvmDstTy,
+                                                          llvmSrcVal);
+      return mlir::success();
+    }
     default:
       llvm_unreachable("NYI");
     }

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -53,6 +53,12 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4) {
   float uitofp = (float)x1; // Unsigned integer to floating point
   // CHECK: %{{.+}} = cir.cast(int_to_float, %{{[0-9]+}} : !u32i), f32
 
+  int fptosi = (int)x3; // Floating point to signed integer
+  // CHECK: %{{.+}} = cir.cast(float_to_int, %{{[0-9]+}} : f32), !s32i
+
+  unsigned fptoui = (unsigned)x3; // Floating point to unsigned integer
+  // CHECK: %{{.+}} = cir.cast(float_to_int, %{{[0-9]+}} : f32), !u32i
+
   return 0;
 }
 

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -28,8 +28,8 @@ module {
 // LLVM-NEXT:   ret i32 %0
 // LLVM-NEXT: }
 
-  cir.func @cStyleCasts(%arg0: !u32i, %arg1: !s32i) -> !s32i {
-    // MLIR: llvm.func @cStyleCasts(%arg0: i32, %arg1: i32) -> i32 {
+  cir.func @cStyleCasts(%arg0: !u32i, %arg1: !s32i, %arg2: f32) -> !s32i {
+  // MLIR: llvm.func @cStyleCasts
     %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["x1", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["x2", init] {alignment = 4 : i64}
     %20 = cir.alloca !s16i, cir.ptr <!s16i>, ["x4", init] {alignment = 2 : i64}
@@ -72,6 +72,10 @@ module {
     // MLIR: %{{.+}} = llvm.sitofp %{{.+}} : i32 to f32
     %26 = cir.cast(int_to_float, %arg0 : !u32i), f32
     // MLIR: %{{.+}} = llvm.uitofp %{{.+}} : i32 to f32
+    %27 = cir.cast(float_to_int, %arg2 : f32), !s32i
+    // MLIR: %{{.+}} = llvm.fptosi %{{.+}} : f32 to i32
+    %28 = cir.cast(float_to_int, %arg2 : f32), !u32i
+    // MLIR: %{{.+}} = llvm.fptoui %{{.+}} : f32 to i32
     %18 = cir.const(#cir.int<0> : !s32i) : !s32i
     cir.store %18, %2 : !s32i, cir.ptr <!s32i>
     %19 = cir.load %2 : cir.ptr <!s32i>, !s32i


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127
* __->__ #126
* #125
* #124

Essentially lower !cir.cast ops to LLVM's fptosi/fptoui operations.