### PR TITLE
[CIR][CIRGen] Pass field index to cir.struct_element_addr

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1377,6 +1377,9 @@ def StructElementAddr : CIR_Op<"struct_element_addr"> {
     The `cir.struct_element_addr` operaration gets the address of a particular
     named member from the input struct.
 
+    It expects a pointer to the base struct as well as the name of the member
+    and its field index.
+
     Example:
     ```mlir
     !ty_22struct2EBar22 = type !cir.struct<"struct.Bar", i32, i8>
@@ -1391,9 +1394,24 @@ def StructElementAddr : CIR_Op<"struct_element_addr"> {
 
   let arguments = (ins
     Arg<CIR_PointerType, "the address to load from", [MemRead]>:$struct_addr,
-    StrAttr:$member_name);
+    StrAttr:$member_name,
+    IndexAttr:$member_index);
 
   let results = (outs Res<CIR_PointerType, "">:$result);
+
+  let builders = [
+    OpBuilder<(ins "Type":$type, "Value":$value, "llvm::StringRef":$name,
+              "unsigned":$index),
+    [{
+      mlir::APInt fieldIdx(64, index);
+      build($_builder, $_state, type, value, name, fieldIdx);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return the index of the struct member being accessed.
+    uint64_t getIndex() { return getMemberIndex().getZExtValue(); }
+  }];
 
   // FIXME: add verifier.
 }

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -207,7 +207,8 @@ static void buildLValueForAnyFieldInitialization(CIRGenFunction &CGF,
   if (MemberInit->isIndirectMemberInitializer()) {
     llvm_unreachable("NYI");
   } else {
-    LHS = CGF.buildLValueForFieldInitialization(LHS, Field, Field->getName());
+    LHS = CGF.buildLValueForFieldInitialization(LHS, Field, Field->getName(),
+                                                Field->getFieldIndex());
   }
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -445,8 +445,8 @@ void AggExprEmitter::VisitLambdaExpr(LambdaExpr *E) {
     }
 
     // Emit initialization
-    LValue LV =
-        CGF.buildLValueForFieldInitialization(SlotLV, *CurField, fieldName);
+    LValue LV = CGF.buildLValueForFieldInitialization(
+        SlotLV, *CurField, fieldName, CurField->getFieldIndex());
     if (CurField->hasCapturedVLAType()) {
       llvm_unreachable("NYI");
     }
@@ -701,8 +701,8 @@ void AggExprEmitter::VisitCXXParenListOrInitListExpr(
         CGF.getTypes().isZeroInitializable(ExprToVisit->getType()))
       break;
 
-    LValue LV =
-        CGF.buildLValueForFieldInitialization(DestLV, field, field->getName());
+    LValue LV = CGF.buildLValueForFieldInitialization(
+        DestLV, field, field->getName(), field->getFieldIndex());
     // We never generate write-barries for initialized fields.
     assert(!UnimplementedFeature::setNonGC());
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -44,7 +44,7 @@ class CallOp;
 namespace {
 class ScalarExprEmitter;
 class AggExprEmitter;
-}
+} // namespace
 
 namespace cir {
 
@@ -1448,7 +1448,8 @@ public:
   /// stored in the reference.
   LValue buildLValueForFieldInitialization(LValue Base,
                                            const clang::FieldDecl *Field,
-                                           llvm::StringRef FieldName);
+                                           llvm::StringRef FieldName,
+                                           unsigned FieldIndex);
 
   void buildInitializerForField(clang::FieldDecl *Field, LValue LHS,
                                 clang::Expr *Init);

--- a/clang/test/CIR/CodeGen/String.cpp
+++ b/clang/test/CIR/CodeGen/String.cpp
@@ -21,10 +21,10 @@ void test() {
 // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22class2EString22>
 // CHECK-NEXT:   cir.store %arg0, %0
 // CHECK-NEXT:   %1 = cir.load %0
-// CHECK-NEXT:   %2 = "cir.struct_element_addr"(%1) {member_name = "storage"}
+// CHECK-NEXT:   %2 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "storage"}
 // CHECK-NEXT:   %3 = cir.const(#cir.null : !cir.ptr<!s8i>) : !cir.ptr<!s8i>
 // CHECK-NEXT:   cir.store %3, %2 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
-// CHECK-NEXT:   %4 = "cir.struct_element_addr"(%1) {member_name = "size"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!s64i>
+// CHECK-NEXT:   %4 = "cir.struct_element_addr"(%1) {member_index = 1 : index, member_name = "size"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!s64i>
 // CHECK-NEXT:   %5 = cir.const(#cir.int<0> : !s32i) : !s32i
 // CHECK-NEXT:   %6 = cir.cast(integral, %5 : !s32i), !s64i
 // CHECK-NEXT:   cir.store %6, %4 : !s64i, cir.ptr <!s64i>
@@ -36,10 +36,10 @@ void test() {
 // CHECK-NEXT:   cir.store %arg0, %0
 // CHECK-NEXT:   cir.store %arg1, %1
 // CHECK-NEXT:   %2 = cir.load %0
-// CHECK-NEXT:   %3 = "cir.struct_element_addr"(%2) {member_name = "storage"}
+// CHECK-NEXT:   %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "storage"}
 // CHECK-NEXT:   %4 = cir.const(#cir.null : !cir.ptr<!s8i>)
 // CHECK-NEXT:   cir.store %4, %3
-// CHECK-NEXT:   %5 = "cir.struct_element_addr"(%2) {member_name = "size"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!s64i>
+// CHECK-NEXT:   %5 = "cir.struct_element_addr"(%2) {member_index = 1 : index, member_name = "size"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!s64i>
 // CHECK-NEXT:   %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:   %7 = cir.cast(integral, %6 : !s32i), !s64i
 // CHECK-NEXT:   cir.store %7, %5 : !s64i, cir.ptr <!s64i>
@@ -52,7 +52,7 @@ void test() {
 // CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!ty_22class2EString22>, cir.ptr <!cir.ptr<!ty_22class2EString22>>
 // CHECK-NEXT:   cir.store %arg1, %1 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
 // CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22class2EString22>>, !cir.ptr<!ty_22class2EString22>
-// CHECK-NEXT:   %3 = "cir.struct_element_addr"(%2) {member_name = "storage"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!cir.ptr<!s8i>>
+// CHECK-NEXT:   %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "storage"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!cir.ptr<!s8i>>
 // CHECK-NEXT:   %4 = cir.const(#cir.null : !cir.ptr<!s8i>) : !cir.ptr<!s8i>
 // CHECK-NEXT:   cir.store %4, %3 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
 // CHECK-NEXT:   cir.return

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -35,10 +35,10 @@ void use() { yop{}; }
 
 // CHECK: cir.func @_Z3usev() {
 // CHECK:   %0 = cir.alloca !ty_22struct2Eyep_22, cir.ptr <!ty_22struct2Eyep_22>, ["agg.tmp0"] {alignment = 4 : i64}
-// CHECK:   %1 = "cir.struct_element_addr"(%0) {member_name = "Status"} : (!cir.ptr<!ty_22struct2Eyep_22>) -> !cir.ptr<!u32i>
+// CHECK:   %1 = "cir.struct_element_addr"(%0) {member_index = 0 : index, member_name = "Status"} : (!cir.ptr<!ty_22struct2Eyep_22>) -> !cir.ptr<!u32i>
 // CHECK:   %2 = cir.const(#cir.int<0> : !u32i) : !u32i
 // CHECK:   cir.store %2, %1 : !u32i, cir.ptr <!u32i>
-// CHECK:   %3 = "cir.struct_element_addr"(%0) {member_name = "HC"} : (!cir.ptr<!ty_22struct2Eyep_22>) -> !cir.ptr<!u32i>
+// CHECK:   %3 = "cir.struct_element_addr"(%0) {member_index = 1 : index, member_name = "HC"} : (!cir.ptr<!ty_22struct2Eyep_22>) -> !cir.ptr<!u32i>
 // CHECK:   %4 = cir.const(#cir.int<0> : !u32i) : !u32i
 // CHECK:   cir.store %4, %3 : !u32i, cir.ptr <!u32i>
 // CHECK:   cir.return
@@ -68,12 +68,12 @@ void yo() {
 // CHECK:   %1 = cir.alloca !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>, ["ext2", init] {alignment = 8 : i64}
 // CHECK:   %2 = cir.const(#cir.const_struct<{#cir.int<1000070000> : !u32i,#cir.null : !cir.ptr<!void>,#cir.int<0> : !u64i}> : !ty_22struct2EYo22) : !ty_22struct2EYo22
 // CHECK:   cir.store %2, %0 : !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>
-// CHECK:   %3 = "cir.struct_element_addr"(%1) {member_name = "type"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u32i>
+// CHECK:   %3 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "type"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u32i>
 // CHECK:   %4 = cir.const(#cir.int<1000066001> : !u32i) : !u32i
 // CHECK:   cir.store %4, %3 : !u32i, cir.ptr <!u32i>
-// CHECK:   %5 = "cir.struct_element_addr"(%1) {member_name = "next"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!cir.ptr<!void>>
+// CHECK:   %5 = "cir.struct_element_addr"(%1) {member_index = 1 : index, member_name = "next"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!cir.ptr<!void>>
 // CHECK:   %6 = cir.cast(bitcast, %0 : !cir.ptr<!ty_22struct2EYo22>), !cir.ptr<!void>
 // CHECK:   cir.store %6, %5 : !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>
-// CHECK:   %7 = "cir.struct_element_addr"(%1) {member_name = "createFlags"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u64i>
+// CHECK:   %7 = "cir.struct_element_addr"(%1) {member_index = 2 : index, member_name = "createFlags"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u64i>
 // CHECK:   %8 = cir.const(#cir.int<0> : !u64i) : !u64i
 // CHECK:   cir.store %8, %7 : !u64i, cir.ptr <!u64i>

--- a/clang/test/CIR/CodeGen/assign-operator.cpp
+++ b/clang/test/CIR/CodeGen/assign-operator.cpp
@@ -23,7 +23,7 @@ struct String {
 
   // Get address of `this->size`
 
-  // CHECK:   %3 = "cir.struct_element_addr"(%2) {member_name = "size"}
+  // CHECK:   %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "size"}
 
   // Get address of `s`
 
@@ -31,7 +31,7 @@ struct String {
 
   // Get the address of s.size
 
-  // CHECK:   %5 = "cir.struct_element_addr"(%4) {member_name = "size"}
+  // CHECK:   %5 = "cir.struct_element_addr"(%4) {member_index = 0 : index, member_name = "size"}
 
   // Load value from s.size and store in this->size
 
@@ -53,9 +53,9 @@ struct String {
   // CHECK:   cir.store %arg1, %1 : !cir.ptr<!ty_22struct2EStringView22>
   // CHECK:   %3 = cir.load deref %0 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>
   // CHECK:   %4 = cir.load %1 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>
-  // CHECK:   %5 = "cir.struct_element_addr"(%4) {member_name = "size"}
+  // CHECK:   %5 = "cir.struct_element_addr"(%4) {member_index = 0 : index, member_name = "size"}
   // CHECK:   %6 = cir.load %5 : cir.ptr <!s64i>, !s64i
-  // CHECK:   %7 = "cir.struct_element_addr"(%3) {member_name = "size"}
+  // CHECK:   %7 = "cir.struct_element_addr"(%3) {member_index = 0 : index, member_name = "size"}
   // CHECK:   cir.store %6, %7 : !s64i, cir.ptr <!s64i>
   // CHECK:   cir.store %3, %2 : !cir.ptr<!ty_22struct2EStringView22>
   // CHECK:   %8 = cir.load %2 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>

--- a/clang/test/CIR/CodeGen/ctor-member-lvalue-to-rvalue.cpp
+++ b/clang/test/CIR/CodeGen/ctor-member-lvalue-to-rvalue.cpp
@@ -11,9 +11,9 @@ struct String {
 // CHECK:     cir.store %arg0, %0
 // CHECK:     cir.store %arg1, %1
 // CHECK:     %2 = cir.load %0
-// CHECK:     %3 = "cir.struct_element_addr"(%2) {member_name = "size"}
+// CHECK:     %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "size"}
 // CHECK:     %4 = cir.load %1
-// CHECK:     %5 = "cir.struct_element_addr"(%4) {member_name = "size"}
+// CHECK:     %5 = "cir.struct_element_addr"(%4) {member_index = 0 : index, member_name = "size"}
 // CHECK:     %6 = cir.load %5 : cir.ptr <!s64i>, !s64i
 // CHECK:     cir.store %6, %3 : !s64i, cir.ptr <!s64i>
 // CHECK:     cir.return

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -82,7 +82,7 @@ void C3::Layer::Initialize() {
 
 // CHECK:  cir.scope {
 // CHECK:    %2 = cir.base_class_addr(%1 : cir.ptr <!ty_22struct2EC33A3ALayer22>) -> cir.ptr <!ty_22class2EC23A3ALayer22>
-// CHECK:    %3 = "cir.struct_element_addr"(%2) {member_name = "m_C1"} : (!cir.ptr<!ty_22class2EC23A3ALayer22>) -> !cir.ptr<!cir.ptr<!ty_22class2EC222>>
+// CHECK:    %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "m_C1"} : (!cir.ptr<!ty_22class2EC23A3ALayer22>) -> !cir.ptr<!cir.ptr<!ty_22class2EC222>>
 // CHECK:    %4 = cir.load %3 : cir.ptr <!cir.ptr<!ty_22class2EC222>>, !cir.ptr<!ty_22class2EC222>
 // CHECK:    %5 = cir.const(#cir.null : !cir.ptr<!ty_22class2EC222>) : !cir.ptr<!ty_22class2EC222>
 // CHECK:    %6 = cir.cmp(eq, %4, %5) : !cir.ptr<!ty_22class2EC222>, !cir.bool

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -26,12 +26,12 @@ void l0() {
 // CHECK: %0 = cir.alloca !cir.ptr<!ty_22class2Eanon222>, cir.ptr <!cir.ptr<!ty_22class2Eanon222>>, ["this", init] {alignment = 8 : i64}
 // CHECK: cir.store %arg0, %0 : !cir.ptr<!ty_22class2Eanon222>, cir.ptr <!cir.ptr<!ty_22class2Eanon222>>
 // CHECK: %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22class2Eanon222>>, !cir.ptr<!ty_22class2Eanon222>
-// CHECK: %2 = "cir.struct_element_addr"(%1) {member_name = "i"} : (!cir.ptr<!ty_22class2Eanon222>) -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %2 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "i"} : (!cir.ptr<!ty_22class2Eanon222>) -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: %3 = cir.load %2 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: %4 = cir.load %3 : cir.ptr <!s32i>, !s32i
 // CHECK: %5 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK: %6 = cir.binop(add, %4, %5) : !s32i
-// CHECK: %7 = "cir.struct_element_addr"(%1) {member_name = "i"} : (!cir.ptr<!ty_22class2Eanon222>) -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %7 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "i"} : (!cir.ptr<!ty_22class2Eanon222>) -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: %8 = cir.load %7 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: cir.store %6, %8 : !s32i, cir.ptr <!s32i>
 
@@ -50,7 +50,7 @@ auto g() {
 // CHECK: %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK: %2 = cir.const(#cir.int<12> : !s32i) : !s32i
 // CHECK: cir.store %2, %1 : !s32i, cir.ptr <!s32i>
-// CHECK: %3 = "cir.struct_element_addr"(%0) {member_name = "i"} : (!cir.ptr<!ty_22class2Eanon223>) -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %3 = "cir.struct_element_addr"(%0) {member_index = 0 : index, member_name = "i"} : (!cir.ptr<!ty_22class2Eanon223>) -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: cir.store %1, %3 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK: %4 = cir.load %0 : cir.ptr <!ty_22class2Eanon223>, !ty_22class2Eanon223
 // CHECK: cir.return %4 : !ty_22class2Eanon223
@@ -70,7 +70,7 @@ auto g2() {
 // CHECK-NEXT: %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK-NEXT: %2 = cir.const(#cir.int<12> : !s32i) : !s32i
 // CHECK-NEXT: cir.store %2, %1 : !s32i, cir.ptr <!s32i>
-// CHECK-NEXT: %3 = "cir.struct_element_addr"(%0) {member_name = "i"} : (!cir.ptr<!ty_22class2Eanon224>) -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK-NEXT: %3 = "cir.struct_element_addr"(%0) {member_index = 0 : index, member_name = "i"} : (!cir.ptr<!ty_22class2Eanon224>) -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK-NEXT: cir.store %1, %3 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK-NEXT: %4 = cir.load %0 : cir.ptr <!ty_22class2Eanon224>, !ty_22class2Eanon224
 // CHECK-NEXT: cir.return %4 : !ty_22class2Eanon224

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -61,11 +61,11 @@ void init(unsigned numImages) {
 // CHECK:         %13 = cir.alloca !ty_22struct2Etriple22, cir.ptr <!ty_22struct2Etriple22>, ["ref.tmp0"] {alignment = 8 : i64}
 // CHECK:         %14 = cir.const(#cir.zero : !ty_22struct2Etriple22) : !ty_22struct2Etriple22
 // CHECK:         cir.store %14, %13 : !ty_22struct2Etriple22, cir.ptr <!ty_22struct2Etriple22>
-// CHECK:         %15 = "cir.struct_element_addr"(%13) {member_name = "type"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!u32i>
+// CHECK:         %15 = "cir.struct_element_addr"(%13) {member_index = 0 : index, member_name = "type"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!u32i>
 // CHECK:         %16 = cir.const(#cir.int<1000024002> : !u32i) : !u32i
 // CHECK:         cir.store %16, %15 : !u32i, cir.ptr <!u32i>
-// CHECK:         %17 = "cir.struct_element_addr"(%13) {member_name = "next"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!cir.ptr<!void>>
-// CHECK:         %18 = "cir.struct_element_addr"(%13) {member_name = "image"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!u32i>
+// CHECK:         %17 = "cir.struct_element_addr"(%13) {member_index = 1 : index, member_name = "next"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!cir.ptr<!void>>
+// CHECK:         %18 = "cir.struct_element_addr"(%13) {member_index = 2 : index, member_name = "image"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!u32i>
 // CHECK:         %19 = cir.load %7 : cir.ptr <!cir.ptr<!ty_22struct2Etriple22>>, !cir.ptr<!ty_22struct2Etriple22>
 // CHECK:         %20 = cir.call @_ZN6tripleaSEOS_(%19, %13) : (!cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!ty_22struct2Etriple22>
 // CHECK:       }

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -98,14 +98,14 @@ void m() { Adv C; }
 // CHECK:     %0 = cir.alloca !cir.ptr<!ty_22class2EAdv22>, cir.ptr <!cir.ptr<!ty_22class2EAdv22>>, ["this", init] {alignment = 8 : i64}
 // CHECK:     cir.store %arg0, %0 : !cir.ptr<!ty_22class2EAdv22>, cir.ptr <!cir.ptr<!ty_22class2EAdv22>>
 // CHECK:     %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22class2EAdv22>>, !cir.ptr<!ty_22class2EAdv22>
-// CHECK:     %2 = "cir.struct_element_addr"(%1) {member_name = "x"} : (!cir.ptr<!ty_22class2EAdv22>) -> !cir.ptr<!ty_22struct2EMandalore22>
-// CHECK:     %3 = "cir.struct_element_addr"(%2) {member_name = "w"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!u32i>
+// CHECK:     %2 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "x"} : (!cir.ptr<!ty_22class2EAdv22>) -> !cir.ptr<!ty_22struct2EMandalore22>
+// CHECK:     %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "w"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!u32i>
 // CHECK:     %4 = cir.const(#cir.int<1000024001> : !u32i) : !u32i
 // CHECK:     cir.store %4, %3 : !u32i, cir.ptr <!u32i>
-// CHECK:     %5 = "cir.struct_element_addr"(%2) {member_name = "n"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!cir.ptr<!void>>
+// CHECK:     %5 = "cir.struct_element_addr"(%2) {member_index = 1 : index, member_name = "n"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!cir.ptr<!void>>
 // CHECK:     %6 = cir.const(#cir.null : !cir.ptr<!void>) : !cir.ptr<!void>
 // CHECK:     cir.store %6, %5 : !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>
-// CHECK:     %7 = "cir.struct_element_addr"(%2) {member_name = "d"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!s32i>
+// CHECK:     %7 = "cir.struct_element_addr"(%2) {member_index = 2 : index, member_name = "d"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!s32i>
 // CHECK:     %8 = cir.const(#cir.int<0> : !s32i) : !s32i
 // CHECK:     cir.store %8, %7 : !s32i, cir.ptr <!s32i>
 // CHECK:     cir.return
@@ -147,4 +147,4 @@ void ppp() { Entry x; }
 
 // CHECK: cir.func linkonce_odr @_ZN5EntryC2Ev(%arg0: !cir.ptr<!ty_22struct2EEntry22>
 
-// CHECK: = "cir.struct_element_addr"(%1) {member_name = "procAddr"} : (!cir.ptr<!ty_22struct2EEntry22>) -> !cir.ptr<!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>>
+// CHECK: = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "procAddr"} : (!cir.ptr<!ty_22struct2EEntry22>) -> !cir.ptr<!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>>

--- a/clang/test/CIR/CodeGen/unary-deref.cpp
+++ b/clang/test/CIR/CodeGen/unary-deref.cpp
@@ -12,6 +12,6 @@ void foo() {
 
 // CHECK:  cir.func linkonce_odr  @_ZNK12MyIntPointer4readEv
 // CHECK:  %2 = cir.load %0
-// CHECK:  %3 = "cir.struct_element_addr"(%2) {member_name = "ptr"}
+// CHECK:  %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "ptr"}
 // CHECK:  %4 = cir.load deref %3 : cir.ptr <!cir.ptr<!s32i>>
 // CHECK:  %5 = cir.load %4


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #149
* __->__ #148

A `member_index` index attribute in `cir.struct_element_addr` now holds
the index for the member being accessed. A APInt is used as the storage
type for the index, alongside a custom builder to abstract the APInt
object creation.

Before, we only passed the name of the field to cir.struct_element_addr,
which was not very useful since it couldn't be used to recover the index
of the member being accessed. This index is essential for lowering CIR
to LLVM, as LLVM needs to know which element is being accessed in the
struct data aggregate.