### PR TITLE
[CIR][Codegen] Implicit cast RHS to LHS on SHR and SHL binops

### DIFF
--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -51,6 +51,7 @@ struct UnimplementedFeature {
   static bool reportGlobalToASan() { return false; }
   static bool emitAsanPrologueOrEpilogue() { return false; }
   static bool emitCheckedInBoundsGEP() { return false; }
+  static bool shiftExponentSanitizer() { return false; }
 
   // ObjC
   static bool setObjCGCLValueClass() { return false; }

--- a/clang/test/CIR/CodeGen/binop.cpp
+++ b/clang/test/CIR/CodeGen/binop.cpp
@@ -100,3 +100,12 @@ void b3(int a, int b, int c, int d) {
 // CHECK-NEXT:      %14 = cir.load %3
 // CHECK-NEXT:      %15 = cir.cmp(eq, %13, %14)
 // CHECK-NEXT:      %16 = cir.ternary(%15, true
+
+void implicitCasts(unsigned ui, int si) {
+  ui >> si; // Must cast RHS type to LHS type.
+  // CHECK: %[[#SHR_CAST:]] = cir.cast(integral, %{{.+}} : !s32i), !u32i
+  // CHECK: %{{.+}} = cir.binop(shr, %{{.+}}, %[[#SHR_CAST]]) : !u32i
+  ui << si;  // Must cast RHS type to LHS type.
+  // CHECK: %[[#SHL_CAST:]] = cir.cast(integral, %{{.+}} : !s32i), !u32i
+  // CHECK: %{{.+}} = cir.binop(shl, %6, %[[#SHL_CAST]]) : !u32i
+}


### PR DESCRIPTION
CIR binary operations require operands to have the same type, but C/C++ allows SHL and SHR operations to use different integer types. This patch ensures that the RHS is cast to the LHS type before performing the binary operation.

Moreover, extra guards were added to both buildShr and buildShl to track unimplemented features.