### PR TITLE
[CIR][Lowering] Deprecate attributes for LLVM zero-initialization

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1214,14 +1214,11 @@ public:
       return mlir::success();
     } else if (isa<mlir::cir::ZeroAttr, mlir::cir::NullAttr>(init.value())) {
       // TODO(cir): once LLVM's dialect has a proper zeroinitializer attribute
-      // this should be updated. For now, we tag the LLVM global with a cir.zero
-      // attribute that is later replaced with a zeroinitializer. Null pointers
-      // also use this path for simplicity, as we would otherwise require a
-      // region-based initialization for the global op.
-      auto llvmGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
-          op, llvmType, isConst, linkage, symbol, nullptr);
-      auto cirZeroAttr = mlir::cir::ZeroAttr::get(getContext(), llvmType);
-      llvmGlobalOp->setAttr("cir.initial_value", cirZeroAttr);
+      // this should be updated. For now, we use a custom op to initialize
+      // globals to zero.
+      setupRegionInitializedLLVMGlobalOp(op, rewriter);
+      auto init = lowerCirAttrAsValue(attr, loc, rewriter, typeConverter);
+      rewriter.create<mlir::LLVM::ReturnOp>(loc, init);
       return mlir::success();
     } else if (const auto structAttr =
                    init.value().dyn_cast<mlir::cir::ConstStructAttr>()) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -40,17 +40,6 @@ public:
   amendOperation(mlir::Operation *op, mlir::NamedAttribute attribute,
                  mlir::LLVM::ModuleTranslation &moduleTranslation) const final {
 
-    // Translate CIR's zero attribute to LLVM's zero initializer.
-    if (isa<mlir::cir::ZeroAttr>(attribute.getValue())) {
-      if (llvm::isa<mlir::LLVM::GlobalOp>(op)) {
-        auto *globalVal = llvm::cast<llvm::GlobalVariable>(
-            moduleTranslation.lookupGlobal(op));
-        globalVal->setInitializer(
-            llvm::Constant::getNullValue(globalVal->getValueType()));
-      } else
-        return op->emitError("#cir.zero not supported");
-    }
-
     // Translate CIR's extra function attributes to LLVM's function attributes.
     auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op);
     if (!func)

--- a/clang/test/CIR/Translation/zeroinitializer.cir
+++ b/clang/test/CIR/Translation/zeroinitializer.cir
@@ -2,12 +2,18 @@
 // RUN: FileCheck --input-file=%t.ll %s
 
 module {
-  // Should lower #cir.zero on structs to a zeroinitializer.
-  llvm.mlir.global external @bar() {addr_space = 0 : i32, cir.initial_value = #cir.zero : !llvm.struct<"struct.S", (i8, i32)>} : !llvm.struct<"struct.S", (i8, i32)>
+  // Should zero-initialize global structs initialized with cir.llvmir.zeroinit.
+  llvm.mlir.global external @bar() {addr_space = 0 : i32} : !llvm.struct<"struct.S", (i8, i32)> {
+    %0 = cir.llvmir.zeroinit : !llvm.struct<"struct.S", (i8, i32)>
+    llvm.return %0 : !llvm.struct<"struct.S", (i8, i32)>
+  }
   // CHECK: @bar = global %struct.S zeroinitializer
 
-  // Should lower #cir.null on pointers to a null initializer.
-  llvm.mlir.global external @ptr() {addr_space = 0 : i32, cir.initial_value = #cir.zero : !llvm.ptr<i32>} : !llvm.ptr<i32>
+  // Should null-initialize global pointer initialized with cir.llvmir.zeroinit.
+  llvm.mlir.global external @ptr() {addr_space = 0 : i32} : !llvm.ptr<i32> {
+    %0 = cir.llvmir.zeroinit : !llvm.ptr<i32>
+    llvm.return %0 : !llvm.ptr<i32>
+  }
   // CHECK: @ptr = global ptr null
 
   // Should lower aggregates types with elements initialized with cir.llvmir.zeroinit.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #221
* #220
* #219
* #218
* #217
* #216

This replaces the usage of attributes for zero-initializing global
variables, with a more robust zero-initialization op-based method
(cir.llvmir.zeroinit).

The downside of this approach is that is not as compact or efficient as
the attribute-based method, however:

 - Both are temporary solutions, but it's easier to track and patch
   the usage of a single op than an attribute in any op.
 - Attribute-based method is more difficult to lower, requiring more
   maintenance.
 - Op-based method may require a region, but it will populate the region
   with at most a couple of operations.