### PR TITLE
[CIR][CIRGen][NFC] Refactor struct type building

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -26,9 +26,11 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/ErrorHandling.h"
+#include <optional>
 #include <string>
 
 namespace cir {
@@ -154,11 +156,10 @@ public:
       assert(ta && "expected typed attribute member");
       members.push_back(ta.getType());
     }
-    auto *ctx = arrayAttr.getContext();
+
     if (!ty)
-      ty = mlir::cir::StructType::get(ctx, members, mlir::StringAttr::get(ctx),
-                                      /*body=*/true, packed,
-                                      /*ast=*/std::nullopt);
+      ty = getAnonStructTy(members, /*body=*/true, packed);
+
     auto sTy = ty.dyn_cast<mlir::cir::StructType>();
     assert(sTy && "expected struct type");
     return mlir::cir::ConstStructAttr::get(sTy, arrayAttr);
@@ -340,6 +341,25 @@ public:
     if (AddrSpace)
       llvm_unreachable("address space is NYI");
     return typeCache.VoidPtrTy;
+  }
+
+  /// Get a CIR anonymous struct type.
+  mlir::cir::StructType
+  getAnonStructTy(llvm::ArrayRef<mlir::Type> members, bool body,
+                  bool packed = false, const clang::RecordDecl *ast = nullptr) {
+    return getStructTy(members, "", body, packed, ast);
+  }
+
+  /// Get a CIR named struct type.
+  mlir::cir::StructType getStructTy(llvm::ArrayRef<mlir::Type> members,
+                                    llvm::StringRef name, bool body,
+                                    bool packed, const clang::RecordDecl *ast) {
+    const auto nameAttr = getStringAttr(name);
+    std::optional<mlir::cir::ASTRecordDeclAttr> astAttr = std::nullopt;
+    if (ast)
+      astAttr = getAttr<mlir::cir::ASTRecordDeclAttr>(ast);
+    return mlir::cir::StructType::get(getContext(), members, nameAttr, body,
+                                      packed, astAttr);
   }
 
   //

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -169,10 +169,8 @@ mlir::Type CIRGenTypes::convertRecordDeclType(const clang::RecordDecl *RD) {
   // Handle forward decl / incomplete types.
   if (!entry) {
     auto name = getRecordTypeName(RD, "");
-    auto identifier = mlir::StringAttr::get(&getMLIRContext(), name);
-    entry = mlir::cir::StructType::get(
-        &getMLIRContext(), {}, identifier, /*body=*/false, /**packed=*/false,
-        mlir::cir::ASTRecordDeclAttr::get(&getMLIRContext(), RD));
+    entry = Builder.getStructTy({}, name, /*body=*/false,
+                                /*packed=*/false, RD);
     recordDeclTypes[key] = entry;
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -58,7 +58,7 @@ mlir::Type CIRGenVTables::getVTableType(const VTableLayout &layout) {
 
   // FIXME(cir): should VTableLayout be encoded like we do for some
   // AST nodes?
-  return mlir::cir::StructType::get(ctx, tys, "", /*body=*/true);
+  return CGM.getBuilder().getAnonStructTy(tys, /*body=*/true);
 }
 
 /// At this point in the translation unit, does it appear that can we


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #230
* #229
* #228
* #227
* #226
* __->__ #225

Updates every struct type creation to use the CIRGenBuilder API.