### PR TITLE
[CIR][CIRGen][Bugfix] Remove Optional wrapper from MLIR Type

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -660,8 +660,7 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef MangledName, mlir::Type Ty,
   return GV;
 }
 
-mlir::cir::GlobalOp CIRGenModule::buildGlobal(const VarDecl *D,
-                                              std::optional<mlir::Type> Ty,
+mlir::cir::GlobalOp CIRGenModule::buildGlobal(const VarDecl *D, mlir::Type Ty,
                                               ForDefinition_t IsForDefinition) {
   assert(D->hasGlobalStorage() && "Not a global variable");
   QualType ASTTy = D->getType();
@@ -669,7 +668,7 @@ mlir::cir::GlobalOp CIRGenModule::buildGlobal(const VarDecl *D,
     Ty = getTypes().convertTypeForMem(ASTTy);
 
   StringRef MangledName = getMangledName(D);
-  return getOrCreateCIRGlobal(MangledName, *Ty, ASTTy.getAddressSpace(), D,
+  return getOrCreateCIRGlobal(MangledName, Ty, ASTTy.getAddressSpace(), D,
                               IsForDefinition);
 }
 
@@ -679,8 +678,7 @@ mlir::cir::GlobalOp CIRGenModule::buildGlobal(const VarDecl *D,
 /// If IsForDefinition is true, it is guaranteed that an actual global with type
 /// Ty will be returned, not conversion of a variable with the same mangled name
 /// but some other type.
-mlir::Value CIRGenModule::getAddrOfGlobalVar(const VarDecl *D,
-                                             llvm::Optional<mlir::Type> Ty,
+mlir::Value CIRGenModule::getAddrOfGlobalVar(const VarDecl *D, mlir::Type Ty,
                                              ForDefinition_t IsForDefinition) {
   assert(D->hasGlobalStorage() && "Not a global variable");
   QualType ASTTy = D->getType();

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -183,8 +183,7 @@ public:
                        const VarDecl *D,
                        ForDefinition_t IsForDefinition = NotForDefinition);
 
-  mlir::cir::GlobalOp buildGlobal(const VarDecl *D,
-                                  llvm::Optional<mlir::Type> Ty,
+  mlir::cir::GlobalOp buildGlobal(const VarDecl *D, mlir::Type Ty,
                                   ForDefinition_t IsForDefinition);
 
   /// TODO(cir): once we have cir.module, add this as a convenience method
@@ -215,7 +214,7 @@ public:
   /// global with type Ty will be returned, not conversion of a variable with
   /// the same mangled name but some other type.
   mlir::Value
-  getAddrOfGlobalVar(const VarDecl *D, std::optional<mlir::Type> Ty = {},
+  getAddrOfGlobalVar(const VarDecl *D, mlir::Type Ty = {},
                      ForDefinition_t IsForDefinition = NotForDefinition);
 
   CharUnits


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133
* __->__ #132

MLIR Types are inherently wrappers. Checking if a value exists is a
matter of checking if the type is null.

The Optional wrapper was causing a bug in the `CIRGenModule::buildGlobal`
method. If an empty type (`mlir::Type{}`) was passed as `Ty`, the
`if (!ty)` clause would evalute to true, because the `!` operator would
simply validate that there was a `mlir::Type` in the optional wrapper.
Then the code gen would continue and try to emit an invalid type.

This patch removes the wrapper, which ensures that the `!Ty` clause now
checks if the given `mlir::Type` is an empty type. In that case, it
generates a real type from the AST Type:

```
  if (!Ty)
    Ty = getTypes().convertTypeForMem(ASTTy);
```