### PR TITLE
[CIR][Lowering] Lower #cir.zero and #cir.null attributes

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -107,6 +107,9 @@ def ZeroAttr : CIR_Attr<"Zero", "zero", [TypedAttrInterface]> {
 
   let parameters = (ins AttributeSelfTypeParameter<"">:$type);
   let assemblyFormat = [{}];
+  let extraClassDeclaration = [{
+    static llvm::StringRef getName() { return "cir.zero"; };
+  }];
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #163
* #162

LLVM's dialect does not have (at the time of writing) a way to represent
zero-initializers. And, despite being possible to represent null
pointers, it requires it to use a region-based initialization. To avoid
this, LLVM operations that use either of these attributes are marked
with a cir.zero string attribute that will be identified by the
LowerAttrToLLVMIR interface and patch the LLVM IR operation to be
initialized with a zero-initializer or null.