### PR TITLE
[CIR][CodeGen] Support conditional result implicit cast

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -466,11 +466,20 @@ public:
                                      mlir::cir::CastKind::ptr_to_int, src);
   }
 
+  // TODO(cir): the following function was introduced to keep in sync with LLVM
+  // codegen. CIR does not have "zext" operations. It should eventually be
+  // renamed or removed. For now, we just add whatever cast is required here.
   mlir::Value createZExtOrBitCast(mlir::Location loc, mlir::Value src,
                                   mlir::Type newTy) {
-    if (src.getType() == newTy)
+    auto srcTy = src.getType();
+
+    if (srcTy == newTy)
       return src;
-    llvm_unreachable("NYI");
+
+    if (srcTy.isa<mlir::cir::BoolType>() && newTy.isa<mlir::cir::IntType>())
+      return createBoolToInt(src, newTy);
+
+    llvm_unreachable("unhandled extension cast");
   }
 
   mlir::Value createBoolToInt(mlir::Value src, mlir::Type newTy) {

--- a/clang/test/CIR/CodeGen/binop.c
+++ b/clang/test/CIR/CodeGen/binop.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void conditionalResultIimplicitCast(int a, int b, float f) {
+  // Should implicit cast back to int.
+  int x = a && b;
+  // CHECK: %[[#INT:]] = cir.ternary
+  // CHECK: %{{.+}} = cir.cast(bool_to_int, %[[#INT]] : !cir.bool), !s32i
+  float y = f && f;
+  // CHECK: %[[#BOOL:]] = cir.ternary
+  // CHECK: %[[#INT:]] = cir.cast(bool_to_int, %[[#BOOL]] : !cir.bool), !s32i
+  // CHECK: %{{.+}} = cir.cast(int_to_float, %[[#INT]] : !s32i), f32
+}


### PR DESCRIPTION
In C, whenever we logically compare two values, we may store it in any variable type. In this case, the boolean result should be cast to whatever type the variable is. This patch adds support for this.