### PR TITLE
[CIR][Bugfix] Fix vtableAttr const struct usage

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -347,18 +347,18 @@ def VTableAttr : CIR_Attr<"VTable", "vtable", [TypedAttrInterface]> {
   // `vtable_data` is const struct with one element, containing an array of
   // vtable information.
   let parameters = (ins AttributeSelfTypeParameter<"">:$type,
-                        "ConstStructAttr":$vtable_data);
+                        "ArrayAttr":$vtable_data);
 
   let builders = [
     AttrBuilderWithInferredContext<(ins "Type":$type,
-                                        "ConstStructAttr":$vtable_data), [{
+                                        "ArrayAttr":$vtable_data), [{
       return $_get(type.getContext(), type, vtable_data);
     }]>
   ];
 
   let genVerifyDecl = 1;
   let assemblyFormat = [{
-    `<` $vtable_data `>`
+    `<` custom<StructMembers>($vtable_data) `>`
   }];
 }
 

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
@@ -406,9 +406,9 @@ public:
     assert(initCSA &&
            "expected #cir.const_struct attribute to represent vtable data");
     return this->Builder.setGlobalInitializer(
-        global, forVTable
-                    ? mlir::cir::VTableAttr::get(initCSA.getType(), initCSA)
-                    : init);
+        global, forVTable ? mlir::cir::VTableAttr::get(initCSA.getType(),
+                                                       initCSA.getMembers())
+                          : init);
   }
 
   /// Given that this builder was created by beginning an array or struct

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2074,28 +2074,25 @@ LogicalResult TypeInfoAttr::verify(
 
 LogicalResult
 VTableAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
-                   ::mlir::Type type, ConstStructAttr vtableData) {
+                   ::mlir::Type type, ::mlir::ArrayAttr vtableData) {
   auto sTy = type.dyn_cast_or_null<mlir::cir::StructType>();
   if (!sTy) {
     emitError() << "expected !cir.struct type result";
     return failure();
   }
-  if (sTy.getMembers().size() != 1 || vtableData.getMembers().size() != 1) {
+  if (sTy.getMembers().size() != 1 || vtableData.size() != 1) {
     emitError() << "expected struct type with only one subtype";
     return failure();
   }
 
   auto arrayTy = sTy.getMembers()[0].dyn_cast<mlir::cir::ArrayType>();
-  auto constArrayAttr =
-      vtableData.getMembers()[0].dyn_cast<mlir::cir::ConstArrayAttr>();
+  auto constArrayAttr = vtableData[0].dyn_cast<mlir::cir::ConstArrayAttr>();
   if (!arrayTy || !constArrayAttr) {
     emitError() << "expected struct type with one array element";
     return failure();
   }
 
-  if (mlir::cir::ConstStructAttr::verify(emitError, type,
-                                         vtableData.getMembers())
-          .failed())
+  if (mlir::cir::ConstStructAttr::verify(emitError, type, vtableData).failed())
     return failure();
 
   LogicalResult eltTypeCheck = success();

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -73,7 +73,7 @@ public:
 // CHECK:  }
 
 // vtable for B
-// CHECK:   cir.global linkonce_odr @_ZTV1B = #cir.vtable<<{#cir.const_array<[#cir.null : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1B> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1BD2Ev> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1BD0Ev> : !cir.ptr<!u8i>, #cir.global_view<@_ZNK1A5quackEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 5>}>> : ![[VTableTypeA]]
+// CHECK:   cir.global linkonce_odr @_ZTV1B = #cir.vtable<{#cir.const_array<[#cir.null : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1B> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1BD2Ev> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1BD0Ev> : !cir.ptr<!u8i>, #cir.global_view<@_ZNK1A5quackEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 5>}> : ![[VTableTypeA]]
 
 // vtable for __cxxabiv1::__si_class_type_info
 // CHECK:   cir.global "private" external @_ZTVN10__cxxabiv120__si_class_type_infoE : !cir.ptr<!cir.ptr<!u8i>>

--- a/clang/test/CIR/IR/vtableAttr.cir
+++ b/clang/test/CIR/IR/vtableAttr.cir
@@ -1,0 +1,9 @@
+// RUN: cir-opt %s | FileCheck %s
+
+!u8i = !cir.int<u, 8>
+!ty_2222 = !cir.struct<"", !cir.array<!cir.ptr<!u8i> x 1>>
+module {
+    // Should parse VTable attribute.
+    cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.null : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222
+    // CHECK: cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.null : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222
+}


### PR DESCRIPTION
PR #200 broke the vtableAttr usage, as it was not properly refactored to use ArrayAttr instead of ConstStructAttr to store its members.