### PR TITLE
[CIR][CIRGen] Support floating point subtraction

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -362,6 +362,16 @@ public:
                                      mlir::cir::CastKind::floating, v);
   }
 
+  mlir::Value createFSub(mlir::Value lhs, mlir::Value rhs) {
+    assert(!UnimplementedFeature::metaDataNode());
+    if (IsFPConstrained)
+      llvm_unreachable("Constrained FP NYI");
+
+    assert(!UnimplementedFeature::foldBinOpFMF());
+    return create<mlir::cir::BinOp>(lhs.getLoc(), mlir::cir::BinOpKind::Sub,
+                                    lhs, rhs);
+  }
+
   mlir::Value createPtrToBoolCast(mlir::Value v) {
     return create<mlir::cir::CastOp>(v.getLoc(), getBoolTy(),
                                      mlir::cir::CastKind::ptr_to_bool, v);

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1067,7 +1067,8 @@ mlir::Value ScalarExprEmitter::buildSub(const BinOpInfo &Ops) {
 
     assert(!UnimplementedFeature::cirVectorType());
     if (Ops.LHS.getType().isa<mlir::FloatType>()) {
-      llvm_unreachable("NYI");
+      CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(CGF, Ops.FPFeatures);
+      return Builder.createFSub(Ops.LHS, Ops.RHS);
     }
 
     if (Ops.isFixedPointOp())

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -13,6 +13,7 @@
 #include "CIRGenFunction.h"
 #include "CIRGenCXXABI.h"
 #include "CIRGenModule.h"
+#include "UnimplementedFeatureGuarding.h"
 
 #include "clang/AST/ASTLambda.h"
 #include "clang/AST/ExprObjC.h"
@@ -1230,7 +1231,28 @@ void CIRGenFunction::CIRGenFPOptionsRAII::ConstructorHelper(
   if (OldFPFeatures == FPFeatures)
     return;
 
-  llvm_unreachable("NYI");
+  // TODO(cir): create guard to restore fast math configurations.
+  assert(!UnimplementedFeature::fastMathGuard());
+
+  llvm::RoundingMode NewRoundingBehavior = FPFeatures.getRoundingMode();
+  // TODO(cir): override rounding behaviour once FM configs are guarded.
+  auto NewExceptionBehavior =
+      ToConstrainedExceptMD(static_cast<LangOptions::FPExceptionModeKind>(
+          FPFeatures.getExceptionMode()));
+  // TODO(cir): override exception behaviour once FM configs are guarded.
+
+  // TODO(cir): override FP flags once FM configs are guarded.
+  assert(!UnimplementedFeature::fastMathFlags());
+
+  assert((CGF.CurFuncDecl == nullptr || CGF.builder.getIsFPConstrained() ||
+          isa<CXXConstructorDecl>(CGF.CurFuncDecl) ||
+          isa<CXXDestructorDecl>(CGF.CurFuncDecl) ||
+          (NewExceptionBehavior == fp::ebIgnore &&
+           NewRoundingBehavior == llvm::RoundingMode::NearestTiesToEven)) &&
+         "FPConstrained should be enabled on entire function");
+
+  // TODO(cir): mark CIR function with fast math attributes.
+  assert(!UnimplementedFeature::fastMathFuncAttributes());
 }
 
 CIRGenFunction::CIRGenFPOptionsRAII::~CIRGenFPOptionsRAII() {

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -84,6 +84,14 @@ struct UnimplementedFeature {
   static bool mayHaveIntegerOverflow() { return false; }
   static bool llvmLoweringPtrDiffConsidersPointee() { return false; }
 
+  // Folding methods.
+  static bool foldBinOpFMF() { return false; }
+
+  // Fast math.
+  static bool fastMathGuard() { return false; }
+  static bool fastMathFlags() { return false; }
+  static bool fastMathFuncAttributes() { return false; }
+
   static bool capturedByInit() { return false; }
   static bool tryEmitAsConstant() { return false; }
   static bool incrementProfileCounter() { return false; }
@@ -116,6 +124,7 @@ struct UnimplementedFeature {
   static bool chainCalls() { return false; }
   static bool operandBundles() { return false; }
   static bool exceptions() { return false; }
+  static bool metaDataNode() { return false; }
 };
 } // namespace cir
 

--- a/clang/test/CIR/CodeGen/binop.cpp
+++ b/clang/test/CIR/CodeGen/binop.cpp
@@ -100,3 +100,14 @@ void b3(int a, int b, int c, int d) {
 // CHECK-NEXT:      %14 = cir.load %3
 // CHECK-NEXT:      %15 = cir.cmp(eq, %13, %14)
 // CHECK-NEXT:      %16 = cir.ternary(%15, true
+
+void testFloatingPointBinOps(float a, float b) {
+  a * b;
+  // CHECK: cir.binop(mul, %{{.+}}, %{{.+}}) : f32
+  a / b;
+  // CHECK: cir.binop(div, %{{.+}}, %{{.+}}) : f32
+  a + b;
+  // CHECK: cir.binop(add, %{{.+}}, %{{.+}}) : f32
+  a - b;
+  // CHECK: cir.binop(sub, %{{.+}}, %{{.+}}) : f32
+}


### PR DESCRIPTION
While the original codegen attempts to generate a fmuladd, this patch ignores this optimization as it should be deferred to MLIR.

It also updates FP options builder to be closer to the original codegen and improve the tracking of missing features.