### PR TITLE
[CIR][CIRGen] Support for struct call arguments

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -654,12 +654,15 @@ void CIRGenFunction::buildCallArg(CallArgList &args, const Expr *E,
   // we make it to the call.
   if (type->isRecordType() &&
       type->castAs<RecordType>()->getDecl()->isParamDestroyedInCallee()) {
-    llvm_unreachable("NYI");
+    llvm_unreachable("Microsoft C++ ABI is NYI");
   }
 
   if (HasAggregateEvalKind && isa<ImplicitCastExpr>(E) &&
       cast<CastExpr>(E)->getCastKind() == CK_LValueToRValue) {
-    assert(0 && "NYI");
+    LValue L = buildLValue(cast<CastExpr>(E)->getSubExpr());
+    assert(L.isSimple());
+    args.addUncopiedAggregate(L, type);
+    return;
   }
 
   args.add(buildAnyExprToTemp(E), type);

--- a/clang/lib/CIR/CodeGen/CIRGenCall.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.h
@@ -210,6 +210,8 @@ public:
       : RV(rv), HasLV(false), IsUsed(false), Ty(ty) {
     (void)IsUsed;
   }
+  CallArg(LValue lv, clang::QualType ty)
+      : LV(lv), HasLV(true), IsUsed(false), Ty(ty) {}
 
   /// \returns an independent RValue. If the CallArg contains an LValue,
   /// a temporary copy is returned.
@@ -240,6 +242,10 @@ public:
 
   void add(RValue rvalue, clang::QualType type) {
     push_back(CallArg(rvalue, type));
+  }
+
+  void addUncopiedAggregate(LValue LV, clang::QualType type) {
+    push_back(CallArg(LV, type));
   }
 
   /// Add all the arguments from another CallArgList to this one. After doing

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -61,3 +61,10 @@ struct S3 {
   int a;
 } s3[3] = {{1}, {2}, {3}};
 // CHECK-DAG: cir.global external @s3 = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_22struct2ES322, #cir.const_struct<{#cir.int<2> : !s32i}> : !ty_22struct2ES322, #cir.const_struct<{#cir.int<3> : !s32i}> : !ty_22struct2ES322]> : !cir.array<!ty_22struct2ES322 x 3>
+
+void shouldCopyStructAsCallArg(struct S1 s) {
+// CHECK-DAG: cir.func @shouldCopyStructAsCallArg
+  shouldCopyStructAsCallArg(s);
+  // CHECK-DAG: %[[#LV:]] = cir.load %{{.+}} : cir.ptr <!ty_22struct2ES122>, !ty_22struct2ES122
+  // CHECK-DAG: cir.call @shouldCopyStructAsCallArg(%[[#LV]]) : (!ty_22struct2ES122) -> ()
+}


### PR DESCRIPTION
Essentially emits an LValue for the struct and then passes it as a call argument.