### PR TITLE
Update testing.md `lit` instructions

### DIFF
--- a/GettingStarted/testing.md
+++ b/GettingStarted/testing.md
@@ -21,6 +21,6 @@ $ ninja check-clang-cir-codegen
 Using `lit` from build directory:
 
 ```
-$ cd build
-$ ./bin/llvm-lit -a ../clang/test/CIR
+$ cd build-release
+$ ./bin/llvm-lit -a ../../clang/test/CIR
 ```


### PR DESCRIPTION
Update `testing.md` `lit` instructions to be in sync with installation `build-install.md`.