### PR TITLE
[CIR] Refactor StructType printing/parsing

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -113,18 +113,6 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
     "std::optional<::mlir::cir::ASTRecordDeclAttr>":$ast
   );
 
-  let builders = [
-    TypeBuilder<(ins
-      "ArrayRef<mlir::Type>":$members, "StringRef":$typeName,
-      "bool":$body
-    ), [{
-      auto id = mlir::StringAttr::get(context, typeName);
-      auto sTy = StructType::get(context, members, id, body,
-                                 /*packed=*/false, std::nullopt);
-      return sTy;
-    }]>
-  ];
-
   let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -14,6 +14,7 @@
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include <optional>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -1150,7 +1151,7 @@ LogicalResult LoopOp::verify() {
 
 static void printGlobalOpTypeAndInitialValue(OpAsmPrinter &p, GlobalOp op,
                                              TypeAttr type, Attribute initAttr,
-                                             mlir::Region& ctorRegion) {
+                                             mlir::Region &ctorRegion) {
   auto printType = [&]() { p << ": " << type; };
   if (!op.isDeclaration()) {
     p << "= ";
@@ -1177,15 +1178,14 @@ static void printGlobalOpTypeAndInitialValue(OpAsmPrinter &p, GlobalOp op,
 static ParseResult parseGlobalOpTypeAndInitialValue(OpAsmParser &parser,
                                                     TypeAttr &typeAttr,
                                                     Attribute &initialValueAttr,
-                                                    mlir::Region& ctorRegion) {
+                                                    mlir::Region &ctorRegion) {
   mlir::Type opTy;
   if (parser.parseOptionalEqual().failed()) {
     // Absence of equal means a declaration, so we need to parse the type.
     //  cir.global @a : i32
     if (parser.parseColonType(opTy))
       return failure();
-  }
-  else {
+  } else {
     // Parse contructor, example:
     //  cir.global @rgb = ctor : type { ... }
     if (!parser.parseOptionalKeyword("ctor")) {
@@ -1274,10 +1274,10 @@ LogicalResult GlobalOp::verify() {
   return success();
 }
 
-void GlobalOp::build(
-    OpBuilder &odsBuilder, OperationState &odsState, StringRef sym_name,
-    Type sym_type, bool isConstant, cir::GlobalLinkageKind linkage,
-    function_ref<void(OpBuilder &, Location)> ctorBuilder) {
+void GlobalOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                     StringRef sym_name, Type sym_type, bool isConstant,
+                     cir::GlobalLinkageKind linkage,
+                     function_ref<void(OpBuilder &, Location)> ctorBuilder) {
   odsState.addAttribute(getSymNameAttrName(odsState.name),
                         odsBuilder.getStringAttr(sym_name));
   odsState.addAttribute(getSymTypeAttrName(odsState.name),
@@ -2065,9 +2065,10 @@ void SignedOverflowBehaviorAttr::print(::mlir::AsmPrinter &printer) const {
 
 ::mlir::Attribute ASTFunctionDeclAttr::parse(::mlir::AsmParser &parser,
                                              ::mlir::Type type) {
-  // We cannot really parse anything AST related at this point
-  // since we have no serialization/JSON story.
-  return ASTFunctionDeclAttr::get(parser.getContext(), nullptr);
+  // We cannot really parse anything AST related at this point since we have no
+  // serialization/JSON story. Even if the attr is parsed, it just holds nullptr
+  // instead of the AST node.
+  return get(parser.getContext(), nullptr);
 }
 
 void ASTFunctionDeclAttr::print(::mlir::AsmPrinter &printer) const {
@@ -2082,9 +2083,10 @@ LogicalResult ASTFunctionDeclAttr::verify(
 
 ::mlir::Attribute ASTVarDeclAttr::parse(::mlir::AsmParser &parser,
                                         ::mlir::Type type) {
-  // We cannot really parse anything AST related at this point
-  // since we have no serialization/JSON story.
-  return ASTVarDeclAttr::get(parser.getContext(), nullptr);
+  // We cannot really parse anything AST related at this point since we have no
+  // serialization/JSON story. Even if the attr is parsed, it just holds nullptr
+  // instead of the AST node.
+  return get(parser.getContext(), nullptr);
 }
 
 void ASTVarDeclAttr::print(::mlir::AsmPrinter &printer) const {
@@ -2099,9 +2101,10 @@ LogicalResult ASTVarDeclAttr::verify(
 
 ::mlir::Attribute ASTRecordDeclAttr::parse(::mlir::AsmParser &parser,
                                            ::mlir::Type type) {
-  // We cannot really parse anything AST related at this point
-  // since we have no serialization/JSON story.
-  return ASTRecordDeclAttr::get(parser.getContext(), nullptr);
+  // We cannot really parse anything AST related at this point since we have no
+  // serialization/JSON story. Even if the attr is parsed, it just holds nullptr
+  // instead of the AST node.
+  return get(parser.getContext(), nullptr);
 }
 
 void ASTRecordDeclAttr::print(::mlir::AsmPrinter &printer) const {

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir-enable -Wno-unused-value -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-// CHECK: !ty_22struct2EZero22 = !cir.struct<"struct.Zero", !u8i>
-// CHECK: !ty_22struct2Eyep_22 = !cir.struct<"struct.yep_", !u32i, !u32i>
+// CHECK: !ty_22struct2EZero22 = !cir.struct<"struct.Zero" {!u8i}>
+// CHECK: !ty_22struct2Eyep_22 = !cir.struct<"struct.yep_" {!u32i, !u32i}>
 
 struct Zero {
   void yolo();

--- a/clang/test/CIR/CodeGen/atomic.cpp
+++ b/clang/test/CIR/CodeGen/atomic.cpp
@@ -7,4 +7,4 @@ typedef struct _a {
 
 void m() { at y; }
 
-// CHECK: !ty_22struct2E_a22 = !cir.struct<"struct._a", !s32i>
+// CHECK: !ty_22struct2E_a22 = !cir.struct<"struct._a" {!s32i}>

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -14,5 +14,5 @@ void m() {
   __long l;
 }
 
-// CHECK: !ty_22struct2Eanon22 = !cir.struct<"struct.anon", !u32i, #cir.recdecl.ast>
-// CHECK: !ty_22struct2E__long22 = !cir.struct<"struct.__long", !ty_22struct2Eanon22, !u32i, !cir.ptr<!u32i>>
+// CHECK: !ty_22struct2Eanon22 = !cir.struct<"struct.anon" {!u32i} #cir.recdecl.ast>
+// CHECK: !ty_22struct2E__long22 = !cir.struct<"struct.__long" {!ty_22struct2Eanon22, !u32i, !cir.ptr<!u32i>}>

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -126,13 +126,13 @@ co_invoke_fn co_invoke;
 
 }} // namespace folly::coro
 
-// CHECK: ![[VoidTask:ty_.*]] = !cir.struct<"struct.folly::coro::Task", !u8i>
-// CHECK: ![[IntTask:ty_.*]] = !cir.struct<"struct.folly::coro::Task", !u8i>
-// CHECK: ![[VoidPromisse:ty_.*]] = !cir.struct<"struct.folly::coro::Task<void>::promise_type", !u8i>
-// CHECK: ![[CoroHandleVoid:ty_.*]] = !cir.struct<"struct.std::coroutine_handle", !u8i>
-// CHECK: ![[CoroHandlePromise:ty_.*]] = !cir.struct<"struct.std::coroutine_handle", !u8i>
-// CHECK: ![[StdString:ty_.*]] = !cir.struct<"struct.std::string", !u8i
-// CHECK: ![[SuspendAlways:ty_.*]] = !cir.struct<"struct.std::suspend_always", !u8i>
+// CHECK: ![[VoidTask:ty_.*]] = !cir.struct<"struct.folly::coro::Task" {!u8i}>
+// CHECK: ![[IntTask:ty_.*]] = !cir.struct<"struct.folly::coro::Task" {!u8i}>
+// CHECK: ![[VoidPromisse:ty_.*]] = !cir.struct<"struct.folly::coro::Task<void>::promise_type" {!u8i}>
+// CHECK: ![[CoroHandleVoid:ty_.*]] = !cir.struct<"struct.std::coroutine_handle" {!u8i}>
+// CHECK: ![[CoroHandlePromise:ty_.*]] = !cir.struct<"struct.std::coroutine_handle" {!u8i}>
+// CHECK: ![[StdString:ty_.*]] = !cir.struct<"struct.std::string" {!u8i}
+// CHECK: ![[SuspendAlways:ty_.*]] = !cir.struct<"struct.std::suspend_always" {!u8i}>
 
 // CHECK: module {{.*}} {
 // CHECK-NEXT: cir.global external @_ZN5folly4coro9co_invokeE = #cir.zero : !ty_22struct2Efolly3A3Acoro3A3Aco_invoke_fn22

--- a/clang/test/CIR/CodeGen/ctor.cpp
+++ b/clang/test/CIR/CodeGen/ctor.cpp
@@ -11,7 +11,7 @@ void baz() {
   Struk s;
 }
 
-// CHECK: !ty_22struct2EStruk22 = !cir.struct<"struct.Struk", !s32i>
+// CHECK: !ty_22struct2EStruk22 = !cir.struct<"struct.Struk" {!s32i}>
 
 // CHECK:   cir.func linkonce_odr @_ZN5StrukC2Ev(%arg0: !cir.ptr<!ty_22struct2EStruk22>
 // CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!ty_22struct2EStruk22>, cir.ptr <!cir.ptr<!ty_22struct2EStruk22>>, ["this", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -75,8 +75,8 @@ void C3::Layer::Initialize() {
   }
 }
 
-// CHECK: !ty_22class2EC23A3ALayer22 = !cir.struct<"class.C2::Layer", !ty_22class2EC13A3ALayer22, !cir.ptr<!ty_22class2EC222>
-// CHECK: !ty_22struct2EC33A3ALayer22 = !cir.struct<"struct.C3::Layer", !ty_22class2EC23A3ALayer22
+// CHECK: !ty_22class2EC23A3ALayer22 = !cir.struct<"class.C2::Layer" {!ty_22class2EC13A3ALayer22, !cir.ptr<!ty_22class2EC222>
+// CHECK: !ty_22struct2EC33A3ALayer22 = !cir.struct<"struct.C3::Layer" {!ty_22class2EC23A3ALayer22
 
 // CHECK: cir.func @_ZN2C35Layer10InitializeEv
 

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -37,10 +37,10 @@ public:
 };
 
 // Class A
-// CHECK: ![[ClassA:ty_.*]] = !cir.struct<"class.A", !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, #cir.recdecl.ast>
+// CHECK: ![[ClassA:ty_.*]] = !cir.struct<"class.A" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.recdecl.ast>
 
 // Class B
-// CHECK: ![[ClassB:ty_.*]] = !cir.struct<"class.B", ![[ClassA]]>
+// CHECK: ![[ClassB:ty_.*]] = !cir.struct<"class.B" {![[ClassA]]}>
 
 // CHECK: cir.func @_Z4bluev()
 // CHECK:   %0 = cir.alloca !ty_22class2EPSEvent22, cir.ptr <!ty_22class2EPSEvent22>, ["p", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -6,7 +6,7 @@ void fn() {
   a();
 }
 
-//      CHECK: !ty_22class2Eanon22 = !cir.struct<"class.anon", !u8i>
+//      CHECK: !ty_22class2Eanon22 = !cir.struct<"class.anon" {!u8i}>
 //  CHECK-DAG: module
 
 //      CHECK: cir.func lambda internal private @_ZZ2fnvENK3$_0clEv

--- a/clang/test/CIR/CodeGen/move.cpp
+++ b/clang/test/CIR/CodeGen/move.cpp
@@ -16,7 +16,7 @@ struct string {
 
 } // std namespace
 
-// CHECK: ![[StdString:ty_.*]] = !cir.struct<"struct.std::string", !u8i>
+// CHECK: ![[StdString:ty_.*]] = !cir.struct<"struct.std::string" {!u8i}>
 
 std::string getstr();
 void emplace(std::string &&s);

--- a/clang/test/CIR/CodeGen/nrvo.cpp
+++ b/clang/test/CIR/CodeGen/nrvo.cpp
@@ -9,7 +9,7 @@ std::vector<const char*> test_nrvo() {
   return result;
 }
 
-// CHECK: !ty_22class2Estd3A3Avector22 = !cir.struct<"class.std::vector", !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>>
+// CHECK: !ty_22class2Estd3A3Avector22 = !cir.struct<"class.std::vector" {!cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>}>
 
 // CHECK: cir.func @_Z9test_nrvov() -> !ty_22class2Estd3A3Avector22
 // CHECK:   %0 = cir.alloca !ty_22class2Estd3A3Avector22, cir.ptr <!ty_22class2Estd3A3Avector22>, ["__retval", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -21,9 +21,9 @@ void init(unsigned numImages) {
   }
 }
 
-// CHECK: !ty_22struct2Etriple22 = !cir.struct<"struct.triple", !u32i, !cir.ptr<!void>, !u32i>
-// CHECK: !ty_22class2Estd3A3Avector22 = !cir.struct<"class.std::vector", !cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>>
-// CHECK: !ty_22struct2E__vector_iterator22 = !cir.struct<"struct.__vector_iterator", !cir.ptr<!ty_22struct2Etriple22>>
+// CHECK: !ty_22struct2Etriple22 = !cir.struct<"struct.triple" {!u32i, !cir.ptr<!void>, !u32i}>
+// CHECK: !ty_22class2Estd3A3Avector22 = !cir.struct<"class.std::vector" {!cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>}>
+// CHECK: !ty_22struct2E__vector_iterator22 = !cir.struct<"struct.__vector_iterator" {!cir.ptr<!ty_22struct2Etriple22>}>
 
 // CHECK: cir.func @_Z4initj(%arg0: !u32i
 // CHECK:   %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["numImages", init] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -17,8 +17,8 @@ void baz(void) {
   struct Foo f;
 }
 
-// CHECK-DAG: !ty_22struct2EBar22 = !cir.struct<"struct.Bar", !s32i, !s8i>
-// CHECK-DAG: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo", !s32i, !s8i, !ty_22struct2EBar22>
+// CHECK-DAG: !ty_22struct2EBar22 = !cir.struct<"struct.Bar" {!s32i, !s8i}>
+// CHECK-DAG: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo" {!s32i, !s8i, !ty_22struct2EBar22}>
 //  CHECK-DAG: module {{.*}} {
      // CHECK:   cir.func @baz()
 // CHECK-NEXT:     %0 = cir.alloca !ty_22struct2EBar22, cir.ptr <!ty_22struct2EBar22>, ["b"] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -26,13 +26,13 @@ void baz() {
 struct incomplete;
 void yoyo(incomplete *i) {}
 
-//      CHECK: !ty_22struct2Eincomplete22 = !cir.struct<"struct.incomplete", incomplete
-//      CHECK: !ty_22struct2EBar22 = !cir.struct<"struct.Bar", !s32i, !s8i>
+//      CHECK: !ty_22struct2Eincomplete22 = !cir.struct<"struct.incomplete" incomplete
+//      CHECK: !ty_22struct2EBar22 = !cir.struct<"struct.Bar" {!s32i, !s8i}>
 
-//      CHECK: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo", !s32i, !s8i, !ty_22struct2EBar22>
-//      CHECK: !ty_22struct2EMandalore22 = !cir.struct<"struct.Mandalore", !u32i, !cir.ptr<!void>, !s32i, #cir.recdecl.ast>
-//      CHECK: !ty_22class2EAdv22 = !cir.struct<"class.Adv", !ty_22struct2EMandalore22>
-//      CHECK: !ty_22struct2EEntry22 = !cir.struct<"struct.Entry", !cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>>
+//      CHECK: !ty_22struct2EFoo22 = !cir.struct<"struct.Foo" {!s32i, !s8i, !ty_22struct2EBar22}>
+//      CHECK: !ty_22struct2EMandalore22 = !cir.struct<"struct.Mandalore" {!u32i, !cir.ptr<!void>, !s32i} #cir.recdecl.ast>
+//      CHECK: !ty_22class2EAdv22 = !cir.struct<"class.Adv" {!ty_22struct2EMandalore22}>
+//      CHECK: !ty_22struct2EEntry22 = !cir.struct<"struct.Entry" {!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>}>
 
 //      CHECK: cir.func linkonce_odr @_ZN3Bar6methodEv(%arg0: !cir.ptr<!ty_22struct2EBar22>
 // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22struct2EBar22>, cir.ptr <!cir.ptr<!ty_22struct2EBar22>>, ["this", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/union.cpp
+++ b/clang/test/CIR/CodeGen/union.cpp
@@ -12,12 +12,12 @@ void m() {
   yolm3 q3;
 }
 
-// CHECK: !ty_22struct2Eanon22 = !cir.struct<"struct.anon", !cir.bool, !s32i, #cir.recdecl.ast>
-// CHECK: !ty_22struct2Eyolo22 = !cir.struct<"struct.yolo", !s32i, #cir.recdecl.ast>
-// CHECK: !ty_22struct2Eanon221 = !cir.struct<"struct.anon", !cir.ptr<!s32i>, !s32i, #cir.recdecl.ast>
+// CHECK: !ty_22struct2Eanon22 = !cir.struct<"struct.anon" {!cir.bool, !s32i} #cir.recdecl.ast>
+// CHECK: !ty_22struct2Eyolo22 = !cir.struct<"struct.yolo" {!s32i} #cir.recdecl.ast>
+// CHECK: !ty_22struct2Eanon221 = !cir.struct<"struct.anon" {!cir.ptr<!s32i>, !s32i} #cir.recdecl.ast>
 
-// CHECK: !ty_22union2Eyolm22 = !cir.struct<"union.yolm", !ty_22struct2Eyolo22>
-// CHECK: !ty_22union2Eyolm222 = !cir.struct<"union.yolm2", !ty_22struct2Eanon221>
+// CHECK: !ty_22union2Eyolm22 = !cir.struct<"union.yolm" {!ty_22struct2Eyolo22}>
+// CHECK: !ty_22union2Eyolm222 = !cir.struct<"union.yolm2" {!ty_22struct2Eanon221}>
 
 // CHECK:   cir.func @_Z1mv()
 // CHECK:   cir.alloca !ty_22union2Eyolm22, cir.ptr <!ty_22union2Eyolm22>, ["q"] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -18,16 +18,16 @@ public:
 };
 
 // Type info B.
-// CHECK: ![[TypeInfoB:ty_.*]] = !cir.struct<"", !cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>>
+// CHECK: ![[TypeInfoB:ty_.*]] = !cir.struct<"" {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
 
 // vtable for A type
-// CHECK: ![[VTableTypeA:ty_.*]] = !cir.struct<"", !cir.array<!cir.ptr<!u8i> x 5>>
+// CHECK: ![[VTableTypeA:ty_.*]] = !cir.struct<"" {!cir.array<!cir.ptr<!u8i> x 5>}>
 
 // Class A
-// CHECK: ![[ClassA:ty_.*]] = !cir.struct<"class.A", !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, #cir.recdecl.ast>
+// CHECK: ![[ClassA:ty_.*]] = !cir.struct<"class.A" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.recdecl.ast>
 
 // Class B
-// CHECK: ![[ClassB:ty_.*]] = !cir.struct<"class.B", ![[ClassA]]>
+// CHECK: ![[ClassB:ty_.*]] = !cir.struct<"class.B" {![[ClassA]]}>
 
 // B ctor => @B::B()
 // Calls @A::A() and initialize __vptr with address of B's vtable.

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -3,12 +3,12 @@
 !s8i = !cir.int<s, 8>
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
-!ty_22class2EInit22 = !cir.struct<"class.Init", !s8i, #cir.recdecl.ast>
+!ty_22class2EInit22 = !cir.struct<"class.Init" {!s8i} #cir.recdecl.ast>
 module {
   cir.global external @a = #cir.int<3> : !s32i
   cir.global external @rgb = #cir.const_array<[#cir.int<0> : !s8i, #cir.int<-23> : !s8i, #cir.int<33> : !s8i] : !cir.array<!s8i x 3>>
   cir.global external @b = #cir.const_array<"example\00" : !cir.array<!s8i x 8>>
-  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.null : !cir.ptr<!s8i>}> : !cir.struct<"", !s8i, !s64i, !cir.ptr<!s8i>>
+  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.null : !cir.ptr<!s8i>}> : !cir.struct<"" {!s8i, !s64i, !cir.ptr<!s8i>}>
   cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global "private" internal @c : !s32i
   cir.global "private" constant internal @".str2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
@@ -31,8 +31,7 @@ module {
     #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!s8i>,
     #cir.global_view<@type_info_name_B> : !cir.ptr<!s8i>,
     #cir.global_view<@type_info_A> : !cir.ptr<!s8i>}>
-    : !cir.struct<"", !cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>
-  >
+  : !cir.struct<"" {!cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>}>
   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !s8i)
   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22class2EInit22 {
     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22>

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -309,7 +309,7 @@ module {
 
   cir.global external @type_info_B = #cir.typeinfo<{ // expected-error {{element at index 0 has type '!cir.ptr<!cir.int<u, 8>>' but return type for this element is '!cir.ptr<!cir.int<u, 32>>'}}
     #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!u8i>}>
-    : !cir.struct<"", !cir.ptr<!u32i>>
+    : !cir.struct<"" {!cir.ptr<!u32i>}>
 } // expected-error {{'cir.global' expected constant attribute to match type}}
 
 // -----

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -5,17 +5,17 @@
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-!ty_2222 = !cir.struct<"", !cir.array<!cir.ptr<!u8i> x 5>>
-!ty_22221 = !cir.struct<"", !cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>>
-!ty_22class2EA22 = !cir.struct<"class.A", incomplete, #cir.recdecl.ast>
-// CHECK: !ty_22i22 = !cir.struct<"i", incomplete>
-// CHECK: !ty_22S22 = !cir.struct<"S", !u8i, !u16i, !u32i>
-!ty_22struct2ES22 = !cir.struct<"struct.S", !s32i, !s32i>
+!ty_2222 = !cir.struct<"" {!cir.array<!cir.ptr<!u8i> x 5>}>
+!ty_22221 = !cir.struct<"" {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+!ty_22class2EA22 = !cir.struct<"class.A" incomplete #cir.recdecl.ast>
+// CHECK: !ty_22i22 = !cir.struct<"i" incomplete>
+// CHECK: !ty_22S22 = !cir.struct<"S" {!u8i, !u16i, !u32i}>
+!ty_22struct2ES22 = !cir.struct<"struct.S" {!s32i, !s32i}>
 
 module  {
   cir.func @structs() {
-    %0 = cir.alloca !cir.ptr<!cir.struct<"S", !u8i, !u16i, !u32i>>, cir.ptr <!cir.ptr<!cir.struct<"S", !u8i, !u16i, !u32i>>>, ["s", init]
-    %1 = cir.alloca !cir.ptr<!cir.struct<"i", incomplete>>, cir.ptr <!cir.ptr<!cir.struct<"i", incomplete>>>, ["i", init]
+    %0 = cir.alloca !cir.ptr<!cir.struct<"S" {!u8i, !u16i, !u32i}>>, cir.ptr <!cir.ptr<!cir.struct<"S" {!u8i, !u16i, !u32i}>>>, ["s", init]
+    %1 = cir.alloca !cir.ptr<!cir.struct<"i" incomplete>>, cir.ptr <!cir.ptr<!cir.struct<"i" incomplete>>>, ["i", init]
     cir.return
   }
 

--- a/clang/test/CIR/IR/vtableAttr.cir
+++ b/clang/test/CIR/IR/vtableAttr.cir
@@ -1,7 +1,7 @@
 // RUN: cir-opt %s | FileCheck %s
 
 !u8i = !cir.int<u, 8>
-!ty_2222 = !cir.struct<"", !cir.array<!cir.ptr<!u8i> x 1>>
+!ty_2222 = !cir.struct<"" {!cir.array<!cir.ptr<!u8i> x 1>}>
 module {
     // Should parse VTable attribute.
     cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.null : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -10,7 +10,7 @@
 !u32i = !cir.int<u, 32>
 !u64i = !cir.int<u, 64>
 !u8i = !cir.int<u, 8>
-!ty_22struct2EA22 = !cir.struct<"struct.A", !s32i, !cir.array<!cir.array<!s32i x 2> x 2>, #cir.recdecl.ast>
+!ty_22struct2EA22 = !cir.struct<"struct.A" {!s32i, !cir.array<!cir.array<!s32i x 2> x 2>} #cir.recdecl.ast>
 
 module {
   cir.global external @a = #cir.int<3> : !s32i

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -3,11 +3,11 @@
 
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
-!ty_22struct2ES22 = !cir.struct<"struct.S", !u8i, !s32i>
-!ty_22struct2ES2A22 = !cir.struct<"struct.S2A", !s32i, #cir.recdecl.ast>
-!ty_22struct2ES122 = !cir.struct<"struct.S1", !s32i, f32, !cir.ptr<!s32i>, #cir.recdecl.ast>
-!ty_22struct2ES222 = !cir.struct<"struct.S2", !ty_22struct2ES2A22, #cir.recdecl.ast>
-!ty_22struct2ES322 = !cir.struct<"struct.S3", !s32i, #cir.recdecl.ast>
+!ty_22struct2ES22 = !cir.struct<"struct.S" {!u8i, !s32i}>
+!ty_22struct2ES2A22 = !cir.struct<"struct.S2A" {!s32i} #cir.recdecl.ast>
+!ty_22struct2ES122 = !cir.struct<"struct.S1" {!s32i, f32, !cir.ptr<!s32i>} #cir.recdecl.ast>
+!ty_22struct2ES222 = !cir.struct<"struct.S2" {!ty_22struct2ES2A22} #cir.recdecl.ast>
+!ty_22struct2ES322 = !cir.struct<"struct.S3" {!s32i} #cir.recdecl.ast>
 
 module {
   cir.func @test() {

--- a/clang/test/CIR/Lowering/variadics.cir
+++ b/clang/test/CIR/Lowering/variadics.cir
@@ -5,7 +5,7 @@
 !u32i = !cir.int<u, 32>
 !u8i = !cir.int<u, 8>
 
-!ty_22struct2E__va_list_tag22 = !cir.struct<"struct.__va_list_tag", !u32i, !u32i, !cir.ptr<!u8i>, !cir.ptr<!u8i>, #cir.recdecl.ast>
+!ty_22struct2E__va_list_tag22 = !cir.struct<"struct.__va_list_tag" {!u32i, !u32i, !cir.ptr<!u8i>, !cir.ptr<!u8i>} #cir.recdecl.ast>
 
 module {
   cir.func @average(%arg0: !s32i, ...) -> !s32i {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #230
* #229
* #228
* #227
* __->__ #226
* #225

This change simplifies the StructType printing/parsing methods. It also
updates the representations to group members between braces and to
remove commas between type attributes (e.g. id, packed, etc.).