### PR TITLE
Fixed generation of LLVM code for true boolean constants.

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -645,12 +645,12 @@ public:
     mlir::Attribute attr = op.getValue();
 
     if (op.getType().isa<mlir::cir::BoolType>()) {
-      if (op.getValue() ==
-          mlir::cir::BoolAttr::get(
-              getContext(), ::mlir::cir::BoolType::get(getContext()), true))
-        attr = mlir::BoolAttr::get(getContext(), true);
-      else
-        attr = mlir::BoolAttr::get(getContext(), false);
+      int value =
+          (op.getValue() ==
+           mlir::cir::BoolAttr::get(
+               getContext(), ::mlir::cir::BoolType::get(getContext()), true));
+      attr = rewriter.getIntegerAttr(typeConverter->convertType(op.getType()),
+                                     value);
     } else if (op.getType().isa<mlir::cir::IntType>()) {
       attr = rewriter.getIntegerAttr(
           typeConverter->convertType(op.getType()),

--- a/clang/test/CIR/Lowering/bool-to-int.cir
+++ b/clang/test/CIR/Lowering/bool-to-int.cir
@@ -1,0 +1,21 @@
+// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+#false = #cir.bool<false> : !cir.bool
+#true = #cir.bool<true> : !cir.bool
+
+module {
+  cir.func @foo(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+    %1 = cir.const(#true) : !cir.bool
+    %2 = cir.cast(bool_to_int, %1 : !cir.bool), !s32i
+    cir.return %2 : !s32i
+  }
+  cir.func @bar(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+    %1 = cir.const(#false) : !cir.bool
+    %2 = cir.cast(bool_to_int, %1 : !cir.bool), !s32i
+    cir.return %2 : !s32i
+  }
+}
+
+// CHECK: ret i32 1
+// CHECK: ret i32 0

--- a/clang/test/CIR/Lowering/bool.cir
+++ b/clang/test/CIR/Lowering/bool.cir
@@ -14,7 +14,7 @@ module {
 }
 
 //      MLIR: llvm.func @foo()
-//  MLIR-DAG: = llvm.mlir.constant(true) : i8
+//  MLIR-DAG: = llvm.mlir.constant(1 : i8) : i8
 //  MLIR-DAG: [[Value:%[a-z0-9]+]] = llvm.mlir.constant(1 : index) : i64
 //  MLIR-DAG: = llvm.alloca [[Value]] x i8 {alignment = 1 : i64} : (i64) -> !llvm.ptr<i8>
 //  MLIR-DAG: llvm.store %0, %2 : !llvm.ptr<i8>
@@ -22,5 +22,5 @@ module {
 
 //      LLVM: define void @foo()
 // LLVM-NEXT:   %1 = alloca i8, i64 1, align 1
-// LLVM-NEXT:   store i8 -1, ptr %1, align 1
+// LLVM-NEXT:   store i8 1, ptr %1, align 1
 // LLVM-NEXT:   ret void


### PR DESCRIPTION
Before this fix `foo(1, 1)` returned `255` in
```
  int foo(int a, int b) {
    return a && b;
  }
```
The root cause is the sign extension in LLVM dialect to LLVM IR translation in ModuleTranslation.cpp:
```
  if (auto intAttr = dyn_cast<IntegerAttr>(attr))                                                                                                                                                          
    return llvm::ConstantInt::get(                                              
        llvmType,                                                               
        intAttr.getValue().sextOrTrunc(llvmType->getIntegerBitWidth()));        
```