### PR TITLE
[CIR] Yield boolean value in cir.loop condition region

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1108,8 +1108,7 @@ def LoopOp : CIR_Op<"loop",
   let description = [{
     `cir.loop` represents C/C++ loop forms. It defines 3 blocks:
     - `cond`: region can contain multiple blocks, terminated by regular
-    `cir.yield` when control should yield back to the parent, and
-    `cir.yield continue` when execution continues to another region.
+    `cir.yield %x` where `%x` is the boolean value to be evaluated.
     The region destination depends on the loop form specified.
     - `step`: region with one block, containing code to compute the
     loop step, must be terminated with `cir.yield`.
@@ -1124,7 +1123,8 @@ def LoopOp : CIR_Op<"loop",
       //  i = i + 1;
       // }
       cir.loop while(cond :  {
-        cir.yield continue
+        %2 = cir.const(#cir.bool<true>) : !cir.bool
+        cir.yield %2 : !cir.bool
       }, step :  {
         cir.yield
       })  {

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -648,26 +648,6 @@ mlir::LogicalResult CIRGenFunction::buildDefaultStmt(const DefaultStmt &S,
   return res;
 }
 
-static mlir::LogicalResult buildLoopCondYield(mlir::OpBuilder &builder,
-                                              mlir::Location loc,
-                                              mlir::Value cond) {
-  mlir::Block *trueBB = nullptr, *falseBB = nullptr;
-  {
-    mlir::OpBuilder::InsertionGuard guard(builder);
-    trueBB = builder.createBlock(builder.getBlock()->getParent());
-    builder.create<mlir::cir::YieldOp>(loc, YieldOpKind::Continue);
-  }
-  {
-    mlir::OpBuilder::InsertionGuard guard(builder);
-    falseBB = builder.createBlock(builder.getBlock()->getParent());
-    builder.create<mlir::cir::YieldOp>(loc);
-  }
-
-  assert((trueBB && falseBB) && "expected both blocks to exist");
-  builder.create<mlir::cir::BrCondOp>(loc, cond, trueBB, falseBB);
-  return mlir::success();
-}
-
 mlir::LogicalResult
 CIRGenFunction::buildCXXForRangeStmt(const CXXForRangeStmt &S,
                                      ArrayRef<const Attr *> ForAttrs) {
@@ -701,8 +681,7 @@ CIRGenFunction::buildCXXForRangeStmt(const CXXForRangeStmt &S,
           assert(!UnimplementedFeature::createProfileWeightsForLoop());
           assert(!UnimplementedFeature::emitCondLikelihoodViaExpectIntrinsic());
           mlir::Value condVal = evaluateExprAsBool(S.getCond());
-          if (buildLoopCondYield(b, loc, condVal).failed())
-            loopRes = mlir::failure();
+          builder.create<mlir::cir::YieldOp>(loc, condVal);
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
@@ -789,8 +768,7 @@ mlir::LogicalResult CIRGenFunction::buildForStmt(const ForStmt &S) {
                 loc, boolTy,
                 mlir::cir::BoolAttr::get(b.getContext(), boolTy, true));
           }
-          if (buildLoopCondYield(b, loc, condVal).failed())
-            loopRes = mlir::failure();
+          builder.create<mlir::cir::YieldOp>(loc, condVal);
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
@@ -858,8 +836,7 @@ mlir::LogicalResult CIRGenFunction::buildDoStmt(const DoStmt &S) {
           // expression compares unequal to 0. The condition must be a
           // scalar type.
           mlir::Value condVal = evaluateExprAsBool(S.getCond());
-          if (buildLoopCondYield(b, loc, condVal).failed())
-            loopRes = mlir::failure();
+          builder.create<mlir::cir::YieldOp>(loc, condVal);
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
@@ -923,8 +900,7 @@ mlir::LogicalResult CIRGenFunction::buildWhileStmt(const WhileStmt &S) {
           // expression compares unequal to 0. The condition must be a
           // scalar type.
           condVal = evaluateExprAsBool(S.getCond());
-          if (buildLoopCondYield(b, loc, condVal).failed())
-            loopRes = mlir::failure();
+          builder.create<mlir::cir::YieldOp>(loc, condVal);
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -117,27 +117,6 @@ public:
   using LoopKind = mlir::cir::LoopOpKind;
 
   mlir::LogicalResult
-  fetchCondRegionYields(mlir::Region &condRegion,
-                        mlir::cir::YieldOp &yieldToBody,
-                        mlir::cir::YieldOp &yieldToCont) const {
-    for (auto &bb : condRegion) {
-      if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(bb.getTerminator())) {
-        if (!yieldOp.getKind().has_value())
-          yieldToCont = yieldOp;
-        else if (yieldOp.getKind() == mlir::cir::YieldOpKind::Continue)
-          yieldToBody = yieldOp;
-        else
-          return mlir::failure();
-      }
-    }
-
-    // Succeed only if both yields are found.
-    if (!yieldToBody || !yieldToCont)
-      return mlir::failure();
-    return mlir::success();
-  }
-
-  mlir::LogicalResult
   matchAndRewrite(mlir::cir::LoopOp loopOp, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto kind = loopOp.getKind();
@@ -148,9 +127,8 @@ public:
     // Fetch required info from the condition region.
     auto &condRegion = loopOp.getCond();
     auto &condFrontBlock = condRegion.front();
-    mlir::cir::YieldOp yieldToBody, yieldToCont;
-    if (fetchCondRegionYields(condRegion, yieldToBody, yieldToCont).failed())
-      return loopOp.emitError("failed to fetch yields in cond region");
+    auto condYield =
+        cast<mlir::cir::YieldOp>(condRegion.back().getTerminator());
 
     // Fetch required info from the body region.
     auto &bodyRegion = loopOp.getBody();
@@ -163,7 +141,7 @@ public:
     auto &stepRegion = loopOp.getStep();
     auto &stepFrontBlock = stepRegion.front();
     auto stepYield =
-        dyn_cast<mlir::cir::YieldOp>(stepRegion.back().getTerminator());
+        cast<mlir::cir::YieldOp>(stepRegion.back().getTerminator());
 
     // Move loop op region contents to current CFG.
     rewriter.inlineRegionBefore(condRegion, continueBlock);
@@ -176,13 +154,10 @@ public:
     auto &entry = (kind != LoopKind::DoWhile ? condFrontBlock : bodyFrontBlock);
     rewriter.create<mlir::cir::BrOp>(loopOp.getLoc(), &entry);
 
-    // Set loop exit point to continue block.
-    rewriter.setInsertionPoint(yieldToCont);
-    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldToCont, continueBlock);
-
-    // Branch from condition to body.
-    rewriter.setInsertionPoint(yieldToBody);
-    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldToBody, &bodyFrontBlock);
+    // Branch to body when true and to exit when false.
+    rewriter.setInsertionPoint(condYield);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrCondOp>(
+        condYield, condYield.getOperand(0), &bodyFrontBlock, continueBlock);
 
     // Branch from body to condition or to step on for-loop cases.
     rewriter.setInsertionPoint(bodyYield);

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -8,7 +8,8 @@ void l0() {
 
 // CHECK: cir.func @_Z2l0v
 // CHECK: cir.loop for(cond :  {
-// CHECK-NEXT:   cir.yield continue
+// CHECK-NEXT:   %0 = cir.const(#true) : !cir.bool
+// CHECK-NEXT:   cir.yield %0
 // CHECK-NEXT: }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT: })  {
@@ -27,11 +28,7 @@ void l1() {
 // CHECK-NEXT:   %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:   %5 = cir.const(#cir.int<10> : !s32i) : !s32i
 // CHECK-NEXT:   %6 = cir.cmp(lt, %4, %5) : !s32i, !cir.bool
-// CHECK-NEXT:   cir.brcond %6 ^bb1, ^bb2
-// CHECK-NEXT:   ^bb1:
-// CHECK-NEXT:     cir.yield continue
-// CHECK-NEXT:   ^bb2:
-// CHECK-NEXT:     cir.yield
+// CHECK-NEXT:   cir.yield %6 : !cir.bool
 // CHECK-NEXT: }, step :  {
 // CHECK-NEXT:   %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:   %5 = cir.const(#cir.int<1> : !s32i) : !s32i
@@ -62,12 +59,8 @@ void l2(bool cond) {
 // CHECK: cir.func @_Z2l2b
 // CHECK:         cir.scope {
 // CHECK-NEXT:     cir.loop while(cond :  {
-// CHECK-NEXT:       %3 = cir.load %0 : cir.ptr <!cir.bool>, !cir.bool
-// CHECK-NEXT:       cir.brcond %3 ^bb1, ^bb2
-// CHECK-NEXT:       ^bb1:
-// CHECK-NEXT:         cir.yield continue
-// CHECK-NEXT:       ^bb2:
-// CHECK-NEXT:         cir.yield
+// CHECK-NEXT:        %3 = cir.load %0 : cir.ptr <!cir.bool>, !cir.bool
+// CHECK-NEXT:        cir.yield %3 : !cir.bool
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {
@@ -80,7 +73,8 @@ void l2(bool cond) {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     cir.loop while(cond :  {
-// CHECK-NEXT:       cir.yield continue
+// CHECK-NEXT:        %3 = cir.const(#true) : !cir.bool
+// CHECK-NEXT:        cir.yield %3 : !cir.bool
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {
@@ -93,13 +87,9 @@ void l2(bool cond) {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     cir.loop while(cond :  {
-// CHECK-NEXT:       %3 = cir.const(#cir.int<1> : !s32i) : !s32i
-// CHECK-NEXT:       %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
-// CHECK-NEXT:       cir.brcond %4 ^bb1, ^bb2
-// CHECK-NEXT:       ^bb1:
-// CHECK-NEXT:         cir.yield continue
-// CHECK-NEXT:       ^bb2:
-// CHECK-NEXT:         cir.yield
+// CHECK-NEXT:        %3 = cir.const(#cir.int<1> : !s32i) : !s32i
+// CHECK-NEXT:        %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
+// CHECK-NEXT:        cir.yield %4 : !cir.bool
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {
@@ -128,11 +118,7 @@ void l3(bool cond) {
 // CHECK: cir.scope {
 // CHECK-NEXT:   cir.loop dowhile(cond :  {
 // CHECK-NEXT:   %3 = cir.load %0 : cir.ptr <!cir.bool>, !cir.bool
-// CHECK-NEXT:   cir.brcond %3 ^bb1, ^bb2
-// CHECK-NEXT:   ^bb1:
-// CHECK-NEXT:     cir.yield continue
-// CHECK-NEXT:   ^bb2:
-// CHECK-NEXT:     cir.yield
+// CHECK-NEXT:   cir.yield %3
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT:   })  {
@@ -145,7 +131,8 @@ void l3(bool cond) {
 // CHECK-NEXT: }
 // CHECK-NEXT: cir.scope {
 // CHECK-NEXT:   cir.loop dowhile(cond :  {
-// CHECK-NEXT:     cir.yield continue
+// CHECK-NEXT:     %3 = cir.const(#true) : !cir.bool
+// CHECK-NEXT:     cir.yield %3 : !cir.bool
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT:   })  {
@@ -160,11 +147,7 @@ void l3(bool cond) {
 // CHECK-NEXT:   cir.loop dowhile(cond :  {
 // CHECK-NEXT:   %3 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK-NEXT:   %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
-// CHECK-NEXT:   cir.brcond %4 ^bb1, ^bb2
-// CHECK-NEXT:   ^bb1:
-// CHECK-NEXT:     cir.yield continue
-// CHECK-NEXT:   ^bb2:
-// CHECK-NEXT:     cir.yield
+// CHECK-NEXT:   cir.yield %4 : !cir.bool
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT:   })  {
@@ -188,7 +171,8 @@ void l4() {
 
 // CHECK: cir.func @_Z2l4v
 // CHECK: cir.loop while(cond :  {
-// CHECK-NEXT:   cir.yield continue
+// CHECK-NEXT:     %4 = cir.const(#true) : !cir.bool
+// CHECK-NEXT:     cir.yield %4 : !cir.bool
 // CHECK-NEXT: }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT: })  {
@@ -215,11 +199,7 @@ void l5() {
 // CHECK-NEXT:     cir.loop dowhile(cond :  {
 // CHECK-NEXT:       %0 = cir.const(#cir.int<0> : !s32i) : !s32i
 // CHECK-NEXT:       %1 = cir.cast(int_to_bool, %0 : !s32i), !cir.bool
-// CHECK-NEXT:       cir.brcond %1 ^bb1, ^bb2
-// CHECK-NEXT:       ^bb1:
-// CHECK-NEXT:         cir.yield continue
-// CHECK-NEXT:       ^bb2:
-// CHECK-NEXT:         cir.yield
+// CHECK-NEXT:       cir.yield %1 : !cir.bool
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {
@@ -238,7 +218,8 @@ void l6() {
 // CHECK: cir.func @_Z2l6v()
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     cir.loop while(cond :  {
-// CHECK-NEXT:       cir.yield continue
+// CHECK-NEXT:       %0 = cir.const(#true) : !cir.bool
+// CHECK-NEXT:       cir.yield %0 : !cir.bool
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -46,11 +46,7 @@ void init(unsigned numImages) {
 // CHECK:     cir.store %11, %6 : !ty_22struct2E__vector_iterator22, cir.ptr <!ty_22struct2E__vector_iterator22>
 // CHECK:     cir.loop for(cond : {
 // CHECK:       %12 = cir.call @_ZNK17__vector_iteratorI6triplePS0_RS0_EneERKS3_(%5, %6) : (!cir.ptr<!ty_22struct2E__vector_iterator22>, !cir.ptr<!ty_22struct2E__vector_iterator22>) -> !cir.bool
-// CHECK:       cir.brcond %12 ^bb1, ^bb2
-// CHECK:     ^bb1:  // pred: ^bb0
-// CHECK:       cir.yield continue
-// CHECK:     ^bb2:  // pred: ^bb0
-// CHECK:       cir.yield
+// CHECK:       cir.yield %12 : !cir.bool
 // CHECK:     }, step : {
 // CHECK:       %12 = cir.call @_ZN17__vector_iteratorI6triplePS0_RS0_EppEv(%5) : (!cir.ptr<!ty_22struct2E__vector_iterator22>) -> !cir.ptr<!ty_22struct2E__vector_iterator22>
 // CHECK:       cir.yield

--- a/clang/test/CIR/IR/branch.cir
+++ b/clang/test/CIR/IR/branch.cir
@@ -7,17 +7,13 @@ cir.func @b0() {
   cir.scope {
     cir.loop while(cond :  {
       %0 = cir.const(#true) : !cir.bool
-      cir.brcond %0 ^bb1, ^bb2
-      ^bb1:
-        cir.yield continue
-      ^bb2:
-        cir.yield
+      cir.yield %0 : !cir.bool
     }, step :  {
       cir.yield
     })  {
       cir.br ^bb1
     ^bb1:
-      cir.return
+      cir.yield
     }
   }
   cir.return
@@ -27,17 +23,13 @@ cir.func @b0() {
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
 // CHECK-NEXT:      %0 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:      cir.brcond %0 ^bb1, ^bb2
-// CHECK-NEXT:      ^bb1:
-// CHECK-NEXT:        cir.yield continue
-// CHECK-NEXT:      ^bb2:
-// CHECK-NEXT:        cir.yield
+// CHECK-NEXT:      cir.yield %0 : !cir.bool
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {
 // CHECK-NEXT:      cir.br ^bb1
 // CHECK-NEXT:    ^bb1:
-// CHECK-NEXT:      cir.return
+// CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:  cir.return

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -163,7 +163,7 @@ cir.func @cast4(%p: !cir.ptr<!u32i>) {
 #true = #cir.bool<true> : !cir.bool
 cir.func @b0() {
   cir.scope {
-    cir.loop while(cond :  {  // expected-error {{cond region must be terminated with 'cir.yield' or 'cir.yield continue'}}
+    cir.loop while(cond :  {  // expected-error {{cond region must yield a single boolean value}}
       %0 = cir.const(#true) : !cir.bool
       cir.brcond %0 ^bb1, ^bb2
       ^bb1:
@@ -177,6 +177,72 @@ cir.func @b0() {
     ^bb1:
       cir.return
     }
+  }
+  cir.return
+}
+
+// -----
+
+#false = #cir.bool<false> : !cir.bool
+#true = #cir.bool<true> : !cir.bool
+cir.func @b0() {
+  cir.loop while(cond :  {  // expected-error {{cond and step regions must be terminated with 'cir.yield'}}
+    %0 = cir.const(#true) : !cir.bool
+    cir.return %0 : !cir.bool
+  }, step :  {
+    cir.yield
+  })  {
+    cir.yield
+  }
+  cir.return
+}
+
+// -----
+
+#false = #cir.bool<false> : !cir.bool
+#true = #cir.bool<true> : !cir.bool
+cir.func @b0() {
+  cir.loop while(cond :  {  // expected-error {{cond and step regions must be terminated with 'cir.yield'}}
+    %0 = cir.const(#true) : !cir.bool
+    cir.yield %0 : !cir.bool
+  }, step :  {
+    cir.return
+  })  {
+    cir.return
+  }
+  cir.return
+}
+
+// -----
+
+#false = #cir.bool<false> : !cir.bool
+#true = #cir.bool<true> : !cir.bool
+cir.func @b0() {
+  cir.loop while(cond :  {  // expected-error {{step region should not yield values}}
+    %0 = cir.const(#true) : !cir.bool
+    cir.yield %0 : !cir.bool
+  }, step :  {
+    %1 = cir.const(#true) : !cir.bool
+    cir.yield %1 : !cir.bool
+  })  {
+    cir.return
+  }
+  cir.return
+}
+
+// -----
+
+#false = #cir.bool<false> : !cir.bool
+#true = #cir.bool<true> : !cir.bool
+cir.func @b0() {
+  cir.loop while(cond :  {  // expected-error {{body region must not yield values}}
+    %0 = cir.const(#true) : !cir.bool
+    cir.yield %0 : !cir.bool
+  }, step :  {
+    cir.yield
+  })  {
+    %1 = cir.const(#true) : !cir.bool
+    cir.yield %1 : !cir.bool
   }
   cir.return
 }

--- a/clang/test/CIR/IR/loop.cir
+++ b/clang/test/CIR/IR/loop.cir
@@ -15,11 +15,7 @@ cir.func @l0() {
       %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
       %5 = cir.const(#cir.int<10> : !u32i) : !u32i
       %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-      cir.brcond %6 ^bb1, ^bb2
-      ^bb1:
-        cir.yield continue
-      ^bb2:
-        cir.yield
+      cir.yield %6 : !cir.bool
     }, step :  {
       %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
       %5 = cir.const(#cir.int<1> : !u32i) : !u32i
@@ -46,11 +42,7 @@ cir.func @l0() {
       %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
       %5 = cir.const(#cir.int<10> : !u32i) : !u32i
       %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-      cir.brcond %6 ^bb1, ^bb2
-      ^bb1:
-        cir.yield continue
-      ^bb2:
-        cir.yield
+      cir.yield %6 : !cir.bool
     }, step :  {
       cir.yield
     })  {
@@ -74,11 +66,7 @@ cir.func @l0() {
       %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
       %5 = cir.const(#cir.int<10> : !u32i) : !u32i
       %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-      cir.brcond %6 ^bb1, ^bb2
-      ^bb1:
-        cir.yield continue
-      ^bb2:
-        cir.yield
+      cir.yield %6 : !cir.bool
     }, step :  {
       cir.yield
     })  {
@@ -97,11 +85,7 @@ cir.func @l0() {
 // CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
 // CHECK-NEXT:     %5 = cir.const(#cir.int<10> : !u32i) : !u32i
 // CHECK-NEXT:     %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-// CHECK-NEXT:     cir.brcond %6 ^bb1, ^bb2
-// CHECK-NEXT:     ^bb1:
-// CHECK-NEXT:       cir.yield continue
-// CHECK-NEXT:     ^bb2:
-// CHECK-NEXT:       cir.yield
+// CHECK-NEXT:     cir.yield %6 : !cir.bool
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
 // CHECK-NEXT:     %5 = cir.const(#cir.int<1> : !u32i) : !u32i
@@ -124,11 +108,7 @@ cir.func @l0() {
 // CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
 // CHECK-NEXT:     %5 = cir.const(#cir.int<10> : !u32i) : !u32i
 // CHECK-NEXT:     %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-// CHECK-NEXT:     cir.brcond %6 ^bb1, ^bb2
-// CHECK-NEXT:     ^bb1:
-// CHECK-NEXT:       cir.yield continue
-// CHECK-NEXT:     ^bb2:
-// CHECK-NEXT:       cir.yield
+// CHECK-NEXT:     cir.yield %6 : !cir.bool
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   })  {
@@ -147,11 +127,7 @@ cir.func @l0() {
 // CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
 // CHECK-NEXT:     %5 = cir.const(#cir.int<10> : !u32i) : !u32i
 // CHECK-NEXT:     %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-// CHECK-NEXT:     cir.brcond %6 ^bb1, ^bb2
-// CHECK-NEXT:     ^bb1:
-// CHECK-NEXT:       cir.yield continue
-// CHECK-NEXT:     ^bb2:
-// CHECK-NEXT:       cir.yield
+// CHECK-NEXT:     cir.yield %6 : !cir.bool
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   })  {
@@ -165,7 +141,8 @@ cir.func @l0() {
 cir.func @l1() {
   cir.scope {
     cir.loop while(cond :  {
-      cir.yield continue
+      %0 = cir.const(#true) : !cir.bool
+      cir.yield %0 : !cir.bool
     }, step :  {
       cir.yield
     })  {
@@ -178,7 +155,8 @@ cir.func @l1() {
 // CHECK: cir.func @l1
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      cir.yield continue
+// CHECK-NEXT:      %0 = cir.const(#true) : !cir.bool
+// CHECK-NEXT:      cir.yield %0 : !cir.bool
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {
@@ -191,7 +169,8 @@ cir.func @l1() {
 cir.func @l2() {
   cir.scope {
     cir.loop while(cond :  {
-      cir.yield
+      %0 = cir.const(#true) : !cir.bool
+      cir.yield %0 : !cir.bool
     }, step :  {
       cir.yield
     })  {
@@ -204,7 +183,8 @@ cir.func @l2() {
 // CHECK: cir.func @l2
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      cir.yield
+// CHECK-NEXT:      %0 = cir.const(#true) : !cir.bool
+// CHECK-NEXT:      cir.yield %0 : !cir.bool
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {

--- a/clang/test/CIR/Lowering/dot.cir
+++ b/clang/test/CIR/Lowering/dot.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
+// RUN: cir-opt %s -cir-to-llvm -reconcile-unrealized-casts -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
 
 !s32i = !cir.int<s, 32>
@@ -23,11 +23,7 @@ module {
         %11 = cir.load %2 : cir.ptr <!s32i>, !s32i
         %12 = cir.cmp(lt, %10, %11) : !s32i, !s32i
         %13 = cir.cast(int_to_bool, %12 : !s32i), !cir.bool
-        cir.brcond %13 ^bb1, ^bb2
-      ^bb1:  // pred: ^bb0
-        cir.yield continue
-      ^bb2:  // pred: ^bb0
-        cir.yield
+        cir.yield %13 : !cir.bool
       }, step : {
         %10 = cir.load %8 : cir.ptr <!s32i>, !s32i
         %11 = cir.unary(inc, %10) : !s32i, !s32i
@@ -80,7 +76,7 @@ module {
 // MLIR-NEXT:     %13 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:     llvm.store %13, %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     llvm.br ^bb2
-// MLIR-NEXT:   ^bb2:  // 2 preds: ^bb1, ^bb6
+// MLIR-NEXT:   ^bb2:  // 2 preds: ^bb1, ^bb4
 // MLIR-NEXT:     %14 = llvm.load %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     %15 = llvm.load %5 : !llvm.ptr<i32>
 // MLIR-NEXT:     %16 = llvm.icmp "slt" %14, %15 : i32
@@ -89,12 +85,8 @@ module {
 // MLIR-NEXT:     %19 = llvm.icmp "ne" %17, %18 : i32
 // MLIR-NEXT:     %20 = llvm.zext %19 : i1 to i8
 // MLIR-NEXT:     %21 = llvm.trunc %20 : i8 to i1
-// MLIR-NEXT:     llvm.cond_br %21, ^bb3, ^bb4
+// MLIR-NEXT:     llvm.cond_br %21, ^bb3, ^bb5
 // MLIR-NEXT:   ^bb3:  // pred: ^bb2
-// MLIR-NEXT:     llvm.br ^bb5
-// MLIR-NEXT:   ^bb4:  // pred: ^bb2
-// MLIR-NEXT:     llvm.br ^bb7
-// MLIR-NEXT:   ^bb5:  // pred: ^bb3
 // MLIR-NEXT:     %22 = llvm.load %1 : !llvm.ptr<ptr<f64>>
 // MLIR-NEXT:     %23 = llvm.load %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     %24 = llvm.getelementptr %22[%23] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
@@ -107,16 +99,16 @@ module {
 // MLIR-NEXT:     %31 = llvm.load %9 : !llvm.ptr<f64>
 // MLIR-NEXT:     %32 = llvm.fadd %31, %30  : f64
 // MLIR-NEXT:     llvm.store %32, %9 : !llvm.ptr<f64>
-// MLIR-NEXT:     llvm.br ^bb6
-// MLIR-NEXT:   ^bb6:  // pred: ^bb5
+// MLIR-NEXT:     llvm.br ^bb4
+// MLIR-NEXT:   ^bb4:  // pred: ^bb3
 // MLIR-NEXT:     %33 = llvm.load %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     %34 = llvm.mlir.constant(1 : i32) : i32
 // MLIR-NEXT:     %35 = llvm.add %33, %34  : i32
 // MLIR-NEXT:     llvm.store %35, %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     llvm.br ^bb2
-// MLIR-NEXT:   ^bb7:  // pred: ^bb4
-// MLIR-NEXT:     llvm.br ^bb8
-// MLIR-NEXT:   ^bb8:  // pred: ^bb7
+// MLIR-NEXT:   ^bb5:  // pred: ^bb2
+// MLIR-NEXT:     llvm.br ^bb6
+// MLIR-NEXT:   ^bb6:  // pred: ^bb5
 // MLIR-NEXT:     %36 = llvm.load %9 : !llvm.ptr<f64>
 // MLIR-NEXT:     llvm.store %36, %7 : !llvm.ptr<f64>
 // MLIR-NEXT:     %37 = llvm.load %7 : !llvm.ptr<f64>

--- a/clang/test/CIR/Lowering/loop.cir
+++ b/clang/test/CIR/Lowering/loop.cir
@@ -1,5 +1,5 @@
-// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
-// RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
+// RUN: cir-opt %s -cir-to-llvm -reconcile-unrealized-casts -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
 
 !s32i = !cir.int<s, 32>
 module {
@@ -12,11 +12,7 @@ module {
       %3 = cir.const(#cir.int<10> : !s32i) : !s32i
       %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
       %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-      cir.brcond %5 ^bb1, ^bb2
-    ^bb1:  // pred: ^bb0
-      cir.yield continue
-    ^bb2:  // pred: ^bb0
-      cir.yield
+      cir.yield %5 : !cir.bool
     }, step : {
       %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
       %3 = cir.unary(inc, %2) : !s32i, !s32i
@@ -28,161 +24,90 @@ module {
     cir.return
   }
 
-//      MLIR: module {
-// MLIR-NEXT:   llvm.func @testFor()
-// MLIR-NEXT:     %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:     %2 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:     llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:     llvm.br ^bb1
-// ============= Condition block =============
-// MLIR-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb5
-// MLIR-NEXT:     %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:     %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:     %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:     %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:     %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:     %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:     %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:     %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:     llvm.cond_br %10, ^bb2, ^bb3
-// MLIR-NEXT:   ^bb2:  // pred: ^bb1
-// MLIR-NEXT:     llvm.br ^bb4
-// MLIR-NEXT:   ^bb3:  // pred: ^bb1
-// MLIR-NEXT:     llvm.br ^bb6
-// ============= Body block =============
-// MLIR-NEXT:   ^bb4:  // pred: ^bb2
-// MLIR-NEXT:     llvm.br ^bb5
-// ============= Step block =============
-// MLIR-NEXT:   ^bb5:  // pred: ^bb4
-// MLIR-NEXT:     %11 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:     %12 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:     %13 = llvm.add %11, %12  : i32
-// MLIR-NEXT:     llvm.store %13, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:     llvm.br ^bb1
-// ============= Exit block =============
-// MLIR-NEXT:   ^bb6:  // pred: ^bb3
-// MLIR-NEXT:     llvm.return
-// MLIR-NEXT:   }
+  // CHECK:  llvm.func @testFor()
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#BODY:]], ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#BODY]]:
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#STEP:]]
+  // CHECK:  ^bb[[#STEP]]:
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND]]
+  // CHECK:  ^bb[[#EXIT]]:
+  //           [...]
+  // CHECK:  }
+
 
   // Test while cir.loop operation lowering.
   cir.func @testWhile(%arg0: !s32i) {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
-    cir.scope {
-      cir.loop while(cond : {
-        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-        %2 = cir.const(#cir.int<10> : !s32i) : !s32i
-        %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
-        %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
-        cir.brcond %4 ^bb1, ^bb2
-      ^bb1:  // pred: ^bb0
-        cir.yield continue
-      ^bb2:  // pred: ^bb0
-        cir.yield
-      }, step : {
-        cir.yield
-      }) {
-        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-        %2 = cir.unary(inc, %1) : !s32i, !s32i
-        cir.store %2, %0 : !s32i, cir.ptr <!s32i>
-        cir.yield
-      }
+    cir.loop while(cond : {
+      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+      %2 = cir.const(#cir.int<10> : !s32i) : !s32i
+      %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
+      %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
+      cir.yield %4 : !cir.bool
+    }, step : {
+      cir.yield
+    }) {
+      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+      %2 = cir.unary(inc, %1) : !s32i, !s32i
+      cir.store %2, %0 : !s32i, cir.ptr <!s32i>
+      cir.yield
     }
     cir.return
   }
 
-  //      MLIR:  llvm.func @testWhile(%arg0: i32)
-  // MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
-  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-  // MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
-  // MLIR-NEXT:    llvm.br ^bb1
-  // MLIR-NEXT:  ^bb1:
-  // MLIR-NEXT:    llvm.br ^bb2
-  // ============= Condition block =============
-  // MLIR-NEXT:  ^bb2:  // 2 preds: ^bb1, ^bb5
-  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr<i32>
-  // MLIR-NEXT:    %3 = llvm.mlir.constant(10 : i32) : i32
-  // MLIR-NEXT:    %4 = llvm.icmp "slt" %2, %3 : i32
-  // MLIR-NEXT:    %5 = llvm.zext %4 : i1 to i32
-  // MLIR-NEXT:    %6 = llvm.mlir.constant(0 : i32) : i32
-  // MLIR-NEXT:    %7 = llvm.icmp "ne" %5, %6 : i32
-  // MLIR-NEXT:    %8 = llvm.zext %7 : i1 to i8
-  // MLIR-NEXT:    %9 = llvm.trunc %8 : i8 to i1
-  // MLIR-NEXT:    llvm.cond_br %9, ^bb3, ^bb4
-  // MLIR-NEXT:  ^bb3:  // pred: ^bb2
-  // MLIR-NEXT:    llvm.br ^bb5
-  // MLIR-NEXT:  ^bb4:  // pred: ^bb2
-  // MLIR-NEXT:    llvm.br ^bb6
-  // ============= Body block =============
-  // MLIR-NEXT:  ^bb5:  // pred: ^bb3
-  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr<i32>
-  // MLIR-NEXT:    %11 = llvm.mlir.constant(1 : i32) : i32
-  // MLIR-NEXT:    %12 = llvm.add %10, %11  : i32
-  // MLIR-NEXT:    llvm.store %12, %1 : !llvm.ptr<i32>
-  // MLIR-NEXT:    llvm.br ^bb2
-  // ============= Exit block =============
-  // MLIR-NEXT:  ^bb6:  // pred: ^bb4
-  // MLIR-NEXT:    llvm.br ^bb7
+  // CHECK:  llvm.func @testWhile
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#BODY:]], ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#BODY]]:
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND]]
+  // CHECK:  ^bb[[#EXIT]]:
+  //           [...]
+  // CHECK:  }
+
 
   // Test do-while cir.loop operation lowering.
   cir.func @testDoWhile(%arg0: !s32i) {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
-    cir.scope {
-      cir.loop dowhile(cond : {
-        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-        %2 = cir.const(#cir.int<10> : !s32i) : !s32i
-        %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
-        %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
-        cir.brcond %4 ^bb1, ^bb2
-      ^bb1:  // pred: ^bb0
-        cir.yield continue
-      ^bb2:  // pred: ^bb0
-        cir.yield
-      }, step : {
-        cir.yield
-      }) {
-        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-        %2 = cir.unary(inc, %1) : !s32i, !s32i
-        cir.store %2, %0 : !s32i, cir.ptr <!s32i>
-        cir.yield
-      }
+    cir.loop dowhile(cond : {
+      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+      %2 = cir.const(#cir.int<10> : !s32i) : !s32i
+      %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
+      %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
+      cir.yield %4 : !cir.bool
+    }, step : {
+      cir.yield
+    }) {
+      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+      %2 = cir.unary(inc, %1) : !s32i, !s32i
+      cir.store %2, %0 : !s32i, cir.ptr <!s32i>
+      cir.yield
     }
     cir.return
   }
 
-  //      MLIR:  llvm.func @testDoWhile(%arg0: i32)
-  // MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
-  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-  // MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
-  // MLIR-NEXT:    llvm.br ^bb1
-  // MLIR-NEXT:  ^bb1:
-  // MLIR-NEXT:    llvm.br ^bb5
-  // ============= Condition block =============
-  // MLIR-NEXT:  ^bb2:
-  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr<i32>
-  // MLIR-NEXT:    %3 = llvm.mlir.constant(10 : i32) : i32
-  // MLIR-NEXT:    %4 = llvm.icmp "slt" %2, %3 : i32
-  // MLIR-NEXT:    %5 = llvm.zext %4 : i1 to i32
-  // MLIR-NEXT:    %6 = llvm.mlir.constant(0 : i32) : i32
-  // MLIR-NEXT:    %7 = llvm.icmp "ne" %5, %6 : i32
-  // MLIR-NEXT:    %8 = llvm.zext %7 : i1 to i8
-  // MLIR-NEXT:    %9 = llvm.trunc %8 : i8 to i1
-  // MLIR-NEXT:    llvm.cond_br %9, ^bb3, ^bb4
-  // MLIR-NEXT:  ^bb3:
-  // MLIR-NEXT:    llvm.br ^bb5
-  // MLIR-NEXT:  ^bb4:
-  // MLIR-NEXT:    llvm.br ^bb6
-  // ============= Body block =============
-  // MLIR-NEXT:  ^bb5:
-  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr<i32>
-  // MLIR-NEXT:    %11 = llvm.mlir.constant(1 : i32) : i32
-  // MLIR-NEXT:    %12 = llvm.add %10, %11  : i32
-  // MLIR-NEXT:    llvm.store %12, %1 : !llvm.ptr<i32>
-  // MLIR-NEXT:    llvm.br ^bb2
-  // ============= Exit block =============
-  // MLIR-NEXT:  ^bb6:
-  // MLIR-NEXT:    llvm.br ^bb7
+  // CHECK:  llvm.func @testDoWhile
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#COND:]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#BODY]], ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#BODY]]:
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND]]
+  // CHECK:  ^bb[[#EXIT]]:
+  //           [...]
+  // CHECK:  }
 
 }

--- a/clang/test/CIR/Transforms/merge-cleanups.cir
+++ b/clang/test/CIR/Transforms/merge-cleanups.cir
@@ -65,11 +65,7 @@ module  {
     cir.scope {
       cir.loop while(cond :  {
         %0 = cir.const(#true) : !cir.bool
-        cir.brcond %0 ^bb1, ^bb2
-        ^bb1:
-          cir.yield continue
-        ^bb2:
-          cir.yield
+        cir.yield %0 : !cir.bool
       }, step :  {
         cir.yield
       })  {
@@ -85,11 +81,7 @@ module  {
     cir.scope {
       cir.loop while(cond :  {
         %0 = cir.const(#false) : !cir.bool
-        cir.brcond %0 ^bb1, ^bb2
-        ^bb1:
-          cir.yield continue
-        ^bb2:
-          cir.yield
+        cir.yield %0 : !cir.bool
       }, step :  {
         cir.yield
       })  {
@@ -141,7 +133,8 @@ module  {
 // CHECK: cir.func @l0
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      cir.yield continue
+// CHECK-NEXT:      %0 = cir.const(#true) : !cir.bool
+// CHECK-NEXT:      cir.yield %0 : !cir.bool
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {
@@ -154,7 +147,8 @@ module  {
 // CHECK: cir.func @l1
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      cir.yield
+// CHECK-NEXT:      %0 = cir.const(#false) : !cir.bool
+// CHECK-NEXT:      cir.yield %0 : !cir.bool
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {


### PR DESCRIPTION
Before this patch, the loop operation condition block yielded either empty or continue. This was replaced by a yield of a boolean value.

This change simplifies both codegen and lowering, while also being semantically closer to the C language.

It also refactors loop op codegen tests to validate only the lowering related to the cir.loop operation.

Fixes #161