### PR TITLE
[CIR][CodeGen] Emit globals with constructor initializer

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -564,11 +564,12 @@ def YieldOpKind : I32EnumAttr<
 
 def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     ParentOneOf<["IfOp", "ScopeOp", "SwitchOp", "LoopOp", "AwaitOp",
-                 "TernaryOp"]>]> {
+                 "TernaryOp", "GlobalOp"]>]> {
   let summary = "Terminate CIR regions";
   let description = [{
     The `cir.yield` operation terminates regions on different CIR operations:
-    `cir.if`, `cir.scope`, `cir.switch`, `cir.loop`, `cir.await` and `cir.ternary`.
+    `cir.if`, `cir.scope`, `cir.switch`, `cir.loop`, `cir.await`, `cir.ternary`
+    and `cir.global`.
 
     Might yield an SSA value and the semantics of how the values are yielded is
     defined by the parent operation.
@@ -1236,7 +1237,7 @@ def SignedOverflowBehaviorEnum : I32EnumAttr<
 }
 
 
-def GlobalOp : CIR_Op<"global", [Symbol]> {
+def GlobalOp : CIR_Op<"global", [Symbol, DeclareOpInterfaceMethods<RegionBranchOpInterface>, NoRegionArguments]> {
   let summary = "Declares or defines a global variable";
   let description = [{
     The `cir.global` operation declares or defines a named global variable.
@@ -1274,19 +1275,19 @@ def GlobalOp : CIR_Op<"global", [Symbol]> {
                        OptionalAttr<AnyAttr>:$initial_value,
                        UnitAttr:$constant,
                        OptionalAttr<I64Attr>:$alignment);
-
+  let regions = (region AnyRegion:$ctorRegion, AnyRegion:$dtorRegion);
   let assemblyFormat = [{
        ($sym_visibility^)?
        (`constant` $constant^)?
        $linkage
        $sym_name
-       custom<GlobalOpTypeAndInitialValue>($sym_type, $initial_value)
+       custom<GlobalOpTypeAndInitialValue>($sym_type, $initial_value, $ctorRegion, $dtorRegion)
        attr-dict
   }];
 
   let extraClassDeclaration = [{
     bool isDeclaration() {
-      return !getInitialValue();
+      return !getInitialValue() && getCtorRegion().empty() && getDtorRegion().empty();
     }
     bool hasInitializer() { return !isDeclaration(); }
     bool hasAvailableExternallyLinkage() {
@@ -1312,8 +1313,11 @@ def GlobalOp : CIR_Op<"global", [Symbol]> {
       CArg<"bool", "false">:$isConstant,
       // CIR defaults to external linkage.
       CArg<"cir::GlobalLinkageKind",
-            "cir::GlobalLinkageKind::ExternalLinkage">:$linkage
-      )>
+            "cir::GlobalLinkageKind::ExternalLinkage">:$linkage,
+      CArg<"function_ref<void(OpBuilder &, Location)>",
+           "nullptr">:$ctorBuilder,
+      CArg<"function_ref<void(OpBuilder &, Location)>",
+           "nullptr">:$dtorBuilder)>
   ];
 
   let hasVerifier = 1;

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1275,19 +1275,19 @@ def GlobalOp : CIR_Op<"global", [Symbol, DeclareOpInterfaceMethods<RegionBranchO
                        OptionalAttr<AnyAttr>:$initial_value,
                        UnitAttr:$constant,
                        OptionalAttr<I64Attr>:$alignment);
-  let regions = (region AnyRegion:$ctorRegion, AnyRegion:$dtorRegion);
+  let regions = (region AnyRegion:$ctorRegion);
   let assemblyFormat = [{
        ($sym_visibility^)?
        (`constant` $constant^)?
        $linkage
        $sym_name
-       custom<GlobalOpTypeAndInitialValue>($sym_type, $initial_value, $ctorRegion, $dtorRegion)
+       custom<GlobalOpTypeAndInitialValue>($sym_type, $initial_value, $ctorRegion)
        attr-dict
   }];
 
   let extraClassDeclaration = [{
     bool isDeclaration() {
-      return !getInitialValue() && getCtorRegion().empty() && getDtorRegion().empty();
+      return !getInitialValue() && getCtorRegion().empty();
     }
     bool hasInitializer() { return !isDeclaration(); }
     bool hasAvailableExternallyLinkage() {
@@ -1315,9 +1315,7 @@ def GlobalOp : CIR_Op<"global", [Symbol, DeclareOpInterfaceMethods<RegionBranchO
       CArg<"cir::GlobalLinkageKind",
             "cir::GlobalLinkageKind::ExternalLinkage">:$linkage,
       CArg<"function_ref<void(OpBuilder &, Location)>",
-           "nullptr">:$ctorBuilder,
-      CArg<"function_ref<void(OpBuilder &, Location)>",
-           "nullptr">:$dtorBuilder)>
+           "nullptr">:$ctorBuilder)>
   ];
 
   let hasVerifier = 1;

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -20,6 +20,32 @@
 using namespace clang;
 using namespace cir;
 
+static void buildDeclInit(CIRGenFunction &CGF, const VarDecl *D,
+                          Address DeclPtr) {
+  assert((D->hasGlobalStorage() ||
+          (D->hasLocalStorage() &&
+           CGF.getContext().getLangOpts().OpenCLCPlusPlus)) &&
+         "VarDecl must have global or local (in the case of OpenCL) storage!");
+  assert(!D->getType()->isReferenceType() &&
+         "Should not call buildDeclInit on a reference!");
+
+  QualType type = D->getType();
+  LValue lv = CGF.makeAddrLValue(DeclPtr, type);
+
+  const Expr *Init = D->getInit();
+  switch (CIRGenFunction::getEvaluationKind(type)) {
+  case TEK_Aggregate:
+    CGF.buildAggExpr(
+        Init, AggValueSlot::forLValue(lv, AggValueSlot::IsDestructed,
+                                      AggValueSlot::DoesNotNeedGCBarriers,
+                                      AggValueSlot::IsNotAliased,
+                                      AggValueSlot::DoesNotOverlap));
+    return;
+  default:
+    llvm_unreachable("bad evaluation kind");
+  }
+}
+
 mlir::cir::FuncOp CIRGenModule::codegenCXXStructor(GlobalDecl GD) {
   const auto &FnInfo = getTypes().arrangeCXXStructorDeclaration(GD);
   auto Fn = getAddrOfCXXStructor(GD, &FnInfo, /*FnType=*/nullptr,
@@ -37,4 +63,21 @@ mlir::cir::FuncOp CIRGenModule::codegenCXXStructor(GlobalDecl GD) {
   // TODO: setNonAliasAttributes
   // TODO: SetLLVMFunctionAttributesForDefinition
   return Fn;
+}
+
+void CIRGenModule::codegenGlobalInitCxxStructor(const VarDecl *D,
+                                                mlir::cir::GlobalOp Addr) {
+  CIRGenFunction CGF{*this, builder, true};
+  CurCGF = &CGF;
+  CurCGF->CurFn = Addr;
+  {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    auto block = builder.createBlock(&Addr.getCtorRegion());
+    builder.setInsertionPointToStart(block);
+    Address DeclAddr(getAddrOfGlobalVar(D), getASTContext().getDeclAlign(D));
+    buildDeclInit(CGF, D, DeclAddr);
+    builder.setInsertionPointToEnd(block);
+    builder.create<mlir::cir::YieldOp>(Addr->getLoc());
+  }
+  CurCGF = nullptr;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -41,6 +41,10 @@ static void buildDeclInit(CIRGenFunction &CGF, const VarDecl *D,
                                       AggValueSlot::IsNotAliased,
                                       AggValueSlot::DoesNotOverlap));
     return;
+  case TEK_Scalar:
+    llvm_unreachable("scalar evaluation NYI");
+  case TEK_Complex:
+    llvm_unreachable("complext evaluation NYI");
   default:
     llvm_unreachable("bad evaluation kind");
   }

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -254,7 +254,9 @@ CIRGenFunction::buildCoroutineBody(const CoroutineBodyStmt &S) {
   auto openCurlyLoc = getLoc(S.getBeginLoc());
   auto nullPtrCst = builder.getNullPtr(VoidPtrTy, openCurlyLoc);
 
-  CurFn.setCoroutineAttr(mlir::UnitAttr::get(builder.getContext()));
+  auto Fn = dyn_cast<mlir::cir::FuncOp>(CurFn);
+  assert(Fn && "other callables NYI");
+  Fn.setCoroutineAttr(mlir::UnitAttr::get(builder.getContext()));
   auto coroId = buildCoroIDBuiltinCall(openCurlyLoc, nullPtrCst);
   createCoroData(*this, CurCoro, coroId);
 

--- a/clang/lib/CIR/CodeGen/CIRGenDeclCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDeclCXX.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CIRGenFunction.h"
 #include "CIRGenModule.h"
 #include "TargetInfo.h"
 #include "clang/AST/Attr.h"
@@ -28,4 +29,52 @@ void CIRGenModule::buildCXXGlobalInitFunc() {
     return;
 
   assert(0 && "NYE");
+}
+
+void CIRGenModule::buildGlobalVarDeclInit(const VarDecl *D,
+                                          mlir::cir::GlobalOp Addr,
+                                          bool PerformInit) {
+  // According to E.2.3.1 in CUDA-7.5 Programming guide: __device__,
+  // __constant__ and __shared__ variables defined in namespace scope,
+  // that are of class type, cannot have a non-empty constructor. All
+  // the checks have been done in Sema by now. Whatever initializers
+  // are allowed are empty and we just need to ignore them here.
+  if (getLangOpts().CUDAIsDevice && !getLangOpts().GPUAllowDeviceInit &&
+      (D->hasAttr<CUDADeviceAttr>() || D->hasAttr<CUDAConstantAttr>() ||
+       D->hasAttr<CUDASharedAttr>()))
+    return;
+
+  assert(!getLangOpts().OpenMP && "OpenMP global var init not implemented");
+
+  // Check if we've already initialized this decl.
+  auto I = DelayedCXXInitPosition.find(D);
+  if (I != DelayedCXXInitPosition.end() && I->second == ~0U)
+    return;
+
+  if (PerformInit) {
+    QualType T = D->getType();
+
+    // TODO: handle address space
+    // The address space of a static local variable (DeclPtr) may be different
+    // from the address space of the "this" argument of the constructor. In that
+    // case, we need an addrspacecast before calling the constructor.
+    //
+    // struct StructWithCtor {
+    //   __device__ StructWithCtor() {...}
+    // };
+    // __device__ void foo() {
+    //   __shared__ StructWithCtor s;
+    //   ...
+    // }
+    //
+    // For example, in the above CUDA code, the static local variable s has a
+    // "shared" address space qualifier, but the constructor of StructWithCtor
+    // expects "this" in the "generic" address space.
+    assert(!UnimplementedFeature::addressSpace());
+
+    if (!T->isReferenceType()) {
+      codegenGlobalInitCxxStructor(D, Addr);
+      return;
+    }
+  }
 }

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2133,7 +2133,7 @@ mlir::Value CIRGenFunction::buildAlloca(StringRef name, mlir::Type ty,
                                         mlir::Location loc, CharUnits alignment,
                                         bool insertIntoFnEntryBlock) {
   mlir::Block *entryBlock = insertIntoFnEntryBlock
-                                ? &CurFn->getRegion(0).front()
+                                ? getCurFunctionEntryBlock()
                                 : currLexScope->getEntryBlock();
   return buildAlloca(name, ty, loc, alignment,
                      builder.getBestAllocaInsertPoint(entryBlock));

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -353,7 +353,8 @@ static CIRGenCallee buildDirectCallee(CIRGenModule &CGM, GlobalDecl GD) {
 
     // When directing calling an inline builtin, call it through it's mangled
     // name to make it clear it's not the actual builtin.
-    if (CGF.CurFn.getName() != FDInlineName &&
+    auto Fn = cast<mlir::cir::FuncOp>(CGF.CurFn);
+    if (Fn.getName() != FDInlineName &&
         onlyHasInlineBuiltinDeclaration(FD)) {
       assert(0 && "NYI");
     }
@@ -2132,7 +2133,7 @@ mlir::Value CIRGenFunction::buildAlloca(StringRef name, mlir::Type ty,
                                         mlir::Location loc, CharUnits alignment,
                                         bool insertIntoFnEntryBlock) {
   mlir::Block *entryBlock = insertIntoFnEntryBlock
-                                ? &CurFn.getRegion().front()
+                                ? &CurFn->getRegion(0).front()
                                 : currLexScope->getEntryBlock();
   return buildAlloca(name, ty, loc, alignment,
                      builder.getBestAllocaInsertPoint(entryBlock));
@@ -2512,7 +2513,9 @@ mlir::Value CIRGenFunction::buildScalarConstant(
 LValue CIRGenFunction::buildPredefinedLValue(const PredefinedExpr *E) {
   auto SL = E->getFunctionName();
   assert(SL != nullptr && "No StringLiteral name in PredefinedExpr");
-  StringRef FnName = CurFn.getName();
+  auto Fn = dyn_cast<mlir::cir::FuncOp>(CurFn);
+  assert(Fn && "other callables NYI");
+  StringRef FnName = Fn.getName();
   if (FnName.startswith("\01"))
     FnName = FnName.substr(1);
   StringRef NameItems[] = {PredefinedExpr::getIdentKindName(E->getIdentKind()),

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -319,7 +319,9 @@ void CIRGenFunction::LexicalScopeGuard::cleanup() {
 
   auto buildReturn = [&](mlir::Location loc) {
     // If we are on a coroutine, add the coro_end builtin call.
-    if (CGF.CurFn.getCoroutine())
+    auto Fn = dyn_cast<mlir::cir::FuncOp>(CGF.CurFn);
+    assert(Fn && "other callables NYI");
+    if (Fn.getCoroutine())
       CGF.buildCoroEndBuiltinCall(
           loc, builder.getNullPtr(builder.getVoidPtrTy(), loc));
 
@@ -1009,7 +1011,9 @@ void CIRGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
     const auto *MD = cast<CXXMethodDecl>(D);
     if (MD->getParent()->isLambda() && MD->getOverloadedOperator() == OO_Call) {
       // We're in a lambda.
-      CurFn.setLambdaAttr(mlir::UnitAttr::get(builder.getContext()));
+      auto Fn = dyn_cast<mlir::cir::FuncOp>(CurFn);
+      assert(Fn && "other callables NYI");
+      Fn.setLambdaAttr(mlir::UnitAttr::get(builder.getContext()));
 
       // Figure out the captures.
       MD->getParent()->getCaptureFields(LambdaCaptureFields,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -576,7 +576,9 @@ public:
   const clang::Decl *CurCodeDecl;
   const CIRGenFunctionInfo *CurFnInfo;
   clang::QualType FnRetTy;
-  mlir::cir::FuncOp CurFn = nullptr;
+
+  /// This is the current function or global initializer that is generated code for.
+  mlir::Operation *CurFn = nullptr;
 
   /// Save Parameter Decl for coroutine.
   llvm::SmallVector<const ParmVarDecl *, 4> FnArgs;

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -593,6 +593,12 @@ public:
 
   CIRGenModule &getCIRGenModule() { return CGM; }
 
+  mlir::Block* getCurFunctionEntryBlock() {
+    auto Fn = dyn_cast<mlir::cir::FuncOp>(CurFn);
+    assert(Fn && "other callables NYI");
+    return &Fn.getRegion().front();
+  }
+
   /// Sanitizers enabled for this function.
   clang::SanitizerSet SanOpts;
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -477,7 +477,7 @@ mlir::cir::GlobalOp CIRGenModule::createGlobalOp(CIRGenModule &CGM,
     // Be sure to insert global before the current function
     auto *curCGF = CGM.getCurrCIRGenFun();
     if (curCGF)
-      builder.setInsertionPoint(curCGF->CurFn.getOperation());
+      builder.setInsertionPoint(curCGF->CurFn);
 
     g = builder.create<mlir::cir::GlobalOp>(loc, name, t, isCst);
     if (!curCGF)
@@ -783,8 +783,14 @@ void CIRGenModule::buildGlobalVarDefinition(const clang::VarDecl *D,
   // TODO(cir): LLVM's codegen uses a llvm::TrackingVH here. Is that
   // necessary here for CIR gen?
   mlir::Attribute Init;
-  // TODO(cir): bool NeedsGlobalCtor = false;
+  bool NeedsGlobalCtor = false;
+  // Whether the definition of the variable is available externally.
+  // If yes, we shouldn't emit the GloablCtor and GlobalDtor for the variable
+  // since this is the job for its original source.
+  bool IsDefinitionAvailableExternally =
+      astCtx.GetGVALinkageForVariable(D) == GVA_AvailableExternally;
   bool NeedsGlobalDtor =
+      !IsDefinitionAvailableExternally &&
       D->needsDestruction(astCtx) == QualType::DK_cxx_destructor;
 
   const VarDecl *InitDecl;
@@ -830,7 +836,19 @@ void CIRGenModule::buildGlobalVarDefinition(const clang::VarDecl *D,
     emitter.emplace(*this);
     auto Initializer = emitter->tryEmitForInitializer(*InitDecl);
     if (!Initializer) {
-      assert(0 && "not implemented");
+      QualType T = InitExpr->getType();
+      if (D->getType()->isReferenceType())
+        T = D->getType();
+
+      if (getLangOpts().CPlusPlus) {
+        if (InitDecl->hasFlexibleArrayInit(astCtx))
+          ErrorUnsupported(D, "flexible array initializer");
+        Init = builder.getZeroInitAttr(getCIRType(T));
+        if (!IsDefinitionAvailableExternally)
+          NeedsGlobalCtor = true;
+      } else {
+        ErrorUnsupported(D, "static initializer");
+      }
     } else {
       Init = Initializer;
       // We don't need an initializer, so remove the entry for the delayed
@@ -972,8 +990,8 @@ void CIRGenModule::buildGlobalVarDefinition(const clang::VarDecl *D,
 
   // TODO(cir):
   // Emit the initializer function if necessary.
-  // if (NeedsGlobalCtor || NeedsGlobalDtor)
-  //   EmitCXXGlobalVarDeclInitFunc(D, GV, NeedsGlobalCtor);
+  if (NeedsGlobalCtor || NeedsGlobalDtor)
+    buildGlobalVarDeclInit(D, GV, NeedsGlobalCtor);
 
   // TODO(cir): sanitizers (reportGlobalToASan) and global variable debug
   // information.
@@ -1788,7 +1806,7 @@ CIRGenModule::createCIRFunction(mlir::Location loc, StringRef name,
     // Be sure to insert a new function before a current one.
     auto *curCGF = getCurrCIRGenFun();
     if (curCGF)
-      builder.setInsertionPoint(curCGF->CurFn.getOperation());
+      builder.setInsertionPoint(curCGF->CurFn);
 
     f = builder.create<mlir::cir::FuncOp>(loc, name, Ty);
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -477,6 +477,10 @@ public:
   void buildGlobalVarDefinition(const clang::VarDecl *D,
                                 bool IsTentative = false);
 
+  /// Emit the function that initializes the specified global
+  void buildGlobalVarDeclInit(const VarDecl *D, mlir::cir::GlobalOp Addr,
+                                  bool PerformInit);
+
   void addDeferredVTable(const CXXRecordDecl *RD) {
     DeferredVTables.push_back(RD);
   }
@@ -507,6 +511,10 @@ public:
   // apply any ABI rules about which other constructors/destructors are needed
   // or if they are alias to each other.
   mlir::cir::FuncOp codegenCXXStructor(clang::GlobalDecl GD);
+
+  // Produce code for this constructor/destructor for global initialzation.
+  void codegenGlobalInitCxxStructor(const clang::VarDecl *D,
+                                    mlir::cir::GlobalOp Addr);
 
   bool lookupRepresentativeDecl(llvm::StringRef MangledName,
                                 clang::GlobalDecl &Result) const;

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1149,49 +1149,81 @@ LogicalResult LoopOp::verify() {
 //===----------------------------------------------------------------------===//
 
 static void printGlobalOpTypeAndInitialValue(OpAsmPrinter &p, GlobalOp op,
-                                             TypeAttr type,
-                                             Attribute initAttr) {
+                                             TypeAttr type, Attribute initAttr,
+                                             mlir::Region& ctorRegion,
+                                             mlir::Region& dtorRegion) {
   auto printType = [&]() { p << ": " << type; };
   if (!op.isDeclaration()) {
     p << "= ";
-    // This also prints the type...
-    printConstant(p, initAttr);
-    if (initAttr.isa<SymbolRefAttr>())
+    if (!ctorRegion.empty()) {
+      p << "ctor ";
       printType();
+      p << " ";
+      p.printRegion(ctorRegion,
+                    /*printEntryBlockArgs=*/false,
+                    /*printBlockTerminators=*/false);
+    } else {
+      // This also prints the type...
+      if (initAttr)
+        printConstant(p, initAttr);
+      if (initAttr.isa<SymbolRefAttr>())
+        printType();
+    }
+
   } else {
     printType();
   }
 }
 
-static ParseResult
-parseGlobalOpTypeAndInitialValue(OpAsmParser &parser, TypeAttr &typeAttr,
-                                 Attribute &initialValueAttr) {
+static ParseResult parseGlobalOpTypeAndInitialValue(OpAsmParser &parser,
+                                                    TypeAttr &typeAttr,
+                                                    Attribute &initialValueAttr,
+                                                    mlir::Region& ctorRegion,
+                                                    mlir::Region& dtorRegion) {
+  mlir::Type opTy;
   if (parser.parseOptionalEqual().failed()) {
     // Absence of equal means a declaration, so we need to parse the type.
     //  cir.global @a : i32
-    Type type;
-    if (parser.parseColonType(type))
-      return failure();
-    typeAttr = TypeAttr::get(type);
-    return success();
-  }
-
-  // Parse constant with initializer, examples:
-  //  cir.global @y = 3.400000e+00 : f32
-  //  cir.global @rgb = #cir.const_array<[...] : !cir.array<i8 x 3>>
-  if (parseConstantValue(parser, initialValueAttr).failed())
-    return failure();
-
-  mlir::Type opTy;
-  if (auto sra = initialValueAttr.dyn_cast<SymbolRefAttr>()) {
     if (parser.parseColonType(opTy))
       return failure();
-  } else {
-    // Handle StringAttrs
-    assert(initialValueAttr.isa<mlir::TypedAttr>() &&
-           "Non-typed attrs shouldn't appear here.");
-    auto typedAttr = initialValueAttr.cast<mlir::TypedAttr>();
-    opTy = typedAttr.getType();
+  }
+  else {
+    // Parse contructor, example:
+    //  cir.global @rgb = ctor : type { ... }
+    if (!parser.parseOptionalKeyword("ctor")) {
+      if (parser.parseColonType(opTy))
+        return failure();
+      auto parseLoc = parser.getCurrentLocation();
+      if (parser.parseRegion(ctorRegion, /*arguments=*/{}, /*argTypes=*/{}))
+        return failure();
+      if (!ctorRegion.hasOneBlock())
+        return parser.emitError(parser.getCurrentLocation(),
+                                "ctor region must have exactly one block");
+      if (ctorRegion.back().empty())
+        return parser.emitError(parser.getCurrentLocation(),
+                                "ctor region shall not be empty");
+      if (checkBlockTerminator(parser, parseLoc,
+                               ctorRegion.back().back().getLoc(), &ctorRegion)
+              .failed())
+        return failure();
+    } else {
+      // Parse constant with initializer, examples:
+      //  cir.global @y = 3.400000e+00 : f32
+      //  cir.global @rgb = #cir.const_array<[...] : !cir.array<i8 x 3>>
+      if (parseConstantValue(parser, initialValueAttr).failed())
+        return failure();
+
+      if (auto sra = initialValueAttr.dyn_cast<SymbolRefAttr>()) {
+        if (parser.parseColonType(opTy))
+          return failure();
+      } else {
+        // Handle StringAttrs
+        assert(initialValueAttr.isa<mlir::TypedAttr>() &&
+               "Non-typed attrs shouldn't appear here.");
+        auto typedAttr = initialValueAttr.cast<mlir::TypedAttr>();
+        opTy = typedAttr.getType();
+      }
+    }
   }
 
   typeAttr = TypeAttr::get(opTy);
@@ -1244,9 +1276,11 @@ LogicalResult GlobalOp::verify() {
   return success();
 }
 
-void GlobalOp::build(OpBuilder &odsBuilder, OperationState &odsState,
-                     StringRef sym_name, Type sym_type, bool isConstant,
-                     cir::GlobalLinkageKind linkage) {
+void GlobalOp::build(
+    OpBuilder &odsBuilder, OperationState &odsState, StringRef sym_name,
+    Type sym_type, bool isConstant, cir::GlobalLinkageKind linkage,
+    function_ref<void(OpBuilder &, Location)> ctorBuilder,
+    function_ref<void(OpBuilder &, Location)> dtorBuilder) {
   odsState.addAttribute(getSymNameAttrName(odsState.name),
                         odsBuilder.getStringAttr(sym_name));
   odsState.addAttribute(getSymTypeAttrName(odsState.name),
@@ -1258,6 +1292,48 @@ void GlobalOp::build(OpBuilder &odsBuilder, OperationState &odsState,
   ::mlir::cir::GlobalLinkageKindAttr linkageAttr =
       cir::GlobalLinkageKindAttr::get(odsBuilder.getContext(), linkage);
   odsState.addAttribute(getLinkageAttrName(odsState.name), linkageAttr);
+
+  Region *ctorRegion = odsState.addRegion();
+  Region *dtorRegion = odsState.addRegion();
+  if (ctorBuilder) {
+    odsBuilder.createBlock(ctorRegion);
+    ctorBuilder(odsBuilder, odsState.location);
+  }
+  if (dtorBuilder) {
+    odsBuilder.createBlock(dtorRegion);
+    dtorBuilder(odsBuilder, odsState.location);
+  }
+}
+
+/// Given the region at `index`, or the parent operation if `index` is None,
+/// return the successor regions. These are the regions that may be selected
+/// during the flow of control. `operands` is a set of optional attributes that
+/// correspond to a constant value for each operand, or null if that operand is
+/// not a constant.
+void GlobalOp::getSuccessorRegions(std::optional<unsigned> index,
+                                   ArrayRef<Attribute> operands,
+                                   SmallVectorImpl<RegionSuccessor> &regions) {
+  // The `then` and the `else` region branch back to the parent operation.
+  if (index.has_value()) {
+    regions.push_back(RegionSuccessor());
+    return;
+  }
+
+  // Don't consider the ctor region if it is empty.
+  Region *ctorRegion = &this->getCtorRegion();
+  if (ctorRegion->empty())
+    ctorRegion = nullptr;
+
+  // Don't consider the dtor region if it is empty.
+  Region *dtorRegion = &this->getCtorRegion();
+  if (dtorRegion->empty())
+    dtorRegion = nullptr;
+
+  // If the condition isn't constant, both regions may be executed.
+  if (ctorRegion)
+    regions.push_back(RegionSuccessor(ctorRegion));
+  if (dtorRegion)
+    regions.push_back(RegionSuccessor(dtorRegion));
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/CIR/CodeGen/static.cpp
+++ b/clang/test/CIR/CodeGen/static.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: cir-opt %t.cir -o - | FileCheck %s -check-prefix=CIR
+
+class Init {
+
+public:
+  Init(bool a) ;
+
+private:
+  static bool _S_synced_with_stdio;
+};
+
+
+static Init __ioinit(true);
+
+// CIR:      module {{.*}} {
+// CIR-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !cir.bool)
+// CIR-NEXT:   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22class2EInit22 {
+// CIR-NEXT:     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22>
+// CIR-NEXT:     %1 = cir.const(#true) : !cir.bool
+// CIR-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
+// CIR-NEXT:   }
+// CIR-NEXT: }

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -3,6 +3,7 @@
 !s8i = !cir.int<s, 8>
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
+!ty_22class2EInit22 = !cir.struct<"class.Init", !s8i, #cir.recdecl.ast>
 module {
   cir.global external @a = #cir.int<3> : !s32i
   cir.global external @rgb = #cir.const_array<[#cir.int<0> : !s8i, #cir.int<-23> : !s8i, #cir.int<33> : !s8i] : !cir.array<!s8i x 3>>
@@ -32,6 +33,12 @@ module {
     #cir.global_view<@type_info_A> : !cir.ptr<!s8i>}>
     : !cir.struct<"", !cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>
   >
+  cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !s8i)
+  cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22class2EInit22 {
+    %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22>
+    %1 = cir.const(#cir.int<3> : !s8i) : !s8i
+    cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !s8i) -> ()
+  }
 }
 
 // CHECK: cir.global external @a = #cir.int<3> : !s32i
@@ -44,3 +51,9 @@ module {
 
 // CHECK: cir.func @use_global()
 // CHECK-NEXT: %0 = cir.get_global @a : cir.ptr <!s32i>
+
+// CHECK:      cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22class2EInit22 {
+// CHECK-NEXT:  %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22>
+// CHECK-NEXT:  %1 = cir.const(#cir.int<3> : !s8i) : !s8i
+// CHECK-NEXT:  cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !s8i) -> ()
+// CHECK-NEXT: }


### PR DESCRIPTION
This change does the CIR generation for globals initialized by a constructor call. It currently only covers C++ to CIR generation. The corresponding LLVM lowering will be in a follow-up commit.

A motivating example is

```
class Init {
  friend class ios_base;

public:
  Init(bool);
  ~Init();

private:
  static bool _S_synced_with_stdio;
};

static Init ioinit(true);
```

Unlike what the default Clang codegen generates LLVM that detaches the initialization code from the global var definition (like below), we are taking a different approach that keeps them together, which we think will make the later dataflow analysis/transform easier.

```
@_ZL8ioinit = internal global %class.Init zeroinitializer, align 1, !dbg !0

define internal void @cxx_global_var_init() #0 section ".text.startup" !dbg !23 {
entry:
  call void @_ZN4InitC2Ev(ptr noundef nonnull align 1 dereferenceable(1) @_ZL8ioinit), !dbg !27
  %0 = call i32 @cxa_atexit(ptr @_ZN4InitD1Ev, ptr @_ZL8ioinit, ptr @dso_handle) #3, !dbg !29
  ret void, !dbg !27
}
```

So on CIR, we have something like:

```
  cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22class2EInit22 {
    %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22> loc(#loc8)
    %1 = cir.const(#true) : !cir.bool loc(#loc5)
    cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> () loc(#loc6)
}
```

The destructor support will also be in a separate change.

