### PR TITLE
[CIR][Lowering] Fix CIR casts lowering

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -333,13 +333,17 @@ public:
       if (dstType.getWidth() < srcType.getWidth()) {
         rewriter.replaceOpWithNewOp<mlir::LLVM::TruncOp>(castOp, llvmDstTy,
                                                          llvmSrcVal);
-      } else {
+      }
+      // Target integer is larger: sign extend or zero extend.
+      else if (dstType.getWidth() > srcType.getWidth()) {
         if (srcType.isUnsigned())
           rewriter.replaceOpWithNewOp<mlir::LLVM::ZExtOp>(castOp, llvmDstTy,
                                                           llvmSrcVal);
         else
           rewriter.replaceOpWithNewOp<mlir::LLVM::SExtOp>(castOp, llvmDstTy,
                                                           llvmSrcVal);
+      } else { // Target integer is of the same size: do nothing.
+        rewriter.replaceOp(castOp, llvmSrcVal);
       }
       break;
     }

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -32,6 +32,15 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4) {
   long long d = (long long)x2; // sign extend
   // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !s32i), !s64i
 
+  unsigned ui = (unsigned)x2; // sign drop
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !s32i), !u32i
+
+  int si = (int)x1; // sign add
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !u32i), !s32i
+
+  unsigned uu = (unsigned)x1; // should not be generated
+  // CHECK-NOT: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !u32i), !u32i
+
   int arr[3];
   int* e = (int*)arr; // explicit pointer decay
   // CHECK: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %{{[0-9]+}} : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -57,6 +57,10 @@ module {
     %15 = cir.load %1 : cir.ptr <!s32i>, !s32i
     %16 = cir.cast(integral, %15 : !s32i), !s64i
     // MLIR: %{{[0-9]+}} = llvm.sext %{{[0-9]+}} : i32 to i64
+    %30 = cir.cast(integral, %arg1 : !s32i), !u32i
+    // Should not produce a cast.
+    %32 = cir.cast(integral, %arg0 : !u32i), !s32i
+    // Should not produce a cast.
     cir.store %16, %6 : !s64i, cir.ptr <!s64i>
     %17 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
     // MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr<array<3 x i32>>) -> !llvm.ptr<i32>

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -1,6 +1,5 @@
 // RUN: cir-tool %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-tool %s -cir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
-// XFAIL: *
 
 !s16i = !cir.int<s, 16>
 !s32i = !cir.int<s, 32>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #157
* #156
* #155
* __->__ #154

Casts from one integer type to another, should not be lowered to LLVM
if the integers are of the same size. These may represent sign drops or
inclusion in CIR but do not make sense in LLVM. This patch fixes that.