### PR TITLE
[CIR][Lowering] Lower global multidimensional array initializers.

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -209,6 +209,14 @@ public:
       return true;
     }
 
+    if (const auto arrayVal = attr.dyn_cast<mlir::cir::ConstArrayAttr>()) {
+      for (const auto elt : arrayVal.getElts().cast<mlir::ArrayAttr>()) {
+        if (!isNullValue(elt))
+          return false;
+      }
+      return true;
+    }
+
     llvm_unreachable("NYI");
   }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -717,16 +717,30 @@ convertStringAttrToDenseElementsAttr(mlir::cir::ConstArrayAttr attr,
 }
 
 template <typename AttrTy, typename StorageTy>
+void convertToDenseElementsAttrImpl(mlir::cir::ConstArrayAttr attr,
+                                    llvm::SmallVectorImpl<StorageTy> &values) {
+  auto arrayAttr = attr.getElts().cast<mlir::ArrayAttr>();
+  for (auto eltAttr : arrayAttr) {
+    if (auto valueAttr = eltAttr.dyn_cast<AttrTy>()) {
+      values.push_back(valueAttr.getValue());
+    } else if (auto subArrayAttr =
+                   eltAttr.dyn_cast<mlir::cir::ConstArrayAttr>()) {
+      convertToDenseElementsAttrImpl<AttrTy>(subArrayAttr, values);
+    } else {
+      llvm_unreachable("unknown element in ConstArrayAttr");
+    }
+  }
+}
+
+template <typename AttrTy, typename StorageTy>
 mlir::DenseElementsAttr
