### PR TITLE
[CIR][Lowering] Fixed break/continue lowering for loops

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1149,7 +1149,7 @@ public:
         case mlir::cir::YieldOpKind::Break:
           rewriteYieldOp(rewriter, yieldOp, exitBlock);
           break;
-        case mlir::cir::YieldOpKind::Continue: // Contniue is handled only in
+        case mlir::cir::YieldOpKind::Continue: // Continue is handled only in
                                                // loop lowering
           break;
         default:

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -241,6 +241,42 @@ public:
     return mlir::success();
   }
 
+  void makeYieldIf(mlir::cir::YieldOpKind kind, mlir::cir::YieldOp &op, mlir::Block *to,
+                   mlir::ConversionPatternRewriter &rewriter) const {
+    if (op.getKind() == kind) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(op, op.getArgs(), to);
+    }
+  }
+
+  void lowerNestedBreakContinue(mlir::Region &loopBody, mlir::Block *exitBlock,
+                                mlir::Block *continueBlock,
+                                mlir::ConversionPatternRewriter &rewriter) const {
+
+    auto processBreak = [&](mlir::Operation *op) {
+      if (isa<mlir::cir::LoopOp, mlir::cir::SwitchOp>(*op)) // don't process breaks in nested loops and switches
+        return mlir::WalkResult::skip();
+
+      if (auto yield = dyn_cast<mlir::cir::YieldOp>(*op))
+          makeYieldIf(mlir::cir::YieldOpKind::Break, yield, exitBlock, rewriter);
+
+      return mlir::WalkResult::advance();
+    };
+
+    auto processContinue = [&](mlir::Operation *op) {
+      if (isa<mlir::cir::LoopOp>(*op)) // don't process continues in nested loops
+        return mlir::WalkResult::skip();
+
+      if (auto yield = dyn_cast<mlir::cir::YieldOp>(*op))
+        makeYieldIf(mlir::cir::YieldOpKind::Continue, yield, continueBlock, rewriter);
+
+      return mlir::WalkResult::advance();
+    };
+
+    loopBody.walk<mlir::WalkOrder::PreOrder>(processBreak);
+    loopBody.walk<mlir::WalkOrder::PreOrder>(processContinue);
+  }
+  
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::LoopOp loopOp, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
@@ -268,6 +304,9 @@ public:
     auto &stepFrontBlock = stepRegion.front();
     auto stepYield =
         dyn_cast<mlir::cir::YieldOp>(stepRegion.back().getTerminator());
+    auto &stepBlock = (kind == LoopKind::For ? stepFrontBlock : condFrontBlock);
+
+    lowerNestedBreakContinue(bodyRegion, continueBlock, &stepBlock, rewriter);
 
     // Move loop op region contents to current CFG.
     rewriter.inlineRegionBefore(condRegion, continueBlock);
@@ -290,8 +329,7 @@ public:
 
     // Branch from body to condition or to step on for-loop cases.
     rewriter.setInsertionPoint(bodyYield);
-    auto &bodyExit = (kind == LoopKind::For ? stepFrontBlock : condFrontBlock);
-    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(bodyYield, &bodyExit);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(bodyYield, &stepBlock);
 
     // Is a for loop: branch from step to condition.
     if (kind == LoopKind::For) {
@@ -483,6 +521,11 @@ public:
   }
 };
 
