### PR TITLE
[CIR][Bugfix] Fix #cir.const_struct parsing

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -175,9 +175,7 @@ def ConstStructAttr : CIR_Attr<"ConstStruct", "const_struct",
   ];
 
   let assemblyFormat = [{
-    `<`
-      custom<ConstStructMembers>($type, $members)
-    `>`
+    `<` custom<StructMembers>($members) `>`
   }];
 
   let genVerifyDecl = 1;
@@ -307,12 +305,12 @@ def TypeInfoAttr : CIR_Attr<"TypeInfo", "typeinfo", [TypedAttrInterface]> {
   }];
 
   let parameters = (ins AttributeSelfTypeParameter<"">:$type,
-                        "ConstStructAttr":$typeinfo_data);
+                        "mlir::ArrayAttr":$data);
 
   let builders = [
     AttrBuilderWithInferredContext<(ins "Type":$type,
-                                        "ConstStructAttr":$typeinfo_data), [{
-      return $_get(type.getContext(), type, typeinfo_data);
+                                        "mlir::ArrayAttr":$data), [{
+      return $_get(type.getContext(), type, data);
     }]>
   ];
 
@@ -320,7 +318,7 @@ def TypeInfoAttr : CIR_Attr<"TypeInfo", "typeinfo", [TypedAttrInterface]> {
   // element type.
   let genVerifyDecl = 1;
   let assemblyFormat = [{
-    `<` $typeinfo_data `>`
+    `<` custom<StructMembers>($data) `>`
   }];
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -144,7 +144,7 @@ public:
 
   mlir::cir::TypeInfoAttr getTypeInfo(mlir::ArrayAttr fieldsAttr) {
     auto anonStruct = getAnonConstStruct(fieldsAttr);
-    return mlir::cir::TypeInfoAttr::get(anonStruct.getType(), anonStruct);
+    return mlir::cir::TypeInfoAttr::get(anonStruct.getType(), fieldsAttr);
   }
 
   mlir::TypedAttr getZeroInitAttr(mlir::Type ty) {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -1560,7 +1561,6 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
        getFunctionTypeAttrName(), getLinkageAttrName(), getBuiltinAttrName(),
        getNoProtoAttrName(), getExtraAttrsAttrName()});
 
-
   if (auto aliaseeName = getAliasee()) {
     p << " alias(";
     p.printSymbolName(*aliaseeName);
@@ -2056,14 +2056,13 @@ LogicalResult ASTRecordDeclAttr::verify(
 
 LogicalResult TypeInfoAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
-    ::mlir::Type type, ConstStructAttr typeinfoData) {
+    ::mlir::Type type, ::mlir::ArrayAttr typeinfoData) {
 
-  if (mlir::cir::ConstStructAttr::verify(emitError, type,
-                                         typeinfoData.getMembers())
+  if (mlir::cir::ConstStructAttr::verify(emitError, type, typeinfoData)
           .failed())
     return failure();
 
-  for (auto &member : typeinfoData.getMembers()) {
+  for (auto &member : typeinfoData) {
     auto gview = member.dyn_cast_or_null<GlobalViewAttr>();
     if (gview)
       continue;

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -66,7 +66,7 @@ void yo() {
 // CHECK: cir.func @_Z2yov()
 // CHECK:   %0 = cir.alloca !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>, ["ext"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.alloca !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>, ["ext2", init] {alignment = 8 : i64}
-// CHECK:   %2 = cir.const(#cir.const_struct<{#cir.int<1000070000> : !u32i,#cir.null : !cir.ptr<!void>,#cir.int<0> : !u64i}> : !ty_22struct2EYo22) : !ty_22struct2EYo22
+// CHECK:   %2 = cir.const(#cir.const_struct<{#cir.int<1000070000> : !u32i, #cir.null : !cir.ptr<!void>, #cir.int<0> : !u64i}> : !ty_22struct2EYo22) : !ty_22struct2EYo22
 // CHECK:   cir.store %2, %0 : !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>
 // CHECK:   %3 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "type"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u32i>
 // CHECK:   %4 = cir.const(#cir.int<1000066001> : !u32i) : !u32i

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -30,7 +30,7 @@ void shouldConstInitStructs(void) {
 // CHECK: cir.func @shouldConstInitStructs
   struct Foo f = {1, 2, {3, 4}};
   // CHECK: %[[#V0:]] = cir.alloca !ty_22struct2EFoo22, cir.ptr <!ty_22struct2EFoo22>, ["f"] {alignment = 4 : i64}
-  // CHECK: %[[#V1:]] = cir.const(#cir.const_struct<{#cir.int<1> : !s32i,#cir.int<2> : !s8i,#cir.const_struct<{#cir.int<3> : !s32i,#cir.int<4> : !s8i}> : !ty_22struct2EBar22}> : !ty_22struct2EFoo22) : !ty_22struct2EFoo22
+  // CHECK: %[[#V1:]] = cir.const(#cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s8i, #cir.const_struct<{#cir.int<3> : !s32i, #cir.int<4> : !s8i}> : !ty_22struct2EBar22}> : !ty_22struct2EFoo22) : !ty_22struct2EFoo22
   // CHECK: cir.store %[[#V1]], %[[#V0]] : !ty_22struct2EFoo22, cir.ptr <!ty_22struct2EFoo22>
 }
 

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -85,7 +85,7 @@ public:
 // CHECK:   cir.global "private" constant external @_ZTI1A : !cir.ptr<!u8i>
 
 // typeinfo for B
-// CHECK: cir.global constant external @_ZTI1B = #cir.typeinfo<<{#cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [#cir.int<2> : !s64i]> : !cir.ptr<!u8i>,#cir.global_view<@_ZTS1B> : !cir.ptr<!u8i>,#cir.global_view<@_ZTI1A> : !cir.ptr<!u8i>}>> : ![[TypeInfoB]]
+// CHECK: cir.global constant external @_ZTI1B = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [#cir.int<2> : !s64i]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS1B> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1A> : !cir.ptr<!u8i>}> : ![[TypeInfoB]]
 
 // Checks for dtors in dtors.cpp
 

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -1,4 +1,5 @@
-// RUN: cir-opt %s | FileCheck %s
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
 !s8i = !cir.int<s, 8>
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
@@ -6,7 +7,7 @@ module {
   cir.global external @a = #cir.int<3> : !s32i
   cir.global external @rgb = #cir.const_array<[#cir.int<0> : !s8i, #cir.int<-23> : !s8i, #cir.int<33> : !s8i] : !cir.array<!s8i x 3>>
   cir.global external @b = #cir.const_array<"example\00" : !cir.array<!s8i x 8>>
-  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.null : !cir.ptr<!s8i>}> : !cir.struct<"", !s8i, i64, !cir.ptr<!s8i>>
+  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.null : !cir.ptr<!s8i>}> : !cir.struct<"", !s8i, !s64i, !cir.ptr<!s8i>>
   cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global "private" internal @c : !s32i
   cir.global "private" constant internal @".str2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
@@ -25,10 +26,10 @@ module {
   cir.global "private" constant external @type_info_A : !cir.ptr<!s8i>
   cir.global constant external @type_info_name_B = #cir.const_array<"1B\00" : !cir.array<!s8i x 3>>
 
-  cir.global external @type_info_B = #cir.typeinfo<<{
+  cir.global external @type_info_B = #cir.typeinfo<{
     #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!s8i>,
     #cir.global_view<@type_info_name_B> : !cir.ptr<!s8i>,
-    #cir.global_view<@type_info_A> : !cir.ptr<!s8i>}>>
+    #cir.global_view<@type_info_A> : !cir.ptr<!s8i>}>
     : !cir.struct<"", !cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>
   >
 }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -307,8 +307,8 @@ module {
   // rid of this somehow in favor of clarity?
   cir.global "private" external @_ZTVN10__cxxabiv120__si_class_type_infoE : !cir.ptr<!u32i>
 
-  cir.global external @type_info_B = #cir.typeinfo<<{ // expected-error {{element at index 0 has type '!cir.ptr<!cir.int<u, 8>>' but return type for this element is '!cir.ptr<!cir.int<u, 32>>'}}
-    #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!u8i>}>>
+  cir.global external @type_info_B = #cir.typeinfo<{ // expected-error {{element at index 0 has type '!cir.ptr<!cir.int<u, 8>>' but return type for this element is '!cir.ptr<!cir.int<u, 32>>'}}
+    #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!u8i>}>
     : !cir.struct<"", !cir.ptr<!u32i>>
 } // expected-error {{'cir.global' expected constant attribute to match type}}
 

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -2,11 +2,15 @@
 
 !u8i = !cir.int<u, 8>
 !u16i = !cir.int<u, 16>
+!s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
 !ty_2222 = !cir.struct<"", !cir.array<!cir.ptr<!u8i> x 5>>
 !ty_22221 = !cir.struct<"", !cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>>
 !ty_22class2EA22 = !cir.struct<"class.A", incomplete, #cir.recdecl.ast>
+// CHECK: !ty_22i22 = !cir.struct<"i", incomplete>
+// CHECK: !ty_22S22 = !cir.struct<"S", !u8i, !u16i, !u32i>
+!ty_22struct2ES22 = !cir.struct<"struct.S", !s32i, !s32i>
 
 module  {
   cir.func @structs() {
@@ -14,12 +18,14 @@ module  {
     %1 = cir.alloca !cir.ptr<!cir.struct<"i", incomplete>>, cir.ptr <!cir.ptr<!cir.struct<"i", incomplete>>>, ["i", init]
     cir.return
   }
+
+// CHECK: cir.func @structs() {
+// CHECK:     %0 = cir.alloca !cir.ptr<!ty_22S22>, cir.ptr <!cir.ptr<!ty_22S22>>, ["s", init]
+// CHECK:     %1 = cir.alloca !cir.ptr<!ty_22i22>, cir.ptr <!cir.ptr<!ty_22i22>>, ["i", init]
+
+  cir.func @shouldSuccessfullyParseConstStructAttrs() {
+    %0 = cir.const(#cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !ty_22struct2ES22) : !ty_22struct2ES22
+    // CHECK: cir.const(#cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !ty_22struct2ES22) : !ty_22struct2ES22
+    cir.return
+  }
 }
-
-//      CHECK: !ty_22i22 = !cir.struct<"i", incomplete>
-//      CHECK: !ty_22S22 = !cir.struct<"S", !u8i, !u16i, !u32i>
-
-// CHECK-NEXT: module {
-// CHECK-NEXT: cir.func @structs() {
-// CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!ty_22S22>, cir.ptr <!cir.ptr<!ty_22S22>>, ["s", init]
-// CHECK-NEXT:     %1 = cir.alloca !cir.ptr<!ty_22i22>, cir.ptr <!cir.ptr<!ty_22i22>>, ["i", init]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

At its core, this patch fixes an issue where the ConstStruct parser
would infer its type from the list of elements and override its explicit
attribute type that had already been parsed. This caused type mismatches
since the name of the StructType would be dropped.

Since `cir.typeinfo` depended on this broken parsing method to work, it
was also fixed to use a `ArrayAttr` instead of a `cir.const_struct` to
store its values.

To simplify parsing and printing struct member on both `cir.typeinfo`
and `cir.const_struct`, the custom `ConstStructMembers` parser/printer
was renamed to `StructMembers` and is now used on both attributes. It
was also refactored to patch malformed spacing between members and to
simplify the code.