### PR TITLE
[CIR][CIRGen] Support function basic static variables

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1298,6 +1298,9 @@ def GlobalOp : CIR_Op<"global", [Symbol]> {
 
       return isDeclaration();
     }
+
+    /// Whether the definition of this global may be replaced at link time.
+    bool isWeakForLinker() { return cir::isWeakForLinker(getLinkage()); }
   }];
 
   let skipDefaultBuilders = 1;

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -39,7 +39,7 @@ static mlir::cir::FuncOp buildFunctionDeclPointer(CIRGenModule &CGM,
   const auto *FD = cast<FunctionDecl>(GD.getDecl());
 
   if (FD->hasAttr<WeakRefAttr>()) {
-    mlir::Operation* aliasee = CGM.getWeakRefReference(FD);
+    mlir::Operation *aliasee = CGM.getWeakRefReference(FD);
     return dyn_cast<FuncOp>(aliasee);
   }
 
@@ -639,10 +639,17 @@ LValue CIRGenFunction::buildDeclRefLValue(const DeclRefExpr *E) {
     // Otherwise, it might be static local we haven't emitted yet for some
     // reason; most likely, because it's in an outer function.
     else if (VD->isStaticLocal()) {
-      llvm_unreachable("NYI");
+      mlir::cir::GlobalOp var = CGM.getOrCreateStaticVarDecl(
+          *VD, CGM.getCIRLinkageVarDefinition(VD, /*IsConstant=*/false));
+      addr = Address(builder.createGetGlobal(var), convertType(VD->getType()),
+                     getContext().getDeclAlign(VD));
     } else {
       llvm_unreachable("DeclRefExpr for decl not entered in LocalDeclMap?");
     }
+
+    // Handle threadlocal function locals.
+    if (VD->getTLSKind() != VarDecl::TLS_None)
+      llvm_unreachable("thread-local storage is NYI");
 
     // Check for OpenMP threadprivate variables.
     if (getLangOpts().OpenMP && !getLangOpts().OpenMPSimd &&
@@ -663,25 +670,30 @@ LValue CIRGenFunction::buildDeclRefLValue(const DeclRefExpr *E) {
                                          VD->getType(), AlignmentSource::Decl)
             : makeAddrLValue(addr, T, AlignmentSource::Decl);
 
-    assert(symbolTable.count(VD) && "should be already mapped");
+    // Statics are defined as globals, so they are not include in the function's
+    // symbol table.
+    assert((VD->isStaticLocal() || symbolTable.count(VD)) &&
+           "non-static locals should be already mapped");
 
     bool isLocalStorage = VD->hasLocalStorage();
 
     bool NonGCable =
         isLocalStorage && !VD->getType()->isReferenceType() && !isBlockByref;
 
-    if (NonGCable) {
-      // TODO: nongcable
+    if (NonGCable && UnimplementedFeature::setNonGC()) {
+      llvm_unreachable("garbage collection is NYI");
     }
 
     bool isImpreciseLifetime =
         (isLocalStorage && !VD->hasAttr<ObjCPreciseLifetimeAttr>());
-    if (isImpreciseLifetime)
-      ; // TODO: LV.setARCPreciseLifetime
-    // TODO: setObjCGCLValueClass(getContext(), E, LV);
+    if (isImpreciseLifetime && UnimplementedFeature::ARC())
+      llvm_unreachable("imprecise lifetime is NYI");
+    assert(!UnimplementedFeature::setObjCGCLValueClass());
 
-    mlir::Value V = symbolTable.lookup(VD);
-    assert(V && "Name lookup must succeed");
+    // Statics are defined as globals, so they are not include in the function's
+    // symbol table.
+    assert((VD->isStaticLocal() || symbolTable.lookup(VD)) &&
+           "Name lookup must succeed for non-static local variables");
 
     return LV;
   }
@@ -1601,7 +1613,7 @@ static Address createReferenceTemporary(CIRGenFunction &CGF,
     QualType Ty = Inner->getType();
     if (CGF.CGM.getCodeGenOpts().MergeAllConstants &&
         (Ty->isArrayType() || Ty->isRecordType()) &&
-        CGF.CGM.isTypeConstant(Ty, true))
+        CGF.CGM.isTypeConstant(Ty, /*ExcludeCtor=*/true, /*ExcludeDtor=*/false))
       assert(0 && "NYI");
     return CGF.CreateMemTemp(Ty, CGF.getLoc(M->getSourceRange()),
                              CGF.getCounterRefTmpAsString(), Alloca);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1270,6 +1270,12 @@ public:
   /// inside a function, including static vars etc.
   void buildVarDecl(const clang::VarDecl &D);
 
+  mlir::cir::GlobalOp addInitializerToStaticVarDecl(const VarDecl &D,
+                                                    mlir::cir::GlobalOp GV);
+
+  void buildStaticVarDecl(const VarDecl &D,
+                          mlir::cir::GlobalLinkageKind Linkage);
+
   /// Perform the usual unary conversions on the specified
   /// expression and compare the result against zero, returning an Int1Ty value.
   mlir::Value evaluateExprAsBool(const clang::Expr *E);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -194,7 +194,7 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
 
 CIRGenModule::~CIRGenModule() {}
 
-bool CIRGenModule::isTypeConstant(QualType Ty, bool ExcludeCtor) {
+bool CIRGenModule::isTypeConstant(QualType Ty, bool ExcludeCtor, bool ExcludeDtor) {
   if (!Ty.isConstant(astCtx) && !Ty->isReferenceType())
     return false;
 
@@ -202,7 +202,7 @@ bool CIRGenModule::isTypeConstant(QualType Ty, bool ExcludeCtor) {
     if (const CXXRecordDecl *Record =
             astCtx.getBaseElementType(Ty)->getAsCXXRecordDecl())
       return ExcludeCtor && !Record->hasMutableFields() &&
-             Record->hasTrivialDestructor();
+             (Record->hasTrivialDestructor() || ExcludeDtor);
   }
 
   return true;

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -76,6 +76,9 @@ struct UnimplementedFeature {
   // Data layout
   static bool dataLayoutGetIndexTypeSizeInBits() { return false; }
 
+  // References related stuff
+  static bool ARC() { return false; } // Automatic reference counting
+
   // Clang early optimizations or things defered to LLVM lowering.
   static bool shouldUseBZeroPlusStoresToInitialize() { return false; }
   static bool shouldUseMemSetToInitialize() { return false; }

--- a/clang/test/CIR/CodeGen/static-vars.c
+++ b/clang/test/CIR/CodeGen/static-vars.c
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void func1(void) {
+  // Should lower default-initialized static vars.
+  static int i;
+  // CHECK-DAG: cir.global "private" internal @func1.i = #cir.int<0> : !s32i
+
+  // Should lower constant-initialized static vars.
+  static int j = 1;
+  // CHECK-DAG: cir.global "private" internal @func1.j = #cir.int<1> : !s32i
+
+  // Should properly shadow static vars in nested scopes.
+  {
+    static int j = 2;
+    // CHECK-DAG: cir.global "private" internal @func1.j.1 = #cir.int<2> : !s32i
+  }
+  {
+    static int j = 3;
+    // CHECK-DAG: cir.global "private" internal @func1.j.2 = #cir.int<3> : !s32i
+  }
+
+  // Should lower basic static vars arithmetics.
+  j++;
+  // CHECK-DAG: %[[#V2:]] = cir.get_global @func1.j : cir.ptr <!s32i>
+  // CHECK-DAG: %[[#V3:]] = cir.load %[[#V2]] : cir.ptr <!s32i>, !s32i
+  // CHECK-DAG: %[[#V4:]] = cir.unary(inc, %[[#V3]]) : !s32i, !s32i
+  // CHECK-DAG: cir.store %[[#V4]], %[[#V2]] : !s32i, cir.ptr <!s32i>
+}
+
+// Should shadow static vars on different functions.
+void func2(void) {
+  static char i;
+  // CHECK-DAG: cir.global "private" internal @func2.i = #cir.int<0> : !s8i
+  static float j;
+  // CHECK-DAG: cir.global "private" internal @func2.j = 0.000000e+00 : f32
+}

--- a/clang/test/CIR/CodeGen/static-vars.cpp
+++ b/clang/test/CIR/CodeGen/static-vars.cpp
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void func1(void) {
+  // Should lower default-initialized static vars.
+  static int i;
+  // CHECK-DAG: cir.global "private" internal @_ZZ5func1vE1i = #cir.int<0> : !s32i
+
+  // Should lower constant-initialized static vars.
+  static int j = 1;
+  // CHECK-DAG: cir.global "private" internal @_ZZ5func1vE1j = #cir.int<1> : !s32i
+
+  // Should properly shadow static vars in nested scopes.
+  {
+    static int j = 2;
+    // CHECK-DAG: cir.global "private" internal @_ZZ5func1vE1j_0 = #cir.int<2> : !s32i
+  }
+  {
+    static int j = 3;
+    // CHECK-DAG: cir.global "private" internal @_ZZ5func1vE1j_1 = #cir.int<3> : !s32i
+  }
+
+  // Should lower basic static vars arithmetics.
+  j++;
+  // CHECK-DAG: %[[#V2:]] = cir.get_global @_ZZ5func1vE1j : cir.ptr <!s32i>
+  // CHECK-DAG: %[[#V3:]] = cir.load %[[#V2]] : cir.ptr <!s32i>, !s32i
+  // CHECK-DAG: %[[#V4:]] = cir.unary(inc, %[[#V3]]) : !s32i, !s32i
+  // CHECK-DAG: cir.store %[[#V4]], %[[#V2]] : !s32i, cir.ptr <!s32i>
+}
+
+// Should shadow static vars on different functions.
+void func2(void) {
+  static char i;
+  // CHECK-DAG: cir.global "private" internal @_ZZ5func2vE1i = #cir.int<0> : !s8i
+  static float j;
+  // CHECK-DAG: cir.global "private" internal @_ZZ5func2vE1j = 0.000000e+00 : f32
+}


### PR DESCRIPTION
Whenever a variable declaration is found, it is created as a global variable in the module. In C, these variables must be instantiated with the CIRGenBuilder::createVersionedGlobal to prevent naming conflicts when multiple static variables are declared across the compilation unit. In C++, name mangling is used to prevent naming conflicts.