-convertToDenseElementsAttr(mlir::cir::ConstArrayAttr attr, mlir::Type type) {
+convertToDenseElementsAttr(mlir::cir::ConstArrayAttr attr,
+                           const llvm::SmallVectorImpl<int64_t> &dims,
+                           mlir::Type type) {
   auto values = llvm::SmallVector<StorageTy, 8>{};
-  auto arrayAttr = attr.getElts().dyn_cast<mlir::ArrayAttr>();
-  assert(arrayAttr && "expected array here");
-  for (auto element : arrayAttr)
-    values.push_back(element.cast<AttrTy>().getValue());
-  return mlir::DenseElementsAttr::get(
-      mlir::RankedTensorType::get({(int64_t)values.size()}, type),
-      llvm::ArrayRef(values));
+  convertToDenseElementsAttrImpl<AttrTy>(attr, values);
+  return mlir::DenseElementsAttr::get(mlir::RankedTensorType::get(dims, type),
+                                      llvm::ArrayRef(values));
 }
 
 std::optional<mlir::Attribute>
@@ -742,7 +756,12 @@ lowerConstArrayAttr(mlir::cir::ConstArrayAttr constArr,
   assert(cirArrayType && "cir::ConstArrayAttr is not a cir::ArrayType");
 
   // Is a ConstArrayAttr with an cir::ArrayType: fetch element type.
-  auto type = cirArrayType.getEltType();
+  mlir::Type type = cirArrayType;
+  auto dims = llvm::SmallVector<int64_t, 2>{};
+  while (auto arrayType = type.dyn_cast<mlir::cir::ArrayType>()) {
+    dims.push_back(arrayType.getSize());
+    type = arrayType.getEltType();
+  }
 
   // Convert array attr to LLVM compatible dense elements attr.
   if (constArr.getElts().isa<mlir::StringAttr>())
@@ -750,10 +769,10 @@ lowerConstArrayAttr(mlir::cir::ConstArrayAttr constArr,
                                                 converter->convertType(type));
   if (type.isa<mlir::cir::IntType>())
     return convertToDenseElementsAttr<mlir::cir::IntAttr, mlir::APInt>(
-        constArr, converter->convertType(type));
+        constArr, dims, converter->convertType(type));
   if (type.isa<mlir::FloatType>())
     return convertToDenseElementsAttr<mlir::FloatAttr, mlir::APFloat>(
-        constArr, converter->convertType(type));
+        constArr, dims, converter->convertType(type));
 
   return std::nullopt;
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -132,9 +132,6 @@ mlir::Value lowerCirAttrAsValue(mlir::cir::ConstArrayAttr constArr,
   auto llvmTy = converter->convertType(constArr.getType());
   mlir::Value result = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
   auto arrayAttr = constArr.getElts().cast<mlir::ArrayAttr>();
-  auto cirArrayType = constArr.getType().cast<mlir::cir::ArrayType>();
-  assert(cirArrayType.getEltType().isa<mlir::cir::StructType>() &&
-         "Types other than ConstArrayAttr are NYI");
 
   // Iteratively lower each constant element of the array.
   for (auto [idx, elt] : llvm::enumerate(arrayAttr)) {
@@ -1145,20 +1142,16 @@ public:
       if (auto attr = constArr.getElts().dyn_cast<mlir::StringAttr>()) {
         init = rewriter.getStringAttr(attr.getValue());
       } else if (auto attr = constArr.getElts().dyn_cast<mlir::ArrayAttr>()) {
-        auto eltTy =
-            constArr.getType().cast<mlir::cir::ArrayType>().getEltType();
-        if (eltTy.isa<mlir::cir::StructType>()) {
+        // Failed to use a compact attribute as an initializer:
+        // initialize elements individually.
+        if (!(init = lowerConstArrayAttr(constArr, getTypeConverter()))) {
+          auto eltTy =
+              constArr.getType().cast<mlir::cir::ArrayType>().getEltType();
           setupRegionInitializedLLVMGlobalOp(op, rewriter);
           rewriter.create<mlir::LLVM::ReturnOp>(
               op->getLoc(), lowerCirAttrAsValue(constArr, op->getLoc(),
                                                 rewriter, typeConverter));
           return mlir::success();
-        }
-        if (!(init = lowerConstArrayAttr(constArr, getTypeConverter()))) {
-          op.emitError()
-              << "unsupported lowering for #cir.const_array with element type "
-              << op.getSymType();
-          return mlir::failure();
         }
       } else {
         op.emitError()

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -26,6 +26,15 @@ int tentativeE[];
 int tentativeE[2] = {1, 2};
 // CHECK: cir.global external @tentativeE = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>
 
+int twoDim[2][2] = {{1, 2}, {3, 4}};
+// CHECK: cir.global external @twoDim = #cir.const_array<[#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>
+
+struct {
+  int x;
+  int y[2][2];
+} nestedTwoDim = {1, {{2, 3}, {4, 5}}};
+// CHECK: cir.global external @nestedTwoDim = #cir.const_struct<{#cir.int<1> : !s32i, #cir.const_array<[#cir.const_array<[#cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>}> : !ty_22struct2Eanon22
+
 // TODO: test tentatives with internal linkage.
 
 // Tentative definition is THE definition. Should be zero-initialized.

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -10,6 +10,8 @@
 !u32i = !cir.int<u, 32>
 !u64i = !cir.int<u, 64>
 !u8i = !cir.int<u, 8>
+!ty_22struct2EA22 = !cir.struct<"struct.A", !s32i, !cir.array<!cir.array<!s32i x 2> x 2>, #cir.recdecl.ast>
+
 module {
   cir.global external @a = #cir.int<3> : !s32i
   cir.global external @c = #cir.int<2> : !u64i
@@ -83,6 +85,10 @@ module {
   cir.global external @ll = #cir.const_array<[#cir.int<999999999> : !s64i, #cir.int<0> : !s64i, #cir.int<0> : !s64i, #cir.int<0> : !s64i]> : !cir.array<!s64i x 4>
   // MLIR: llvm.mlir.global external @ll(dense<[999999999, 0, 0, 0]> : tensor<4xi64>) {addr_space = 0 : i32} : !llvm.array<4 x i64>
   // LLVM: @ll = global [4 x i64] [i64 999999999, i64 0, i64 0, i64 0]
+  cir.global external @twoDim = #cir.const_array<[#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>
+  // LLVM: @twoDim = global [2 x [2 x i32{{\]\] \[\[}}2 x i32] [i32 1, i32 2], [2 x i32] [i32 3, i32 4{{\]\]}}
+  cir.global external @nestedTwoDim = #cir.const_struct<{#cir.int<1> : !s32i, #cir.const_array<[#cir.const_array<[#cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>}> : !ty_22struct2EA22
+  // LLVM: @nestedTwoDim = global %struct.A { i32 1, [2 x [2 x i32{{\]\] \[\[}}2 x i32] [i32 2, i32 3], [2 x i32] [i32 4, i32 5{{\]\]}} }
   cir.func @_Z11get_globalsv() {
     %0 = cir.alloca !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>, ["s", init] {alignment = 8 : i64}
     %1 = cir.alloca !cir.ptr<!u32i>, cir.ptr <!cir.ptr<!u32i>>, ["u", init] {alignment = 8 : i64}

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -86,6 +86,7 @@ module {
   // MLIR: llvm.mlir.global external @ll(dense<[999999999, 0, 0, 0]> : tensor<4xi64>) {addr_space = 0 : i32} : !llvm.array<4 x i64>
   // LLVM: @ll = global [4 x i64] [i64 999999999, i64 0, i64 0, i64 0]
   cir.global external @twoDim = #cir.const_array<[#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>
+  // MLIR: llvm.mlir.global external @twoDim(dense<{{\[\[}}1, 2], [3, 4{{\]\]}}> : tensor<2x2xi32>) {addr_space = 0 : i32} : !llvm.array<2 x array<2 x i32>>
   // LLVM: @twoDim = global [2 x [2 x i32{{\]\] \[\[}}2 x i32] [i32 1, i32 2], [2 x i32] [i32 3, i32 4{{\]\]}}
   cir.global external @nestedTwoDim = #cir.const_struct<{#cir.int<1> : !s32i, #cir.const_array<[#cir.const_array<[#cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>}> : !ty_22struct2EA22
   // LLVM: @nestedTwoDim = global %struct.A { i32 1, [2 x [2 x i32{{\]\] \[\[}}2 x i32] [i32 2, i32 3], [2 x i32] [i32 4, i32 5{{\]\]}} }


### PR DESCRIPTION
This change extends `GlobalOpLowering` to handle multi-dimensional arrays in addition to structs.

It slightly changes the logic of how `ConstArrayAttr` is processed: we now first try to lower it to dense attribute (via `lowerConstArrayAttr`) and then, if it failed, proceed with heavyweight region-based lowering.

I'm not sure this commit is in line with future plans for design of `lowerCirAttrAsValue` and friends so let me know if it should be refactored in some way.
