### PR TITLE
Revert "[CIR] Yield boolean value in cir.loop condition region"

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1108,7 +1108,8 @@ def LoopOp : CIR_Op<"loop",
   let description = [{
     `cir.loop` represents C/C++ loop forms. It defines 3 blocks:
     - `cond`: region can contain multiple blocks, terminated by regular
-    `cir.yield %x` where `%x` is the boolean value to be evaluated.
+    `cir.yield` when control should yield back to the parent, and
+    `cir.yield continue` when execution continues to another region.
     The region destination depends on the loop form specified.
     - `step`: region with one block, containing code to compute the
     loop step, must be terminated with `cir.yield`.
@@ -1123,8 +1124,7 @@ def LoopOp : CIR_Op<"loop",
       //  i = i + 1;
       // }
       cir.loop while(cond :  {
-        %2 = cir.const(#cir.bool<true>) : !cir.bool
-        cir.yield %2 : !cir.bool
+        cir.yield continue
       }, step :  {
         cir.yield
       })  {

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -631,6 +631,26 @@ mlir::LogicalResult CIRGenFunction::buildDefaultStmt(const DefaultStmt &S,
   return res;
 }
 
+static mlir::LogicalResult buildLoopCondYield(mlir::OpBuilder &builder,
+                                              mlir::Location loc,
+                                              mlir::Value cond) {
+  mlir::Block *trueBB = nullptr, *falseBB = nullptr;
+  {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    trueBB = builder.createBlock(builder.getBlock()->getParent());
+    builder.create<mlir::cir::YieldOp>(loc, YieldOpKind::Continue);
+  }
+  {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    falseBB = builder.createBlock(builder.getBlock()->getParent());
+    builder.create<mlir::cir::YieldOp>(loc);
+  }
+
+  assert((trueBB && falseBB) && "expected both blocks to exist");
+  builder.create<mlir::cir::BrCondOp>(loc, cond, trueBB, falseBB);
+  return mlir::success();
+}
+
 mlir::LogicalResult
 CIRGenFunction::buildCXXForRangeStmt(const CXXForRangeStmt &S,
                                      ArrayRef<const Attr *> ForAttrs) {
@@ -664,7 +684,8 @@ CIRGenFunction::buildCXXForRangeStmt(const CXXForRangeStmt &S,
           assert(!UnimplementedFeature::createProfileWeightsForLoop());
           assert(!UnimplementedFeature::emitCondLikelihoodViaExpectIntrinsic());
           mlir::Value condVal = evaluateExprAsBool(S.getCond());
-          builder.create<mlir::cir::YieldOp>(loc, condVal);
+          if (buildLoopCondYield(b, loc, condVal).failed())
+            loopRes = mlir::failure();
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
@@ -747,7 +768,8 @@ mlir::LogicalResult CIRGenFunction::buildForStmt(const ForStmt &S) {
                 loc, boolTy,
                 mlir::cir::BoolAttr::get(b.getContext(), boolTy, true));
           }
-          builder.create<mlir::cir::YieldOp>(loc, condVal);
+          if (buildLoopCondYield(b, loc, condVal).failed())
+            loopRes = mlir::failure();
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
@@ -811,7 +833,8 @@ mlir::LogicalResult CIRGenFunction::buildDoStmt(const DoStmt &S) {
           // expression compares unequal to 0. The condition must be a
           // scalar type.
           mlir::Value condVal = evaluateExprAsBool(S.getCond());
-          builder.create<mlir::cir::YieldOp>(loc, condVal);
+          if (buildLoopCondYield(b, loc, condVal).failed())
+            loopRes = mlir::failure();
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
@@ -871,7 +894,8 @@ mlir::LogicalResult CIRGenFunction::buildWhileStmt(const WhileStmt &S) {
           // expression compares unequal to 0. The condition must be a
           // scalar type.
           condVal = evaluateExprAsBool(S.getCond());
-          builder.create<mlir::cir::YieldOp>(loc, condVal);
+          if (buildLoopCondYield(b, loc, condVal).failed())
+            loopRes = mlir::failure();
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -14,7 +14,6 @@
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
-#include "llvm/ADT/SmallVector.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -1104,9 +1103,12 @@ void LoopOp::build(OpBuilder &builder, OperationState &result,
 void LoopOp::getSuccessorRegions(std::optional<unsigned> index,
                                  ArrayRef<Attribute> operands,
                                  SmallVectorImpl<RegionSuccessor> &regions) {
-  // If any index, do nothing.
-  if (index.has_value())
+  // If any index all the underlying regions branch back to the parent
+  // operation.
+  if (index.has_value()) {
+    regions.push_back(RegionSuccessor());
     return;
+  }
 
   // FIXME: we want to look at cond region for getting more accurate results
   // if the other regions will get a chance to execute.
@@ -1118,29 +1120,26 @@ void LoopOp::getSuccessorRegions(std::optional<unsigned> index,
 Region &LoopOp::getLoopBody() { return getBody(); }
 
 LogicalResult LoopOp::verify() {
+  // Cond regions should only terminate with plain 'cir.yield' or
+  // 'cir.yield continue'.
+  auto terminateError = [&]() {
+    return emitOpError() << "cond region must be terminated with "
+                            "'cir.yield' or 'cir.yield continue'";
+  };
 
-  if (getCond().empty() || getStep().empty() || getBody().empty())
-    return emitOpError("regions must not be empty");
-
-  auto condYield = dyn_cast<YieldOp>(getCond().back().getTerminator());
-  auto stepYield = dyn_cast<YieldOp>(getStep().back().getTerminator());
-
-  if (!condYield || !stepYield)
-    return emitOpError(
-        "cond and step regions must be terminated with 'cir.yield'");
-
-  if (condYield.getNumOperands() != 1 ||
-      !condYield.getOperand(0).getType().isa<cir::BoolType>())
-    return emitOpError("cond region must yield a single boolean value");
-
-  if (stepYield.getNumOperands() != 0)
-    return emitOpError("step region should not yield values");
-
-  // Body may yield or return.
-  auto *bodyTerminator = getBody().back().getTerminator();
-
-  if (isa<YieldOp>(bodyTerminator) && bodyTerminator->getNumOperands() != 0)
-    return emitOpError("body region must not yield values");
+  auto &blocks = getCond().getBlocks();
+  for (Block &block : blocks) {
+    if (block.empty())
+      continue;
+    auto &op = block.back();
+    if (isa<BrCondOp>(op))
+      continue;
+    if (!isa<YieldOp>(op))
+      terminateError();
+    auto y = cast<YieldOp>(op);
+    if (!(y.isPlain() || y.isContinue()))
+      terminateError();
+  }
 
   return success();
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -117,6 +117,27 @@ public:
   using LoopKind = mlir::cir::LoopOpKind;
 
   mlir::LogicalResult
+  fetchCondRegionYields(mlir::Region &condRegion,
+                        mlir::cir::YieldOp &yieldToBody,
+                        mlir::cir::YieldOp &yieldToCont) const {
+    for (auto &bb : condRegion) {
+      if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(bb.getTerminator())) {
+        if (!yieldOp.getKind().has_value())
+          yieldToCont = yieldOp;
+        else if (yieldOp.getKind() == mlir::cir::YieldOpKind::Continue)
+          yieldToBody = yieldOp;
+        else
+          return mlir::failure();
+      }
+    }
+
+    // Succeed only if both yields are found.
+    if (!yieldToBody || !yieldToCont)
+      return mlir::failure();
+    return mlir::success();
+  }
+
+  mlir::LogicalResult
   matchAndRewrite(mlir::cir::LoopOp loopOp, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto kind = loopOp.getKind();
@@ -127,8 +148,9 @@ public:
     // Fetch required info from the condition region.
     auto &condRegion = loopOp.getCond();
     auto &condFrontBlock = condRegion.front();
-    auto condYield =
-        cast<mlir::cir::YieldOp>(condRegion.back().getTerminator());
+    mlir::cir::YieldOp yieldToBody, yieldToCont;
+    if (fetchCondRegionYields(condRegion, yieldToBody, yieldToCont).failed())
+      return loopOp.emitError("failed to fetch yields in cond region");
 
     // Fetch required info from the body region.
     auto &bodyRegion = loopOp.getBody();
@@ -141,7 +163,7 @@ public:
     auto &stepRegion = loopOp.getStep();
     auto &stepFrontBlock = stepRegion.front();
     auto stepYield =
-        cast<mlir::cir::YieldOp>(stepRegion.back().getTerminator());
+        dyn_cast<mlir::cir::YieldOp>(stepRegion.back().getTerminator());
 
     // Move loop op region contents to current CFG.
     rewriter.inlineRegionBefore(condRegion, continueBlock);
@@ -154,10 +176,13 @@ public:
     auto &entry = (kind != LoopKind::DoWhile ? condFrontBlock : bodyFrontBlock);
     rewriter.create<mlir::cir::BrOp>(loopOp.getLoc(), &entry);
 
-    // Branch to body when true and to exit when false.
-    rewriter.setInsertionPoint(condYield);
-    rewriter.replaceOpWithNewOp<mlir::cir::BrCondOp>(
-        condYield, condYield.getOperand(0), &bodyFrontBlock, continueBlock);
+    // Set loop exit point to continue block.
+    rewriter.setInsertionPoint(yieldToCont);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldToCont, continueBlock);
+
+    // Branch from condition to body.
+    rewriter.setInsertionPoint(yieldToBody);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldToBody, &bodyFrontBlock);
 
     // Branch from body to condition or to step on for-loop cases.
     rewriter.setInsertionPoint(bodyYield);

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -8,8 +8,7 @@ void l0() {
 
 // CHECK: cir.func @_Z2l0v
 // CHECK: cir.loop for(cond :  {
-// CHECK-NEXT:   %0 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:   cir.yield %0
+// CHECK-NEXT:   cir.yield continue
 // CHECK-NEXT: }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT: })  {
@@ -28,7 +27,11 @@ void l1() {
 // CHECK-NEXT:   %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:   %5 = cir.const(#cir.int<10> : !s32i) : !s32i
 // CHECK-NEXT:   %6 = cir.cmp(lt, %4, %5) : !s32i, !cir.bool
-// CHECK-NEXT:   cir.yield %6 : !cir.bool
+// CHECK-NEXT:   cir.brcond %6 ^bb1, ^bb2
+// CHECK-NEXT:   ^bb1:
+// CHECK-NEXT:     cir.yield continue
+// CHECK-NEXT:   ^bb2:
+// CHECK-NEXT:     cir.yield
 // CHECK-NEXT: }, step :  {
 // CHECK-NEXT:   %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:   %5 = cir.const(#cir.int<1> : !s32i) : !s32i
@@ -59,8 +62,12 @@ void l2(bool cond) {
 // CHECK: cir.func @_Z2l2b
 // CHECK:         cir.scope {
 // CHECK-NEXT:     cir.loop while(cond :  {
-// CHECK-NEXT:        %3 = cir.load %0 : cir.ptr <!cir.bool>, !cir.bool
-// CHECK-NEXT:        cir.yield %3 : !cir.bool
+// CHECK-NEXT:       %3 = cir.load %0 : cir.ptr <!cir.bool>, !cir.bool
+// CHECK-NEXT:       cir.brcond %3 ^bb1, ^bb2
+// CHECK-NEXT:       ^bb1:
+// CHECK-NEXT:         cir.yield continue
+// CHECK-NEXT:       ^bb2:
+// CHECK-NEXT:         cir.yield
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {
@@ -73,8 +80,7 @@ void l2(bool cond) {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     cir.loop while(cond :  {
-// CHECK-NEXT:        %3 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:        cir.yield %3 : !cir.bool
+// CHECK-NEXT:       cir.yield continue
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {
@@ -87,9 +93,13 @@ void l2(bool cond) {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     cir.loop while(cond :  {
-// CHECK-NEXT:        %3 = cir.const(#cir.int<1> : !s32i) : !s32i
-// CHECK-NEXT:        %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
-// CHECK-NEXT:        cir.yield %4 : !cir.bool
+// CHECK-NEXT:       %3 = cir.const(#cir.int<1> : !s32i) : !s32i
+// CHECK-NEXT:       %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
+// CHECK-NEXT:       cir.brcond %4 ^bb1, ^bb2
+// CHECK-NEXT:       ^bb1:
+// CHECK-NEXT:         cir.yield continue
+// CHECK-NEXT:       ^bb2:
+// CHECK-NEXT:         cir.yield
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {
@@ -118,7 +128,11 @@ void l3(bool cond) {
 // CHECK: cir.scope {
 // CHECK-NEXT:   cir.loop dowhile(cond :  {
 // CHECK-NEXT:   %3 = cir.load %0 : cir.ptr <!cir.bool>, !cir.bool
-// CHECK-NEXT:   cir.yield %3
+// CHECK-NEXT:   cir.brcond %3 ^bb1, ^bb2
+// CHECK-NEXT:   ^bb1:
+// CHECK-NEXT:     cir.yield continue
+// CHECK-NEXT:   ^bb2:
+// CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT:   })  {
@@ -131,8 +145,7 @@ void l3(bool cond) {
 // CHECK-NEXT: }
 // CHECK-NEXT: cir.scope {
 // CHECK-NEXT:   cir.loop dowhile(cond :  {
-// CHECK-NEXT:     %3 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:     cir.yield %3 : !cir.bool
+// CHECK-NEXT:     cir.yield continue
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT:   })  {
@@ -147,7 +160,11 @@ void l3(bool cond) {
 // CHECK-NEXT:   cir.loop dowhile(cond :  {
 // CHECK-NEXT:   %3 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK-NEXT:   %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
-// CHECK-NEXT:   cir.yield %4 : !cir.bool
+// CHECK-NEXT:   cir.brcond %4 ^bb1, ^bb2
+// CHECK-NEXT:   ^bb1:
+// CHECK-NEXT:     cir.yield continue
+// CHECK-NEXT:   ^bb2:
+// CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT:   })  {
@@ -171,8 +188,7 @@ void l4() {
 
 // CHECK: cir.func @_Z2l4v
 // CHECK: cir.loop while(cond :  {
-// CHECK-NEXT:     %4 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:     cir.yield %4 : !cir.bool
+// CHECK-NEXT:   cir.yield continue
 // CHECK-NEXT: }, step :  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT: })  {
@@ -199,7 +215,11 @@ void l5() {
 // CHECK-NEXT:     cir.loop dowhile(cond :  {
 // CHECK-NEXT:       %0 = cir.const(#cir.int<0> : !s32i) : !s32i
 // CHECK-NEXT:       %1 = cir.cast(int_to_bool, %0 : !s32i), !cir.bool
-// CHECK-NEXT:       cir.yield %1 : !cir.bool
+// CHECK-NEXT:       cir.brcond %1 ^bb1, ^bb2
+// CHECK-NEXT:       ^bb1:
+// CHECK-NEXT:         cir.yield continue
+// CHECK-NEXT:       ^bb2:
+// CHECK-NEXT:         cir.yield
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {
@@ -218,8 +238,7 @@ void l6() {
 // CHECK: cir.func @_Z2l6v()
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     cir.loop while(cond :  {
-// CHECK-NEXT:       %0 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:       cir.yield %0 : !cir.bool
+// CHECK-NEXT:       cir.yield continue
 // CHECK-NEXT:     }, step :  {
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     })  {

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -46,7 +46,11 @@ void init(unsigned numImages) {
 // CHECK:     cir.store %11, %6 : !ty_22struct2E__vector_iterator22, cir.ptr <!ty_22struct2E__vector_iterator22>
 // CHECK:     cir.loop for(cond : {
 // CHECK:       %12 = cir.call @_ZNK17__vector_iteratorI6triplePS0_RS0_EneERKS3_(%5, %6) : (!cir.ptr<!ty_22struct2E__vector_iterator22>, !cir.ptr<!ty_22struct2E__vector_iterator22>) -> !cir.bool
-// CHECK:       cir.yield %12 : !cir.bool
+// CHECK:       cir.brcond %12 ^bb1, ^bb2
+// CHECK:     ^bb1:  // pred: ^bb0
+// CHECK:       cir.yield continue
+// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:       cir.yield
 // CHECK:     }, step : {
 // CHECK:       %12 = cir.call @_ZN17__vector_iteratorI6triplePS0_RS0_EppEv(%5) : (!cir.ptr<!ty_22struct2E__vector_iterator22>) -> !cir.ptr<!ty_22struct2E__vector_iterator22>
 // CHECK:       cir.yield

--- a/clang/test/CIR/IR/branch.cir
+++ b/clang/test/CIR/IR/branch.cir
@@ -7,13 +7,17 @@ cir.func @b0() {
   cir.scope {
     cir.loop while(cond :  {
       %0 = cir.const(#true) : !cir.bool
-      cir.yield %0 : !cir.bool
+      cir.brcond %0 ^bb1, ^bb2
+      ^bb1:
+        cir.yield continue
+      ^bb2:
+        cir.yield
     }, step :  {
       cir.yield
     })  {
       cir.br ^bb1
     ^bb1:
-      cir.yield
+      cir.return
     }
   }
   cir.return
@@ -23,13 +27,17 @@ cir.func @b0() {
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
 // CHECK-NEXT:      %0 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:      cir.yield %0 : !cir.bool
+// CHECK-NEXT:      cir.brcond %0 ^bb1, ^bb2
+// CHECK-NEXT:      ^bb1:
+// CHECK-NEXT:        cir.yield continue
+// CHECK-NEXT:      ^bb2:
+// CHECK-NEXT:        cir.yield
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {
 // CHECK-NEXT:      cir.br ^bb1
 // CHECK-NEXT:    ^bb1:
-// CHECK-NEXT:      cir.yield
+// CHECK-NEXT:      cir.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:  cir.return

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -163,7 +163,7 @@ cir.func @cast4(%p: !cir.ptr<!u32i>) {
 #true = #cir.bool<true> : !cir.bool
 cir.func @b0() {
   cir.scope {
-    cir.loop while(cond :  {  // expected-error {{cond region must yield a single boolean value}}
+    cir.loop while(cond :  {  // expected-error {{cond region must be terminated with 'cir.yield' or 'cir.yield continue'}}
       %0 = cir.const(#true) : !cir.bool
       cir.brcond %0 ^bb1, ^bb2
       ^bb1:
@@ -177,72 +177,6 @@ cir.func @b0() {
     ^bb1:
       cir.return
     }
-  }
-  cir.return
-}
-
-// -----
-
-#false = #cir.bool<false> : !cir.bool
-#true = #cir.bool<true> : !cir.bool
-cir.func @b0() {
-  cir.loop while(cond :  {  // expected-error {{cond and step regions must be terminated with 'cir.yield'}}
-    %0 = cir.const(#true) : !cir.bool
-    cir.return %0 : !cir.bool
-  }, step :  {
-    cir.yield
-  })  {
-    cir.yield
-  }
-  cir.return
-}
-
-// -----
-
-#false = #cir.bool<false> : !cir.bool
-#true = #cir.bool<true> : !cir.bool
-cir.func @b0() {
-  cir.loop while(cond :  {  // expected-error {{cond and step regions must be terminated with 'cir.yield'}}
-    %0 = cir.const(#true) : !cir.bool
-    cir.yield %0 : !cir.bool
-  }, step :  {
-    cir.return
-  })  {
-    cir.return
-  }
-  cir.return
-}
-
-// -----
-
-#false = #cir.bool<false> : !cir.bool
-#true = #cir.bool<true> : !cir.bool
-cir.func @b0() {
-  cir.loop while(cond :  {  // expected-error {{step region should not yield values}}
-    %0 = cir.const(#true) : !cir.bool
-    cir.yield %0 : !cir.bool
-  }, step :  {
-    %1 = cir.const(#true) : !cir.bool
-    cir.yield %1 : !cir.bool
-  })  {
-    cir.return
-  }
-  cir.return
-}
-
-// -----
-
-#false = #cir.bool<false> : !cir.bool
-#true = #cir.bool<true> : !cir.bool
-cir.func @b0() {
-  cir.loop while(cond :  {  // expected-error {{body region must not yield values}}
-    %0 = cir.const(#true) : !cir.bool
-    cir.yield %0 : !cir.bool
-  }, step :  {
-    cir.yield
-  })  {
-    %1 = cir.const(#true) : !cir.bool
-    cir.yield %1 : !cir.bool
   }
   cir.return
 }

--- a/clang/test/CIR/IR/loop.cir
+++ b/clang/test/CIR/IR/loop.cir
@@ -15,7 +15,11 @@ cir.func @l0() {
       %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
       %5 = cir.const(#cir.int<10> : !u32i) : !u32i
       %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-      cir.yield %6 : !cir.bool
+      cir.brcond %6 ^bb1, ^bb2
+      ^bb1:
+        cir.yield continue
+      ^bb2:
+        cir.yield
     }, step :  {
       %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
       %5 = cir.const(#cir.int<1> : !u32i) : !u32i
@@ -42,7 +46,11 @@ cir.func @l0() {
       %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
       %5 = cir.const(#cir.int<10> : !u32i) : !u32i
       %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-      cir.yield %6 : !cir.bool
+      cir.brcond %6 ^bb1, ^bb2
+      ^bb1:
+        cir.yield continue
+      ^bb2:
+        cir.yield
     }, step :  {
       cir.yield
     })  {
@@ -66,7 +74,11 @@ cir.func @l0() {
       %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
       %5 = cir.const(#cir.int<10> : !u32i) : !u32i
       %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-      cir.yield %6 : !cir.bool
+      cir.brcond %6 ^bb1, ^bb2
+      ^bb1:
+        cir.yield continue
+      ^bb2:
+        cir.yield
     }, step :  {
       cir.yield
     })  {
@@ -85,7 +97,11 @@ cir.func @l0() {
 // CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
 // CHECK-NEXT:     %5 = cir.const(#cir.int<10> : !u32i) : !u32i
 // CHECK-NEXT:     %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-// CHECK-NEXT:     cir.yield %6 : !cir.bool
+// CHECK-NEXT:     cir.brcond %6 ^bb1, ^bb2
+// CHECK-NEXT:     ^bb1:
+// CHECK-NEXT:       cir.yield continue
+// CHECK-NEXT:     ^bb2:
+// CHECK-NEXT:       cir.yield
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
 // CHECK-NEXT:     %5 = cir.const(#cir.int<1> : !u32i) : !u32i
@@ -108,7 +124,11 @@ cir.func @l0() {
 // CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
 // CHECK-NEXT:     %5 = cir.const(#cir.int<10> : !u32i) : !u32i
 // CHECK-NEXT:     %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-// CHECK-NEXT:     cir.yield %6 : !cir.bool
+// CHECK-NEXT:     cir.brcond %6 ^bb1, ^bb2
+// CHECK-NEXT:     ^bb1:
+// CHECK-NEXT:       cir.yield continue
+// CHECK-NEXT:     ^bb2:
+// CHECK-NEXT:       cir.yield
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   })  {
@@ -127,7 +147,11 @@ cir.func @l0() {
 // CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
 // CHECK-NEXT:     %5 = cir.const(#cir.int<10> : !u32i) : !u32i
 // CHECK-NEXT:     %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-// CHECK-NEXT:     cir.yield %6 : !cir.bool
+// CHECK-NEXT:     cir.brcond %6 ^bb1, ^bb2
+// CHECK-NEXT:     ^bb1:
+// CHECK-NEXT:       cir.yield continue
+// CHECK-NEXT:     ^bb2:
+// CHECK-NEXT:       cir.yield
 // CHECK-NEXT:   }, step :  {
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   })  {
@@ -141,8 +165,7 @@ cir.func @l0() {
 cir.func @l1() {
   cir.scope {
     cir.loop while(cond :  {
-      %0 = cir.const(#true) : !cir.bool
-      cir.yield %0 : !cir.bool
+      cir.yield continue
     }, step :  {
       cir.yield
     })  {
@@ -155,8 +178,7 @@ cir.func @l1() {
 // CHECK: cir.func @l1
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      %0 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:      cir.yield %0 : !cir.bool
+// CHECK-NEXT:      cir.yield continue
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {
@@ -169,8 +191,7 @@ cir.func @l1() {
 cir.func @l2() {
   cir.scope {
     cir.loop while(cond :  {
-      %0 = cir.const(#true) : !cir.bool
-      cir.yield %0 : !cir.bool
+      cir.yield
     }, step :  {
       cir.yield
     })  {
@@ -183,8 +204,7 @@ cir.func @l2() {
 // CHECK: cir.func @l2
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      %0 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:      cir.yield %0 : !cir.bool
+// CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {

--- a/clang/test/CIR/Lowering/dot.cir
+++ b/clang/test/CIR/Lowering/dot.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt %s -cir-to-llvm -reconcile-unrealized-casts -o %t.mlir
+// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
 
 !s32i = !cir.int<s, 32>
@@ -23,7 +23,11 @@ module {
         %11 = cir.load %2 : cir.ptr <!s32i>, !s32i
         %12 = cir.cmp(lt, %10, %11) : !s32i, !s32i
         %13 = cir.cast(int_to_bool, %12 : !s32i), !cir.bool
-        cir.yield %13 : !cir.bool
+        cir.brcond %13 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
       }, step : {
         %10 = cir.load %8 : cir.ptr <!s32i>, !s32i
         %11 = cir.unary(inc, %10) : !s32i, !s32i
@@ -76,7 +80,7 @@ module {
 // MLIR-NEXT:     %13 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:     llvm.store %13, %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     llvm.br ^bb2
-// MLIR-NEXT:   ^bb2:  // 2 preds: ^bb1, ^bb4
+// MLIR-NEXT:   ^bb2:  // 2 preds: ^bb1, ^bb6
 // MLIR-NEXT:     %14 = llvm.load %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     %15 = llvm.load %5 : !llvm.ptr<i32>
 // MLIR-NEXT:     %16 = llvm.icmp "slt" %14, %15 : i32
@@ -85,8 +89,12 @@ module {
 // MLIR-NEXT:     %19 = llvm.icmp "ne" %17, %18 : i32
 // MLIR-NEXT:     %20 = llvm.zext %19 : i1 to i8
 // MLIR-NEXT:     %21 = llvm.trunc %20 : i8 to i1
-// MLIR-NEXT:     llvm.cond_br %21, ^bb3, ^bb5
+// MLIR-NEXT:     llvm.cond_br %21, ^bb3, ^bb4
 // MLIR-NEXT:   ^bb3:  // pred: ^bb2
+// MLIR-NEXT:     llvm.br ^bb5
+// MLIR-NEXT:   ^bb4:  // pred: ^bb2
+// MLIR-NEXT:     llvm.br ^bb7
+// MLIR-NEXT:   ^bb5:  // pred: ^bb3
 // MLIR-NEXT:     %22 = llvm.load %1 : !llvm.ptr<ptr<f64>>
 // MLIR-NEXT:     %23 = llvm.load %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     %24 = llvm.getelementptr %22[%23] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
@@ -99,16 +107,16 @@ module {
 // MLIR-NEXT:     %31 = llvm.load %9 : !llvm.ptr<f64>
 // MLIR-NEXT:     %32 = llvm.fadd %31, %30  : f64
 // MLIR-NEXT:     llvm.store %32, %9 : !llvm.ptr<f64>
-// MLIR-NEXT:     llvm.br ^bb4
-// MLIR-NEXT:   ^bb4:  // pred: ^bb3
+// MLIR-NEXT:     llvm.br ^bb6
+// MLIR-NEXT:   ^bb6:  // pred: ^bb5
 // MLIR-NEXT:     %33 = llvm.load %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     %34 = llvm.mlir.constant(1 : i32) : i32
 // MLIR-NEXT:     %35 = llvm.add %33, %34  : i32
 // MLIR-NEXT:     llvm.store %35, %12 : !llvm.ptr<i32>
 // MLIR-NEXT:     llvm.br ^bb2
-// MLIR-NEXT:   ^bb5:  // pred: ^bb2
-// MLIR-NEXT:     llvm.br ^bb6
-// MLIR-NEXT:   ^bb6:  // pred: ^bb5
+// MLIR-NEXT:   ^bb7:  // pred: ^bb4
+// MLIR-NEXT:     llvm.br ^bb8
+// MLIR-NEXT:   ^bb8:  // pred: ^bb7
 // MLIR-NEXT:     %36 = llvm.load %9 : !llvm.ptr<f64>
 // MLIR-NEXT:     llvm.store %36, %7 : !llvm.ptr<f64>
 // MLIR-NEXT:     %37 = llvm.load %7 : !llvm.ptr<f64>

--- a/clang/test/CIR/Lowering/loop.cir
+++ b/clang/test/CIR/Lowering/loop.cir
@@ -1,5 +1,5 @@
-// RUN: cir-opt %s -cir-to-llvm -reconcile-unrealized-casts -o %t.mlir
-// RUN: FileCheck --input-file=%t.mlir %s
+// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
 
 !s32i = !cir.int<s, 32>
 module {
@@ -12,7 +12,11 @@ module {
       %3 = cir.const(#cir.int<10> : !s32i) : !s32i
       %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
       %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-      cir.yield %5 : !cir.bool
+      cir.brcond %5 ^bb1, ^bb2
+    ^bb1:  // pred: ^bb0
+      cir.yield continue
+    ^bb2:  // pred: ^bb0
+      cir.yield
     }, step : {
       %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
       %3 = cir.unary(inc, %2) : !s32i, !s32i
@@ -24,90 +28,161 @@ module {
     cir.return
   }
 
-  // CHECK:  llvm.func @testFor()
-  //           [...]
-  // CHECK:    llvm.br ^bb[[#COND:]]
-  // CHECK:  ^bb[[#COND]]:
-  //           [...]
-  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#BODY:]], ^bb[[#EXIT:]]
-  // CHECK:  ^bb[[#BODY]]:
-  //           [...]
-  // CHECK:    llvm.br ^bb[[#STEP:]]
-  // CHECK:  ^bb[[#STEP]]:
-  //           [...]
-  // CHECK:    llvm.br ^bb[[#COND]]
-  // CHECK:  ^bb[[#EXIT]]:
-  //           [...]
-  // CHECK:  }
-
+//      MLIR: module {
+// MLIR-NEXT:   llvm.func @testFor()
+// MLIR-NEXT:     %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:     %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:     %2 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:     llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:     llvm.br ^bb1
+// ============= Condition block =============
+// MLIR-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb5
+// MLIR-NEXT:     %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:     %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:     %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:     %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:     %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:     %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:     %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:     %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:     llvm.cond_br %10, ^bb2, ^bb3
+// MLIR-NEXT:   ^bb2:  // pred: ^bb1
+// MLIR-NEXT:     llvm.br ^bb4
+// MLIR-NEXT:   ^bb3:  // pred: ^bb1
+// MLIR-NEXT:     llvm.br ^bb6
+// ============= Body block =============
+// MLIR-NEXT:   ^bb4:  // pred: ^bb2
+// MLIR-NEXT:     llvm.br ^bb5
+// ============= Step block =============
+// MLIR-NEXT:   ^bb5:  // pred: ^bb4
+// MLIR-NEXT:     %11 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:     %12 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:     %13 = llvm.add %11, %12  : i32
+// MLIR-NEXT:     llvm.store %13, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:     llvm.br ^bb1
+// ============= Exit block =============
+// MLIR-NEXT:   ^bb6:  // pred: ^bb3
+// MLIR-NEXT:     llvm.return
+// MLIR-NEXT:   }
 
   // Test while cir.loop operation lowering.
   cir.func @testWhile(%arg0: !s32i) {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
-    cir.loop while(cond : {
-      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-      %2 = cir.const(#cir.int<10> : !s32i) : !s32i
-      %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
-      %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
-      cir.yield %4 : !cir.bool
-    }, step : {
-      cir.yield
-    }) {
-      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-      %2 = cir.unary(inc, %1) : !s32i, !s32i
-      cir.store %2, %0 : !s32i, cir.ptr <!s32i>
-      cir.yield
+    cir.scope {
+      cir.loop while(cond : {
+        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %2 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
+        %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
+        cir.brcond %4 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        cir.yield
+      }) {
+        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %2 = cir.unary(inc, %1) : !s32i, !s32i
+        cir.store %2, %0 : !s32i, cir.ptr <!s32i>
+        cir.yield
+      }
     }
     cir.return
   }
 
-  // CHECK:  llvm.func @testWhile
-  //           [...]
-  // CHECK:    llvm.br ^bb[[#COND:]]
-  // CHECK:  ^bb[[#COND]]:
-  //           [...]
-  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#BODY:]], ^bb[[#EXIT:]]
-  // CHECK:  ^bb[[#BODY]]:
-  //           [...]
-  // CHECK:    llvm.br ^bb[[#COND]]
-  // CHECK:  ^bb[[#EXIT]]:
-  //           [...]
-  // CHECK:  }
-
+  //      MLIR:  llvm.func @testWhile(%arg0: i32)
+  // MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
+  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.br ^bb1
+  // MLIR-NEXT:  ^bb1:
+  // MLIR-NEXT:    llvm.br ^bb2
+  // ============= Condition block =============
+  // MLIR-NEXT:  ^bb2:  // 2 preds: ^bb1, ^bb5
+  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %3 = llvm.mlir.constant(10 : i32) : i32
+  // MLIR-NEXT:    %4 = llvm.icmp "slt" %2, %3 : i32
+  // MLIR-NEXT:    %5 = llvm.zext %4 : i1 to i32
+  // MLIR-NEXT:    %6 = llvm.mlir.constant(0 : i32) : i32
+  // MLIR-NEXT:    %7 = llvm.icmp "ne" %5, %6 : i32
+  // MLIR-NEXT:    %8 = llvm.zext %7 : i1 to i8
+  // MLIR-NEXT:    %9 = llvm.trunc %8 : i8 to i1
+  // MLIR-NEXT:    llvm.cond_br %9, ^bb3, ^bb4
+  // MLIR-NEXT:  ^bb3:  // pred: ^bb2
+  // MLIR-NEXT:    llvm.br ^bb5
+  // MLIR-NEXT:  ^bb4:  // pred: ^bb2
+  // MLIR-NEXT:    llvm.br ^bb6
+  // ============= Body block =============
+  // MLIR-NEXT:  ^bb5:  // pred: ^bb3
+  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %11 = llvm.mlir.constant(1 : i32) : i32
+  // MLIR-NEXT:    %12 = llvm.add %10, %11  : i32
+  // MLIR-NEXT:    llvm.store %12, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.br ^bb2
+  // ============= Exit block =============
+  // MLIR-NEXT:  ^bb6:  // pred: ^bb4
+  // MLIR-NEXT:    llvm.br ^bb7
 
   // Test do-while cir.loop operation lowering.
   cir.func @testDoWhile(%arg0: !s32i) {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
-    cir.loop dowhile(cond : {
-      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-      %2 = cir.const(#cir.int<10> : !s32i) : !s32i
-      %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
-      %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
-      cir.yield %4 : !cir.bool
-    }, step : {
-      cir.yield
-    }) {
-      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-      %2 = cir.unary(inc, %1) : !s32i, !s32i
-      cir.store %2, %0 : !s32i, cir.ptr <!s32i>
-      cir.yield
+    cir.scope {
+      cir.loop dowhile(cond : {
+        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %2 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %3 = cir.cmp(lt, %1, %2) : !s32i, !s32i
+        %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
+        cir.brcond %4 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        cir.yield
+      }) {
+        %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %2 = cir.unary(inc, %1) : !s32i, !s32i
+        cir.store %2, %0 : !s32i, cir.ptr <!s32i>
+        cir.yield
+      }
     }
     cir.return
   }
 
-  // CHECK:  llvm.func @testDoWhile
-  //           [...]
-  // CHECK:    llvm.br ^bb[[#BODY:]]
-  // CHECK:  ^bb[[#COND:]]:
-  //           [...]
-  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#BODY]], ^bb[[#EXIT:]]
-  // CHECK:  ^bb[[#BODY]]:
-  //           [...]
-  // CHECK:    llvm.br ^bb[[#COND]]
-  // CHECK:  ^bb[[#EXIT]]:
-  //           [...]
-  // CHECK:  }
+  //      MLIR:  llvm.func @testDoWhile(%arg0: i32)
+  // MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
+  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.br ^bb1
+  // MLIR-NEXT:  ^bb1:
+  // MLIR-NEXT:    llvm.br ^bb5
+  // ============= Condition block =============
+  // MLIR-NEXT:  ^bb2:
+  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %3 = llvm.mlir.constant(10 : i32) : i32
+  // MLIR-NEXT:    %4 = llvm.icmp "slt" %2, %3 : i32
+  // MLIR-NEXT:    %5 = llvm.zext %4 : i1 to i32
+  // MLIR-NEXT:    %6 = llvm.mlir.constant(0 : i32) : i32
+  // MLIR-NEXT:    %7 = llvm.icmp "ne" %5, %6 : i32
+  // MLIR-NEXT:    %8 = llvm.zext %7 : i1 to i8
+  // MLIR-NEXT:    %9 = llvm.trunc %8 : i8 to i1
+  // MLIR-NEXT:    llvm.cond_br %9, ^bb3, ^bb4
+  // MLIR-NEXT:  ^bb3:
+  // MLIR-NEXT:    llvm.br ^bb5
+  // MLIR-NEXT:  ^bb4:
+  // MLIR-NEXT:    llvm.br ^bb6
+  // ============= Body block =============
+  // MLIR-NEXT:  ^bb5:
+  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %11 = llvm.mlir.constant(1 : i32) : i32
+  // MLIR-NEXT:    %12 = llvm.add %10, %11  : i32
+  // MLIR-NEXT:    llvm.store %12, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.br ^bb2
+  // ============= Exit block =============
+  // MLIR-NEXT:  ^bb6:
+  // MLIR-NEXT:    llvm.br ^bb7
 
 }

--- a/clang/test/CIR/Transforms/merge-cleanups.cir
+++ b/clang/test/CIR/Transforms/merge-cleanups.cir
@@ -65,7 +65,11 @@ module  {
     cir.scope {
       cir.loop while(cond :  {
         %0 = cir.const(#true) : !cir.bool
-        cir.yield %0 : !cir.bool
+        cir.brcond %0 ^bb1, ^bb2
+        ^bb1:
+          cir.yield continue
+        ^bb2:
+          cir.yield
       }, step :  {
         cir.yield
       })  {
@@ -81,7 +85,11 @@ module  {
     cir.scope {
       cir.loop while(cond :  {
         %0 = cir.const(#false) : !cir.bool
-        cir.yield %0 : !cir.bool
+        cir.brcond %0 ^bb1, ^bb2
+        ^bb1:
+          cir.yield continue
+        ^bb2:
+          cir.yield
       }, step :  {
         cir.yield
       })  {
@@ -133,8 +141,7 @@ module  {
 // CHECK: cir.func @l0
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      %0 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:      cir.yield %0 : !cir.bool
+// CHECK-NEXT:      cir.yield continue
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {
@@ -147,8 +154,7 @@ module  {
 // CHECK: cir.func @l1
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      %0 = cir.const(#false) : !cir.bool
-// CHECK-NEXT:      cir.yield %0 : !cir.bool
+// CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    }, step :  {
 // CHECK-NEXT:      cir.yield
 // CHECK-NEXT:    })  {


### PR DESCRIPTION
The changes made to `getSuccessorRegion` seem to have caused an issue. Reverting it until an alternative is found.

This reverts commit 5e449c0cd5d3ba4de61357cafc4ea0fb4463dfd5.