### PR TITLE
[CIR][Lowering] Lower unions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -138,8 +138,14 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
     bool isOpaque() const { return !getBody(); }
     bool isPadded(const ::mlir::DataLayout &dataLayout) const;
 
+    /// Return the member with the largest bit-length.
+    mlir::Type getLargestMember(const ::mlir::DataLayout &dataLayout) const;
+
     /// Return whether this is a class declaration.
     bool isClass() const { return getKind() == RecordKind::CLASS; }
+
+    /// Return whether this is a union declaration.
+    bool isUnion() const { return getKind() == RecordKind::UNION; }
   }];
 
   let extraClassDefinition = [{

--- a/clang/test/CIR/Lowering/unions.cir
+++ b/clang/test/CIR/Lowering/unions.cir
@@ -1,0 +1,42 @@
+// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+!s16i = !cir.int<s, 16>
+!s32i = !cir.int<s, 32>
+#true = #cir.bool<true> : !cir.bool
+!ty_22union2EU122 = !cir.struct<union "union.U1" {!cir.bool, !s16i, !s32i} #cir.recdecl.ast>
+!ty_22union2EU222 = !cir.struct<union "union.U2" {f64, !ty_22union2EU122} #cir.recdecl.ast>
+!ty_22union2EU322 = !cir.struct<union "union.U3" {!s16i, !ty_22union2EU122} #cir.recdecl.ast>
+module {
+  // Should lower union to struct with only the largest member.
+  cir.global external @u1 = #cir.zero : !ty_22union2EU122
+  // CHECK: llvm.mlir.global external @u1() {addr_space = 0 : i32, cir.initial_value = #cir.zero : !llvm.struct<"union.U1", (i32)>} : !llvm.struct<"union.U1", (i32)>
+
+  // Should recursively find the largest member if there are nested unions.
+  cir.global external @u2 = #cir.zero : !ty_22union2EU222
+  cir.global external @u3 = #cir.zero : !ty_22union2EU322
+  // CHECK: llvm.mlir.global external @u2() {addr_space = 0 : i32, cir.initial_value = #cir.zero : !llvm.struct<"union.U2", (f64)>} : !llvm.struct<"union.U2", (f64)>
+  // CHECK: llvm.mlir.global external @u3() {addr_space = 0 : i32, cir.initial_value = #cir.zero : !llvm.struct<"union.U3", (i32)>} : !llvm.struct<"union.U3", (i32)>
+
+  // CHECK: llvm.func @test
+  cir.func @test(%arg0: !cir.ptr<!ty_22union2EU122>) {
+
+    // Should store directly to the union's base address.
+    %5 = cir.const(#true) : !cir.bool
+    %6 = cir.get_member %arg0[0] {name = "b"} : !cir.ptr<!ty_22union2EU122> -> !cir.ptr<!cir.bool>
+    cir.store %5, %6 : !cir.bool, cir.ptr <!cir.bool>
+    // CHECK: %[[#VAL:]] = llvm.mlir.constant(1 : i8) : i8
+    // The bitcast it just to bypass the type checker. It will be replaced by an opaque pointer.
+    // CHECK: %[[#ADDR:]] = llvm.bitcast %{{.+}} : !llvm.ptr<struct<"union.U1", (i32)>> to !llvm.ptr<i8>
+    // CHECK: llvm.store %[[#VAL]], %[[#ADDR]] : !llvm.ptr<i8>
+
+    // Should load direclty from the union's base address.
+    %7 = cir.get_member %arg0[0] {name = "b"} : !cir.ptr<!ty_22union2EU122> -> !cir.ptr<!cir.bool>
+    %8 = cir.load %7 : cir.ptr <!cir.bool>, !cir.bool
+    // The bitcast it just to bypass the type checker. It will be replaced by an opaque pointer.
+    // CHECK: %[[#BASE:]] = llvm.bitcast %{{.+}} : !llvm.ptr<struct<"union.U1", (i32)>> to !llvm.ptr<i8>
+    // CHECK: %{{.+}} = llvm.load %[[#BASE]] : !llvm.ptr<i8>
+
+    cir.return
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #230
* #229
* #228
* #227
* #226
* #225

Converts a union to a struct containing only its largest element.
GetMemberOp for unions is lowered as bitcasts instead of GEPs, since
union members share the same address space.