+static bool isLoopYield(mlir::cir::YieldOp &op) {
+  return op.getKind() == mlir::cir::YieldOpKind::Break ||
+         op.getKind() == mlir::cir::YieldOpKind::Continue;
+}
+
 class CIRIfLowering : public mlir::OpConversionPattern<mlir::cir::IfOp> {
 public:
   using mlir::OpConversionPattern<mlir::cir::IfOp>::OpConversionPattern;
@@ -511,7 +554,8 @@ public:
     rewriter.setInsertionPointToEnd(thenAfterBody);
     if (auto thenYieldOp =
             dyn_cast<mlir::cir::YieldOp>(thenAfterBody->getTerminator())) {
-      rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
+      if (!isLoopYield(thenYieldOp)) // lowering of parent loop yields is deferred to loop lowering
+	rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
           thenYieldOp, thenYieldOp.getArgs(), continueBlock);
     } else if (!dyn_cast<mlir::cir::ReturnOp>(thenAfterBody->getTerminator())) {
       llvm_unreachable("what are we terminating with?");
@@ -540,7 +584,8 @@ public:
       rewriter.setInsertionPointToEnd(elseAfterBody);
       if (auto elseYieldOp =
               dyn_cast<mlir::cir::YieldOp>(elseAfterBody->getTerminator())) {
-        rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
+	if (!isLoopYield(elseYieldOp)) // lowering of parent loop yields is deferred to loop lowering
+	  rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
             elseYieldOp, elseYieldOp.getArgs(), continueBlock);
       } else if (!dyn_cast<mlir::cir::ReturnOp>(
                      elseAfterBody->getTerminator())) {
@@ -1080,6 +1125,8 @@ public:
         // Break out of switch: branch to exit block.
         case mlir::cir::YieldOpKind::Break:
           rewriteYieldOp(rewriter, yieldOp, exitBlock);
+          break;
+	case mlir::cir::YieldOpKind::Continue: // Contniue is handled only in loop lowering
           break;
         default:
           return op->emitError("invalid yield kind in case statement");

--- a/clang/test/CIR/Lowering/loops-with-break.cir
+++ b/clang/test/CIR/Lowering/loops-with-break.cir
@@ -44,29 +44,29 @@ module {
   // CHECK:  llvm.func @testFor()
   //           [...]
   // CHECK:    llvm.br ^bb[[#COND:]]
-  // CHECK:  ^bb[[#COlf ND]]:
+  // CHECK:  ^bb[[#COND]]:
   //           [...]
   // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preBREAK0:]], ^bb[[#preEXIT0:]]
-  // CHECK:  ^bb[[#preBREAK0]]: 
+  // CHECK:  ^bb[[#preBREAK0]]:
   // CHECK:    llvm.br ^bb[[#preBREAK1:]]
-  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:  ^bb[[#preEXIT0]]:
   // CHECK:    llvm.br ^bb[[#EXIT:]]
-  // CHECK:  ^bb[[#preBREAK1]]: 
+  // CHECK:  ^bb[[#preBREAK1]]:
   // CHECK:    llvm.br ^bb[[#preBREAK2:]]
-  // CHECK:  ^bb[[#preBREAK2]]: 
+  // CHECK:  ^bb[[#preBREAK2]]:
   // CHECK:    llvm.br ^bb[[#BREAK:]]
-  // CHECK:  ^bb[[#BREAK]]: 
+  // CHECK:  ^bb[[#BREAK]]:
   //           [...]
   // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preEXIT1:]], ^bb[[#preBODY0:]]
-  // CHECK:  ^bb[[#preEXIT1]]: 
+  // CHECK:  ^bb[[#preEXIT1]]:
   // CHECK:    llvm.br ^bb[[#EXIT:]]
-  // CHECK:  ^bb[[#preBODY0]]: 
+  // CHECK:  ^bb[[#preBODY0]]:
   // CHECK:    llvm.br ^bb[[#preBODY1:]]
-  // CHECK:  ^bb[[#preBODY1]]: 
+  // CHECK:  ^bb[[#preBODY1]]:
   // CHECK:    llvm.br ^bb[[#BODY:]]
-  // CHECK:  ^bb[[#BODY]]:   
+  // CHECK:  ^bb[[#BODY]]:
   // CHECK:    llvm.br ^bb[[#STEP:]]
-  // CHECK:  ^bb[[#STEP]]: 
+  // CHECK:  ^bb[[#STEP]]:
   //           [...]
   // CHECK:    llvm.br ^bb[[#COND:]]
   // CHECK:  ^bb[[#EXIT]]: 

--- a/clang/test/CIR/Lowering/loops-with-break.cir
+++ b/clang/test/CIR/Lowering/loops-with-break.cir
@@ -1,0 +1,447 @@
+// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
+
+!s32i = !cir.int<s, 32>
+module {
+  cir.func @testFor() {
+    cir.scope {
+      %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+      %1 = cir.const(#cir.int<1> : !s32i) : !s32i
+      cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+      cir.loop for(cond : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.brcond %5 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, cir.ptr <!s32i>
+        cir.yield
+      }) {
+        cir.scope {
+          cir.scope {
+            %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+            %3 = cir.const(#cir.int<5> : !s32i) : !s32i
+            %4 = cir.cmp(eq, %2, %3) : !s32i, !s32i
+            %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+            cir.if %5 {
+              cir.yield break
+            }
+          }
+        }
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+// MLIR:          llvm.func @testFor()
+// MLIR-NEXT:        llvm.br ^bb1
+// MLIR-NEXT:      ^bb1:  // pred: ^bb0
+// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %2 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Condition block =============
+// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb12
+// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
+// MLIR-NEXT:      ^bb3:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb5
+// MLIR-NEXT:      ^bb4:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb13
+// MLIR-NEXT:      ^bb5:  // pred: ^bb3
+// MLIR-NEXT:        llvm.br ^bb6
+// MLIR-NEXT:      ^bb6:  // pred: ^bb5
+// MLIR-NEXT:        llvm.br ^bb7
+// ============= Block with break =============
+// MLIR-NEXT:      ^bb7:  // pred: ^bb6
+// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %12 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:        %13 = llvm.icmp "eq" %11, %12 : i32
+// MLIR-NEXT:        %14 = llvm.zext %13 : i1 to i32
+// MLIR-NEXT:        %15 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %16 = llvm.icmp "ne" %14, %15 : i32
+// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i8
+// MLIR-NEXT:        %18 = llvm.trunc %17 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %18, ^bb8, ^bb9
+// MLIR-NEXT:      ^bb8:  // pred: ^bb7
+// MLIR-NEXT:        llvm.br ^bb13
+// MLIR-NEXT:      ^bb9:  // pred: ^bb7
+// MLIR-NEXT:        llvm.br ^bb10
+// MLIR-NEXT:      ^bb10:  // pred: ^bb9
+// MLIR-NEXT:        llvm.br ^bb11
+// MLIR-NEXT:      ^bb11:  // pred: ^bb10
+// MLIR-NEXT:        llvm.br ^bb12
+// ============= Body block =============
+// MLIR-NEXT:      ^bb12:  // pred: ^bb11
+// MLIR-NEXT:        %19 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %20 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %21 = llvm.add %19, %20  : i32
+// MLIR-NEXT:        llvm.store %21, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Exit block =============
+// MLIR-NEXT:      ^bb13:  // 2 preds: ^bb4, ^bb8
+// MLIR-NEXT:        llvm.br ^bb14
+// MLIR-NEXT:      ^bb14:  // pred: ^bb13
+// MLIR-NEXT:        llvm.return
+// MLIR-NEXT:      }
+
+  cir.func @testForNested() {
+    cir.scope {
+      %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+      %1 = cir.const(#cir.int<1> : !s32i) : !s32i
+      cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+      cir.loop for(cond : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.brcond %5 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, cir.ptr <!s32i>
+        cir.yield
+      }) {
+        cir.scope {
+          cir.scope {
+            %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["j", init] {alignment = 4 : i64}
+            %3 = cir.const(#cir.int<1> : !s32i) : !s32i
+            cir.store %3, %2 : !s32i, cir.ptr <!s32i>
+            cir.loop for(cond : {
+              %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+              %5 = cir.const(#cir.int<10> : !s32i) : !s32i
+              %6 = cir.cmp(lt, %4, %5) : !s32i, !s32i
+              %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+              cir.brcond %7 ^bb1, ^bb2
+            ^bb1:  // pred: ^bb0
+              cir.yield continue
+            ^bb2:  // pred: ^bb0
+              cir.yield
+            }, step : {
+              %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+              %5 = cir.unary(inc, %4) : !s32i, !s32i
+              cir.store %5, %2 : !s32i, cir.ptr <!s32i>
+              cir.yield
+            }) {
+              cir.scope {
+                cir.scope {
+                  %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+                  %5 = cir.const(#cir.int<5> : !s32i) : !s32i
+                  %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
+                  %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+                  cir.if %7 {
+                    cir.yield break
+                  }
+                }
+              }
+              cir.yield
+            }
+          }
+        }
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+// MLIR:           llvm.func @testForNested()
+// MLIR-NEXT:        llvm.br ^bb1
+// MLIR-NEXT:      ^bb1:  // pred: ^bb0
+// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %2 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Condition block =============
+// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb22
+// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
+// MLIR-NEXT:      ^bb3:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb5
+// MLIR-NEXT:      ^bb4:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb23
+// MLIR-NEXT:      ^bb5:  // pred: ^bb3
+// MLIR-NEXT:        llvm.br ^bb6
+// MLIR-NEXT:      ^bb6:  // pred: ^bb5
+// MLIR-NEXT:        llvm.br ^bb7
+// ============= Nested loop =============
+// MLIR-NEXT:      ^bb7:  // pred: ^bb6
+// MLIR-NEXT:        %11 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %12 = llvm.alloca %11 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %13 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        llvm.store %13, %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb8
+// ============= Condition block nested =============
+// MLIR-NEXT:      ^bb8:  // 2 preds: ^bb7, ^bb18
+// MLIR-NEXT:        %14 = llvm.load %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        %15 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %16 = llvm.icmp "slt" %14, %15 : i32
+// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
+// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
+// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
+// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %21, ^bb9, ^bb10
+// MLIR-NEXT:      ^bb9:  // pred: ^bb8
+// MLIR-NEXT:        llvm.br ^bb11
+// MLIR-NEXT:      ^bb10:  // pred: ^bb8
+// MLIR-NEXT:        llvm.br ^bb19
+// MLIR-NEXT:      ^bb11:  // pred: ^bb9
+// MLIR-NEXT:        llvm.br ^bb12
+// MLIR-NEXT:      ^bb12:  // pred: ^bb11
+// MLIR-NEXT:        llvm.br ^bb13
+// ============= Block with break in nested loop =============
+// MLIR-NEXT:      ^bb13:  // pred: ^bb12
+// MLIR-NEXT:        %22 = llvm.load %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        %23 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:        %24 = llvm.icmp "eq" %22, %23 : i32
+// MLIR-NEXT:        %25 = llvm.zext %24 : i1 to i32
+// MLIR-NEXT:        %26 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %27 = llvm.icmp "ne" %25, %26 : i32
+// MLIR-NEXT:        %28 = llvm.zext %27 : i1 to i8
+// MLIR-NEXT:        %29 = llvm.trunc %28 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %29, ^bb14, ^bb15
+// MLIR-NEXT:      ^bb14:  // pred: ^bb13
+// MLIR-NEXT:        llvm.br ^bb19
+// MLIR-NEXT:      ^bb15:  // pred: ^bb13
+// MLIR-NEXT:        llvm.br ^bb16
+// MLIR-NEXT:      ^bb16:  // pred: ^bb15
+// MLIR-NEXT:        llvm.br ^bb17
+// MLIR-NEXT:      ^bb17:  // pred: ^bb16
+// MLIR-NEXT:        llvm.br ^bb18
+// ============= Body block in nested loop =============
+// MLIR-NEXT:      ^bb18:  // pred: ^bb17
+// MLIR-NEXT:        %30 = llvm.load %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        %31 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %32 = llvm.add %30, %31  : i32
+// MLIR-NEXT:        llvm.store %32, %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb8
+// MLIR-NEXT:      ^bb19:  // 2 preds: ^bb10, ^bb14
+// MLIR-NEXT:        llvm.br ^bb20
+// MLIR-NEXT:      ^bb20:  // pred: ^bb19
+// MLIR-NEXT:        llvm.br ^bb21
+// ============= Exit block in nested loop =============
+// MLIR-NEXT:      ^bb21:  // pred: ^bb20
+// MLIR-NEXT:        llvm.br ^bb22
+// ============= Body block =============
+// MLIR-NEXT:      ^bb22:  // pred: ^bb21
+// MLIR-NEXT:        %33 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %34 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %35 = llvm.add %33, %34  : i32
+// MLIR-NEXT:        llvm.store %35, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Exit block =============
+// MLIR-NEXT:      ^bb23:  // pred: ^bb4
+// MLIR-NEXT:        llvm.br ^bb24
+// MLIR-NEXT:      ^bb24:  // pred: ^bb23
+// MLIR-NEXT:        llvm.return
+// MLIR-NEXT:      }
+
+  cir.func  @testWhile() {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+    %1 = cir.const(#cir.int<0> : !s32i) : !s32i
+    cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      cir.loop while(cond : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.brcond %5 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        cir.yield
+      }) {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, cir.ptr <!s32i>
+        cir.scope {
+          %4 = cir.load %0 : cir.ptr <!s32i>, !s32i
+          %5 = cir.const(#cir.int<5> : !s32i) : !s32i
+          %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
+          %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+          cir.if %7 {
+            cir.yield break
+          }
+        }
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+// MLIR:           llvm.func @testWhile()
+// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %2 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb1
+// MLIR-NEXT:      ^bb1:  // pred: ^bb0
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Condition block =============
+// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb9
+// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
+// MLIR-NEXT:      ^bb3:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb5
+// MLIR-NEXT:      ^bb4:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb10
+// ============= Body block =============
+// MLIR-NEXT:      ^bb5:  // pred: ^bb3
+// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %12 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %13 = llvm.add %11, %12  : i32
+// MLIR-NEXT:        llvm.store %13, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb6
+// ============= Block with break =============
+// MLIR-NEXT:      ^bb6:  // pred: ^bb5
+// MLIR-NEXT:        %14 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %15 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:        %16 = llvm.icmp "eq" %14, %15 : i32
+// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
+// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
+// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
+// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %21, ^bb7, ^bb8
+// MLIR-NEXT:      ^bb7:  // pred: ^bb6
+// MLIR-NEXT:        llvm.br ^bb10
+// MLIR-NEXT:      ^bb8:  // pred: ^bb6
+// MLIR-NEXT:        llvm.br ^bb9
+// MLIR-NEXT:      ^bb9:  // pred: ^bb8
+// MLIR-NEXT:        llvm.br ^bb2
+// MLIR-NEXT:      ^bb10:  // 2 preds: ^bb4, ^bb7
+// MLIR-NEXT:        llvm.br ^bb11
+// ============= Exit block =============
+// MLIR-NEXT:      ^bb11:  // pred: ^bb10
+// MLIR-NEXT:        llvm.return
+// MLIR-NEXT:      }
+
+cir.func @testDoWhile() {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+    %1 = cir.const(#cir.int<0> : !s32i) : !s32i
+    cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      cir.loop dowhile(cond : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.brcond %5 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        cir.yield
+      }) {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, cir.ptr <!s32i>
+        cir.scope {
+          %4 = cir.load %0 : cir.ptr <!s32i>, !s32i
+          %5 = cir.const(#cir.int<5> : !s32i) : !s32i
+          %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
+          %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+          cir.if %7 {
+            cir.yield break
+          }
+        }
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+// MLIR:          llvm.func @testDoWhile()
+// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %2 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb1
+// MLIR-NEXT:      ^bb1:  // pred: ^bb0
+// MLIR-NEXT:        llvm.br ^bb5
+// ============= Condition block =============
+// MLIR-NEXT:      ^bb2:  // pred: ^bb9
+// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
+// MLIR-NEXT:      ^bb3:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb5
+// MLIR-NEXT:      ^bb4:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb10
+// ============= Body block =============
+// MLIR-NEXT:      ^bb5:  // 2 preds: ^bb1, ^bb3
+// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %12 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %13 = llvm.add %11, %12  : i32
+// MLIR-NEXT:        llvm.store %13, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb6
+// ============= Block with break =============
+// MLIR-NEXT:      ^bb6:  // pred: ^bb5
+// MLIR-NEXT:        %14 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %15 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:        %16 = llvm.icmp "eq" %14, %15 : i32
+// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
+// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
+// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
+// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %21, ^bb7, ^bb8
+// MLIR-NEXT:      ^bb7:  // pred: ^bb6
+// MLIR-NEXT:        llvm.br ^bb10
+// MLIR-NEXT:      ^bb8:  // pred: ^bb6
+// MLIR-NEXT:        llvm.br ^bb9
+// MLIR-NEXT:      ^bb9:  // pred: ^bb8
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Exit block =============
+// MLIR-NEXT:      ^bb10:  // 2 preds: ^bb4, ^bb7
+// MLIR-NEXT:        llvm.br ^bb11
+// MLIR-NEXT:      ^bb11:  // pred: ^bb10
+// MLIR-NEXT:        llvm.return
+// MLIR-NEXT:      }
+
+}

--- a/clang/test/CIR/Lowering/loops-with-break.cir
+++ b/clang/test/CIR/Lowering/loops-with-break.cir
@@ -1,5 +1,5 @@
-// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
-// RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
+// RUN: cir-opt %s -cir-to-llvm -reconcile-unrealized-casts -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
 
 !s32i = !cir.int<s, 32>
 module {
@@ -41,65 +41,37 @@ module {
     cir.return
   }
 
-// MLIR:          llvm.func @testFor()
-// MLIR-NEXT:        llvm.br ^bb1
-// MLIR-NEXT:      ^bb1:  // pred: ^bb0
-// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %2 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Condition block =============
-// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb12
-// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
-// MLIR-NEXT:      ^bb3:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb5
-// MLIR-NEXT:      ^bb4:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb13
-// MLIR-NEXT:      ^bb5:  // pred: ^bb3
-// MLIR-NEXT:        llvm.br ^bb6
-// MLIR-NEXT:      ^bb6:  // pred: ^bb5
-// MLIR-NEXT:        llvm.br ^bb7
-// ============= Block with break =============
-// MLIR-NEXT:      ^bb7:  // pred: ^bb6
-// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %12 = llvm.mlir.constant(5 : i32) : i32
-// MLIR-NEXT:        %13 = llvm.icmp "eq" %11, %12 : i32
-// MLIR-NEXT:        %14 = llvm.zext %13 : i1 to i32
-// MLIR-NEXT:        %15 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %16 = llvm.icmp "ne" %14, %15 : i32
-// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i8
-// MLIR-NEXT:        %18 = llvm.trunc %17 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %18, ^bb8, ^bb9
-// MLIR-NEXT:      ^bb8:  // pred: ^bb7
-// MLIR-NEXT:        llvm.br ^bb13
-// MLIR-NEXT:      ^bb9:  // pred: ^bb7
-// MLIR-NEXT:        llvm.br ^bb10
-// MLIR-NEXT:      ^bb10:  // pred: ^bb9
-// MLIR-NEXT:        llvm.br ^bb11
-// MLIR-NEXT:      ^bb11:  // pred: ^bb10
-// MLIR-NEXT:        llvm.br ^bb12
-// ============= Body block =============
-// MLIR-NEXT:      ^bb12:  // pred: ^bb11
-// MLIR-NEXT:        %19 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %20 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %21 = llvm.add %19, %20  : i32
-// MLIR-NEXT:        llvm.store %21, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Exit block =============
-// MLIR-NEXT:      ^bb13:  // 2 preds: ^bb4, ^bb8
-// MLIR-NEXT:        llvm.br ^bb14
-// MLIR-NEXT:      ^bb14:  // pred: ^bb13
-// MLIR-NEXT:        llvm.return
-// MLIR-NEXT:      }
+  // CHECK:  llvm.func @testFor()
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COlf ND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preBREAK0:]], ^bb[[#preEXIT0:]]
+  // CHECK:  ^bb[[#preBREAK0]]: 
+  // CHECK:    llvm.br ^bb[[#preBREAK1:]]
+  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#preBREAK1]]: 
+  // CHECK:    llvm.br ^bb[[#preBREAK2:]]
+  // CHECK:  ^bb[[#preBREAK2]]: 
+  // CHECK:    llvm.br ^bb[[#BREAK:]]
+  // CHECK:  ^bb[[#BREAK]]: 
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preEXIT1:]], ^bb[[#preBODY0:]]
+  // CHECK:  ^bb[[#preEXIT1]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#preBODY0]]: 
+  // CHECK:    llvm.br ^bb[[#preBODY1:]]
+  // CHECK:  ^bb[[#preBODY1]]: 
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#BODY]]:   
+  // CHECK:    llvm.br ^bb[[#STEP:]]
+  // CHECK:  ^bb[[#STEP]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#EXIT]]: 
+  //           [...]
+  // CHECK:  }
 
   cir.func @testForNested() {
     cir.scope {
@@ -164,105 +136,59 @@ module {
     cir.return
   }
 
-// MLIR:           llvm.func @testForNested()
-// MLIR-NEXT:        llvm.br ^bb1
-// MLIR-NEXT:      ^bb1:  // pred: ^bb0
-// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %2 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Condition block =============
-// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb22
-// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
-// MLIR-NEXT:      ^bb3:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb5
-// MLIR-NEXT:      ^bb4:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb23
-// MLIR-NEXT:      ^bb5:  // pred: ^bb3
-// MLIR-NEXT:        llvm.br ^bb6
-// MLIR-NEXT:      ^bb6:  // pred: ^bb5
-// MLIR-NEXT:        llvm.br ^bb7
-// ============= Nested loop =============
-// MLIR-NEXT:      ^bb7:  // pred: ^bb6
-// MLIR-NEXT:        %11 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %12 = llvm.alloca %11 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %13 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        llvm.store %13, %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb8
-// ============= Condition block nested =============
-// MLIR-NEXT:      ^bb8:  // 2 preds: ^bb7, ^bb18
-// MLIR-NEXT:        %14 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        %15 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %16 = llvm.icmp "slt" %14, %15 : i32
-// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
-// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
-// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
-// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %21, ^bb9, ^bb10
-// MLIR-NEXT:      ^bb9:  // pred: ^bb8
-// MLIR-NEXT:        llvm.br ^bb11
-// MLIR-NEXT:      ^bb10:  // pred: ^bb8
-// MLIR-NEXT:        llvm.br ^bb19
-// MLIR-NEXT:      ^bb11:  // pred: ^bb9
-// MLIR-NEXT:        llvm.br ^bb12
-// MLIR-NEXT:      ^bb12:  // pred: ^bb11
-// MLIR-NEXT:        llvm.br ^bb13
-// ============= Block with break in nested loop =============
-// MLIR-NEXT:      ^bb13:  // pred: ^bb12
-// MLIR-NEXT:        %22 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        %23 = llvm.mlir.constant(5 : i32) : i32
-// MLIR-NEXT:        %24 = llvm.icmp "eq" %22, %23 : i32
-// MLIR-NEXT:        %25 = llvm.zext %24 : i1 to i32
-// MLIR-NEXT:        %26 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %27 = llvm.icmp "ne" %25, %26 : i32
-// MLIR-NEXT:        %28 = llvm.zext %27 : i1 to i8
-// MLIR-NEXT:        %29 = llvm.trunc %28 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %29, ^bb14, ^bb15
-// MLIR-NEXT:      ^bb14:  // pred: ^bb13
-// MLIR-NEXT:        llvm.br ^bb19
-// MLIR-NEXT:      ^bb15:  // pred: ^bb13
-// MLIR-NEXT:        llvm.br ^bb16
-// MLIR-NEXT:      ^bb16:  // pred: ^bb15
-// MLIR-NEXT:        llvm.br ^bb17
-// MLIR-NEXT:      ^bb17:  // pred: ^bb16
-// MLIR-NEXT:        llvm.br ^bb18
-// ============= Body block in nested loop =============
-// MLIR-NEXT:      ^bb18:  // pred: ^bb17
-// MLIR-NEXT:        %30 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        %31 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %32 = llvm.add %30, %31  : i32
-// MLIR-NEXT:        llvm.store %32, %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb8
-// MLIR-NEXT:      ^bb19:  // 2 preds: ^bb10, ^bb14
-// MLIR-NEXT:        llvm.br ^bb20
-// MLIR-NEXT:      ^bb20:  // pred: ^bb19
-// MLIR-NEXT:        llvm.br ^bb21
-// ============= Exit block in nested loop =============
-// MLIR-NEXT:      ^bb21:  // pred: ^bb20
-// MLIR-NEXT:        llvm.br ^bb22
-// ============= Body block =============
-// MLIR-NEXT:      ^bb22:  // pred: ^bb21
-// MLIR-NEXT:        %33 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %34 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %35 = llvm.add %33, %34  : i32
-// MLIR-NEXT:        llvm.store %35, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Exit block =============
-// MLIR-NEXT:      ^bb23:  // pred: ^bb4
-// MLIR-NEXT:        llvm.br ^bb24
-// MLIR-NEXT:      ^bb24:  // pred: ^bb23
-// MLIR-NEXT:        llvm.return
-// MLIR-NEXT:      }
+  // CHECK:  llvm.func @testForNested()  
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preNESTED0:]], ^bb[[#preEXIT0:]]
+  // CHECK:  ^bb[[#preNESTED0]]: 
+  // CHECK:    llvm.br ^bb[[#preNESTED1:]]
+  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#preNESTED1]]: 
+  // CHECK:    llvm.br ^bb[[#preNESTED2:]]
+  // CHECK:  ^bb[[#preNESTED2]]: 
+  // CHECK:    llvm.br ^bb[[#NESTED:]]
+  // CHECK:  ^bb[[#NESTED]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND_NESTED:]]
+  // CHECK:  ^bb[[#COND_NESTED]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preBREAK0:]], ^bb[[#preEXIT1:]]
+  // CHECK:  ^bb[[#preBREAK0]]: 
+  // CHECK:    llvm.br ^bb[[#preBREAK1:]]
+  // CHECK:  ^bb[[#preEXIT1]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT_NESTED:]]
+  // CHECK:  ^bb[[#preBREAK1]]: 
+  // CHECK:    llvm.br ^bb[[#preBREAK2:]]
+  // CHECK:  ^bb[[#preBREAK2]]: 
+  // CHECK:    llvm.br ^bb[[#BREAK:]]
+  // CHECK:  ^bb[[#BREAK]]: 
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preEXIT2:]], ^bb[[#preBODY0:]]
+  // CHECK:  ^bb[[#preEXIT2]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT_NESTED:]]
+  // CHECK:  ^bb[[#preBODY0]]: 
+  // CHECK:    llvm.br ^bb[[#preBODY1:]]
+  // CHECK:  ^bb[[#preBODY1]]: 
+  // CHECK:    llvm.br ^bb[[#BODY_NESTED:]]
+  // CHECK:  ^bb[[#BODY_NESTED]]: 
+  // CHECK:    llvm.br ^bb[[#STEP_NESTED:]]
+  // CHECK:  ^bb[[#STEP_NESTED]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND_NESTED:]]
+  // CHECK:  ^bb[[#EXIT_NESTED]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#BODY]]: 
+  // CHECK:    llvm.br ^bb[[#STEP:]]
+  // CHECK:  ^bb[[#STEP]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#EXIT]]: 
+  //           [...]
+  // CHECK:  }
 
   cir.func  @testWhile() {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
@@ -300,60 +226,35 @@ module {
     cir.return
   }
 
-// MLIR:           llvm.func @testWhile()
-// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %2 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb1
-// MLIR-NEXT:      ^bb1:  // pred: ^bb0
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Condition block =============
-// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb9
-// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
-// MLIR-NEXT:      ^bb3:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb5
-// MLIR-NEXT:      ^bb4:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb10
-// ============= Body block =============
-// MLIR-NEXT:      ^bb5:  // pred: ^bb3
-// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %12 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %13 = llvm.add %11, %12  : i32
-// MLIR-NEXT:        llvm.store %13, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb6
-// ============= Block with break =============
-// MLIR-NEXT:      ^bb6:  // pred: ^bb5
-// MLIR-NEXT:        %14 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %15 = llvm.mlir.constant(5 : i32) : i32
-// MLIR-NEXT:        %16 = llvm.icmp "eq" %14, %15 : i32
-// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
-// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
-// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
-// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %21, ^bb7, ^bb8
-// MLIR-NEXT:      ^bb7:  // pred: ^bb6
-// MLIR-NEXT:        llvm.br ^bb10
-// MLIR-NEXT:      ^bb8:  // pred: ^bb6
-// MLIR-NEXT:        llvm.br ^bb9
-// MLIR-NEXT:      ^bb9:  // pred: ^bb8
-// MLIR-NEXT:        llvm.br ^bb2
-// MLIR-NEXT:      ^bb10:  // 2 preds: ^bb4, ^bb7
-// MLIR-NEXT:        llvm.br ^bb11
-// ============= Exit block =============
-// MLIR-NEXT:      ^bb11:  // pred: ^bb10
-// MLIR-NEXT:        llvm.return
-// MLIR-NEXT:      }
 
+  // CHECK:  llvm.func @testWhile()
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preBODY:]], ^bb[[#preEXIT0:]]
+  // CHECK:  ^bb[[#preBODY]]: 
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#BODY]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#BREAK:]]
+  // CHECK:  ^bb[[#BREAK]]: 
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preEXIT1:]], ^bb[[#preCOND0:]]
+  // CHECK:  ^bb[[#preEXIT1]]: 
+  // CHECK:    llvm.br ^bb[[#preEXIT2:]]
+  // CHECK:  ^bb[[#preCOND0]]: 
+  // CHECK:    llvm.br ^bb[[#preCOND1:]]
+  // CHECK:  ^bb[[#preCOND1]]: 
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#preEXIT2]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#EXIT]]: 
+  //           [...]
+  // CHECK:  }
+ 
 cir.func @testDoWhile() {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
     %1 = cir.const(#cir.int<0> : !s32i) : !s32i
@@ -390,58 +291,32 @@ cir.func @testDoWhile() {
     cir.return
   }
 
-// MLIR:          llvm.func @testDoWhile()
-// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %2 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb1
-// MLIR-NEXT:      ^bb1:  // pred: ^bb0
-// MLIR-NEXT:        llvm.br ^bb5
-// ============= Condition block =============
-// MLIR-NEXT:      ^bb2:  // pred: ^bb9
-// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
-// MLIR-NEXT:      ^bb3:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb5
-// MLIR-NEXT:      ^bb4:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb10
-// ============= Body block =============
-// MLIR-NEXT:      ^bb5:  // 2 preds: ^bb1, ^bb3
-// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %12 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %13 = llvm.add %11, %12  : i32
-// MLIR-NEXT:        llvm.store %13, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb6
-// ============= Block with break =============
-// MLIR-NEXT:      ^bb6:  // pred: ^bb5
-// MLIR-NEXT:        %14 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %15 = llvm.mlir.constant(5 : i32) : i32
-// MLIR-NEXT:        %16 = llvm.icmp "eq" %14, %15 : i32
-// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
-// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
-// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
-// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %21, ^bb7, ^bb8
-// MLIR-NEXT:      ^bb7:  // pred: ^bb6
-// MLIR-NEXT:        llvm.br ^bb10
-// MLIR-NEXT:      ^bb8:  // pred: ^bb6
-// MLIR-NEXT:        llvm.br ^bb9
-// MLIR-NEXT:      ^bb9:  // pred: ^bb8
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Exit block =============
-// MLIR-NEXT:      ^bb10:  // 2 preds: ^bb4, ^bb7
-// MLIR-NEXT:        llvm.br ^bb11
-// MLIR-NEXT:      ^bb11:  // pred: ^bb10
-// MLIR-NEXT:        llvm.return
-// MLIR-NEXT:      }
+  // CHECK:  llvm.func @testDoWhile()
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preBODY:]], ^bb[[#preEXIT0:]]
+  // CHECK:  ^bb[[#preBODY]]: 
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#BODY]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#BREAK:]]
+  // CHECK:  ^bb[[#BREAK]]: 
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preEXIT1:]], ^bb[[#preCOND0:]]
+  // CHECK:  ^bb[[#preEXIT1]]: 
+  // CHECK:    llvm.br ^bb[[#preEXIT2:]]
+  // CHECK:  ^bb[[#preCOND0]]: 
+  // CHECK:    llvm.br ^bb[[#preCOND1:]]
+  // CHECK:  ^bb[[#preCOND1]]: 
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#preEXIT2]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#EXIT]]: 
+  //           [...]
+  // CHECK:  }
 
 }

--- a/clang/test/CIR/Lowering/loops-with-continue.cir
+++ b/clang/test/CIR/Lowering/loops-with-continue.cir
@@ -1,0 +1,449 @@
+// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
+
+!s32i = !cir.int<s, 32>
+module {
+  cir.func @testFor() {
+    cir.scope {
+      %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+      %1 = cir.const(#cir.int<1> : !s32i) : !s32i
+      cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+      cir.loop for(cond : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.brcond %5 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, cir.ptr <!s32i>
+        cir.yield
+      }) {
+        cir.scope {
+          cir.scope {
+            %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+            %3 = cir.const(#cir.int<5> : !s32i) : !s32i
+            %4 = cir.cmp(eq, %2, %3) : !s32i, !s32i
+            %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+            cir.if %5 {
+              cir.yield continue
+            }
+          }
+        }
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+// MLIR:          llvm.func @testFor()
+// MLIR-NEXT:        llvm.br ^bb1
+// MLIR-NEXT:      ^bb1:  // pred: ^bb0
+// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %2 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Condition block =============
+// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb12
+// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
+// MLIR-NEXT:      ^bb3:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb5
+// MLIR-NEXT:      ^bb4:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb13
+// MLIR-NEXT:      ^bb5:  // pred: ^bb3
+// MLIR-NEXT:        llvm.br ^bb6
+// MLIR-NEXT:      ^bb6:  // pred: ^bb5
+// MLIR-NEXT:        llvm.br ^bb7
+// ============= Block with continue =============
+// MLIR-NEXT:      ^bb7:  // pred: ^bb6
+// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %12 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:        %13 = llvm.icmp "eq" %11, %12 : i32
+// MLIR-NEXT:        %14 = llvm.zext %13 : i1 to i32
+// MLIR-NEXT:        %15 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %16 = llvm.icmp "ne" %14, %15 : i32
+// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i8
+// MLIR-NEXT:        %18 = llvm.trunc %17 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %18, ^bb8, ^bb9
+// MLIR-NEXT:      ^bb8:  // pred: ^bb7
+// MLIR-NEXT:        llvm.br ^bb12
+// MLIR-NEXT:      ^bb9:  // pred: ^bb7
+// MLIR-NEXT:        llvm.br ^bb10
+// MLIR-NEXT:      ^bb10:  // pred: ^bb9
+// MLIR-NEXT:        llvm.br ^bb11
+// ============= Body block =============
+// MLIR-NEXT:      ^bb11:  // pred: ^bb10
+// MLIR-NEXT:        llvm.br ^bb12
+// ============= Step block =============
+// MLIR-NEXT:      ^bb12:  // 2 preds: ^bb8, ^bb11
+// MLIR-NEXT:        %19 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %20 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %21 = llvm.add %19, %20  : i32
+// MLIR-NEXT:        llvm.store %21, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Exit block =============
+// MLIR-NEXT:      ^bb13:  // pred: ^bb4
+// MLIR-NEXT:        llvm.br ^bb14
+// MLIR-NEXT:      ^bb14:  // pred: ^bb13
+// MLIR-NEXT:        llvm.return
+// MLIR-NEXT:      }
+
+  cir.func @testForNested() {
+    cir.scope {
+      %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+      %1 = cir.const(#cir.int<1> : !s32i) : !s32i
+      cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+      cir.loop for(cond : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.brcond %5 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, cir.ptr <!s32i>
+        cir.yield
+      }) {
+        cir.scope {
+          cir.scope {
+            %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["j", init] {alignment = 4 : i64}
+            %3 = cir.const(#cir.int<1> : !s32i) : !s32i
+            cir.store %3, %2 : !s32i, cir.ptr <!s32i>
+            cir.loop for(cond : {
+              %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+              %5 = cir.const(#cir.int<10> : !s32i) : !s32i
+              %6 = cir.cmp(lt, %4, %5) : !s32i, !s32i
+              %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+              cir.brcond %7 ^bb1, ^bb2
+            ^bb1:  // pred: ^bb0
+              cir.yield continue
+            ^bb2:  // pred: ^bb0
+              cir.yield
+            }, step : {
+              %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+              %5 = cir.unary(inc, %4) : !s32i, !s32i
+              cir.store %5, %2 : !s32i, cir.ptr <!s32i>
+              cir.yield
+            }) {
+              cir.scope {
+                cir.scope {
+                  %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+                  %5 = cir.const(#cir.int<5> : !s32i) : !s32i
+                  %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
+                  %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+                  cir.if %7 {
+                    cir.yield continue
+                  }
+                }
+              }
+              cir.yield
+            }
+          }
+        }
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+// MLIR:          llvm.func @testForNested()
+// MLIR-NEXT:        llvm.br ^bb1
+// MLIR-NEXT:      ^bb1:  // pred: ^bb0
+// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %2 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Condition block =============
+// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb22
+// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
+// MLIR-NEXT:      ^bb3:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb5
+// MLIR-NEXT:      ^bb4:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb23
+// MLIR-NEXT:      ^bb5:  // pred: ^bb3
+// MLIR-NEXT:        llvm.br ^bb6
+// MLIR-NEXT:      ^bb6:  // pred: ^bb5
+// MLIR-NEXT:        llvm.br ^bb7
+// MLIR-NEXT:      ^bb7:  // pred: ^bb6
+// MLIR-NEXT:        %11 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %12 = llvm.alloca %11 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %13 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        llvm.store %13, %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb8
+// ============= Condition block in nested loop =============
+// MLIR-NEXT:      ^bb8:  // 2 preds: ^bb7, ^bb18
+// MLIR-NEXT:        %14 = llvm.load %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        %15 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %16 = llvm.icmp "slt" %14, %15 : i32
+// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
+// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
+// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
+// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %21, ^bb9, ^bb10
+// MLIR-NEXT:      ^bb9:  // pred: ^bb8
+// MLIR-NEXT:        llvm.br ^bb11
+// MLIR-NEXT:      ^bb10:  // pred: ^bb8
+// MLIR-NEXT:        llvm.br ^bb19
+// MLIR-NEXT:      ^bb11:  // pred: ^bb9
+// MLIR-NEXT:        llvm.br ^bb12
+// MLIR-NEXT:      ^bb12:  // pred: ^bb11
+// MLIR-NEXT:        llvm.br ^bb13
+// ============= Block with continue in nested loop =============
+// MLIR-NEXT:      ^bb13:  // pred: ^bb12
+// MLIR-NEXT:        %22 = llvm.load %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        %23 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:        %24 = llvm.icmp "eq" %22, %23 : i32
+// MLIR-NEXT:        %25 = llvm.zext %24 : i1 to i32
+// MLIR-NEXT:        %26 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %27 = llvm.icmp "ne" %25, %26 : i32
+// MLIR-NEXT:        %28 = llvm.zext %27 : i1 to i8
+// MLIR-NEXT:        %29 = llvm.trunc %28 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %29, ^bb14, ^bb15
+// MLIR-NEXT:      ^bb14:  // pred: ^bb13
+// MLIR-NEXT:        llvm.br ^bb18
+// MLIR-NEXT:      ^bb15:  // pred: ^bb13
+// MLIR-NEXT:        llvm.br ^bb16
+// MLIR-NEXT:      ^bb16:  // pred: ^bb15
+// MLIR-NEXT:        llvm.br ^bb17
+// ============= Body block in nested loop =============
+// MLIR-NEXT:      ^bb17:  // pred: ^bb16
+// MLIR-NEXT:        llvm.br ^bb18
+// ============= Step block in nested loop =============
+// MLIR-NEXT:      ^bb18:  // 2 preds: ^bb14, ^bb17
+// MLIR-NEXT:        %30 = llvm.load %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        %31 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %32 = llvm.add %30, %31  : i32
+// MLIR-NEXT:        llvm.store %32, %12 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb8
+// MLIR-NEXT:      ^bb19:  // pred: ^bb10
+// MLIR-NEXT:        llvm.br ^bb20
+// ============= Exit block in nested loop =============
+// MLIR-NEXT:      ^bb20:  // pred: ^bb19
+// MLIR-NEXT:        llvm.br ^bb21
+// ============= Body block =============
+// MLIR-NEXT:      ^bb21:  // pred: ^bb20
+// MLIR-NEXT:        llvm.br ^bb22
+// ============= Step block =============
+// MLIR-NEXT:      ^bb22:  // pred: ^bb21
+// MLIR-NEXT:        %33 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %34 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %35 = llvm.add %33, %34  : i32
+// MLIR-NEXT:        llvm.store %35, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Exit block =============
+// MLIR-NEXT:      ^bb23:  // pred: ^bb4
+// MLIR-NEXT:        llvm.br ^bb24
+// MLIR-NEXT:      ^bb24:  // pred: ^bb23
+// MLIR-NEXT:        llvm.return
+// MLIR-NEXT:      }
+
+  cir.func @testWhile() {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+    %1 = cir.const(#cir.int<0> : !s32i) : !s32i
+    cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      cir.loop while(cond : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.brcond %5 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        cir.yield
+      }) {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, cir.ptr <!s32i>
+        cir.scope {
+          %4 = cir.load %0 : cir.ptr <!s32i>, !s32i
+          %5 = cir.const(#cir.int<5> : !s32i) : !s32i
+          %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
+          %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+          cir.if %7 {
+            cir.yield continue
+          }
+        }
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+// MLIR:          llvm.func @testWhile()
+// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %2 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb1
+// MLIR-NEXT:      ^bb1:  // pred: ^bb0
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Condition block =============
+// MLIR-NEXT:      ^bb2:  // 3 preds: ^bb1, ^bb7, ^bb9
+// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
+// MLIR-NEXT:      ^bb3:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb5
+// MLIR-NEXT:      ^bb4:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb10
+// ============= Body block =============
+// MLIR-NEXT:      ^bb5:  // pred: ^bb3
+// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %12 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %13 = llvm.add %11, %12  : i32
+// MLIR-NEXT:        llvm.store %13, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb6
+// ============= Block with continue =============
+// MLIR-NEXT:      ^bb6:  // pred: ^bb5
+// MLIR-NEXT:        %14 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %15 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:        %16 = llvm.icmp "eq" %14, %15 : i32
+// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
+// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
+// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
+// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %21, ^bb7, ^bb8
+// MLIR-NEXT:      ^bb7:  // pred: ^bb6
+// MLIR-NEXT:        llvm.br ^bb2
+// MLIR-NEXT:      ^bb8:  // pred: ^bb6
+// MLIR-NEXT:        llvm.br ^bb9
+// MLIR-NEXT:      ^bb9:  // pred: ^bb8
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Exit block =============
+// MLIR-NEXT:      ^bb10:  // pred: ^bb4
+// MLIR-NEXT:        llvm.br ^bb11
+// MLIR-NEXT:      ^bb11:  // pred: ^bb10
+// MLIR-NEXT:        llvm.return
+// MLIR-NEXT:      }
+
+  cir.func @testDoWhile() {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
+    %1 = cir.const(#cir.int<0> : !s32i) : !s32i
+    cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      cir.loop dowhile(cond : {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.const(#cir.int<10> : !s32i) : !s32i
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.brcond %5 ^bb1, ^bb2
+      ^bb1:  // pred: ^bb0
+        cir.yield continue
+      ^bb2:  // pred: ^bb0
+        cir.yield
+      }, step : {
+        cir.yield
+      }) {
+        %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, cir.ptr <!s32i>
+        cir.scope {
+          %4 = cir.load %0 : cir.ptr <!s32i>, !s32i
+          %5 = cir.const(#cir.int<5> : !s32i) : !s32i
+          %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
+          %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+          cir.if %7 {
+            cir.yield continue
+          }
+        }
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+// MLIR:          llvm.func @testDoWhile()
+// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:        %2 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb1
+// MLIR-NEXT:      ^bb1:  // pred: ^bb0
+// MLIR-NEXT:        llvm.br ^bb5
+// ============= Condition block =============
+// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb7, ^bb9
+// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
+// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
+// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
+// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
+// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
+// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
+// MLIR-NEXT:      ^bb3:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb5
+// MLIR-NEXT:      ^bb4:  // pred: ^bb2
+// MLIR-NEXT:        llvm.br ^bb10
+// ============= Body block =============
+// MLIR-NEXT:      ^bb5:  // 2 preds: ^bb1, ^bb3
+// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %12 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:        %13 = llvm.add %11, %12  : i32
+// MLIR-NEXT:        llvm.store %13, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        llvm.br ^bb6
+// ============= Block with continue =============
+// MLIR-NEXT:      ^bb6:  // pred: ^bb5
+// MLIR-NEXT:        %14 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:        %15 = llvm.mlir.constant(5 : i32) : i32
+// MLIR-NEXT:        %16 = llvm.icmp "eq" %14, %15 : i32
+// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
+// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
+// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
+// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
+// MLIR-NEXT:        llvm.cond_br %21, ^bb7, ^bb8
+// MLIR-NEXT:      ^bb7:  // pred: ^bb6
+// MLIR-NEXT:        llvm.br ^bb2
+// MLIR-NEXT:      ^bb8:  // pred: ^bb6
+// MLIR-NEXT:        llvm.br ^bb9
+// MLIR-NEXT:      ^bb9:  // pred: ^bb8
+// MLIR-NEXT:        llvm.br ^bb2
+// ============= Exit block =============
+// MLIR-NEXT:      ^bb10:  // pred: ^bb4
+// MLIR-NEXT:        llvm.br ^bb11
+// MLIR-NEXT:      ^bb11:  // pred: ^bb10
+// MLIR-NEXT:        llvm.return
+// MLIR-NEXT:      }
+
+}

--- a/clang/test/CIR/Lowering/loops-with-continue.cir
+++ b/clang/test/CIR/Lowering/loops-with-continue.cir
@@ -1,5 +1,5 @@
-// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
-// RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
+// RUN: cir-opt %s -cir-to-llvm -reconcile-unrealized-casts -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
 
 !s32i = !cir.int<s, 32>
 module {
@@ -41,66 +41,38 @@ module {
     cir.return
   }
 
-// MLIR:          llvm.func @testFor()
-// MLIR-NEXT:        llvm.br ^bb1
-// MLIR-NEXT:      ^bb1:  // pred: ^bb0
-// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %2 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Condition block =============
-// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb12
-// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
-// MLIR-NEXT:      ^bb3:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb5
-// MLIR-NEXT:      ^bb4:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb13
-// MLIR-NEXT:      ^bb5:  // pred: ^bb3
-// MLIR-NEXT:        llvm.br ^bb6
-// MLIR-NEXT:      ^bb6:  // pred: ^bb5
-// MLIR-NEXT:        llvm.br ^bb7
-// ============= Block with continue =============
-// MLIR-NEXT:      ^bb7:  // pred: ^bb6
-// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %12 = llvm.mlir.constant(5 : i32) : i32
-// MLIR-NEXT:        %13 = llvm.icmp "eq" %11, %12 : i32
-// MLIR-NEXT:        %14 = llvm.zext %13 : i1 to i32
-// MLIR-NEXT:        %15 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %16 = llvm.icmp "ne" %14, %15 : i32
-// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i8
-// MLIR-NEXT:        %18 = llvm.trunc %17 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %18, ^bb8, ^bb9
-// MLIR-NEXT:      ^bb8:  // pred: ^bb7
-// MLIR-NEXT:        llvm.br ^bb12
-// MLIR-NEXT:      ^bb9:  // pred: ^bb7
-// MLIR-NEXT:        llvm.br ^bb10
-// MLIR-NEXT:      ^bb10:  // pred: ^bb9
-// MLIR-NEXT:        llvm.br ^bb11
-// ============= Body block =============
-// MLIR-NEXT:      ^bb11:  // pred: ^bb10
-// MLIR-NEXT:        llvm.br ^bb12
-// ============= Step block =============
-// MLIR-NEXT:      ^bb12:  // 2 preds: ^bb8, ^bb11
-// MLIR-NEXT:        %19 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %20 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %21 = llvm.add %19, %20  : i32
-// MLIR-NEXT:        llvm.store %21, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Exit block =============
-// MLIR-NEXT:      ^bb13:  // pred: ^bb4
-// MLIR-NEXT:        llvm.br ^bb14
-// MLIR-NEXT:      ^bb14:  // pred: ^bb13
-// MLIR-NEXT:        llvm.return
-// MLIR-NEXT:      }
+  // CHECK:  llvm.func @testFor()
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preCONTINUE0:]], ^bb[[#preEXIT0:]]
+  // CHECK:  ^bb[[#preCONTINUE0]]: 
+  // CHECK:    llvm.br ^bb[[#preCONTINUE1:]]
+  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#preCONTINUE1]]: 
+  // CHECK:    llvm.br ^bb[[#preCONTINUE2:]]
+  // CHECK:  ^bb[[#preCONTINUE2]]: 
+  // CHECK:    llvm.br ^bb[[#CONTINUE:]]
+  // CHECK:  ^bb[[#CONTINUE]]: 
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preSTEP:]], ^bb[[#preBODY0:]]
+  // CHECK:  ^bb[[#preSTEP]]: 
+  // CHECK:    llvm.br ^bb[[#STEP:]]
+  // CHECK:  ^bb[[#preBODY0]]: 
+  // CHECK:    llvm.br ^bb[[#preBODY1:]]
+  // CHECK:  ^bb[[#preBODY1]]: 
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#BODY]]: 
+  // CHECK:    llvm.br ^bb[[#STEP:]]
+  // CHECK:  ^bb[[#STEP]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#EXIT]]: 
+  //           [...]
+  // CHECK:  }
+
 
   cir.func @testForNested() {
     cir.scope {
@@ -165,108 +137,60 @@ module {
     cir.return
   }
 
-// MLIR:          llvm.func @testForNested()
-// MLIR-NEXT:        llvm.br ^bb1
-// MLIR-NEXT:      ^bb1:  // pred: ^bb0
-// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %2 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Condition block =============
-// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb1, ^bb22
-// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
-// MLIR-NEXT:      ^bb3:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb5
-// MLIR-NEXT:      ^bb4:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb23
-// MLIR-NEXT:      ^bb5:  // pred: ^bb3
-// MLIR-NEXT:        llvm.br ^bb6
-// MLIR-NEXT:      ^bb6:  // pred: ^bb5
-// MLIR-NEXT:        llvm.br ^bb7
-// MLIR-NEXT:      ^bb7:  // pred: ^bb6
-// MLIR-NEXT:        %11 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %12 = llvm.alloca %11 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %13 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        llvm.store %13, %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb8
-// ============= Condition block in nested loop =============
-// MLIR-NEXT:      ^bb8:  // 2 preds: ^bb7, ^bb18
-// MLIR-NEXT:        %14 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        %15 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %16 = llvm.icmp "slt" %14, %15 : i32
-// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
-// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
-// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
-// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %21, ^bb9, ^bb10
-// MLIR-NEXT:      ^bb9:  // pred: ^bb8
-// MLIR-NEXT:        llvm.br ^bb11
-// MLIR-NEXT:      ^bb10:  // pred: ^bb8
-// MLIR-NEXT:        llvm.br ^bb19
-// MLIR-NEXT:      ^bb11:  // pred: ^bb9
-// MLIR-NEXT:        llvm.br ^bb12
-// MLIR-NEXT:      ^bb12:  // pred: ^bb11
-// MLIR-NEXT:        llvm.br ^bb13
-// ============= Block with continue in nested loop =============
-// MLIR-NEXT:      ^bb13:  // pred: ^bb12
-// MLIR-NEXT:        %22 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        %23 = llvm.mlir.constant(5 : i32) : i32
-// MLIR-NEXT:        %24 = llvm.icmp "eq" %22, %23 : i32
-// MLIR-NEXT:        %25 = llvm.zext %24 : i1 to i32
-// MLIR-NEXT:        %26 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %27 = llvm.icmp "ne" %25, %26 : i32
-// MLIR-NEXT:        %28 = llvm.zext %27 : i1 to i8
-// MLIR-NEXT:        %29 = llvm.trunc %28 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %29, ^bb14, ^bb15
-// MLIR-NEXT:      ^bb14:  // pred: ^bb13
-// MLIR-NEXT:        llvm.br ^bb18
-// MLIR-NEXT:      ^bb15:  // pred: ^bb13
-// MLIR-NEXT:        llvm.br ^bb16
-// MLIR-NEXT:      ^bb16:  // pred: ^bb15
-// MLIR-NEXT:        llvm.br ^bb17
-// ============= Body block in nested loop =============
-// MLIR-NEXT:      ^bb17:  // pred: ^bb16
-// MLIR-NEXT:        llvm.br ^bb18
-// ============= Step block in nested loop =============
-// MLIR-NEXT:      ^bb18:  // 2 preds: ^bb14, ^bb17
-// MLIR-NEXT:        %30 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        %31 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %32 = llvm.add %30, %31  : i32
-// MLIR-NEXT:        llvm.store %32, %12 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb8
-// MLIR-NEXT:      ^bb19:  // pred: ^bb10
-// MLIR-NEXT:        llvm.br ^bb20
-// ============= Exit block in nested loop =============
-// MLIR-NEXT:      ^bb20:  // pred: ^bb19
-// MLIR-NEXT:        llvm.br ^bb21
-// ============= Body block =============
-// MLIR-NEXT:      ^bb21:  // pred: ^bb20
-// MLIR-NEXT:        llvm.br ^bb22
-// ============= Step block =============
-// MLIR-NEXT:      ^bb22:  // pred: ^bb21
-// MLIR-NEXT:        %33 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %34 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %35 = llvm.add %33, %34  : i32
-// MLIR-NEXT:        llvm.store %35, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Exit block =============
-// MLIR-NEXT:      ^bb23:  // pred: ^bb4
-// MLIR-NEXT:        llvm.br ^bb24
-// MLIR-NEXT:      ^bb24:  // pred: ^bb23
-// MLIR-NEXT:        llvm.return
-// MLIR-NEXT:      }
+  // CHECK:  llvm.func @testForNested()
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preNESTED0:]], ^bb[[#preEXIT0:]]
+  // CHECK:  ^bb[[#preNESTED0]]: 
+  // CHECK:    llvm.br ^bb[[#preNESTED1:]]
+  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#preNESTED1]]: 
+  // CHECK:    llvm.br ^bb[[#preNESTED2:]]
+  // CHECK:  ^bb[[#preNESTED2]]: 
+  // CHECK:    llvm.br ^bb[[#NESTED:]]
+  // CHECK:  ^bb[[#NESTED]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND_NESTED:]]
+  // CHECK:  ^bb[[#COND_NESTED]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preCONTINUE0:]], ^bb[[#preEXIT1:]]
+  // CHECK:  ^bb[[#preCONTINUE0]]: 
+  // CHECK:    llvm.br ^bb[[#preCONTINUE1:]]
+  // CHECK:  ^bb[[#preEXIT1]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT_NESTED:]]
+  // CHECK:  ^bb[[#preCONTINUE1]]: 
+  // CHECK:    llvm.br ^bb[[#preCONTINUE2:]]
+  // CHECK:  ^bb[[#preCONTINUE2]]: 
+  // CHECK:    llvm.br ^bb[[#CONTINUE:]]
+  // CHECK:  ^bb[[#CONTINUE]]: 
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preSTEP0:]], ^bb[[#preBODY0:]]
+  // CHECK:  ^bb[[#preSTEP0]]: 
+  // CHECK:    llvm.br ^bb[[#STEP_NESTED:]]
+  // CHECK:  ^bb[[#preBODY0]]: 
+  // CHECK:    llvm.br ^bb[[#preBODY1:]]
+  // CHECK:  ^bb[[#preBODY1]]: 
+  // CHECK:    llvm.br ^bb[[#BODY_NESTED:]]
+  // CHECK:  ^bb[[#BODY_NESTED]]: 
+  // CHECK:    llvm.br ^bb[[#STEP_NESTED:]]
+  // CHECK:  ^bb[[#STEP_NESTED]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND_NESTED:]]
+  // CHECK:  ^bb[[#EXIT_NESTED]]: 
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#BODY]]: 
+  // CHECK:    llvm.br ^bb[[#STEP:]]
+  // CHECK:  ^bb[[#STEP]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#EXIT]]: 
+  //           [...]
+  // CHECK:  }
 
-  cir.func @testWhile() {
+cir.func @testWhile() {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
     %1 = cir.const(#cir.int<0> : !s32i) : !s32i
     cir.store %1, %0 : !s32i, cir.ptr <!s32i>
@@ -302,59 +226,31 @@ module {
     cir.return
   }
 
-// MLIR:          llvm.func @testWhile()
-// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %2 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb1
-// MLIR-NEXT:      ^bb1:  // pred: ^bb0
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Condition block =============
-// MLIR-NEXT:      ^bb2:  // 3 preds: ^bb1, ^bb7, ^bb9
-// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
-// MLIR-NEXT:      ^bb3:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb5
-// MLIR-NEXT:      ^bb4:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb10
-// ============= Body block =============
-// MLIR-NEXT:      ^bb5:  // pred: ^bb3
-// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %12 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %13 = llvm.add %11, %12  : i32
-// MLIR-NEXT:        llvm.store %13, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb6
-// ============= Block with continue =============
-// MLIR-NEXT:      ^bb6:  // pred: ^bb5
-// MLIR-NEXT:        %14 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %15 = llvm.mlir.constant(5 : i32) : i32
-// MLIR-NEXT:        %16 = llvm.icmp "eq" %14, %15 : i32
-// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
-// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
-// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
-// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %21, ^bb7, ^bb8
-// MLIR-NEXT:      ^bb7:  // pred: ^bb6
-// MLIR-NEXT:        llvm.br ^bb2
-// MLIR-NEXT:      ^bb8:  // pred: ^bb6
-// MLIR-NEXT:        llvm.br ^bb9
-// MLIR-NEXT:      ^bb9:  // pred: ^bb8
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Exit block =============
-// MLIR-NEXT:      ^bb10:  // pred: ^bb4
-// MLIR-NEXT:        llvm.br ^bb11
-// MLIR-NEXT:      ^bb11:  // pred: ^bb10
-// MLIR-NEXT:        llvm.return
-// MLIR-NEXT:      }
+  // CHECK:  llvm.func @testWhile()
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preBODY:]], ^bb[[#preEXIT0:]]
+  // CHECK:  ^bb[[#preBODY]]: 
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#BODY]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#CONTINUE:]]
+  // CHECK:  ^bb[[#CONTINUE]]: 
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preCOND0:]], ^bb[[#preCOND1:]]
+  // CHECK:  ^bb[[#preCOND0]]: 
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#preCOND1]]: 
+  // CHECK:    llvm.br ^bb[[#preCOND2:]]
+  // CHECK:  ^bb[[#preCOND2]]: 
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#EXIT]]: 
+  //           [...]
+  // CHECK:  }
 
   cir.func @testDoWhile() {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
@@ -392,58 +288,31 @@ module {
     cir.return
   }
 
-// MLIR:          llvm.func @testDoWhile()
-// MLIR-NEXT:        %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:        %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:        %2 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb1
-// MLIR-NEXT:      ^bb1:  // pred: ^bb0
-// MLIR-NEXT:        llvm.br ^bb5
-// ============= Condition block =============
-// MLIR-NEXT:      ^bb2:  // 2 preds: ^bb7, ^bb9
-// MLIR-NEXT:        %3 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %4 = llvm.mlir.constant(10 : i32) : i32
-// MLIR-NEXT:        %5 = llvm.icmp "slt" %3, %4 : i32
-// MLIR-NEXT:        %6 = llvm.zext %5 : i1 to i32
-// MLIR-NEXT:        %7 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %8 = llvm.icmp "ne" %6, %7 : i32
-// MLIR-NEXT:        %9 = llvm.zext %8 : i1 to i8
-// MLIR-NEXT:        %10 = llvm.trunc %9 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %10, ^bb3, ^bb4
-// MLIR-NEXT:      ^bb3:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb5
-// MLIR-NEXT:      ^bb4:  // pred: ^bb2
-// MLIR-NEXT:        llvm.br ^bb10
-// ============= Body block =============
-// MLIR-NEXT:      ^bb5:  // 2 preds: ^bb1, ^bb3
-// MLIR-NEXT:        %11 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %12 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:        %13 = llvm.add %11, %12  : i32
-// MLIR-NEXT:        llvm.store %13, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        llvm.br ^bb6
-// ============= Block with continue =============
-// MLIR-NEXT:      ^bb6:  // pred: ^bb5
-// MLIR-NEXT:        %14 = llvm.load %1 : !llvm.ptr<i32>
-// MLIR-NEXT:        %15 = llvm.mlir.constant(5 : i32) : i32
-// MLIR-NEXT:        %16 = llvm.icmp "eq" %14, %15 : i32
-// MLIR-NEXT:        %17 = llvm.zext %16 : i1 to i32
-// MLIR-NEXT:        %18 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:        %19 = llvm.icmp "ne" %17, %18 : i32
-// MLIR-NEXT:        %20 = llvm.zext %19 : i1 to i8
-// MLIR-NEXT:        %21 = llvm.trunc %20 : i8 to i1
-// MLIR-NEXT:        llvm.cond_br %21, ^bb7, ^bb8
-// MLIR-NEXT:      ^bb7:  // pred: ^bb6
-// MLIR-NEXT:        llvm.br ^bb2
-// MLIR-NEXT:      ^bb8:  // pred: ^bb6
-// MLIR-NEXT:        llvm.br ^bb9
-// MLIR-NEXT:      ^bb9:  // pred: ^bb8
-// MLIR-NEXT:        llvm.br ^bb2
-// ============= Exit block =============
-// MLIR-NEXT:      ^bb10:  // pred: ^bb4
-// MLIR-NEXT:        llvm.br ^bb11
-// MLIR-NEXT:      ^bb11:  // pred: ^bb10
-// MLIR-NEXT:        llvm.return
-// MLIR-NEXT:      }
+
+  // CHECK:  llvm.func @testDoWhile()
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#COND]]:
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preBODY:]], ^bb[[#preEXIT0:]]
+  // CHECK:  ^bb[[#preBODY]]: 
+  // CHECK:    llvm.br ^bb[[#BODY:]]
+  // CHECK:  ^bb[[#preEXIT0]]: 
+  // CHECK:    llvm.br ^bb[[#EXIT:]]
+  // CHECK:  ^bb[[#BODY]]: 
+  //           [...]
+  // CHECK:    llvm.br ^bb[[#CONTINUE:]]
+  // CHECK:  ^bb[[#CONTINUE]]: 
+  //           [...]
+  // CHECK:    llvm.cond_br %{{.+}}, ^bb[[#preCOND0:]], ^bb[[#preCOND1:]]
+  // CHECK:  ^bb[[#preCOND0]]: 
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#preCOND1]]: 
+  // CHECK:    llvm.br ^bb[[#preCOND2:]]
+  // CHECK:  ^bb[[#preCOND2]]: 
+  // CHECK:    llvm.br ^bb[[#COND:]]
+  // CHECK:  ^bb[[#EXIT]]: 
+  //           [...]
+  // CHECK:  }
 
 }


### PR DESCRIPTION
This PR fixes lowering for `break/continue`  in loops.
The idea is to replace `cir.yield break`  and `cir.yield continue` with the branch operations to the corresponding blocks. Note, that we need to ignore nesting loops and don't touch `break` in switch operations. Also, `yield` from `if` need to be considered only when it's not the loop `yield` and `continue` in switch is ignored since it's processed in the loops lowering. 

Fixes #160 