### PR TITLE
[CIR][Bugfix] Fix cir.array getTypeSizeInBits method

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -202,7 +202,7 @@ unsigned PointerType::getPreferredAlignment(
 unsigned
 ArrayType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
                              ::mlir::DataLayoutEntryListRef params) const {
-  return dataLayout.getTypeSizeInBits(getEltType());
+  return getSize() * dataLayout.getTypeSizeInBits(getEltType());
 }
 
 unsigned

--- a/clang/test/CIR/CodeGen/static-vars.c
+++ b/clang/test/CIR/CodeGen/static-vars.c
@@ -35,3 +35,9 @@ void func2(void) {
   static float j;
   // CHECK-DAG: cir.global "private" internal @func2.j = 0.000000e+00 : f32
 }
+
+// Should match type size in bytes between var and initializer.
+void func4(void) {
+  static char string[] = "Hello";
+  // CHECK-DAG: cir.global "private" internal @func4.string = #cir.const_array<"Hello\00" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6>
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #207
* __->__ #206

Constant initialization of static local arrays would fail due to a
mismatch between the variable and the initializer type size. This patch
fixes the data layout interface implementation for the cir.array type.

A complete array in C/C++ should have its type size in bits equal to
the size of the array times the size of the element type.