### PR TITLE
[CIR][CIRGen][Bugfix] Fix pointer subscript operator access

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1136,19 +1136,22 @@ static mlir::Value buildArrayAccessOp(mlir::OpBuilder &builder,
                                       mlir::Location arrayLocBegin,
                                       mlir::Location arrayLocEnd,
                                       mlir::Value arrayPtr, mlir::Type eltTy,
-                                      mlir::Value idx) {
-  mlir::Value basePtr =
-      maybeBuildArrayDecay(builder, arrayLocBegin, arrayPtr, eltTy);
+                                      mlir::Value idx, bool shouldDecay) {
+  mlir::Value basePtr = arrayPtr;
+  if (shouldDecay)
+    basePtr = maybeBuildArrayDecay(builder, arrayLocBegin, arrayPtr, eltTy);
   mlir::Type flatPtrTy = basePtr.getType();
 
   return builder.create<mlir::cir::PtrStrideOp>(arrayLocEnd, flatPtrTy, basePtr,
                                                 idx);
 }
 
-static mlir::Value buildArraySubscriptPtr(
-    CIRGenFunction &CGF, mlir::Location beginLoc, mlir::Location endLoc,
-    mlir::Value ptr, mlir::Type eltTy, ArrayRef<mlir::Value> indices,
-    bool inbounds, bool signedIndices, const llvm::Twine &name = "arrayidx") {
+static mlir::Value
+buildArraySubscriptPtr(CIRGenFunction &CGF, mlir::Location beginLoc,
+                       mlir::Location endLoc, mlir::Value ptr, mlir::Type eltTy,
+                       ArrayRef<mlir::Value> indices, bool inbounds,
+                       bool signedIndices, bool shouldDecay,
+                       const llvm::Twine &name = "arrayidx") {
   assert(indices.size() == 1 && "cannot handle multiple indices yet");
   auto idx = indices.back();
   auto &CGM = CGF.getCIRGenModule();
@@ -1156,14 +1159,14 @@ static mlir::Value buildArraySubscriptPtr(
   // that would enhance tracking this later in CIR?
   if (inbounds)
     assert(!UnimplementedFeature::emitCheckedInBoundsGEP() && "NYI");
-  return buildArrayAccessOp(CGM.getBuilder(), beginLoc, endLoc, ptr, eltTy,
-                            idx);
+  return buildArrayAccessOp(CGM.getBuilder(), beginLoc, endLoc, ptr, eltTy, idx,
+                            shouldDecay);
 }
 
 static Address buildArraySubscriptPtr(
     CIRGenFunction &CGF, mlir::Location beginLoc, mlir::Location endLoc,
     Address addr, ArrayRef<mlir::Value> indices, QualType eltType,
-    bool inbounds, bool signedIndices, mlir::Location loc,
+    bool inbounds, bool signedIndices, mlir::Location loc, bool shouldDecay,
     QualType *arrayType = nullptr, const Expr *Base = nullptr,
     const llvm::Twine &name = "arrayidx") {
   // Determine the element size of the statically-sized base.  This is
@@ -1183,7 +1186,7 @@ static Address buildArraySubscriptPtr(
       (!CGF.IsInPreservedAIRegion && !isPreserveAIArrayBase(CGF, Base))) {
     eltPtr = buildArraySubscriptPtr(CGF, beginLoc, endLoc, addr.getPointer(),
                                     addr.getElementType(), indices, inbounds,
-                                    signedIndices, name);
+                                    signedIndices, shouldDecay, name);
   } else {
     // assert(!UnimplementedFeature::generateDebugInfo() && "NYI");
     // assert(indices.size() == 1 && "cannot handle multiple indices yet");
@@ -1273,7 +1276,8 @@ LValue CIRGenFunction::buildArraySubscriptExpr(const ArraySubscriptExpr *E,
         *this, CGM.getLoc(Array->getBeginLoc()), CGM.getLoc(Array->getEndLoc()),
         ArrayLV.getAddress(), {Idx}, E->getType(),
         !getLangOpts().isSignedOverflowDefined(), SignedIndices,
-        CGM.getLoc(E->getExprLoc()), &arrayType, E->getBase());
+        CGM.getLoc(E->getExprLoc()), /*shouldDecay=*/true, &arrayType,
+        E->getBase());
     EltBaseInfo = ArrayLV.getBaseInfo();
     // TODO(cir): EltTBAAInfo
     assert(!UnimplementedFeature::tbaa() && "TBAA is NYI");
@@ -1287,7 +1291,8 @@ LValue CIRGenFunction::buildArraySubscriptExpr(const ArraySubscriptExpr *E,
     Addr = buildArraySubscriptPtr(
         *this, CGM.getLoc(E->getBeginLoc()), CGM.getLoc(E->getEndLoc()), Addr,
         Idx, E->getType(), !getLangOpts().isSignedOverflowDefined(),
-        SignedIndices, CGM.getLoc(E->getExprLoc()), &ptrType, E->getBase());
+        SignedIndices, CGM.getLoc(E->getExprLoc()), /*shouldDecay=*/false,
+        &ptrType, E->getBase());
   }
 
   LValue LV = LValue::makeAddr(Addr, E->getType(), EltBaseInfo);

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -71,3 +71,22 @@ struct S {
   int i;
 } arr[3] = {{1}};
 // CHECK: cir.global external @arr = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_22struct2ES22, #cir.zero : !ty_22struct2ES22, #cir.zero : !ty_22struct2ES22]> : !cir.array<!ty_22struct2ES22 x 3>
+
+void testPointerDecaySubscriptAccess(int arr[]) {
+// CHECK: cir.func @{{.+}}testPointerDecaySubscriptAccess
+  arr[1];
+  // CHECK: %[[#BASE:]] = cir.load %{{.+}} : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
+  // CHECK: %[[#DIM1:]] = cir.const(#cir.int<1> : !s32i) : !s32i
+  // CHECK: cir.ptr_stride(%[[#BASE]] : !cir.ptr<!s32i>, %[[#DIM1]] : !s32i), !cir.ptr<!s32i>
+}
+
+void testPointerDecayedArrayMultiDimSubscriptAccess(int arr[][3]) {
+// CHECK: cir.func @{{.+}}testPointerDecayedArrayMultiDimSubscriptAccess
+  arr[1][2];
+  // CHECK: %[[#V1:]] = cir.load %{{.+}} : cir.ptr <!cir.ptr<!cir.array<!s32i x 3>>>, !cir.ptr<!cir.array<!s32i x 3>>
+  // CHECK: %[[#V2:]] = cir.const(#cir.int<1> : !s32i) : !s32i
+  // CHECK: %[[#V3:]] = cir.ptr_stride(%[[#V1]] : !cir.ptr<!cir.array<!s32i x 3>>, %[[#V2]] : !s32i), !cir.ptr<!cir.array<!s32i x 3>>
+  // CHECK: %[[#V4:]] = cir.const(#cir.int<2> : !s32i) : !s32i
+  // CHECK: %[[#V5:]] = cir.cast(array_to_ptrdecay, %[[#V3]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+  // CHECK: cir.ptr_stride(%[[#V5]] : !cir.ptr<!s32i>, %[[#V4]] : !s32i), !cir.ptr<!s32i>
+}

--- a/clang/test/CIR/CodeGen/pointers.cpp
+++ b/clang/test/CIR/CodeGen/pointers.cpp
@@ -28,3 +28,22 @@ void foo(int *iptr, char *cptr, unsigned ustride) {
   // CHECK: %[[#NEGSTRIDE:]] = cir.unary(minus, %[[#SIGNSTRIDE]]) : !s32i, !s32i
   // CHECK: cir.ptr_stride(%{{.+}} : !cir.ptr<!s32i>, %[[#NEGSTRIDE]] : !s32i), !cir.ptr<!s32i>
 }
+
+void testPointerSubscriptAccess(int *ptr) {
+// CHECK: testPointerSubscriptAccess
+  ptr[1];
+  // CHECK: %[[#V1:]] = cir.load %{{.+}} : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
+  // CHECK: %[[#V2:]] = cir.const(#cir.int<1> : !s32i) : !s32i
+  // CHECK: cir.ptr_stride(%[[#V1]] : !cir.ptr<!s32i>, %[[#V2]] : !s32i), !cir.ptr<!s32i>
+}
+
+void testPointerMultiDimSubscriptAccess(int **ptr) {
+// CHECK: testPointerMultiDimSubscriptAccess
+  ptr[1][2];
+  // CHECK: %[[#V1:]] = cir.load %{{.+}} : cir.ptr <!cir.ptr<!cir.ptr<!s32i>>>, !cir.ptr<!cir.ptr<!s32i>>
+  // CHECK: %[[#V2:]] = cir.const(#cir.int<1> : !s32i) : !s32i
+  // CHECK: %[[#V3:]] = cir.ptr_stride(%[[#V1]] : !cir.ptr<!cir.ptr<!s32i>>, %[[#V2]] : !s32i), !cir.ptr<!cir.ptr<!s32i>>
+  // CHECK: %[[#V4:]] = cir.load %[[#V3]] : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
+  // CHECK: %[[#V5:]] = cir.const(#cir.int<2> : !s32i) : !s32i
+  // CHECK: cir.ptr_stride(%[[#V4]] : !cir.ptr<!s32i>, %[[#V5]] : !s32i), !cir.ptr<!s32i>
+}


### PR DESCRIPTION
When using subscript access operators on pointers and decayed arrays, an `array_to_ptrdecay` was wrongly applied, generating invalid strides.