### PR TITLE
[CIR][Lowering] Support lowering on cir::TernaryOp.

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1065,6 +1065,58 @@ public:
   }
 };
 
+class CIRTernaryOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::TernaryOp> {
+public:
+  using OpConversionPattern<mlir::cir::TernaryOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::TernaryOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    auto *condBlock = rewriter.getInsertionBlock();
+    auto opPosition = rewriter.getInsertionPoint();
+    auto *remainingOpsBlock = rewriter.splitBlock(condBlock, opPosition);
+    auto *continueBlock = rewriter.createBlock(
+        remainingOpsBlock, op->getResultTypes(),
+        SmallVector<mlir::Location>(/* result number always 1 */ 1, loc));
+    rewriter.create<mlir::cir::BrOp>(loc, remainingOpsBlock);
+
+    auto &trueRegion = op.getTrueRegion();
+    auto *trueBlock = &trueRegion.front();
+    mlir::Operation *trueTerminator = trueRegion.back().getTerminator();
+    rewriter.setInsertionPointToEnd(&trueRegion.back());
+    auto trueYieldOp = dyn_cast<mlir::cir::YieldOp>(trueTerminator);
+
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
+        trueYieldOp, trueYieldOp.getArgs(), continueBlock);
+    rewriter.inlineRegionBefore(trueRegion, continueBlock);
+
+    auto *falseBlock = continueBlock;
+    auto &falseRegion = op.getFalseRegion();
+
+    falseBlock = &falseRegion.front();
+    mlir::Operation *falseTerminator = falseRegion.back().getTerminator();
+    rewriter.setInsertionPointToEnd(&falseRegion.back());
+    auto falseYieldOp = dyn_cast<mlir::cir::YieldOp>(falseTerminator);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
+        falseYieldOp, falseYieldOp.getArgs(), continueBlock);
+    rewriter.inlineRegionBefore(falseRegion, continueBlock);
+
+    rewriter.setInsertionPointToEnd(condBlock);
+    auto condition = adaptor.getCond();
+    auto i1Condition = rewriter.create<mlir::LLVM::TruncOp>(
+        op.getLoc(), rewriter.getI1Type(), condition);
+    rewriter.create<mlir::LLVM::CondBrOp>(loc, i1Condition.getResult(),
+                                          trueBlock, falseBlock);
+
+    rewriter.replaceOp(op, continueBlock->getArguments());
+
+    // Ok, we're done!
+    return mlir::success();
+  }
+};
+
 class CIRCmpOpLowering : public mlir::OpConversionPattern<mlir::cir::CmpOp> {
 public:
   using OpConversionPattern<mlir::cir::CmpOp>::OpConversionPattern;
@@ -1143,14 +1195,14 @@ public:
   }
 };
 
