### PR TITLE
[CIR][Lowering] Enable IR-printing for LLVM passes.

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1228,6 +1228,8 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule,
   pm.addNestedPass<mlir::LLVM::LLVMFuncOp>(
       mlir::LLVM::createDIScopeForLLVMFuncOpPass());
 
+  (void)mlir::applyPassManagerCLOptions(pm);
+
   auto result = !mlir::failed(pm.run(theModule));
   if (!result)
     report_fatal_error(

--- a/clang/test/CIR/CodeGen/mlirprint.c
+++ b/clang/test/CIR/CodeGen/mlirprint.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.ll 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -fclangir-enable -emit-llvm -mmlir --mlir-print-ir-after-all -mllvm -print-after-all  %s -o %t.ll 2>&1 | FileCheck %s -check-prefix=CIR -check-prefix=LLVM
 
 int foo() {
   int i = 3;
@@ -7,7 +7,11 @@ int foo() {
 }
 
 
-// CHECK: IR Dump After MergeCleanups (cir-merge-cleanups)
-// cir.func @foo() -> !s32i
-// CHECK: IR Dump After DropAST (cir-drop-ast)
-// cir.func @foo() -> !s32i
+// CIR:  IR Dump After MergeCleanups (cir-merge-cleanups)
+// CIR:  cir.func @foo() -> !s32i
+// CIR:  IR Dump After DropAST (cir-drop-ast)
+// CIR:  cir.func @foo() -> !s32i
+// LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-to-llvm)
+// LLVM: llvm.func @foo() -> i32
+// LLVM: IR Dump After VerifierPass on [module] ***
+// LLVM: define i32 @foo()


### PR DESCRIPTION

Enabling IR printing to LLVM-lowering related passes.