### PR TITLE
[CIR][Lowering] Lower structured while loops

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -34,6 +34,7 @@
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -109,12 +110,82 @@ public:
 class CIRLoopOpLowering : public mlir::OpConversionPattern<mlir::cir::LoopOp> {
 public:
   using mlir::OpConversionPattern<mlir::cir::LoopOp>::OpConversionPattern;
+  using LoopKind = mlir::cir::LoopOpKind;
+
+  mlir::LogicalResult
+  fetchCondRegionYields(mlir::Region &condRegion,
+                        mlir::cir::YieldOp &yieldToBody,
+                        mlir::cir::YieldOp &yieldToCont) const {
+    for (auto &bb : condRegion) {
+      if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(bb.getTerminator())) {
+        if (!yieldOp.getKind().has_value())
+          yieldToCont = yieldOp;
+        else if (yieldOp.getKind() == mlir::cir::YieldOpKind::Continue)
+          yieldToBody = yieldOp;
+        else
+          return mlir::failure();
+      }
+    }
+    return mlir::success();
+  }
+
+  mlir::LogicalResult
+  rewriteWhileLoop(mlir::cir::LoopOp loopOp, OpAdaptor adaptor,
+                   mlir::ConversionPatternRewriter &rewriter) const {
+    auto *currentBlock = rewriter.getInsertionBlock();
+    auto *continueBlock =
+        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+
+    // Fetch required info from the condition region.
+    auto &condRegion = loopOp.getCond();
+    auto &condFrontBlock = condRegion.front();
+    mlir::cir::YieldOp yieldToBody, yieldToCont;
+    if (fetchCondRegionYields(condRegion, yieldToBody, yieldToCont).failed())
+      loopOp.emitError("invalid yield op kind in cond region");
+
+    // Fetch required info from the condition region.
+    auto &bodyRegion = loopOp.getBody();
+    auto &bodyFrontBlock = bodyRegion.front();
+    auto bodyYield =
+        dyn_cast<mlir::cir::YieldOp>(bodyRegion.back().getTerminator());
+    assert(bodyYield && "unstructured while loops are NYI");
+
+    // Move loop op region contents to current CFG.
+    rewriter.inlineRegionBefore(condRegion, continueBlock);
+    rewriter.inlineRegionBefore(bodyRegion, continueBlock);
+
+    // Set loop entry point to condition block.
+    rewriter.setInsertionPointToEnd(currentBlock);
+    rewriter.create<mlir::cir::BrOp>(loopOp.getLoc(), &condFrontBlock);
+
+    // Set loop exit point to continue block.
+    rewriter.setInsertionPoint(yieldToCont);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldToCont, continueBlock);
+
+    // Branch from condition to body.
+    rewriter.setInsertionPoint(yieldToBody);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldToBody, &bodyFrontBlock);
+
+    // Branch from body to condition.
+    rewriter.setInsertionPoint(bodyYield);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(bodyYield, &condFrontBlock);
+
+    // Remove the loop op.
+    rewriter.eraseOp(loopOp);
+    return mlir::success();
+  }
 
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::LoopOp loopOp, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    if (loopOp.getKind() != mlir::cir::LoopOpKind::For)
+    switch (loopOp.getKind()) {
+    case LoopKind::For:
+      break;
+    case LoopKind::While:
+      return rewriteWhileLoop(loopOp, adaptor, rewriter);
+    case LoopKind::DoWhile:
       llvm_unreachable("NYI");
+    }
 
     auto loc = loopOp.getLoc();
 

--- a/clang/test/CIR/Lowering/loop.cir
+++ b/clang/test/CIR/Lowering/loop.cir
@@ -27,7 +27,6 @@ module {
     }
     cir.return
   }
-}
 
 //      MLIR: module {
 // MLIR-NEXT:   llvm.func @foo() {
@@ -61,7 +60,6 @@ module {
 // MLIR-NEXT:   ^bb6:  // pred: ^bb3
 // MLIR-NEXT:     llvm.return
 // MLIR-NEXT:   }
-// MLIR-NEXT: }
 
 //      LLVM: define void @foo() {
 //  LLVM-NEXT:   %1 = alloca i32, i64 1, align 4
@@ -95,3 +93,65 @@ module {
 //  LLVM-NEXT: 15:
 //  LLVM-NEXT:   ret void
 //  LLVM-NEXT: }
+
+  // Test while cir.loop operation lowering.
+  cir.func @testWhile(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      cir.loop while(cond : {
+        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %2 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
+        %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
+        cir.brcond %4 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        cir.yield
+      }) {
+        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %2 = cir.unary(inc, %1) : !s32i, !s32i
+        cir.store %2, %0 : !s32i, cir.ptr <!s32i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  //      MLIR:  llvm.func @testWhile(%arg0: i32) {
+  // MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
+  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.br ^bb1
+  // MLIR-NEXT:  ^bb1:
+  // MLIR-NEXT:    llvm.br ^bb2
+  // ============= Condition block =============
+  // MLIR-NEXT:  ^bb2:  // 2 preds: ^bb1, ^bb5
+  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %3 = llvm.mlir.constant(10 : i32) : i32
+  // MLIR-NEXT:    %4 = llvm.icmp "slt" %2, %3 : i32
+  // MLIR-NEXT:    %5 = llvm.zext %4 : i1 to i32
+  // MLIR-NEXT:    %6 = llvm.mlir.constant(0 : i32) : i32
+  // MLIR-NEXT:    %7 = llvm.icmp "ne" %5, %6 : i32
+  // MLIR-NEXT:    %8 = llvm.zext %7 : i1 to i8
+  // MLIR-NEXT:    %9 = llvm.trunc %8 : i8 to i1
+  // MLIR-NEXT:    llvm.cond_br %9, ^bb3, ^bb4
+  // MLIR-NEXT:  ^bb3:  // pred: ^bb2
+  // MLIR-NEXT:    llvm.br ^bb5
+  // MLIR-NEXT:  ^bb4:  // pred: ^bb2
+  // MLIR-NEXT:    llvm.br ^bb6
+  // ============= Body block =============
+  // MLIR-NEXT:  ^bb5:  // pred: ^bb3
+  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %11 = llvm.mlir.constant(1 : i32) : i32
+  // MLIR-NEXT:    %12 = llvm.add %10, %11  : i32
+  // MLIR-NEXT:    llvm.store %12, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.br ^bb2
+  // ============= Exit block =============
+  // MLIR-NEXT:  ^bb6:  // pred: ^bb4
+  // MLIR-NEXT:    llvm.br ^bb7
+
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147
* #146
* __->__ #145
* #144

Essentially converts a `cir.loop` op of the `while` kind to a CFG. The
implementation, however, was only tested with structured loops, so if
breaks, continues, or returns are found in the body, it is likely to
break.