### PR TITLE
[CIR][Lowering] Lower globals with global_view initializer

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1209,6 +1209,15 @@ public:
           op->getLoc(), lowerCirAttrAsValue(structAttr, op->getLoc(), rewriter,
                                             typeConverter));
       return mlir::success();
+    } else if (auto attr = init.value().dyn_cast<mlir::cir::GlobalViewAttr>()) {
+      setupRegionInitializedLLVMGlobalOp(op, rewriter);
+
+      // Return the address of the global symbol.
+      auto elementType = typeConverter->convertType(attr.getType());
+      auto addrOfOp = rewriter.create<mlir::LLVM::AddressOfOp>(
+          op->getLoc(), elementType, attr.getSymbol());
+      rewriter.create<mlir::LLVM::ReturnOp>(op->getLoc(), addrOfOp.getResult());
+      return mlir::success();
     } else {
       op.emitError() << "usupported initializer '" << init.value() << "'";
       return mlir::failure();

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -1,5 +1,7 @@
-// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s -cir-to-llvm -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=MLIR
+// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 !s16i = !cir.int<s, 16>
 !s32i = !cir.int<s, 32>
@@ -26,6 +28,11 @@ module {
   // MLIR: }
   // LLVM: @.str = internal constant [8 x i8] c"example\00"
   // LLVM: @s = global ptr @.str
+  cir.global external @aPtr = #cir.global_view<@a> : !cir.ptr<!s32i>
+  // MLIR: llvm.mlir.global external @aPtr() {addr_space = 0 : i32} : !llvm.ptr<i32> {
+  // MLIR:   %0 = llvm.mlir.addressof @a : !llvm.ptr<i32>
+  // MLIR:   llvm.return %0 : !llvm.ptr<i32>
+  // MLIR: }
   cir.global "private" constant internal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
   cir.global external @s1 = @".str1": !cir.ptr<!s8i>
   cir.global external @s2 = @".str": !cir.ptr<!s8i>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Adds lowering logic for CIR's global_view attributes with no indexes.
This is done by converting the global to a region-initialized LLVM
global operation, where the region returns the address of the global
used in the gloval_view initializer attribute.