### PR TITLE
[CIR][CIRGen] Support symbol addresses in global initializers.

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -846,6 +846,9 @@ void CIRGenModule::buildGlobalVarDefinition(const clang::VarDecl *D,
     if (arrayTy)
       InitType = mlir::cir::PointerType::get(builder.getContext(),
                                              arrayTy.getEltType());
+    else
+      InitType = mlir::cir::PointerType::get(builder.getContext(),
+                                             g.getSymType());
   } else {
     assert(Init.isa<mlir::TypedAttr>() && "This should have a type");
     auto TypedInitAttr = Init.cast<mlir::TypedAttr>();

--- a/clang/test/CIR/CodeGen/pointer-to-tentative.c
+++ b/clang/test/CIR/CodeGen/pointer-to-tentative.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s
+
+int x;
+int *px = &x;
+// CHECK: cir.global external @px = @x
+
+int a[100];
+int *pa = a;
+// CHECK: cir.global external @pa = @a
+
+


### PR DESCRIPTION
This is a draft fix for code like
```
int data;
int *p = &data;
```
which currently crashes on trunk.

For tentative definition of `data` I have to force creation of global in `ConstantLValueEmitter::tryEmitBase` to avoid crash later in `CIRGenModule::buildGlobalVarDefinition` in
```
  if (auto symAttr = Init.dyn_cast<mlir::SymbolRefAttr>()) {                    
    auto cstGlobal = mlir::SymbolTable::lookupSymbolIn(theModule, symAttr);  // Expects cir.global @data to be present
```

I'm not a huge expert in frontend yet and I'm sure if that approach is the best one so suggestions are welcomed...
