### PR TITLE
[CIR][CIRGen] Update C++ codegen to use #cir.zero on structs

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -281,10 +281,9 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
 
   // TODO(cir): emit a #cir.zero if all elements are null values.
   auto &builder = CGM.getBuilder();
-  return builder.getAnonConstStruct(
-      mlir::ArrayAttr::get(builder.getContext(),
-                           Packed ? PackedElems : UnpackedElems),
-      Packed, DesiredTy);
+  auto arrAttr = mlir::ArrayAttr::get(builder.getContext(),
+                                      Packed ? PackedElems : UnpackedElems);
+  return builder.getConstStructOrZeroAttr(arrAttr, Packed, DesiredTy);
 }
 
 void ConstantAggregateBuilder::condense(CharUnits Offset,
@@ -1461,14 +1460,6 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
     const ArrayType *ArrayTy = CGM.getASTContext().getAsArrayType(DestType);
     unsigned NumElements = Value.getArraySize();
     unsigned NumInitElts = Value.getArrayInitializedElts();
-    auto isNullValue = [&](mlir::Attribute f) {
-      // TODO(cir): introduce char type in CIR and check for that instead.
-      auto intVal = f.dyn_cast_or_null<mlir::cir::IntAttr>();
-      assert(intVal && "not implemented");
-      if (intVal.getValue() == 0)
-        return true;
-      return false;
-    };
 
     // Emit array filler, if there is one.
     mlir::Attribute Filler;
@@ -1481,7 +1472,7 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
 
     // Emit initializer elements.
     SmallVector<mlir::TypedAttr, 16> Elts;
-    if (Filler && isNullValue(Filler))
+    if (Filler && builder.isNullValue(Filler))
       Elts.reserve(NumInitElts + 1);
     else
       Elts.reserve(NumElements);

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -65,3 +65,9 @@ int multidim(int i, int j) {
 // Should globally zero-initialize null arrays.
 int globalNullArr[] = {0, 0};
 // CHECK: cir.global external @globalNullArr = #cir.zero : !cir.array<!s32i x 2>
+
+// Should implicitly zero-initialize global array elements.
+struct S {
+  int i;
+} arr[3] = {{1}};
+// CHECK: cir.global external @arr = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_22struct2ES22, #cir.zero : !ty_22struct2ES22, #cir.zero : !ty_22struct2ES22]> : !cir.array<!ty_22struct2ES22 x 3>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #221
* #220
* #219
* #218
* __->__ #217
* #216

This small improvement allows for a more compact representation of
structs with zero-initialized fields in the C++ codegen.