### PR TITLE
[CIR][Lowering] Lower #cir.zero nested in initializer attributes

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -107,6 +107,15 @@ lowerCirAttrAsValue(mlir::FloatAttr fltAttr, mlir::Location loc,
       loc, converter->convertType(fltAttr.getType()), fltAttr.getValue());
 }
 
+/// ZeroAttr visitor.
+inline mlir::Value
+lowerCirAttrAsValue(mlir::cir::ZeroAttr zeroAttr, mlir::Location loc,
+                    mlir::ConversionPatternRewriter &rewriter,
+                    mlir::TypeConverter *converter) {
+  return rewriter.create<mlir::cir::ZeroInitConstOp>(
+      loc, converter->convertType(zeroAttr.getType()));
+}
+
 /// ConstStruct visitor.
 mlir::Value lowerCirAttrAsValue(mlir::cir::ConstStructAttr constStruct,
                                 mlir::Location loc,
@@ -157,10 +166,10 @@ lowerCirAttrAsValue(mlir::Attribute attr, mlir::Location loc,
     return lowerCirAttrAsValue(constStruct, loc, rewriter, converter);
   if (const auto constArr = attr.dyn_cast<mlir::cir::ConstArrayAttr>())
     return lowerCirAttrAsValue(constArr, loc, rewriter, converter);
-  if (const auto zeroAttr = attr.dyn_cast<mlir::cir::BoolAttr>())
+  if (const auto boolAttr = attr.dyn_cast<mlir::cir::BoolAttr>())
     llvm_unreachable("bool attribute is NYI");
   if (const auto zeroAttr = attr.dyn_cast<mlir::cir::ZeroAttr>())
-    llvm_unreachable("zero attribute is NYI");
+    return lowerCirAttrAsValue(zeroAttr, loc, rewriter, converter);
 
   llvm_unreachable("unhandled attribute type");
 }

--- a/clang/test/CIR/Lowering/array.cir
+++ b/clang/test/CIR/Lowering/array.cir
@@ -1,12 +1,14 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-translate %s -cir-to-llvmir -o -  | FileCheck %s -check-prefix=LLVM
 
+!s32i = !cir.int<s, 32>
+!ty_22struct2ES22 = !cir.struct<"struct.S", !s32i, #cir.recdecl.ast>
+
 module {
   cir.func @foo() {
     %0 = cir.alloca !cir.array<i32 x 10>, cir.ptr <!cir.array<i32 x 10>>, ["a"] {alignment = 16 : i64}
     cir.return
   }
-}
 
 //      MLIR: module {
 // MLIR-NEXT: func @foo()
@@ -18,3 +20,16 @@ module {
 
 //      LLVM: %1 = alloca [10 x i32], i64 1, align 16
 // LLVM-NEXT: ret void
+
+  cir.global external @arr = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_22struct2ES22, #cir.zero : !ty_22struct2ES22]> : !cir.array<!ty_22struct2ES22 x 2>
+  // CHECK: llvm.mlir.global external @arr() {addr_space = 0 : i32} : !llvm.array<2 x struct<"struct.S", (i32)>> {
+  // CHECK:   %0 = llvm.mlir.undef : !llvm.array<2 x struct<"struct.S", (i32)>>
+  // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"struct.S", (i32)>
+  // CHECK:   %2 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK:   %3 = llvm.insertvalue %2, %1[0] : !llvm.struct<"struct.S", (i32)> 
+  // CHECK:   %4 = llvm.insertvalue %3, %0[0] : !llvm.array<2 x struct<"struct.S", (i32)>> 
+  // CHECK:   %5 = cir.llvmir.zeroinit : !llvm.struct<"struct.S", (i32)>
+  // CHECK:   %6 = llvm.insertvalue %5, %4[1] : !llvm.array<2 x struct<"struct.S", (i32)>> 
+  // CHECK:   llvm.return %6 : !llvm.array<2 x struct<"struct.S", (i32)>>
+  // CHECK: }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #221
* #220
* __->__ #219
* #218
* #217
* #216

Supports lowering for #cir.zero attributes when it appears in aggregate
attributes such as #const.array and #cir.struct.