### PR TITLE
[CIR][Lowering] Implement cir.llvmir.zeroinit operation

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1860,4 +1860,22 @@ def VAArgOp : CIR_Op<"va.arg">,
   let hasVerifier = 0;
 }
 
+//===----------------------------------------------------------------------===//
+// Operations Lowered Directly to LLVM IR
+//
+// These operations are hacks to get around missing features in LLVM's dialect.
+// Use it sparingly and remove it once the features are added.
+//===----------------------------------------------------------------------===//
+
+def ZeroInitConstOp : CIR_Op<"llvmir.zeroinit", [Pure]>,
+                      Results<(outs AnyType:$result)> {
+  let summary = "Zero initializes a constant value of a given type";
+  let description = [{
+    This operation circumvents the lack of a zeroinitializer operation in LLVM
+    Dialect. It can zeroinitialize any LLVM type.
+  }];
+  let assemblyFormat = "attr-dict `:` type($result)";
+  let hasVerifier = 0;
+}
+
 #endif // MLIR_CIR_DIALECT_CIR_OPS

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerAttrToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerAttrToLLVMIR.cpp
@@ -75,6 +75,20 @@ public:
     op->removeAttr(attribute.getName());
     return mlir::success();
   }
+
+  /// Translates the given operation to LLVM IR using the provided IR builder
+  /// and saving the state in `moduleTranslation`.
+  mlir::LogicalResult convertOperation(
+      mlir::Operation *op, llvm::IRBuilderBase &builder,
+      mlir::LLVM::ModuleTranslation &moduleTranslation) const final {
+
+    if (auto cirOp = llvm::dyn_cast<mlir::cir::ZeroInitConstOp>(op))
+      moduleTranslation.mapValue(cirOp.getResult()) =
+          llvm::Constant::getNullValue(
+              moduleTranslation.convertType(cirOp.getType()));
+
+    return mlir::success();
+  }
 };
 
 void registerCIRDialectTranslation(mlir::DialectRegistry &registry) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1773,6 +1773,9 @@ void ConvertCIRToLLVMPass::runOnOperation() {
   target.addIllegalDialect<mlir::BuiltinDialect, mlir::cir::CIRDialect,
                            mlir::func::FuncDialect>();
 
+  // Allow operations that will be lowered directly to LLVM IR.
+  target.addLegalOp<mlir::cir::ZeroInitConstOp>();
+
   getOperation()->removeAttr("cir.sob");
   getOperation()->removeAttr("cir.lang");
 

--- a/clang/test/CIR/Translation/zeroinitializer.cir
+++ b/clang/test/CIR/Translation/zeroinitializer.cir
@@ -9,4 +9,13 @@ module {
   // Should lower #cir.null on pointers to a null initializer.
   llvm.mlir.global external @ptr() {addr_space = 0 : i32, cir.initial_value = #cir.zero : !llvm.ptr<i32>} : !llvm.ptr<i32>
   // CHECK: @ptr = global ptr null
+
+  // Should lower aggregates types with elements initialized with cir.llvmir.zeroinit.
+  llvm.mlir.global external @arr() {addr_space = 0 : i32} : !llvm.array<1 x !llvm.struct<"struct.S", (i8, i32)>> {
+    %0 = llvm.mlir.undef : !llvm.array<1 x !llvm.struct<"struct.S", (i8, i32)>>
+    %1 = cir.llvmir.zeroinit : !llvm.struct<"struct.S", (i8, i32)>
+    %2 = llvm.insertvalue %1, %0[0] : !llvm.array<1 x !llvm.struct<"struct.S", (i8, i32)>> 
+    llvm.return %2 : !llvm.array<1 x !llvm.struct<"struct.S", (i8, i32)>>
+  }
+  // CHECK: @arr = global [1 x %struct.S] zeroinitializer
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #221
* #220
* #219
* __->__ #218
* #217
* #216

Due to the lack of zeroinitializer support in LLVM, some cases are
tricky to lower #cir.zero. An example is when an array is only partially
initialize with #cir.zero attributes. Since we can't just zeroinitialize
the whole array, the current #cir.zero attribute amend does not suffice.
To simplify the lowering, this patch introduces a new operation that is
solely used to generate zeroinitialize LLVM IR constants.