### PR TITLE
[CIR][CIRGen][Bugfix] Patch struct builder element initialization

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -495,7 +495,7 @@ bool ConstStructBuilder::Build(InitListExpr *ILE, bool AllowOverwrite) {
 
     mlir::Attribute EltInit;
     if (Init)
-      Emitter.tryEmitPrivateForMemory(Init, Field->getType());
+      EltInit = Emitter.tryEmitPrivateForMemory(Init, Field->getType());
     else
       llvm_unreachable("NYI");
 
@@ -859,8 +859,7 @@ public:
   }
 
   mlir::Attribute EmitRecordInitialization(InitListExpr *ILE, QualType T) {
-    assert(0 && "not implemented");
-    return {};
+    return ConstStructBuilder::BuildStruct(Emitter, ILE, T);
   }
 
   mlir::Attribute VisitImplicitValueInitExpr(ImplicitValueInitExpr *E,

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -26,5 +26,13 @@ void baz(void) {
 // CHECK-NEXT:     cir.return
 // CHECK-NEXT:   }
 
+void shouldConstInitStructs(void) {
+// CHECK: cir.func @shouldConstInitStructs
+  struct Foo f = {1, 2, {3, 4}};
+  // CHECK: %[[#V0:]] = cir.alloca !ty_22struct2EFoo22, cir.ptr <!ty_22struct2EFoo22>, ["f"] {alignment = 4 : i64}
+  // CHECK: %[[#V1:]] = cir.const(#cir.const_struct<{#cir.int<1> : !s32i,#cir.int<2> : !s8i,#cir.const_struct<{#cir.int<3> : !s32i,#cir.int<4> : !s8i}> : !ty_22struct2EBar22}> : !ty_22struct2EFoo22) : !ty_22struct2EFoo22
+  // CHECK: cir.store %[[#V1]], %[[#V0]] : !ty_22struct2EFoo22, cir.ptr <!ty_22struct2EFoo22>
+}
+
 // Check if global structs are zero-initialized.
 //      CHECK: cir.global external @bar = #cir.zero : !ty_22struct2EBar22

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -115,6 +115,10 @@ struct A {
   int a;
 };
 
+// Should globally const-initialize struct members.
+struct A simpleConstInit = {1};
+// CHECK: cir.global external @simpleConstInit = #cir.const_struct<{#cir.int<1> : !s32i}> : !ty_22struct2EA22
+
 A get_default() { return A{2}; }
 
 struct S {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #186
* #185
* __->__ #184

When const initializing a struct builder, the element initialization was
not returning the expected typed attribute with the constant value,
which caused a cast error. This patch fixes this issue. It also adds
missing codegen for building basic records initialization.