### PR TITLE
[CIR][CIRGen] Static initialize global addresses

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -102,6 +102,14 @@ public:
   // Attribute helpers
   // -----------------
   //
+
+  /// Get constant address of a global variable as an MLIR attribute.
+  mlir::Attribute getGlobalViewAttr(mlir::cir::GlobalOp globalOp) {
+    auto type = getPointerTo(globalOp.getSymType());
+    auto symRef = mlir::FlatSymbolRefAttr::get(globalOp.getSymNameAttr());
+    return mlir::cir::GlobalViewAttr::get(type, symRef);
+  }
+
   mlir::TypedAttr getZeroAttr(mlir::Type t) {
     return mlir::cir::ZeroAttr::get(getContext(), t);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -17,6 +17,7 @@
 #include "CIRGenModule.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -996,8 +997,9 @@ namespace {
 /// A struct which can be used to peephole certain kinds of finalization
 /// that normally happen during l-value emission.
 struct ConstantLValue {
+  // FIXME(cir): does it make sense to have both parent and child type here?
   using SymbolTy = mlir::SymbolRefAttr;
-  llvm::PointerUnion<mlir::Value, SymbolTy> Value;
+  llvm::PointerUnion<mlir::Value, SymbolTy, mlir::Attribute> Value;
   bool HasOffsetApplied;
 
   /*implicit*/ ConstantLValue(mlir::Value value, bool hasOffsetApplied = false)
@@ -1006,6 +1008,7 @@ struct ConstantLValue {
   /*implicit*/ ConstantLValue(SymbolTy address) : Value(address) {}
 
   ConstantLValue(std::nullptr_t) : ConstantLValue({}, false) {}
+  ConstantLValue(mlir::Attribute value) : Value(value) {}
 };
 
 /// A helper class for emitting constant l-values.
@@ -1050,10 +1053,13 @@ private:
   /// Return the value offset.
   mlir::Attribute getOffset() { llvm_unreachable("NYI"); }
 
+  // TODO(cir): create a proper interface to absctract CIR constant values.
+
   /// Apply the value offset to the given constant.
-  mlir::Attribute applyOffset(mlir::Attribute C) {
+  ConstantLValue applyOffset(ConstantLValue &C) {
     if (!hasNonZeroOffset())
       return C;
+
     // TODO(cir): use ptr_stride, or something...
     llvm_unreachable("NYI");
   }
@@ -1089,15 +1095,17 @@ mlir::Attribute ConstantLValueEmitter::tryEmit() {
     return {};
 
   // Apply the offset if necessary and not already done.
-  if (!result.HasOffsetApplied && !value.is<ConstantLValue::SymbolTy>()) {
-    assert(0 && "NYI");
+  if (!result.HasOffsetApplied && !value.is<mlir::SymbolRefAttr>()) {
+    value = applyOffset(result).Value;
   }
 
   // Convert to the appropriate type; this could be an lvalue for
   // an integer. FIXME: performAddrSpaceCast
   if (destTy.isa<mlir::cir::PointerType>()) {
-    if (value.is<ConstantLValue::SymbolTy>())
-      return value.get<ConstantLValue::SymbolTy>();
+    if (value.is<mlir::SymbolRefAttr>())
+      return value.get<mlir::SymbolRefAttr>();
+    if (value.is<mlir::Attribute>())
+      return value.get<mlir::Attribute>();
     llvm_unreachable("NYI");
   }
 
@@ -1121,7 +1129,30 @@ ConstantLValue
 ConstantLValueEmitter::tryEmitBase(const APValue::LValueBase &base) {
   // Handle values.
   if (const ValueDecl *D = base.dyn_cast<const ValueDecl *>()) {
-    assert(0 && "NYI");
+    // The constant always points to the canonical declaration. We want to look
+    // at properties of the most recent declaration at the point of emission.
+    D = cast<ValueDecl>(D->getMostRecentDecl());
+
+    if (D->hasAttr<WeakRefAttr>())
+      llvm_unreachable("emit pointer base for weakref is NYI");
+
+    if (auto *FD = dyn_cast<FunctionDecl>(D))
+      llvm_unreachable("emit pointer base for fun decl is NYI");
+
+    if (auto *VD = dyn_cast<VarDecl>(D)) {
+      // We can never refer to a variable with local storage.
+      if (!VD->hasLocalStorage()) {
+        if (VD->isFileVarDecl() || VD->hasExternalStorage())
+          return CGM.getAddrOfGlobalVarAttr(VD);
+
+        if (VD->isLocalVarDecl()) {
+          auto linkage =
+              CGM.getCIRLinkageVarDefinition(VD, /*IsConstant=*/false);
+          return CGM.getBuilder().getGlobalViewAttr(
+              CGM.getOrCreateStaticVarDecl(*VD, linkage));
+        }
+      }
+    }
   }
 
   // Handle typeid(T).

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -699,6 +699,19 @@ mlir::Value CIRGenModule::getAddrOfGlobalVar(const VarDecl *D, mlir::Type Ty,
                                                 ptrTy, g.getSymName());
 }
 
+mlir::cir::GlobalViewAttr
+CIRGenModule::getAddrOfGlobalVarAttr(const VarDecl *D, mlir::Type Ty,
+                                     ForDefinition_t IsForDefinition) {
+  assert(D->hasGlobalStorage() && "Not a global variable");
+  QualType ASTTy = D->getType();
+  if (!Ty)
+    Ty = getTypes().convertTypeForMem(ASTTy);
+
+  auto globalOp = buildGlobal(D, Ty, IsForDefinition);
+  auto symRef = mlir::FlatSymbolRefAttr::get(globalOp.getSymNameAttr());
+  return mlir::cir::GlobalViewAttr::get(builder.getPointerTo(Ty), symRef);
+}
+
 mlir::Operation* CIRGenModule::getWeakRefReference(const ValueDecl *VD) {
   const AliasAttr *AA = VD->getAttr<AliasAttr>();
   assert(AA && "No alias?");

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -231,6 +231,11 @@ public:
   getAddrOfGlobalVar(const VarDecl *D, mlir::Type Ty = {},
                      ForDefinition_t IsForDefinition = NotForDefinition);
 
+  /// Return the mlir::GlobalViewAttr for the address of the given global.
+  mlir::cir::GlobalViewAttr
+  getAddrOfGlobalVarAttr(const VarDecl *D, mlir::Type Ty = {},
+                         ForDefinition_t IsForDefinition = NotForDefinition);
+
   /// Get a reference to the target of VD.
   mlir::Operation* getWeakRefReference(const ValueDecl *VD);
 

--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -115,3 +115,8 @@ int testExternVar(void) { return externVar; }
 // CHECK: cir.global "private" external @externVar : !s32i
 // CHECK: cir.func @{{.+}}testExternVar
 // CHECK:   cir.get_global @externVar : cir.ptr <!s32i>
+
+// Should constant initialize global with constant address.
+int var = 1;
+int *constAddr = &var;
+// CHECK-DAG: cir.global external @constAddr = #cir.global_view<@var> : !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGen/static-vars.c
+++ b/clang/test/CIR/CodeGen/static-vars.c
@@ -35,3 +35,10 @@ void func2(void) {
   static float j;
   // CHECK-DAG: cir.global "private" internal @func2.j = 0.000000e+00 : f32
 }
+
+// Should const initialize static vars with constant addresses.
+void func3(void) {
+  static int var;
+  static int *constAddr = &var;
+  // CHECK-DAG: cir.global "private" internal @func3.constAddr = #cir.global_view<@func3.var> : !cir.ptr<!s32i>
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Global addresses are constant, so we can initialize them at compile time
using CIR's global_view attribute. This patch adds codegen support for
initialization of variables with constant global addresses.