### PR TITLE
[CIR] Separate CIR to LLVM IR translation tests

### DIFF
--- a/clang/test/CIR/CodeGen/pointer.cpp
+++ b/clang/test/CIR/CodeGen/pointer.cpp
@@ -1,10 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// FIXME(cir): Move the test below to lowering and us a separate tool to lower from CIR to LLVM IR.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
 
 // Global pointer should be zero initialized by default.
 int *ptr;
 // CHECK: cir.global external @ptr = #cir.null : !cir.ptr<!s32i>
-// LLVM: @ptr = global ptr null

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -1,8 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// FIXME(cir): Move the test below to lowering and us a separate tool to lower from CIR to LLVM IR.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
 
 struct Bar {
   int a;
@@ -31,4 +28,3 @@ void baz(void) {
 
 // Check if global structs are zero-initialized.
 //      CHECK: cir.global external @bar = #cir.zero : !ty_22struct2EBar22
-//      LLVM: @bar = global %struct.Bar zeroinitializer

--- a/clang/test/CIR/Translation/zeroinitializer.cir
+++ b/clang/test/CIR/Translation/zeroinitializer.cir
@@ -1,0 +1,12 @@
+// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s
+
+module {
+  // Should lower #cir.zero on structs to a zeroinitializer.
+  llvm.mlir.global external @bar() {addr_space = 0 : i32, cir.initial_value = #cir.zero : !llvm.struct<"struct.S", (i8, i32)>} : !llvm.struct<"struct.S", (i8, i32)>
+  // CHECK: @bar = global %struct.S zeroinitializer
+
+  // Should lower #cir.null on pointers to a null initializer.
+  llvm.mlir.global external @ptr() {addr_space = 0 : i32, cir.initial_value = #cir.zero : !llvm.ptr<i32>} : !llvm.ptr<i32>
+  // CHECK: @ptr = global ptr null
+}


### PR DESCRIPTION
The goal is to keep tests self-contained and focused. Mixing CIR to LLVM IR translation with codegen tests, or with CIR to LLVM Dialect lowering tests, makes it harder to understand what is being tested and requires the same file to go through multiple tools.

This patch creates a separate `clang/tests/CIR/Translation` folder dedicated strictly to CIR's LLVM IR translation interface. While `tests/Lowering` should validate the `lowerDirectlyFromCIRToLLVMIR` pass, `tests/Translation` should validate `CIRDialectLLVMIRTranslationInterface`.