### PR TITLE
[CIR][Lowering] Partially lower global #cir.const_struct initializers

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -278,6 +278,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
     llvm_unreachable("NYI");
   }
 
+  // TODO(cir): emit a #cir.zero if all elements are null values.
   auto &builder = CGM.getBuilder();
   return builder.getAnonConstStruct(
       mlir::ArrayAttr::get(builder.getContext(),

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -53,8 +53,11 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Passes.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cstdint>
@@ -65,6 +68,85 @@ using namespace llvm;
 
 namespace cir {
 namespace direct {
+
+//===----------------------------------------------------------------------===//
+// Visitors for Lowering CIR Const Attributes
+//===----------------------------------------------------------------------===//
+
+/// Switches on the type of attribute and calls the appropriate conversion.
+inline mlir::Value
+lowerCirAttrAsValue(mlir::Attribute attr, mlir::Location loc,
+                    mlir::ConversionPatternRewriter &rewriter,
+                    mlir::TypeConverter *converter);
+
+/// IntAttr visitor.
+inline mlir::Value
+lowerCirAttrAsValue(mlir::cir::IntAttr intAttr, mlir::Location loc,
+                    mlir::ConversionPatternRewriter &rewriter,
+                    mlir::TypeConverter *converter) {
+  return rewriter.create<mlir::LLVM::ConstantOp>(
+      loc, converter->convertType(intAttr.getType()), intAttr.getValue());
+}
+
+/// NullAttr visitor.
+inline mlir::Value
+lowerCirAttrAsValue(mlir::cir::NullAttr nullAttr, mlir::Location loc,
+                    mlir::ConversionPatternRewriter &rewriter,
+                    mlir::TypeConverter *converter) {
+  return rewriter.create<mlir::LLVM::NullOp>(
+      loc, converter->convertType(nullAttr.getType()));
+}
+
+/// FloatAttr visitor.
+inline mlir::Value
+lowerCirAttrAsValue(mlir::FloatAttr fltAttr, mlir::Location loc,
+                    mlir::ConversionPatternRewriter &rewriter,
+                    mlir::TypeConverter *converter) {
+  return rewriter.create<mlir::LLVM::ConstantOp>(
+      loc, converter->convertType(fltAttr.getType()), fltAttr.getValue());
+}
+
+/// ConstStruct visitor.
+mlir::Value lowerCirAttrAsValue(mlir::cir::ConstStructAttr constStruct,
+                                mlir::Location loc,
+                                mlir::ConversionPatternRewriter &rewriter,
+                                mlir::TypeConverter *converter) {
+  auto llvmTy = converter->convertType(constStruct.getType());
+  mlir::Value result = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
+
+  // Iteratively lower each constant element of the struct.
+  for (auto [idx, elt] : llvm::enumerate(constStruct.getMembers())) {
+    mlir::Value init = lowerCirAttrAsValue(elt, loc, rewriter, converter);
+    result = rewriter.create<mlir::LLVM::InsertValueOp>(loc, result, init, idx);
+  }
+
+  return result;
+}
+
+/// Switches on the type of attribute and calls the appropriate conversion.
+inline mlir::Value
+lowerCirAttrAsValue(mlir::Attribute attr, mlir::Location loc,
+                    mlir::ConversionPatternRewriter &rewriter,
+                    mlir::TypeConverter *converter) {
+  if (const auto intAttr = attr.dyn_cast<mlir::cir::IntAttr>())
+    return lowerCirAttrAsValue(intAttr, loc, rewriter, converter);
+  if (const auto fltAttr = attr.dyn_cast<mlir::FloatAttr>())
+    return lowerCirAttrAsValue(fltAttr, loc, rewriter, converter);
+  if (const auto nullAttr = attr.dyn_cast<mlir::cir::NullAttr>())
+    return lowerCirAttrAsValue(nullAttr, loc, rewriter, converter);
+  if (const auto constStruct = attr.dyn_cast<mlir::cir::ConstStructAttr>())
+    return lowerCirAttrAsValue(constStruct, loc, rewriter, converter);
+  if (const auto constArr = attr.dyn_cast<mlir::cir::ConstArrayAttr>())
+    llvm_unreachable("const array attribute is NYI");
+  if (const auto zeroAttr = attr.dyn_cast<mlir::cir::BoolAttr>())
+    llvm_unreachable("bool attribute is NYI");
+  if (const auto zeroAttr = attr.dyn_cast<mlir::cir::ZeroAttr>())
+    llvm_unreachable("zero attribute is NYI");
+
+  llvm_unreachable("unhandled attribute type");
+}
+
+//===----------------------------------------------------------------------===//
 
 mlir::LLVM::Linkage convertLinkage(mlir::cir::GlobalLinkageKind linkage) {
   using CIR = mlir::cir::GlobalLinkageKind;
@@ -1078,6 +1160,13 @@ public:
       auto cirZeroAttr = mlir::cir::ZeroAttr::get(getContext(), llvmType);
       llvmGlobalOp->setAttr("cir.initial_value", cirZeroAttr);
       return mlir::success();
+    } else if (const auto structAttr =
+                   init.value().dyn_cast<mlir::cir::ConstStructAttr>()) {
+      setupRegionInitializedLLVMGlobalOp(op, rewriter);
+      rewriter.create<mlir::LLVM::ReturnOp>(
+          op->getLoc(), lowerCirAttrAsValue(structAttr, op->getLoc(), rewriter,
+                                            typeConverter));
+      return mlir::success();
     } else {
       op.emitError() << "usupported initializer '" << init.value() << "'";
       return mlir::failure();
@@ -1523,10 +1612,20 @@ mlir::LLVMTypeConverter prepareTypeConverter(mlir::MLIRContext *ctx) {
     llvm::SmallVector<mlir::Type> llvmMembers;
     for (auto ty : type.getMembers())
       llvmMembers.push_back(converter.convertType(ty));
-    auto llvmStruct = mlir::LLVM::LLVMStructType::getIdentified(
-        type.getContext(), type.getTypeName());
-    if (llvmStruct.setBody(llvmMembers, /*isPacked=*/type.getPacked()).failed())
-      llvm_unreachable("Failed to set body of struct");
+
+    // Struct has a name: lower as an identified struct.
+    mlir::LLVM::LLVMStructType llvmStruct;
+    if (type.getTypeName().size() != 0) {
+      llvmStruct = mlir::LLVM::LLVMStructType::getIdentified(
+          type.getContext(), type.getTypeName());
+      if (llvmStruct.setBody(llvmMembers, /*isPacked=*/type.getPacked())
+              .failed())
+        llvm_unreachable("Failed to set body of struct");
+    } else { // Struct has no name: lower as literal struct.
+      llvmStruct = mlir::LLVM::LLVMStructType::getLiteral(
+          type.getContext(), llvmMembers, /*isPacked=*/type.getPacked());
+    }
+
     return llvmStruct;
   });
   converter.addConversion([&](mlir::cir::VoidType type) -> mlir::Type {
@@ -1584,8 +1683,7 @@ std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass() {
 extern void registerCIRDialectTranslation(mlir::MLIRContext &context);
 
 std::unique_ptr<llvm::Module>
-lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule,
-                             LLVMContext &llvmCtx) {
+lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx) {
   mlir::MLIRContext *mlirCtx = theModule.getContext();
   mlir::PassManager pm(mlirCtx);
 

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -17,10 +17,10 @@ void baz(void) {
   struct Foo f;
 }
 
-//      CHECK: !ty_22struct2EBar22 = !cir.struct<"struct.Bar", !s32i, !s8i>
-// CHECK-NEXT: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo", !s32i, !s8i, !ty_22struct2EBar22>
+// CHECK-DAG: !ty_22struct2EBar22 = !cir.struct<"struct.Bar", !s32i, !s8i>
+// CHECK-DAG: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo", !s32i, !s8i, !ty_22struct2EBar22>
 //  CHECK-DAG: module {{.*}} {
-// CHECK-NEXT:   cir.func @baz()
+     // CHECK:   cir.func @baz()
 // CHECK-NEXT:     %0 = cir.alloca !ty_22struct2EBar22, cir.ptr <!ty_22struct2EBar22>, ["b"] {alignment = 4 : i64}
 // CHECK-NEXT:     %1 = cir.alloca !ty_22struct2EFoo22, cir.ptr <!ty_22struct2EFoo22>, ["f"] {alignment = 4 : i64}
 // CHECK-NEXT:     cir.return
@@ -34,5 +34,25 @@ void shouldConstInitStructs(void) {
   // CHECK: cir.store %[[#V1]], %[[#V0]] : !ty_22struct2EFoo22, cir.ptr <!ty_22struct2EFoo22>
 }
 
-// Check if global structs are zero-initialized.
-//      CHECK: cir.global external @bar = #cir.zero : !ty_22struct2EBar22
+// Should zero-initialize uninitialized global structs.
+struct S {
+  int a,b;
+} s;
+// CHECK-DAG: cir.global external @s = #cir.zero : !ty_22struct2ES22
+
+// Should initialize basic global structs.
+struct S1 {
+  int a;
+  float f;
+  int *p;
+} s1 = {1, .1, 0};
+// CHECK-DAG: cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, 1.000000e-01 : f32, #cir.null : !cir.ptr<!s32i>}> : !ty_22struct2ES122
+
+// Should initialize global nested structs.
+struct S2 {
+  struct S2A {
+    int a;
+  } s2a;
+} s2 = {{1}};
+// CHECK-DAG: cir.global external @s2 = #cir.const_struct<{#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_22struct2ES2A22}> : !ty_22struct2ES222
+

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -4,6 +4,10 @@
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
 !ty_22struct2ES22 = !cir.struct<"struct.S", !u8i, !s32i>
+!ty_22struct2ES2A22 = !cir.struct<"struct.S2A", !s32i, #cir.recdecl.ast>
+!ty_22struct2ES122 = !cir.struct<"struct.S1", !s32i, f32, !cir.ptr<!s32i>, #cir.recdecl.ast>
+!ty_22struct2ES222 = !cir.struct<"struct.S2", !ty_22struct2ES2A22, #cir.recdecl.ast>
+
 module {
   cir.func @test() {
     %1 = cir.alloca !ty_22struct2ES22, cir.ptr <!ty_22struct2ES22>, ["x"] {alignment = 4 : i64}
@@ -15,4 +19,28 @@ module {
     // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 1] : (!llvm.ptr<struct<"struct.S", (i8, i32)>>) -> !llvm.ptr<i32>
     cir.return
   }
+
+  // Should lower basic #cir.const_struct initializer.
+  cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, 1.000000e-01 : f32, #cir.null : !cir.ptr<!s32i>}> : !ty_22struct2ES122
+  // CHECK: llvm.mlir.global external @s1() {addr_space = 0 : i32} : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> {
+  // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
+  // CHECK:   %1 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK:   %2 = llvm.insertvalue %1, %0[0] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> 
+  // CHECK:   %3 = llvm.mlir.constant(1.000000e-01 : f32) : f32
+  // CHECK:   %4 = llvm.insertvalue %3, %2[1] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> 
+  // CHECK:   %5 = llvm.mlir.null : !llvm.ptr<i32>
+  // CHECK:   %6 = llvm.insertvalue %5, %4[2] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> 
+  // CHECK:   llvm.return %6 : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
+  // CHECK: }
+
+  // Should lower nested #cir.const_struct initializer.
+  cir.global external @s2 = #cir.const_struct<{#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_22struct2ES2A22}> : !ty_22struct2ES222
+  // CHECK: llvm.mlir.global external @s2() {addr_space = 0 : i32} : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)> {
+  // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)>
+  // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"struct.S2A", (i32)>
+  // CHECK:   %2 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK:   %3 = llvm.insertvalue %2, %1[0] : !llvm.struct<"struct.S2A", (i32)> 
+  // CHECK:   %4 = llvm.insertvalue %3, %0[0] : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)> 
+  // CHECK:   llvm.return %4 : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)>
+  // CHECK: }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #203
* #202
* __->__ #201
* #200
* #199

Adds support for CIR globals with basic struct initializers. This patch
tackes only primitive, pointers, and simple nested structs. Arrays,
char pointers, and other more complex types are not supported yet.