### PR TITLE
[CIR][Lowering][NFC] Rename LowerAttrToLLVMIR to LowerToLLVMIR

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LLVM_LINK_COMPONENTS
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_clang_library(clangCIRLoweringDirectToLLVM
-  LowerAttrToLLVMIR.cpp
+  LowerToLLVMIR.cpp
   LowerToLLVM.cpp
 
   DEPENDS

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1687,8 +1687,7 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                CIRVAStartLowering, CIRVAEndLowering, CIRVACopyLowering,
                CIRVAArgLowering, CIRBrOpLowering, CIRTernaryOpLowering,
                CIRStructElementAddrOpLowering, CIRSwitchOpLowering,
-               CIRPtrDiffOpLowering>(
-      converter, patterns.getContext());
+               CIRPtrDiffOpLowering>(converter, patterns.getContext());
 }
 
 namespace {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -1,4 +1,4 @@
-//====- LowerAttrToLLVMIR.cpp - Lowering CIR attributes to LLVMIR ---------===//
+//====- LoweToLLVMIR.cpp - Lowering CIR attributes to LLVMIR ---------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implements lowering of CIR attributes to LLVMIR.
+// This file implements lowering of CIR attributes and operations directly to
+// LLVMIR.
 //
 //===----------------------------------------------------------------------===//
 
@@ -58,7 +59,8 @@ public:
     if (auto extraAttr = attribute.getValue()
                              .dyn_cast<mlir::cir::ExtraFuncAttributesAttr>()) {
       for (auto attr : extraAttr.getElements()) {
-        if (auto inlineAttr = attr.getValue().dyn_cast<mlir::cir::InlineAttr>()) {
+        if (auto inlineAttr =
+                attr.getValue().dyn_cast<mlir::cir::InlineAttr>()) {
           if (inlineAttr.isNoInline())
             llvmFunc->addFnAttr(llvm::Attribute::NoInline);
           else if (inlineAttr.isAlwaysInline())
@@ -93,9 +95,10 @@ public:
 
 void registerCIRDialectTranslation(mlir::DialectRegistry &registry) {
   registry.insert<mlir::cir::CIRDialect>();
-  registry.addExtension(+[](mlir::MLIRContext *ctx, mlir::cir::CIRDialect *dialect) {
-    dialect->addInterfaces<CIRDialectLLVMIRTranslationInterface>();
-  });
+  registry.addExtension(
+      +[](mlir::MLIRContext *ctx, mlir::cir::CIRDialect *dialect) {
+        dialect->addInterfaces<CIRDialectLLVMIRTranslationInterface>();
+      });
 }
 
 void registerCIRDialectTranslation(mlir::MLIRContext &context) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #221
* __->__ #220
* #219
* #218
* #217
* #216

The rationale is that we are lowering more than just attributes now,
also to maintain the naming standard of the other lowering files
(e.g. LowerToLLVM).