### PR TITLE
[CIR][CIRGen][Bugfix] Refactor lexical scope locations

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1830,18 +1830,8 @@ CIRGenFunction::buildConditionalBlocks(const AbstractConditionalOperator *E,
           .create<mlir::cir::TernaryOp>(
               loc, condV, /*trueBuilder=*/
               [&](mlir::OpBuilder &b, mlir::Location loc) {
-                // FIXME: abstract all this massive location handling elsewhere.
-                SmallVector<mlir::Location, 2> locs;
-                if (loc.isa<mlir::FileLineColLoc>()) {
-                  locs.push_back(loc);
-                  locs.push_back(loc);
-                } else if (loc.isa<mlir::FusedLoc>()) {
-                  auto fusedLoc = loc.cast<mlir::FusedLoc>();
-                  locs.push_back(fusedLoc.getLocations()[0]);
-                  locs.push_back(fusedLoc.getLocations()[1]);
-                }
                 CIRGenFunction::LexicalScopeContext lexScope{
-                    locs[0], locs[1], b.getInsertionBlock()};
+                    loc, b.getInsertionBlock()};
                 CIRGenFunction::LexicalScopeGuard lexThenGuard{CGF, &lexScope};
                 CGF.currLexScope->setAsTernary();
 
@@ -1862,11 +1852,8 @@ CIRGenFunction::buildConditionalBlocks(const AbstractConditionalOperator *E,
               },
               /*falseBuilder=*/
               [&](mlir::OpBuilder &b, mlir::Location loc) {
-                auto fusedLoc = loc.cast<mlir::FusedLoc>();
-                auto locBegin = fusedLoc.getLocations()[0];
-                auto locEnd = fusedLoc.getLocations()[1];
                 CIRGenFunction::LexicalScopeContext lexScope{
-                    locBegin, locEnd, b.getInsertionBlock()};
+                    loc, b.getInsertionBlock()};
                 CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
                 CGF.currLexScope->setAsTernary();
 
@@ -1963,17 +1950,8 @@ LValue CIRGenFunction::buildLValue(const Expr *E) {
     [[maybe_unused]] auto scope = builder.create<mlir::cir::ScopeOp>(
         scopeLoc, /*scopeBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          SmallVector<mlir::Location, 2> locs;
-          if (loc.isa<mlir::FileLineColLoc>()) {
-            locs.push_back(loc);
-            locs.push_back(loc);
-          } else if (loc.isa<mlir::FusedLoc>()) {
-            auto fusedLoc = loc.cast<mlir::FusedLoc>();
-            locs.push_back(fusedLoc.getLocations()[0]);
-            locs.push_back(fusedLoc.getLocations()[1]);
-          }
           CIRGenFunction::LexicalScopeContext lexScope{
-              locs[0], locs[1], builder.getInsertionBlock()};
+              loc, builder.getInsertionBlock()};
           CIRGenFunction::LexicalScopeGuard lexScopeGuard{*this, &lexScope};
 
           LV = buildLValue(cleanups->getSubExpr());
@@ -2068,28 +2046,23 @@ mlir::LogicalResult CIRGenFunction::buildIfOnBoolExpr(const Expr *cond,
       loc, condV, elseS,
       /*thenBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        // FIXME: abstract all this massive location handling elsewhere.
-        SmallVector<mlir::Location, 2> locs;
-        if (loc.isa<mlir::FileLineColLoc>()) {
-          locs.push_back(loc);
-          locs.push_back(loc);
-        } else if (loc.isa<mlir::FusedLoc>()) {
-          auto fusedLoc = loc.cast<mlir::FusedLoc>();
-          locs.push_back(fusedLoc.getLocations()[0]);
-          locs.push_back(fusedLoc.getLocations()[1]);
+        if (const auto fusedLoc = loc.dyn_cast<mlir::FusedLoc>()) {
+          loc = mlir::FusedLoc::get(
+              builder.getContext(),
+              {fusedLoc.getLocations()[0], fusedLoc.getLocations()[1]});
         }
-        LexicalScopeContext lexScope{locs[0], locs[1],
-                                     builder.getInsertionBlock()};
+        LexicalScopeContext lexScope{loc, builder.getInsertionBlock()};
         LexicalScopeGuard lexThenGuard{*this, &lexScope};
         resThen = buildStmt(thenS, /*useCurrentScope=*/true);
       },
       /*elseBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto locBegin = fusedLoc.getLocations()[2];
-        auto locEnd = fusedLoc.getLocations()[3];
-        LexicalScopeContext lexScope{locBegin, locEnd,
-                                     builder.getInsertionBlock()};
+        if (const auto fusedLoc = loc.dyn_cast<mlir::FusedLoc>()) {
+          loc = mlir::FusedLoc::get(
+              builder.getContext(),
+              {fusedLoc.getLocations()[2], fusedLoc.getLocations()[3]});
+        }
+        LexicalScopeContext lexScope{loc, builder.getInsertionBlock()};
         LexicalScopeGuard lexElseGuard{*this, &lexScope};
         resElse = buildStmt(elseS, /*useCurrentScope=*/true);
       });

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -401,17 +401,8 @@ void AggExprEmitter::VisitExprWithCleanups(ExprWithCleanups *E) {
   [[maybe_unused]] auto scope = builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        SmallVector<mlir::Location, 2> locs;
-        if (loc.isa<mlir::FileLineColLoc>()) {
-          locs.push_back(loc);
-          locs.push_back(loc);
-        } else if (loc.isa<mlir::FusedLoc>()) {
-          auto fusedLoc = loc.cast<mlir::FusedLoc>();
-          locs.push_back(fusedLoc.getLocations()[0]);
-          locs.push_back(fusedLoc.getLocations()[1]);
-        }
         CIRGenFunction::LexicalScopeContext lexScope{
-            locs[0], locs[1], builder.getInsertionBlock()};
+            loc, builder.getInsertionBlock()};
         CIRGenFunction::LexicalScopeGuard lexScopeGuard{CGF, &lexScope};
         Visit(E->getSubExpr());
       });

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1821,17 +1821,8 @@ mlir::Value ScalarExprEmitter::VisitExprWithCleanups(ExprWithCleanups *E) {
   auto scope = builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Type &yieldTy, mlir::Location loc) {
-        SmallVector<mlir::Location, 2> locs;
-        if (loc.isa<mlir::FileLineColLoc>()) {
-          locs.push_back(loc);
-          locs.push_back(loc);
-        } else if (loc.isa<mlir::FusedLoc>()) {
-          auto fusedLoc = loc.cast<mlir::FusedLoc>();
-          locs.push_back(fusedLoc.getLocations()[0]);
-          locs.push_back(fusedLoc.getLocations()[1]);
-        }
         CIRGenFunction::LexicalScopeContext lexScope{
-            locs[0], locs[1], builder.getInsertionBlock()};
+            loc, builder.getInsertionBlock()};
         CIRGenFunction::LexicalScopeGuard lexScopeGuard{CGF, &lexScope};
         auto scopeYieldVal = Visit(E->getSubExpr());
         if (scopeYieldVal) {
@@ -2024,17 +2015,7 @@ mlir::Value ScalarExprEmitter::VisitAbstractConditionalOperator(
   return builder.create<mlir::cir::TernaryOp>(
       loc, condV, /*trueBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        // FIXME: abstract all this massive location handling elsewhere.
-        SmallVector<mlir::Location, 2> locs;
-        if (loc.isa<mlir::FileLineColLoc>()) {
-          locs.push_back(loc);
-          locs.push_back(loc);
-        } else if (loc.isa<mlir::FusedLoc>()) {
-          auto fusedLoc = loc.cast<mlir::FusedLoc>();
-          locs.push_back(fusedLoc.getLocations()[0]);
-          locs.push_back(fusedLoc.getLocations()[1]);
-        }
-        CIRGenFunction::LexicalScopeContext lexScope{locs[0], locs[1],
+        CIRGenFunction::LexicalScopeContext lexScope{loc,
                                                      b.getInsertionBlock()};
         CIRGenFunction::LexicalScopeGuard lexThenGuard{CGF, &lexScope};
         CGF.currLexScope->setAsTernary();
@@ -2055,10 +2036,7 @@ mlir::Value ScalarExprEmitter::VisitAbstractConditionalOperator(
       },
       /*falseBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto locBegin = fusedLoc.getLocations()[0];
-        auto locEnd = fusedLoc.getLocations()[1];
-        CIRGenFunction::LexicalScopeContext lexScope{locBegin, locEnd,
+        CIRGenFunction::LexicalScopeContext lexScope{loc,
                                                      b.getInsertionBlock()};
         CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
         CGF.currLexScope->setAsTernary();
@@ -2122,7 +2100,7 @@ mlir::Value ScalarExprEmitter::VisitBinLAnd(const clang::BinaryOperator *E) {
   auto ResOp = Builder.create<mlir::cir::TernaryOp>(
       Loc, LHSCondV, /*trueBuilder=*/
       [&](mlir::OpBuilder &B, mlir::Location Loc) {
-        CIRGenFunction::LexicalScopeContext LexScope{Loc, Loc,
+        CIRGenFunction::LexicalScopeContext LexScope{Loc,
                                                      B.getInsertionBlock()};
         CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &LexScope};
         CGF.currLexScope->setAsTernary();
@@ -2130,17 +2108,8 @@ mlir::Value ScalarExprEmitter::VisitBinLAnd(const clang::BinaryOperator *E) {
         auto res = B.create<mlir::cir::TernaryOp>(
             Loc, RHSCondV, /*trueBuilder*/
             [&](mlir::OpBuilder &B, mlir::Location Loc) {
-              SmallVector<mlir::Location, 2> Locs;
-              if (Loc.isa<mlir::FileLineColLoc>()) {
-                Locs.push_back(Loc);
-                Locs.push_back(Loc);
-              } else if (Loc.isa<mlir::FusedLoc>()) {
-                auto fusedLoc = Loc.cast<mlir::FusedLoc>();
-                Locs.push_back(fusedLoc.getLocations()[0]);
-                Locs.push_back(fusedLoc.getLocations()[1]);
-              }
               CIRGenFunction::LexicalScopeContext lexScope{
-                  Locs[0], Locs[1], B.getInsertionBlock()};
+                  Loc, B.getInsertionBlock()};
               CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
               CGF.currLexScope->setAsTernary();
               auto res = B.create<mlir::cir::ConstantOp>(
@@ -2151,17 +2120,8 @@ mlir::Value ScalarExprEmitter::VisitBinLAnd(const clang::BinaryOperator *E) {
             },
             /*falseBuilder*/
             [&](mlir::OpBuilder &b, mlir::Location Loc) {
-              SmallVector<mlir::Location, 2> Locs;
-              if (Loc.isa<mlir::FileLineColLoc>()) {
-                Locs.push_back(Loc);
-                Locs.push_back(Loc);
-              } else if (Loc.isa<mlir::FusedLoc>()) {
-                auto fusedLoc = Loc.cast<mlir::FusedLoc>();
-                Locs.push_back(fusedLoc.getLocations()[0]);
-                Locs.push_back(fusedLoc.getLocations()[1]);
-              }
               CIRGenFunction::LexicalScopeContext lexScope{
-                  Locs[0], Locs[1], b.getInsertionBlock()};
+                  Loc, b.getInsertionBlock()};
               CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
               CGF.currLexScope->setAsTernary();
               auto res = b.create<mlir::cir::ConstantOp>(
@@ -2174,16 +2134,7 @@ mlir::Value ScalarExprEmitter::VisitBinLAnd(const clang::BinaryOperator *E) {
       },
       /*falseBuilder*/
       [&](mlir::OpBuilder &B, mlir::Location Loc) {
-        SmallVector<mlir::Location, 2> Locs;
-        if (Loc.isa<mlir::FileLineColLoc>()) {
-          Locs.push_back(Loc);
-          Locs.push_back(Loc);
-        } else if (Loc.isa<mlir::FusedLoc>()) {
-          auto fusedLoc = Loc.cast<mlir::FusedLoc>();
-          Locs.push_back(fusedLoc.getLocations()[0]);
-          Locs.push_back(fusedLoc.getLocations()[1]);
-        }
-        CIRGenFunction::LexicalScopeContext lexScope{Loc, Loc,
+        CIRGenFunction::LexicalScopeContext lexScope{Loc,
                                                      B.getInsertionBlock()};
         CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
         CGF.currLexScope->setAsTernary();
@@ -2229,16 +2180,7 @@ mlir::Value ScalarExprEmitter::VisitBinLOr(const clang::BinaryOperator *E) {
   auto ResOp = Builder.create<mlir::cir::TernaryOp>(
       Loc, LHSCondV, /*trueBuilder=*/
       [&](mlir::OpBuilder &B, mlir::Location Loc) {
-        SmallVector<mlir::Location, 2> Locs;
-        if (Loc.isa<mlir::FileLineColLoc>()) {
-          Locs.push_back(Loc);
-          Locs.push_back(Loc);
-        } else if (Loc.isa<mlir::FusedLoc>()) {
-          auto fusedLoc = Loc.cast<mlir::FusedLoc>();
-          Locs.push_back(fusedLoc.getLocations()[0]);
-          Locs.push_back(fusedLoc.getLocations()[1]);
-        }
-        CIRGenFunction::LexicalScopeContext lexScope{Loc, Loc,
+        CIRGenFunction::LexicalScopeContext lexScope{Loc,
                                                      B.getInsertionBlock()};
         CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
         CGF.currLexScope->setAsTernary();
@@ -2249,7 +2191,7 @@ mlir::Value ScalarExprEmitter::VisitBinLOr(const clang::BinaryOperator *E) {
       },
       /*falseBuilder*/
       [&](mlir::OpBuilder &B, mlir::Location Loc) {
-        CIRGenFunction::LexicalScopeContext LexScope{Loc, Loc,
+        CIRGenFunction::LexicalScopeContext LexScope{Loc,
                                                      B.getInsertionBlock()};
         CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &LexScope};
         CGF.currLexScope->setAsTernary();
@@ -2267,7 +2209,7 @@ mlir::Value ScalarExprEmitter::VisitBinLOr(const clang::BinaryOperator *E) {
                 Locs.push_back(fusedLoc.getLocations()[1]);
               }
               CIRGenFunction::LexicalScopeContext lexScope{
-                  Loc, Loc, B.getInsertionBlock()};
+                  Loc, B.getInsertionBlock()};
               CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
               CGF.currLexScope->setAsTernary();
               auto res = B.create<mlir::cir::ConstantOp>(
@@ -2288,7 +2230,7 @@ mlir::Value ScalarExprEmitter::VisitBinLOr(const clang::BinaryOperator *E) {
                 Locs.push_back(fusedLoc.getLocations()[1]);
               }
               CIRGenFunction::LexicalScopeContext lexScope{
-                  Loc, Loc, B.getInsertionBlock()};
+                  Loc, B.getInsertionBlock()};
               CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
               CGF.currLexScope->setAsTernary();
               auto res = b.create<mlir::cir::ConstantOp>(

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -504,7 +504,9 @@ CIRGenFunction::generateCode(clang::GlobalDecl GD, mlir::cir::FuncOp Fn,
     mlir::Block *EntryBB = Fn.addEntryBlock();
     builder.setInsertionPointToStart(EntryBB);
 
-    LexicalScopeContext lexScope{FnBeginLoc, FnEndLoc, EntryBB};
+    const auto fusedLoc =
+        mlir::FusedLoc::get(builder.getContext(), {FnBeginLoc, FnEndLoc});
+    LexicalScopeContext lexScope{fusedLoc, EntryBB};
     LexicalScopeGuard scopeGuard{*this, &lexScope};
 
     // Emit the standard function prologue.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -120,10 +120,19 @@ public:
   public:
     unsigned Depth = 0;
     bool HasReturn = false;
-    LexicalScopeContext(mlir::Location b, mlir::Location e, mlir::Block *eb)
-        : EntryBlock(eb), BeginLoc(b), EndLoc(e) {
+
+    LexicalScopeContext(mlir::Location loc, mlir::Block *eb)
+        : EntryBlock(eb), BeginLoc(loc), EndLoc(loc) {
+      // Has multiple locations: overwrite with separate start and end locs.
+      if (const auto fusedLoc = loc.dyn_cast<mlir::FusedLoc>()) {
+        assert(fusedLoc.getLocations().size() == 2 && "too many locations");
+        BeginLoc = fusedLoc.getLocations()[0];
+        EndLoc = fusedLoc.getLocations()[1];
+      }
+
       assert(EntryBlock && "expected valid block");
     }
+
     ~LexicalScopeContext() = default;
 
     // ---

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -41,11 +41,7 @@ mlir::LogicalResult CIRGenFunction::buildCompoundStmt(const CompoundStmt &S) {
   builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto locBegin = fusedLoc.getLocations()[0];
-        auto locEnd = fusedLoc.getLocations()[1];
-        LexicalScopeContext lexScope{locBegin, locEnd,
-                                     builder.getInsertionBlock()};
+        LexicalScopeContext lexScope{loc, builder.getInsertionBlock()};
         LexicalScopeGuard lexScopeGuard{*this, &lexScope};
         res = compoundStmtBuilder();
       });
@@ -394,11 +390,7 @@ mlir::LogicalResult CIRGenFunction::buildIfStmt(const IfStmt &S) {
   builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto scopeLocBegin = fusedLoc.getLocations()[0];
-        auto scopeLocEnd = fusedLoc.getLocations()[1];
-        LexicalScopeContext lexScope{scopeLocBegin, scopeLocEnd,
-                                     builder.getInsertionBlock()};
+        LexicalScopeContext lexScope{scopeLoc, builder.getInsertionBlock()};
         LexicalScopeGuard lexIfScopeGuard{*this, &lexScope};
         res = ifStmtBuilder();
       });
@@ -490,17 +482,8 @@ mlir::LogicalResult CIRGenFunction::buildReturnStmt(const ReturnStmt &S) {
     builder.create<mlir::cir::ScopeOp>(
         scopeLoc, /*scopeBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          SmallVector<mlir::Location, 2> locs;
-          if (loc.isa<mlir::FileLineColLoc>()) {
-            locs.push_back(loc);
-            locs.push_back(loc);
-          } else if (loc.isa<mlir::FusedLoc>()) {
-            auto fusedLoc = loc.cast<mlir::FusedLoc>();
-            locs.push_back(fusedLoc.getLocations()[0]);
-            locs.push_back(fusedLoc.getLocations()[1]);
-          }
           CIRGenFunction::LexicalScopeContext lexScope{
-              locs[0], locs[1], builder.getInsertionBlock()};
+              loc, builder.getInsertionBlock()};
           CIRGenFunction::LexicalScopeGuard lexScopeGuard{*this, &lexScope};
           handleReturnVal();
         });
@@ -710,14 +693,10 @@ CIRGenFunction::buildCXXForRangeStmt(const CXXForRangeStmt &S,
   builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto scopeLocBegin = fusedLoc.getLocations()[0];
-        auto scopeLocEnd = fusedLoc.getLocations()[1];
         // Create a cleanup scope for the condition variable cleanups.
         // Logical equivalent from LLVM codegn for
         // LexicalScope ConditionScope(*this, S.getSourceRange())...
-        LexicalScopeContext lexScope{scopeLocBegin, scopeLocEnd,
-                                     builder.getInsertionBlock()};
+        LexicalScopeContext lexScope{loc, builder.getInsertionBlock()};
         LexicalScopeGuard lexForScopeGuard{*this, &lexScope};
         res = forStmtBuilder();
       });
@@ -797,11 +776,7 @@ mlir::LogicalResult CIRGenFunction::buildForStmt(const ForStmt &S) {
   builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto scopeLocBegin = fusedLoc.getLocations()[0];
-        auto scopeLocEnd = fusedLoc.getLocations()[1];
-        LexicalScopeContext lexScope{scopeLocBegin, scopeLocEnd,
-                                     builder.getInsertionBlock()};
+        LexicalScopeContext lexScope{loc, builder.getInsertionBlock()};
         LexicalScopeGuard lexForScopeGuard{*this, &lexScope};
         res = forStmtBuilder();
       });
@@ -856,11 +831,7 @@ mlir::LogicalResult CIRGenFunction::buildDoStmt(const DoStmt &S) {
   builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto scopeLocBegin = fusedLoc.getLocations()[0];
-        auto scopeLocEnd = fusedLoc.getLocations()[1];
-        LexicalScopeContext lexScope{scopeLocBegin, scopeLocEnd,
-                                     builder.getInsertionBlock()};
+        LexicalScopeContext lexScope{loc, builder.getInsertionBlock()};
         LexicalScopeGuard lexForScopeGuard{*this, &lexScope};
         res = doStmtBuilder();
       });
@@ -920,11 +891,7 @@ mlir::LogicalResult CIRGenFunction::buildWhileStmt(const WhileStmt &S) {
   builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto scopeLocBegin = fusedLoc.getLocations()[0];
-        auto scopeLocEnd = fusedLoc.getLocations()[1];
-        LexicalScopeContext lexScope{scopeLocBegin, scopeLocEnd,
-                                     builder.getInsertionBlock()};
+        LexicalScopeContext lexScope{loc, builder.getInsertionBlock()};
         LexicalScopeGuard lexForScopeGuard{*this, &lexScope};
         res = whileStmtBuilder();
       });
@@ -1022,11 +989,7 @@ mlir::LogicalResult CIRGenFunction::buildSwitchStmt(const SwitchStmt &S) {
   builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto fusedLoc = loc.cast<mlir::FusedLoc>();
-        auto scopeLocBegin = fusedLoc.getLocations()[0];
-        auto scopeLocEnd = fusedLoc.getLocations()[1];
-        LexicalScopeContext lexScope{scopeLocBegin, scopeLocEnd,
-                                     builder.getInsertionBlock()};
+        LexicalScopeContext lexScope{loc, builder.getInsertionBlock()};
         LexicalScopeGuard lexIfScopeGuard{*this, &lexScope};
         res = switchStmtBuilder();
       });

--- a/clang/test/CIR/CodeGen/spelling-locations.cpp
+++ b/clang/test/CIR/CodeGen/spelling-locations.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+#define multiline_if_macro(c, t) \
+if (c) { \
+  return t; \
+}
+
+int testMacroLocations(void) {
+
+  // Expanded macros will use the location of the expansion site.
+  multiline_if_macro(1, 3);
+  // CHECK: cir.scope {
+  // CHECK:   cir.if %{{.+}} {
+  // CHECK:     cir.return %{{.+}} : !s32i loc(#loc[[#LOC:]])
+  // CHECK:   } loc(#loc[[#LOC]])
+  // CHECK: } loc(#loc[[#LOC]])
+
+  // Regular if statements should use different locations.
+  if (1) {
+    return 3;
+  }
+  //     CHECK: cir.scope {
+  //     CHECK:   cir.if %{{.+}} {
+  //     CHECK:     cir.return %{{.+}} : !s32i loc(#loc[[#LOC:]])
+  // CHECK-NOT:   } loc(#loc[[#LOC]])
+  // CHECK-NOT: } loc(#loc[[#LOC]])
+
+  return 0;
+}


### PR DESCRIPTION
    Refactors LexicalScopContext to receive a single location and decide
    how to use it. This allows the context to have one or two locations for
    distinguishing between the start and end of the scope.
    
    Fixes a bug where a mlir::Location was wrongly casted to a mlir::FusedLoc
    when building the scope surrounding if statements.
    
    In the rare case where the if statement originates from a preprocessor
    macro definition, the location where the macro is expanded is used as
    the source location for both the start and the end of the range. Once
    these locations are fused, MLIR automatically detects the duplicated
    start and end locations and merges them resulting in single a regular
    location. This patch allows the if statement to have a single location
    as its "begin" and "end" locations.
    
    Note: spelling locations are not tracked due to performance issues.