### PR TITLE
[CIR][CIRGen][NFC] Move isNullValue check to CIRGenBuilder

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -169,6 +169,24 @@ public:
     llvm_unreachable("Zero initializer for given type is NYI");
   }
 
+  // TODO(cir): i think this could be a method in each constant attribute, since
+  // default/null initialization is a property covered by the C/C++ language.
+  bool isNullValue(mlir::Attribute attr) const {
+    // TODO(cir): introduce char type in CIR and check for that instead.
+    if (const auto intVal = attr.dyn_cast<mlir::cir::IntAttr>())
+      return intVal.getValue() == 0;
+
+    if (const auto fpVal = attr.dyn_cast<mlir::FloatAttr>()) {
+      bool ignored;
+      llvm::APFloat FV(+0.0);
+      FV.convert(fpVal.getValue().getSemantics(),
+                 llvm::APFloat::rmNearestTiesToEven, &ignored);
+      return FV.bitwiseIsEqual(fpVal.getValue());
+    }
+
+    llvm_unreachable("NYI");
+  }
+
   //
   // Type helpers
   // ------------

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -936,28 +936,14 @@ buildArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
                    SmallVectorImpl<mlir::TypedAttr> &Elements,
                    mlir::TypedAttr Filler) {
   auto &builder = CGM.getBuilder();
-  auto isNullValue = [&](mlir::Attribute f) {
-    // TODO(cir): introduce char type in CIR and check for that instead.
-    if (const auto intVal = f.dyn_cast_or_null<mlir::cir::IntAttr>())
-      return intVal.getValue() == 0;
-
-    if (const auto fpVal = f.dyn_cast_or_null<mlir::FloatAttr>()) {
-      bool ignored;
-      llvm::APFloat FV(+0.0);
-      FV.convert(fpVal.getValue().getSemantics(),
-                 llvm::APFloat::rmNearestTiesToEven, &ignored);
-      return FV.bitwiseIsEqual(fpVal.getValue());
-    }
-
-    llvm_unreachable("NYI");
-  };
 
   // Figure out how long the initial prefix of non-zero elements is.
   unsigned NonzeroLength = ArrayBound;
-  if (Elements.size() < NonzeroLength && isNullValue(Filler))
+  if (Elements.size() < NonzeroLength && builder.isNullValue(Filler))
     NonzeroLength = Elements.size();
   if (NonzeroLength == Elements.size()) {
-    while (NonzeroLength > 0 && isNullValue(Elements[NonzeroLength - 1]))
+    while (NonzeroLength > 0 &&
+           builder.isNullValue(Elements[NonzeroLength - 1]))
       --NonzeroLength;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #186
* __->__ #185
* #184

The rationale here is that, since `isNullValue` is meant to check if the
given constant is what the `getNullValue` method would return for a
certain type, it makes sense for `isNullValue` to be encapsulated in
the builder along the `getNullValue` method.