### PR TITLE
[CIR][Lowering] Lower basic structs

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1208,18 +1208,37 @@ public:
   }
 };
 
+class CIRStructElementAddrOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::StructElementAddr> {
+public:
+  using mlir::OpConversionPattern<
+      mlir::cir::StructElementAddr>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::StructElementAddr op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto llResTy = getTypeConverter()->convertType(op.getType());
+    // Since the base address is a pointer to structs, the first offset is
+    // always zero. The second offset tell us which member it will access.
+    llvm::SmallVector<mlir::LLVM::GEPArg> offset{0, op.getIndex()};
+    rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
+        op, llResTy, adaptor.getStructAddr(), offset);
+    return mlir::success();
+  }
+};
+
 void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter) {
   patterns.add<CIRReturnLowering>(patterns.getContext());
-  patterns.add<CIRCmpOpLowering, CIRLoopOpLowering, CIRBrCondOpLowering,
-               CIRPtrStrideOpLowering, CIRCallLowering, CIRUnaryOpLowering,
-               CIRBinOpLowering, CIRLoadLowering, CIRConstantLowering,
-               CIRStoreLowering, CIRAllocaLowering, CIRFuncLowering,
-               CIRScopeOpLowering, CIRCastOpLowering, CIRIfLowering,
-               CIRGlobalOpLowering, CIRGetGlobalOpLowering, CIRVAStartLowering,
-               CIRVAEndLowering, CIRVACopyLowering, CIRVAArgLowering,
-               CIRBrOpLowering, CIRTernaryOpLowering>(converter,
-                                                      patterns.getContext());
+  patterns.add<
+      CIRCmpOpLowering, CIRLoopOpLowering, CIRBrCondOpLowering,
+      CIRPtrStrideOpLowering, CIRCallLowering, CIRUnaryOpLowering,
+      CIRBinOpLowering, CIRLoadLowering, CIRConstantLowering, CIRStoreLowering,
+      CIRAllocaLowering, CIRFuncLowering, CIRScopeOpLowering, CIRCastOpLowering,
+      CIRIfLowering, CIRGlobalOpLowering, CIRGetGlobalOpLowering,
+      CIRVAStartLowering, CIRVAEndLowering, CIRVACopyLowering, CIRVAArgLowering,
+      CIRBrOpLowering, CIRTernaryOpLowering, CIRStructElementAddrOpLowering>(
+      converter, patterns.getContext());
 }
 
 namespace {

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -1,0 +1,18 @@
+// RUN: cir-tool %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+!s32i = !cir.int<s, 32>
+!u8i = !cir.int<u, 8>
+!ty_22struct2ES22 = !cir.struct<"struct.S", !u8i, !s32i>
+module {
+  cir.func @test() {
+    %1 = cir.alloca !ty_22struct2ES22, cir.ptr <!ty_22struct2ES22>, ["x"] {alignment = 4 : i64}
+    // CHECK: %[[#ARRSIZE:]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK: %[[#STRUCT:]] = llvm.alloca %[[#ARRSIZE]] x !llvm.struct<"struct.S", (i8, i32)>
+    %3 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "c"} : (!cir.ptr<!ty_22struct2ES22>) -> !cir.ptr<!u8i>
+    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 0] : (!llvm.ptr<struct<"struct.S", (i8, i32)>>) -> !llvm.ptr<i8>
+    %5 = "cir.struct_element_addr"(%1) {member_index = 1 : index, member_name = "i"} : (!cir.ptr<!ty_22struct2ES22>) -> !cir.ptr<!s32i>
+    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 1] : (!llvm.ptr<struct<"struct.S", (i8, i32)>>) -> !llvm.ptr<i32>
+    cir.return
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #149
* #148

Maps StructElementAddrOp field indexes to LLVM's GEPOp offsets to access
struct members. The current implementation does not account for
anonymous structs nor nested structs, only simple structs.