### PR TITLE
[CIR][Lowering][Bufix] Cast cir.shift amount to same width as the value

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1246,25 +1246,38 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::ShiftOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    assert((op.getValue().getType() == op.getResult().getType()) &&
-           "inconsistent operands' types not supported yet");
-    auto ty = op.getValue().getType().dyn_cast<mlir::cir::IntType>();
-    assert(ty && "NYI for other than mlir::cir::IntType");
-
+    auto cirAmtTy = op.getAmount().getType().dyn_cast<mlir::cir::IntType>();
+    auto cirValTy = op.getValue().getType().dyn_cast<mlir::cir::IntType>();
     auto llvmTy = getTypeConverter()->convertType(op.getType());
-    auto val = adaptor.getValue();
-    auto amt = adaptor.getAmount();
+    auto loc = op.getLoc();
+    mlir::Value amt = adaptor.getAmount();
+    mlir::Value val = adaptor.getValue();
 
+    assert(cirValTy && cirAmtTy && "non-integer shift is NYI");
+    assert(cirValTy == op.getType() && "inconsistent operands' types NYI");
+
+    // Ensure shift amount is the same type as the value. Some undefined
+    // behavior might occur in the casts below as per [C99 6.5.7.3].
+    if (cirAmtTy.getWidth() > cirValTy.getWidth()) {
+      amt = rewriter.create<mlir::LLVM::TruncOp>(loc, llvmTy, amt);
+    } else if (cirAmtTy.getWidth() < cirValTy.getWidth()) {
+      if (cirAmtTy.isSigned())
+        amt = rewriter.create<mlir::LLVM::SExtOp>(loc, llvmTy, amt);
+      else
+        amt = rewriter.create<mlir::LLVM::ZExtOp>(loc, llvmTy, amt);
+    }
+
+    // Lower to the proper LLVM shift operation.
     if (op.getIsShiftleft())
       rewriter.replaceOpWithNewOp<mlir::LLVM::ShlOp>(op, llvmTy, val, amt);
     else {
-      if (ty.isUnsigned())
+      if (cirValTy.isUnsigned())
         rewriter.replaceOpWithNewOp<mlir::LLVM::LShrOp>(op, llvmTy, val, amt);
       else
         rewriter.replaceOpWithNewOp<mlir::LLVM::AShrOp>(op, llvmTy, val, amt);
     }
 
-    return mlir::LogicalResult::success();
+    return mlir::success();
   }
 };
 

--- a/clang/test/CIR/Lowering/shift.cir
+++ b/clang/test/CIR/Lowering/shift.cir
@@ -1,0 +1,28 @@
+// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+!s16i = !cir.int<s, 16>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!u16i = !cir.int<u, 16>
+module {
+  cir.func @testShiftWithDifferentValueAndAmountTypes(%arg0: !s16i, %arg1: !s32i, %arg2: !s64i, %arg3: !u16i) {
+  // CHECK: testShiftWithDifferentValueAndAmountTypes
+
+    // Should allow shift with larger amount type.
+    %1 = cir.shift(left, %arg1: !s32i, %arg2 : !s64i) -> !s32i
+    // CHECK: %[[#CAST:]] = llvm.trunc %{{.+}} : i64 to i32
+    // CHECK: llvm.shl %{{.+}}, %[[#CAST]]  : i32
+
+    // Should allow shift with signed smaller amount type.
+    %2 = cir.shift(left, %arg1 : !s32i, %arg0 : !s16i) -> !s32i
+    // CHECK: %[[#CAST:]] = llvm.sext %{{.+}} : i16 to i32
+    // CHECK: llvm.shl %{{.+}}, %[[#CAST]]  : i32
+
+    // Should allow shift with unsigned smaller amount type.
+    %14 = cir.shift(left, %arg1 : !s32i, %arg3 : !u16i) -> !s32i
+    // CHECK: %[[#CAST:]] = llvm.zext %{{.+}} : i16 to i32
+    // CHECK: llvm.shl %{{.+}}, %[[#CAST]]  : i32
+    cir.return
+  }
+}


### PR DESCRIPTION
The new cir.shift op allows for distinct value and amount types, however LLVM does not. Before this patch, the amount was not cast to the same width as the value, breaking the lowering process. This patch fixes the issue by casting the amount to the same width as the value.