### PR TITLE
[CIR][Lowering][NFC] Cleanup global ops lowering

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -995,16 +995,29 @@ class CIRGlobalOpLowering
 public:
   using OpConversionPattern<mlir::cir::GlobalOp>::OpConversionPattern;
 
+  /// Replace CIR global with a region initialized LLVM global and update
+  /// insertion point to the end of the initializer block.
+  inline void setupRegionInitializedLLVMGlobalOp(
+      mlir::cir::GlobalOp op, mlir::ConversionPatternRewriter &rewriter) const {
+    const auto llvmType = getTypeConverter()->convertType(op.getSymType());
+    auto newGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
+        op, llvmType, op.getConstant(), convertLinkage(op.getLinkage()),
+        op.getSymName(), nullptr);
+    newGlobalOp.getRegion().push_back(new mlir::Block());
+    rewriter.setInsertionPointToEnd(newGlobalOp.getInitializerBlock());
+  }
+
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::GlobalOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
 
     // Fetch required values to create LLVM op.
-    auto llvmType = getTypeConverter()->convertType(op.getSymType());
-    auto isConst = op.getConstant();
-    auto linkage = convertLinkage(op.getLinkage());
-    auto symbol = op.getSymName();
-    auto init = op.getInitialValue();
+    const auto llvmType = getTypeConverter()->convertType(op.getSymType());
+    const auto isConst = op.getConstant();
+    const auto linkage = convertLinkage(op.getLinkage());
+    const auto symbol = op.getSymName();
+    const auto loc = op.getLoc();
+    std::optional<mlir::Attribute> init = op.getInitialValue();
 
     // Check for missing funcionalities.
     if (!init.has_value()) {
@@ -1038,13 +1051,7 @@ public:
     }
     // Initializer is a global: load global value in initializer block.
     else if (auto attr = init.value().dyn_cast<mlir::FlatSymbolRefAttr>()) {
-      auto newGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
-          op, llvmType, isConst, linkage, symbol, mlir::Attribute());
-      mlir::OpBuilder::InsertionGuard guard(rewriter);
-
-      // Create initializer block.
-      auto *newBlock = new mlir::Block();
-      newGlobalOp.getRegion().push_back(newBlock);
+      setupRegionInitializedLLVMGlobalOp(op, rewriter);
 
       // Fetch global used as initializer.
       auto sourceSymbol =
@@ -1052,16 +1059,13 @@ public:
               op->getParentOfType<mlir::ModuleOp>(), attr.getValue()));
 
       // Load and return the initializer value.
-      rewriter.setInsertionPointToEnd(newBlock);
       auto addressOfOp = rewriter.create<mlir::LLVM::AddressOfOp>(
-          op->getLoc(),
-          mlir::LLVM::LLVMPointerType::get(sourceSymbol.getType()),
+          loc, mlir::LLVM::LLVMPointerType::get(sourceSymbol.getType()),
           sourceSymbol.getSymName());
       llvm::SmallVector<mlir::LLVM::GEPArg> offset{0};
       auto gepOp = rewriter.create<mlir::LLVM::GEPOp>(
-          op->getLoc(), llvmType, addressOfOp.getResult(), offset);
-      rewriter.create<mlir::LLVM::ReturnOp>(op->getLoc(), gepOp.getResult());
-
+          loc, llvmType, addressOfOp.getResult(), offset);
+      rewriter.create<mlir::LLVM::ReturnOp>(loc, gepOp.getResult());
       return mlir::success();
     } else if (isa<mlir::cir::ZeroAttr, mlir::cir::NullAttr>(init.value())) {
       // TODO(cir): once LLVM's dialect has a proper zeroinitializer attribute


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #203
* #202
* #201
* #200
* __->__ #199

Remove boilerplate code for replacing a CIR global op with a region
initialized LLVM global op and mark variables as constant whenever
possible.