### PR TITLE
[CIR][CIRGen] Implicitly zero-initialize global arrays elements

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -186,6 +186,9 @@ public:
   // TODO(cir): Once we have CIR float types, replace this by something like a
   // NullableValueInterface to allow for type-independent queries.
   bool isNullValue(mlir::Attribute attr) const {
+    if (attr.isa<mlir::cir::ZeroAttr>())
+      return true;
+
     // TODO(cir): introduce char type in CIR and check for that instead.
     if (const auto intVal = attr.dyn_cast<mlir::cir::IntAttr>())
       return intVal.isNullValue();

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -866,8 +866,7 @@ public:
 
   mlir::Attribute VisitImplicitValueInitExpr(ImplicitValueInitExpr *E,
                                              QualType T) {
-    assert(0 && "not implemented");
-    return {};
+    return CGM.getBuilder().getZeroInitAttr(CGM.getCIRType(T));
   }
 
   mlir::Attribute VisitInitListExpr(InitListExpr *ILE, QualType T) {

--- a/clang/test/CIR/CodeGen/array.c
+++ b/clang/test/CIR/CodeGen/array.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// Should implicitly zero-initialize global array elements.
+struct S {
+  int i;
+} arr[3] = {{1}};
+// CHECK: cir.global external @arr = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_22struct2ES22, #cir.zero : !ty_22struct2ES22, #cir.zero : !ty_22struct2ES22]> : !cir.array<!ty_22struct2ES22 x 3>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #221
* #220
* #219
* #218
* #217
* __->__ #216

Whenever a global array is declared and initialized with fewer elements
than its size, the remaining elements are implicitly initialized with
zero. For aggregates types, such as structs, the initialization is done
through the #cir.zero attribute.