-class CIRBrOpLowering : public mlir::OpRewritePattern<mlir::cir::BrOp> {
+class CIRBrOpLowering : public mlir::OpConversionPattern<mlir::cir::BrOp> {
 public:
-  using OpRewritePattern<mlir::cir::BrOp>::OpRewritePattern;
+  using OpConversionPattern<mlir::cir::BrOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::BrOp op,
-                  mlir::PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<mlir::LLVM::BrOp>(op, op.getDestOperands(),
+  matchAndRewrite(mlir::cir::BrOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::BrOp>(op, adaptor.getOperands(),
                                                   op.getDest());
     return mlir::LogicalResult::success();
   }
@@ -1158,15 +1210,16 @@ public:
 
 void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter) {
-  patterns.add<CIRBrOpLowering, CIRReturnLowering>(patterns.getContext());
+  patterns.add<CIRReturnLowering>(patterns.getContext());
   patterns.add<CIRCmpOpLowering, CIRLoopOpLowering, CIRBrCondOpLowering,
                CIRPtrStrideOpLowering, CIRCallLowering, CIRUnaryOpLowering,
                CIRBinOpLowering, CIRLoadLowering, CIRConstantLowering,
                CIRStoreLowering, CIRAllocaLowering, CIRFuncLowering,
                CIRScopeOpLowering, CIRCastOpLowering, CIRIfLowering,
                CIRGlobalOpLowering, CIRGetGlobalOpLowering, CIRVAStartLowering,
-               CIRVAEndLowering, CIRVACopyLowering, CIRVAArgLowering>(
-      converter, patterns.getContext());
+               CIRVAEndLowering, CIRVACopyLowering, CIRVAArgLowering,
+               CIRBrOpLowering, CIRTernaryOpLowering>(converter,
+                                                      patterns.getContext());
 }
 
 namespace {

--- a/clang/test/CIR/Lowering/tenary.cir
+++ b/clang/test/CIR/Lowering/tenary.cir
@@ -1,0 +1,54 @@
+// RUN: cir-tool %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+
+!s32i = !cir.int<s, 32>
+
+module {
+cir.func @_Z1xi(%arg0: !s32i) -> !s32i {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["y", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %3 = cir.const(#cir.int<0> : !s32i) : !s32i
+    %4 = cir.cmp(gt, %2, %3) : !s32i, !cir.bool
+    %5 = cir.ternary(%4, true {
+      %7 = cir.const(#cir.int<3> : !s32i) : !s32i
+      cir.yield %7 : !s32i
+    }, false {
+      %7 = cir.const(#cir.int<5> : !s32i) : !s32i
+      cir.yield %7 : !s32i
+    }) : (!cir.bool) -> !s32i
+    cir.store %5, %1 : !s32i, cir.ptr <!s32i>
+    %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    cir.return %6 : !s32i
+  }
+}
+
+//      MLIR: module {
+//      MLIR: llvm.func @_Z1xi(%arg0: i32) -> i32 {
+// MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:    %2 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:    %3 = llvm.alloca %2 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:    %4 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:    %5 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:    %6 = llvm.icmp "sgt" %4, %5 : i32
+// MLIR-NEXT:    %7 = llvm.zext %6 : i1 to i8
+// MLIR-NEXT:    %8 = llvm.trunc %7 : i8 to i1
+// MLIR-NEXT:    llvm.cond_br %8, ^bb1, ^bb2
+// MLIR-NEXT:  ^bb1:  // pred: ^bb0
+// MLIR-NEXT:    %9 = llvm.mlir.constant(3 : i32) : i32
+// MLIR-NEXT:    %10 = builtin.unrealized_conversion_cast %9 : i32 to !s32i
+// MLIR-NEXT:    llvm.br ^bb3(%9 : i32)
+// MLIR-NEXT:  ^bb2:  // pred: ^bb0
+// MLIR-NEXT:    %11 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:    %12 = builtin.unrealized_conversion_cast %11 : i32 to !s32i
+// MLIR-NEXT:    llvm.br ^bb3(%11 : i32)
+// MLIR-NEXT:  ^bb3(%13: i32):  // 2 preds: ^bb1, ^bb2
+// MLIR-NEXT:    llvm.br ^bb4
+// MLIR-NEXT:  ^bb4:  // pred: ^bb3
+// MLIR-NEXT:    llvm.store %13, %3 : !llvm.ptr<i32>
+// MLIR-NEXT:    %14 = llvm.load %3 : !llvm.ptr<i32>
+// MLIR-NEXT:    llvm.return %14 : i32
+// MLIR-NEXT:   }
+// MLIR-NEXT: }


### PR DESCRIPTION
  - Support cir::TernaryOp lowering -cir-to-llvm.
  - Mostly mirror the scf.if to cf and cir.if lowerings.
  - also support cir.br lowering with type converter, like the `cir.br ^bb3(%9 : !s32i)` , !s32i is !cir.int<s, 32>. and this type not supported in LLVM dialect level.
  - current generate `builtin.unrealized_conversion_cast` Ops in tests, will cause the next rountine mlir-translate failed. Need to consider whether to include ReconcileUnrealizedCasts pass or find some other methods.