### PR TITLE
[CIR] Refactor StructElementAddr into GetMemberOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1401,41 +1401,47 @@ def VTableAddrPointOp : CIR_Op<"vtable.address_point",
 }
 
 //===----------------------------------------------------------------------===//
-// StructElementAddr
+// GetMemberOp
 //===----------------------------------------------------------------------===//
 
-// FIXME: rename this among the lines of GetGlobalOp.
-def StructElementAddr : CIR_Op<"struct_element_addr"> {
+def GetMemberOp : CIR_Op<"get_member"> {
   let summary = "Get the address of a member of a struct";
   let description = [{
-    The `cir.struct_element_addr` operaration gets the address of a particular
-    named member from the input struct.
+    The `cir.get_member` operation gets the address of a particular named
+    member from the input record.
 
-    It expects a pointer to the base struct as well as the name of the member
+    It expects a pointer to the base record as well as the name of the member
     and its field index.
 
     Example:
     ```mlir
-    !ty_22struct2EBar22 = type !cir.struct<"struct.Bar", i32, i8>
-    ...
-    %0 = cir.alloca !ty_22struct2EBar22, cir.ptr <!ty_22struct2EBar22>
-    ...
-    %1 = cir.struct_element_addr %0, "Bar.a"
-    %2 = cir.load %1 : cir.ptr <int>, int
-    ...
+    // Suppose we have a struct with multiple members.
+    !s32i = !cir.int<s, 32>
+    !s8i = !cir.int<s, 32>
+    !struct_ty = !cir.struct<"struct.Bar" {!s32i, !s8i}>
+
+    // Get the address of the member at index 1.
+    %1 = cir.get_member %0[1] {name = "i"} : (!cir.ptr<!struct_ty>) -> !cir.ptr<!s8i>
     ```
   }];
 
   let arguments = (ins
-    Arg<CIR_PointerType, "the address to load from", [MemRead]>:$struct_addr,
-    StrAttr:$member_name,
-    IndexAttr:$member_index);
+    Arg<CIR_PointerType, "the address to load from", [MemRead]>:$addr,
+    StrAttr:$name,
+    IndexAttr:$indexAttr);
 
   let results = (outs Res<CIR_PointerType, "">:$result);
 
+  let assemblyFormat = [{
+    $addr `[` $indexAttr `]` attr-dict
+    `:` qualified(type($addr)) `->` qualified(type($result))
+  }];
+
   let builders = [
-    OpBuilder<(ins "Type":$type, "Value":$value, "llvm::StringRef":$name,
-              "unsigned":$index),
+    OpBuilder<(ins "Type":$type,
+                   "Value":$value,
+                   "llvm::StringRef":$name,
+                   "unsigned":$index),
     [{
       mlir::APInt fieldIdx(64, index);
       build($_builder, $_state, type, value, name, fieldIdx);
@@ -1444,10 +1450,18 @@ def StructElementAddr : CIR_Op<"struct_element_addr"> {
 
   let extraClassDeclaration = [{
     /// Return the index of the struct member being accessed.
-    uint64_t getIndex() { return getMemberIndex().getZExtValue(); }
+    uint64_t getIndex() { return getIndexAttr().getZExtValue(); }
+
+    /// Return the record type pointed by the base pointer.
+    mlir::cir::PointerType getAddrTy() { return getAddr().getType(); }
+
+    /// Return the result type.
+    mlir::cir::PointerType getResultTy() {
+      return getResult().getType().cast<mlir::cir::PointerType>();
+    }
   }];
 
-  // FIXME: add verifier.
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -137,6 +137,9 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
     size_t getNumElements() const { return getMembers().size(); }
     bool isOpaque() const { return !getBody(); }
     bool isPadded(const ::mlir::DataLayout &dataLayout) const;
+
+    /// Return whether this is a class declaration.
+    bool isClass() const { return getKind() == RecordKind::CLASS; }
   }];
 
   let extraClassDefinition = [{

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -556,6 +556,13 @@ public:
         global.getLoc(), getPointerTo(global.getSymType()), global.getName());
   }
 
+  /// Create a pointer to a record member.
+  mlir::Value createGetMember(mlir::Location loc, mlir::Type result,
+                              mlir::Value base, llvm::StringRef name,
+                              unsigned index) {
+    return create<mlir::cir::GetMemberOp>(loc, result, base, name, index);
+  }
+
   /// Cast the element type of the given address to a different type,
   /// preserving information like the alignment.
   cir::Address createElementBitCast(mlir::Location loc, cir::Address addr,

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -70,13 +70,13 @@ static Address buildAddrOfFieldStorage(CIRGenFunction &CGF, Address Base,
   // For most cases fieldName is the same as field->getName() but for lambdas,
   // which do not currently carry the name, so it can be passed down from the
   // CaptureStmt.
-  auto sea = CGF.getBuilder().create<mlir::cir::StructElementAddr>(
+  auto memberAddr = CGF.getBuilder().createGetMember(
       loc, fieldPtr, Base.getPointer(), fieldName, fieldIndex);
 
   // TODO: We could get the alignment from the CIRGenRecordLayout, but given the
   // member name based lookup of the member here we probably shouldn't be. We'll
   // have to consider this later.
-  auto addr = Address(sea->getResult(0), CharUnits::One());
+  auto addr = Address(memberAddr, CharUnits::One());
   return addr;
 }
 
@@ -354,8 +354,7 @@ static CIRGenCallee buildDirectCallee(CIRGenModule &CGM, GlobalDecl GD) {
     // When directing calling an inline builtin, call it through it's mangled
     // name to make it clear it's not the actual builtin.
     auto Fn = cast<mlir::cir::FuncOp>(CGF.CurFn);
-    if (Fn.getName() != FDInlineName &&
-        onlyHasInlineBuiltinDeclaration(FD)) {
+    if (Fn.getName() != FDInlineName && onlyHasInlineBuiltinDeclaration(FD)) {
       assert(0 && "NYI");
     }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2176,6 +2176,28 @@ VTableAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
 }
 
 //===----------------------------------------------------------------------===//
+// GetMemberOp Definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult GetMemberOp::verify() {
+
+  const auto recordTy = getAddrTy().getPointee().dyn_cast<StructType>();
+  if (!recordTy)
+    return emitError() << "expected pointer to a record type";
+
+  if (recordTy.getMembers().size() <= getIndex())
+    return emitError() << "member index out of bounds";
+
+  // FIXME(cir): Member type check is disabled for classes since there is a bug
+  // in codegen index for classes.
+  if (!recordTy.isClass() &&
+      recordTy.getMembers()[getIndex()] != getResultTy().getPointee())
+    return emitError() << "member type mismatch";
+
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -481,12 +481,12 @@ static std::string getVarNameFromValue(mlir::Value v) {
 
   if (auto allocaOp = dyn_cast<AllocaOp>(srcOp))
     return allocaOp.getName().str();
-  if (auto getElemOp = dyn_cast<StructElementAddr>(srcOp)) {
-    auto parent = dyn_cast<AllocaOp>(getElemOp.getStructAddr().getDefiningOp());
+  if (auto getElemOp = dyn_cast<GetMemberOp>(srcOp)) {
+    auto parent = dyn_cast<AllocaOp>(getElemOp.getAddr().getDefiningOp());
     if (parent) {
       llvm::SmallString<128> finalName;
       llvm::raw_svector_ostream Out(finalName);
-      Out << parent.getName() << "." << getElemOp.getMemberName();
+      Out << parent.getName() << "." << getElemOp.getName();
       return Out.str().str();
     }
   }
@@ -1052,12 +1052,12 @@ void LifetimeCheckPass::classifyAndInitTypeCategories(mlir::Value addr,
     // Go through uses of the alloca via `cir.struct_element_addr`, and
     // track only the fields that are actually used.
     std::for_each(addr.use_begin(), addr.use_end(), [&](mlir::OpOperand &use) {
-      auto op = dyn_cast<mlir::cir::StructElementAddr>(use.getOwner());
+      auto op = dyn_cast<mlir::cir::GetMemberOp>(use.getOwner());
       if (!op)
         return;
 
       auto eltAddr = op.getResult();
-      // If nothing is using this StructElementAddr, don't bother since
+      // If nothing is using this GetMemberOp, don't bother since
       // it could lead to even more noisy outcomes.
       if (eltAddr.use_empty())
         return;
@@ -1067,7 +1067,7 @@ void LifetimeCheckPass::classifyAndInitTypeCategories(mlir::Value addr,
 
       // Classify exploded types. Keep alloca original location.
       classifyAndInitTypeCategories(eltAddr, eltTy, loc, ++nestLevel);
-      fieldVals[op.getMemberIndex().getZExtValue()] = eltAddr;
+      fieldVals[op.getIndex()] = eltAddr;
     });
 
     // In case this aggregate gets initialized at once, the fields need
@@ -1139,7 +1139,7 @@ void LifetimeCheckPass::checkCoroTaskStore(StoreOp storeOp) {
 mlir::Value LifetimeCheckPass::getLambdaFromMemberAccess(mlir::Value addr) {
   auto op = addr.getDefiningOp();
   // FIXME: we likely want to consider more indirections here...
-  if (!isa<mlir::cir::StructElementAddr>(op))
+  if (!isa<mlir::cir::GetMemberOp>(op))
     return nullptr;
   auto allocaOp =
       dyn_cast<mlir::cir::AllocaOp>(op->getOperand(0).getDefiningOp());
@@ -1447,7 +1447,7 @@ void LifetimeCheckPass::checkPointerDeref(mlir::Value addr, mlir::Location loc,
     D << "returned lambda captures local variable";
   else if (derefStyle == DerefStyle::CallParam ||
            derefStyle == DerefStyle::IndirectCallParam) {
-    bool isAgg = isa_and_nonnull<StructElementAddr>(addr.getDefiningOp());
+    bool isAgg = isa_and_nonnull<GetMemberOp>(addr.getDefiningOp());
     D << "passing ";
     if (!isAgg)
       D << "invalid pointer";

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1660,21 +1660,20 @@ public:
   }
 };
 
-class CIRStructElementAddrOpLowering
-    : public mlir::OpConversionPattern<mlir::cir::StructElementAddr> {
+class CIRGetMemberOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::GetMemberOp> {
 public:
-  using mlir::OpConversionPattern<
-      mlir::cir::StructElementAddr>::OpConversionPattern;
+  using mlir::OpConversionPattern<mlir::cir::GetMemberOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::StructElementAddr op, OpAdaptor adaptor,
+  matchAndRewrite(mlir::cir::GetMemberOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto llResTy = getTypeConverter()->convertType(op.getType());
     // Since the base address is a pointer to structs, the first offset is
     // always zero. The second offset tell us which member it will access.
     llvm::SmallVector<mlir::LLVM::GEPArg> offset{0, op.getIndex()};
-    rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
-        op, llResTy, adaptor.getStructAddr(), offset);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(op, llResTy,
+                                                   adaptor.getAddr(), offset);
     return mlir::success();
   }
 };
@@ -1730,7 +1729,7 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                CIRIfLowering, CIRGlobalOpLowering, CIRGetGlobalOpLowering,
                CIRVAStartLowering, CIRVAEndLowering, CIRVACopyLowering,
                CIRVAArgLowering, CIRBrOpLowering, CIRTernaryOpLowering,
-               CIRStructElementAddrOpLowering, CIRSwitchOpLowering,
+               CIRGetMemberOpLowering, CIRSwitchOpLowering,
                CIRPtrDiffOpLowering>(converter, patterns.getContext());
 }
 

--- a/clang/test/CIR/CodeGen/String.cpp
+++ b/clang/test/CIR/CodeGen/String.cpp
@@ -21,10 +21,10 @@ void test() {
 // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22class2EString22>
 // CHECK-NEXT:   cir.store %arg0, %0
 // CHECK-NEXT:   %1 = cir.load %0
-// CHECK-NEXT:   %2 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "storage"}
+// CHECK-NEXT:   %2 = cir.get_member %1[0] {name = "storage"}
 // CHECK-NEXT:   %3 = cir.const(#cir.null : !cir.ptr<!s8i>) : !cir.ptr<!s8i>
 // CHECK-NEXT:   cir.store %3, %2 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
-// CHECK-NEXT:   %4 = "cir.struct_element_addr"(%1) {member_index = 1 : index, member_name = "size"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!s64i>
+// CHECK-NEXT:   %4 = cir.get_member %1[1] {name = "size"} : !cir.ptr<!ty_22class2EString22> -> !cir.ptr<!s64i>
 // CHECK-NEXT:   %5 = cir.const(#cir.int<0> : !s32i) : !s32i
 // CHECK-NEXT:   %6 = cir.cast(integral, %5 : !s32i), !s64i
 // CHECK-NEXT:   cir.store %6, %4 : !s64i, cir.ptr <!s64i>
@@ -36,10 +36,10 @@ void test() {
 // CHECK-NEXT:   cir.store %arg0, %0
 // CHECK-NEXT:   cir.store %arg1, %1
 // CHECK-NEXT:   %2 = cir.load %0
-// CHECK-NEXT:   %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "storage"}
+// CHECK-NEXT:   %3 = cir.get_member %2[0] {name = "storage"}
 // CHECK-NEXT:   %4 = cir.const(#cir.null : !cir.ptr<!s8i>)
 // CHECK-NEXT:   cir.store %4, %3
-// CHECK-NEXT:   %5 = "cir.struct_element_addr"(%2) {member_index = 1 : index, member_name = "size"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!s64i>
+// CHECK-NEXT:   %5 = cir.get_member %2[1] {name = "size"} : !cir.ptr<!ty_22class2EString22> -> !cir.ptr<!s64i>
 // CHECK-NEXT:   %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:   %7 = cir.cast(integral, %6 : !s32i), !s64i
 // CHECK-NEXT:   cir.store %7, %5 : !s64i, cir.ptr <!s64i>
@@ -52,7 +52,7 @@ void test() {
 // CHECK-NEXT:   cir.store %arg0, %0 : !cir.ptr<!ty_22class2EString22>, cir.ptr <!cir.ptr<!ty_22class2EString22>>
 // CHECK-NEXT:   cir.store %arg1, %1 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
 // CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22class2EString22>>, !cir.ptr<!ty_22class2EString22>
-// CHECK-NEXT:   %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "storage"} : (!cir.ptr<!ty_22class2EString22>) -> !cir.ptr<!cir.ptr<!s8i>>
+// CHECK-NEXT:   %3 = cir.get_member %2[0] {name = "storage"} : !cir.ptr<!ty_22class2EString22> -> !cir.ptr<!cir.ptr<!s8i>>
 // CHECK-NEXT:   %4 = cir.const(#cir.null : !cir.ptr<!s8i>) : !cir.ptr<!s8i>
 // CHECK-NEXT:   cir.store %4, %3 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
 // CHECK-NEXT:   cir.return

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -35,10 +35,10 @@ void use() { yop{}; }
 
 // CHECK: cir.func @_Z3usev()
 // CHECK:   %0 = cir.alloca !ty_22struct2Eyep_22, cir.ptr <!ty_22struct2Eyep_22>, ["agg.tmp0"] {alignment = 4 : i64}
-// CHECK:   %1 = "cir.struct_element_addr"(%0) {member_index = 0 : index, member_name = "Status"} : (!cir.ptr<!ty_22struct2Eyep_22>) -> !cir.ptr<!u32i>
+// CHECK:   %1 = cir.get_member %0[0] {name = "Status"} : !cir.ptr<!ty_22struct2Eyep_22> -> !cir.ptr<!u32i>
 // CHECK:   %2 = cir.const(#cir.int<0> : !u32i) : !u32i
 // CHECK:   cir.store %2, %1 : !u32i, cir.ptr <!u32i>
-// CHECK:   %3 = "cir.struct_element_addr"(%0) {member_index = 1 : index, member_name = "HC"} : (!cir.ptr<!ty_22struct2Eyep_22>) -> !cir.ptr<!u32i>
+// CHECK:   %3 = cir.get_member %0[1] {name = "HC"} : !cir.ptr<!ty_22struct2Eyep_22> -> !cir.ptr<!u32i>
 // CHECK:   %4 = cir.const(#cir.int<0> : !u32i) : !u32i
 // CHECK:   cir.store %4, %3 : !u32i, cir.ptr <!u32i>
 // CHECK:   cir.return
@@ -68,12 +68,12 @@ void yo() {
 // CHECK:   %1 = cir.alloca !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>, ["ext2", init] {alignment = 8 : i64}
 // CHECK:   %2 = cir.const(#cir.const_struct<{#cir.int<1000070000> : !u32i, #cir.null : !cir.ptr<!void>, #cir.int<0> : !u64i}> : !ty_22struct2EYo22) : !ty_22struct2EYo22
 // CHECK:   cir.store %2, %0 : !ty_22struct2EYo22, cir.ptr <!ty_22struct2EYo22>
-// CHECK:   %3 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "type"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u32i>
+// CHECK:   %3 = cir.get_member %1[0] {name = "type"} : !cir.ptr<!ty_22struct2EYo22> -> !cir.ptr<!u32i>
 // CHECK:   %4 = cir.const(#cir.int<1000066001> : !u32i) : !u32i
 // CHECK:   cir.store %4, %3 : !u32i, cir.ptr <!u32i>
-// CHECK:   %5 = "cir.struct_element_addr"(%1) {member_index = 1 : index, member_name = "next"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!cir.ptr<!void>>
+// CHECK:   %5 = cir.get_member %1[1] {name = "next"} : !cir.ptr<!ty_22struct2EYo22> -> !cir.ptr<!cir.ptr<!void>>
 // CHECK:   %6 = cir.cast(bitcast, %0 : !cir.ptr<!ty_22struct2EYo22>), !cir.ptr<!void>
 // CHECK:   cir.store %6, %5 : !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>
-// CHECK:   %7 = "cir.struct_element_addr"(%1) {member_index = 2 : index, member_name = "createFlags"} : (!cir.ptr<!ty_22struct2EYo22>) -> !cir.ptr<!u64i>
+// CHECK:   %7 = cir.get_member %1[2] {name = "createFlags"} : !cir.ptr<!ty_22struct2EYo22> -> !cir.ptr<!u64i>
 // CHECK:   %8 = cir.const(#cir.int<0> : !u64i) : !u64i
 // CHECK:   cir.store %8, %7 : !u64i, cir.ptr <!u64i>

--- a/clang/test/CIR/CodeGen/assign-operator.cpp
+++ b/clang/test/CIR/CodeGen/assign-operator.cpp
@@ -23,7 +23,7 @@ struct String {
 
   // Get address of `this->size`
 
-  // CHECK:   %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "size"}
+  // CHECK:   %3 = cir.get_member %2[0] {name = "size"}
 
   // Get address of `s`
 
@@ -31,7 +31,7 @@ struct String {
 
   // Get the address of s.size
 
-  // CHECK:   %5 = "cir.struct_element_addr"(%4) {member_index = 0 : index, member_name = "size"}
+  // CHECK:   %5 = cir.get_member %4[0] {name = "size"}
 
   // Load value from s.size and store in this->size
 
@@ -53,9 +53,9 @@ struct String {
   // CHECK:   cir.store %arg1, %1 : !cir.ptr<!ty_22struct2EStringView22>
   // CHECK:   %3 = cir.load deref %0 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>
   // CHECK:   %4 = cir.load %1 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>
-  // CHECK:   %5 = "cir.struct_element_addr"(%4) {member_index = 0 : index, member_name = "size"}
+  // CHECK:   %5 = cir.get_member %4[0] {name = "size"}
   // CHECK:   %6 = cir.load %5 : cir.ptr <!s64i>, !s64i
-  // CHECK:   %7 = "cir.struct_element_addr"(%3) {member_index = 0 : index, member_name = "size"}
+  // CHECK:   %7 = cir.get_member %3[0] {name = "size"}
   // CHECK:   cir.store %6, %7 : !s64i, cir.ptr <!s64i>
   // CHECK:   cir.store %3, %2 : !cir.ptr<!ty_22struct2EStringView22>
   // CHECK:   %8 = cir.load %2 : cir.ptr <!cir.ptr<!ty_22struct2EStringView22>>

--- a/clang/test/CIR/CodeGen/ctor-member-lvalue-to-rvalue.cpp
+++ b/clang/test/CIR/CodeGen/ctor-member-lvalue-to-rvalue.cpp
@@ -11,9 +11,9 @@ struct String {
 // CHECK:     cir.store %arg0, %0
 // CHECK:     cir.store %arg1, %1
 // CHECK:     %2 = cir.load %0
-// CHECK:     %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "size"}
+// CHECK:     %3 = cir.get_member %2[0] {name = "size"}
 // CHECK:     %4 = cir.load %1
-// CHECK:     %5 = "cir.struct_element_addr"(%4) {member_index = 0 : index, member_name = "size"}
+// CHECK:     %5 = cir.get_member %4[0] {name = "size"}
 // CHECK:     %6 = cir.load %5 : cir.ptr <!s64i>, !s64i
 // CHECK:     cir.store %6, %3 : !s64i, cir.ptr <!s64i>
 // CHECK:     cir.return

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -82,7 +82,7 @@ void C3::Layer::Initialize() {
 
 // CHECK:  cir.scope {
 // CHECK:    %2 = cir.base_class_addr(%1 : cir.ptr <!ty_22struct2EC33A3ALayer22>) -> cir.ptr <!ty_22class2EC23A3ALayer22>
-// CHECK:    %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "m_C1"} : (!cir.ptr<!ty_22class2EC23A3ALayer22>) -> !cir.ptr<!cir.ptr<!ty_22class2EC222>>
+// CHECK:    %3 = cir.get_member %2[0] {name = "m_C1"} : !cir.ptr<!ty_22class2EC23A3ALayer22> -> !cir.ptr<!cir.ptr<!ty_22class2EC222>>
 // CHECK:    %4 = cir.load %3 : cir.ptr <!cir.ptr<!ty_22class2EC222>>, !cir.ptr<!ty_22class2EC222>
 // CHECK:    %5 = cir.const(#cir.null : !cir.ptr<!ty_22class2EC222>) : !cir.ptr<!ty_22class2EC222>
 // CHECK:    %6 = cir.cmp(eq, %4, %5) : !cir.ptr<!ty_22class2EC222>, !cir.bool

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -26,12 +26,12 @@ void l0() {
 // CHECK: %0 = cir.alloca !cir.ptr<!ty_22class2Eanon222>, cir.ptr <!cir.ptr<!ty_22class2Eanon222>>, ["this", init] {alignment = 8 : i64}
 // CHECK: cir.store %arg0, %0 : !cir.ptr<!ty_22class2Eanon222>, cir.ptr <!cir.ptr<!ty_22class2Eanon222>>
 // CHECK: %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22class2Eanon222>>, !cir.ptr<!ty_22class2Eanon222>
-// CHECK: %2 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "i"} : (!cir.ptr<!ty_22class2Eanon222>) -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %2 = cir.get_member %1[0] {name = "i"} : !cir.ptr<!ty_22class2Eanon222> -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: %3 = cir.load %2 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: %4 = cir.load %3 : cir.ptr <!s32i>, !s32i
 // CHECK: %5 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK: %6 = cir.binop(add, %4, %5) : !s32i
-// CHECK: %7 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "i"} : (!cir.ptr<!ty_22class2Eanon222>) -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %7 = cir.get_member %1[0] {name = "i"} : !cir.ptr<!ty_22class2Eanon222> -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: %8 = cir.load %7 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: cir.store %6, %8 : !s32i, cir.ptr <!s32i>
 
@@ -50,7 +50,7 @@ auto g() {
 // CHECK: %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK: %2 = cir.const(#cir.int<12> : !s32i) : !s32i
 // CHECK: cir.store %2, %1 : !s32i, cir.ptr <!s32i>
-// CHECK: %3 = "cir.struct_element_addr"(%0) {member_index = 0 : index, member_name = "i"} : (!cir.ptr<!ty_22class2Eanon223>) -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %3 = cir.get_member %0[0] {name = "i"} : !cir.ptr<!ty_22class2Eanon223> -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: cir.store %1, %3 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK: %4 = cir.load %0 : cir.ptr <!ty_22class2Eanon223>, !ty_22class2Eanon223
 // CHECK: cir.return %4 : !ty_22class2Eanon223
@@ -70,7 +70,7 @@ auto g2() {
 // CHECK-NEXT: %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK-NEXT: %2 = cir.const(#cir.int<12> : !s32i) : !s32i
 // CHECK-NEXT: cir.store %2, %1 : !s32i, cir.ptr <!s32i>
-// CHECK-NEXT: %3 = "cir.struct_element_addr"(%0) {member_index = 0 : index, member_name = "i"} : (!cir.ptr<!ty_22class2Eanon224>) -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK-NEXT: %3 = cir.get_member %0[0] {name = "i"} : !cir.ptr<!ty_22class2Eanon224> -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK-NEXT: cir.store %1, %3 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK-NEXT: %4 = cir.load %0 : cir.ptr <!ty_22class2Eanon224>, !ty_22class2Eanon224
 // CHECK-NEXT: cir.return %4 : !ty_22class2Eanon224

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -61,11 +61,11 @@ void init(unsigned numImages) {
 // CHECK:         %13 = cir.alloca !ty_22struct2Etriple22, cir.ptr <!ty_22struct2Etriple22>, ["ref.tmp0"] {alignment = 8 : i64}
 // CHECK:         %14 = cir.const(#cir.zero : !ty_22struct2Etriple22) : !ty_22struct2Etriple22
 // CHECK:         cir.store %14, %13 : !ty_22struct2Etriple22, cir.ptr <!ty_22struct2Etriple22>
-// CHECK:         %15 = "cir.struct_element_addr"(%13) {member_index = 0 : index, member_name = "type"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!u32i>
+// CHECK:         %15 = cir.get_member %13[0] {name = "type"} : !cir.ptr<!ty_22struct2Etriple22> -> !cir.ptr<!u32i>
 // CHECK:         %16 = cir.const(#cir.int<1000024002> : !u32i) : !u32i
 // CHECK:         cir.store %16, %15 : !u32i, cir.ptr <!u32i>
-// CHECK:         %17 = "cir.struct_element_addr"(%13) {member_index = 1 : index, member_name = "next"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!cir.ptr<!void>>
-// CHECK:         %18 = "cir.struct_element_addr"(%13) {member_index = 2 : index, member_name = "image"} : (!cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!u32i>
+// CHECK:         %17 = cir.get_member %13[1] {name = "next"} : !cir.ptr<!ty_22struct2Etriple22> -> !cir.ptr<!cir.ptr<!void>>
+// CHECK:         %18 = cir.get_member %13[2] {name = "image"} : !cir.ptr<!ty_22struct2Etriple22> -> !cir.ptr<!u32i>
 // CHECK:         %19 = cir.load %7 : cir.ptr <!cir.ptr<!ty_22struct2Etriple22>>, !cir.ptr<!ty_22struct2Etriple22>
 // CHECK:         %20 = cir.call @_ZN6tripleaSEOS_(%19, %13) : (!cir.ptr<!ty_22struct2Etriple22>, !cir.ptr<!ty_22struct2Etriple22>) -> !cir.ptr<!ty_22struct2Etriple22>
 // CHECK:       }

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -98,14 +98,14 @@ void m() { Adv C; }
 // CHECK:     %0 = cir.alloca !cir.ptr<!ty_22class2EAdv22>, cir.ptr <!cir.ptr<!ty_22class2EAdv22>>, ["this", init] {alignment = 8 : i64}
 // CHECK:     cir.store %arg0, %0 : !cir.ptr<!ty_22class2EAdv22>, cir.ptr <!cir.ptr<!ty_22class2EAdv22>>
 // CHECK:     %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22class2EAdv22>>, !cir.ptr<!ty_22class2EAdv22>
-// CHECK:     %2 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "x"} : (!cir.ptr<!ty_22class2EAdv22>) -> !cir.ptr<!ty_22struct2EMandalore22>
-// CHECK:     %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "w"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!u32i>
+// CHECK:     %2 = cir.get_member %1[0] {name = "x"} : !cir.ptr<!ty_22class2EAdv22> -> !cir.ptr<!ty_22struct2EMandalore22>
+// CHECK:     %3 = cir.get_member %2[0] {name = "w"} : !cir.ptr<!ty_22struct2EMandalore22> -> !cir.ptr<!u32i>
 // CHECK:     %4 = cir.const(#cir.int<1000024001> : !u32i) : !u32i
 // CHECK:     cir.store %4, %3 : !u32i, cir.ptr <!u32i>
-// CHECK:     %5 = "cir.struct_element_addr"(%2) {member_index = 1 : index, member_name = "n"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!cir.ptr<!void>>
+// CHECK:     %5 = cir.get_member %2[1] {name = "n"} : !cir.ptr<!ty_22struct2EMandalore22> -> !cir.ptr<!cir.ptr<!void>>
 // CHECK:     %6 = cir.const(#cir.null : !cir.ptr<!void>) : !cir.ptr<!void>
 // CHECK:     cir.store %6, %5 : !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>
-// CHECK:     %7 = "cir.struct_element_addr"(%2) {member_index = 2 : index, member_name = "d"} : (!cir.ptr<!ty_22struct2EMandalore22>) -> !cir.ptr<!s32i>
+// CHECK:     %7 = cir.get_member %2[2] {name = "d"} : !cir.ptr<!ty_22struct2EMandalore22> -> !cir.ptr<!s32i>
 // CHECK:     %8 = cir.const(#cir.int<0> : !s32i) : !s32i
 // CHECK:     cir.store %8, %7 : !s32i, cir.ptr <!s32i>
 // CHECK:     cir.return
@@ -155,4 +155,4 @@ void ppp() { Entry x; }
 
 // CHECK: cir.func linkonce_odr @_ZN5EntryC2Ev(%arg0: !cir.ptr<!ty_22struct2EEntry22>
 
-// CHECK: = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "procAddr"} : (!cir.ptr<!ty_22struct2EEntry22>) -> !cir.ptr<!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>>
+// CHECK: cir.get_member %1[0] {name = "procAddr"} : !cir.ptr<!ty_22struct2EEntry22> -> !cir.ptr<!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>>

--- a/clang/test/CIR/CodeGen/unary-deref.cpp
+++ b/clang/test/CIR/CodeGen/unary-deref.cpp
@@ -12,6 +12,6 @@ void foo() {
 
 // CHECK:  cir.func linkonce_odr  @_ZNK12MyIntPointer4readEv
 // CHECK:  %2 = cir.load %0
-// CHECK:  %3 = "cir.struct_element_addr"(%2) {member_index = 0 : index, member_name = "ptr"}
+// CHECK:  %3 = cir.get_member %2[0] {name = "ptr"}
 // CHECK:  %4 = cir.load deref %3 : cir.ptr <!cir.ptr<!s32i>>
 // CHECK:  %5 = cir.load %4

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -14,9 +14,9 @@ module {
     %1 = cir.alloca !ty_22struct2ES22, cir.ptr <!ty_22struct2ES22>, ["x"] {alignment = 4 : i64}
     // CHECK: %[[#ARRSIZE:]] = llvm.mlir.constant(1 : index) : i64
     // CHECK: %[[#STRUCT:]] = llvm.alloca %[[#ARRSIZE]] x !llvm.struct<"struct.S", (i8, i32)>
-    %3 = "cir.struct_element_addr"(%1) {member_index = 0 : index, member_name = "c"} : (!cir.ptr<!ty_22struct2ES22>) -> !cir.ptr<!u8i>
+    %3 = cir.get_member %1[0] {name = "c"} : !cir.ptr<!ty_22struct2ES22> -> !cir.ptr<!u8i>
     // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 0] : (!llvm.ptr<struct<"struct.S", (i8, i32)>>) -> !llvm.ptr<i8>
-    %5 = "cir.struct_element_addr"(%1) {member_index = 1 : index, member_name = "i"} : (!cir.ptr<!ty_22struct2ES22>) -> !cir.ptr<!s32i>
+    %5 = cir.get_member %1[1] {name = "i"} : !cir.ptr<!ty_22struct2ES22> -> !cir.ptr<!s32i>
     // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 1] : (!llvm.ptr<struct<"struct.S", (i8, i32)>>) -> !llvm.ptr<i32>
     cir.return
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #230
* #229
* __->__ #228
* #227
* #226
* #225

Improves a few aspects of the old CIR GEP equivalent:

 * Generalize the name to GetMemberOp, since it can be used for
   unions, classes, structs, and others.
 * Add custom assembly format to improve readability.
 * Add a new CIR dialect operation to represent the operation.
 * Remove redundancy from arguments names (e.g. "member_index" to just
   "index") for terseness.
 * Add verifier to check if:
    * The index is within bounds.
    * The type is a record (has members to be accessed).
    * The result type matches the type of the member.
 * Use CIRGenBuilder when building GetMemberOps.
 * Also add some getter wrappers.