### PR TITLE
[CIR][CIRGen][Bugfix] Fixes switch-case sub statements

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1119,10 +1119,18 @@ public:
   mlir::Value buildScalarConstant(const ConstantEmission &Constant, Expr *E);
 
   mlir::Type getCIRType(const clang::QualType &type);
+  
+  const CaseStmt* foldCaseStmt(const clang::CaseStmt& S, 
+                               mlir::Type condType,
+                               SmallVector<mlir::Attribute, 4> &caseAttrs);
 
-  mlir::cir::CaseAttr getAttr(const clang::CaseStmt &S, mlir::Type condType);
-  mlir::cir::CaseAttr getAttr(const clang::DefaultStmt &S);
   void insertFallthrough(const clang::Stmt &S);
+
+  template <typename T>
+  mlir::LogicalResult buildCaseDefaultCascade(const T *stmt,
+                                              mlir::Type condType,
+                                              SmallVector<mlir::Attribute, 4> &caseAttrs,
+                                              mlir::OperationState &os);
 
   mlir::LogicalResult buildCaseStmt(const clang::CaseStmt &S,
                                     mlir::Type condType,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -577,7 +577,8 @@ public:
   const CIRGenFunctionInfo *CurFnInfo;
   clang::QualType FnRetTy;
 
-  /// This is the current function or global initializer that is generated code for.
+  /// This is the current function or global initializer that is generated code
+  /// for.
   mlir::Operation *CurFn = nullptr;
 
   /// Save Parameter Decl for coroutine.
@@ -593,7 +594,7 @@ public:
 
   CIRGenModule &getCIRGenModule() { return CGM; }
 
-  mlir::Block* getCurFunctionEntryBlock() {
+  mlir::Block *getCurFunctionEntryBlock() {
     auto Fn = dyn_cast<mlir::cir::FuncOp>(CurFn);
     assert(Fn && "other callables NYI");
     return &Fn.getRegion().front();
@@ -1119,28 +1120,27 @@ public:
   mlir::Value buildScalarConstant(const ConstantEmission &Constant, Expr *E);
 
   mlir::Type getCIRType(const clang::QualType &type);
-  
-  const CaseStmt* foldCaseStmt(const clang::CaseStmt& S, 
-                               mlir::Type condType,
+
+  const CaseStmt *foldCaseStmt(const clang::CaseStmt &S, mlir::Type condType,
                                SmallVector<mlir::Attribute, 4> &caseAttrs);
 
   void insertFallthrough(const clang::Stmt &S);
 
   template <typename T>
-  mlir::LogicalResult buildCaseDefaultCascade(const T *stmt,
-                                              mlir::Type condType,
-                                              SmallVector<mlir::Attribute, 4> &caseAttrs,
-                                              mlir::OperationState &os);
+  mlir::LogicalResult
+  buildCaseDefaultCascade(const T *stmt, mlir::Type condType,
+                          SmallVector<mlir::Attribute, 4> &caseAttrs,
+                          mlir::OperationState &os);
 
   mlir::LogicalResult buildCaseStmt(const clang::CaseStmt &S,
                                     mlir::Type condType,
                                     SmallVector<mlir::Attribute, 4> &caseAttrs,
                                     mlir::OperationState &op);
 
-  mlir::LogicalResult buildDefaultStmt(const clang::DefaultStmt &S,
-                                       mlir::Type condType,
-                                       SmallVector<mlir::Attribute, 4> &caseAttrs,
-                                       mlir::OperationState &op);
+  mlir::LogicalResult
+  buildDefaultStmt(const clang::DefaultStmt &S, mlir::Type condType,
+                   SmallVector<mlir::Attribute, 4> &caseAttrs,
+                   mlir::OperationState &op);
 
   mlir::cir::FuncOp generateCode(clang::GlobalDecl GD, mlir::cir::FuncOp Fn,
                                  const CIRGenFunctionInfo &FnInfo);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1120,13 +1120,19 @@ public:
 
   mlir::Type getCIRType(const clang::QualType &type);
 
+  mlir::cir::CaseAttr getAttr(const clang::CaseStmt &S, mlir::Type condType);
+  mlir::cir::CaseAttr getAttr(const clang::DefaultStmt &S);
+  void insertFallthrough(const clang::Stmt &S);
+
   mlir::LogicalResult buildCaseStmt(const clang::CaseStmt &S,
                                     mlir::Type condType,
-                                    mlir::cir::CaseAttr &caseEntry);
+                                    SmallVector<mlir::Attribute, 4> &caseAttrs,
+                                    mlir::OperationState &op);
 
   mlir::LogicalResult buildDefaultStmt(const clang::DefaultStmt &S,
                                        mlir::Type condType,
-                                       mlir::cir::CaseAttr &caseEntry);
+                                       SmallVector<mlir::Attribute, 4> &caseAttrs,
+                                       mlir::OperationState &op);
 
   mlir::cir::FuncOp generateCode(clang::GlobalDecl GD, mlir::cir::FuncOp Fn,
                                  const CIRGenFunctionInfo &FnInfo);

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -174,7 +174,10 @@ void sw8(int a) {
 //CHECK:    cir.func @_Z3sw8i
 //CHECK:      case (equal, 3)
 //CHECK-NEXT:   cir.yield break
-//CHECK-NEXT:   },
+//CHECK-NEXT: },
+//CHECK-NEXT: case (equal, 4) {
+//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
 //CHECK-NEXT:   cir.yield break
 //CHECK-NEXT: }  
@@ -191,10 +194,13 @@ void sw9(int a) {
 }
 
 //CHECK:    cir.func @_Z3sw9i
-//CHECK:      case (equal, 3)
+//CHECK:      case (equal, 3) {
 //CHECK-NEXT:   cir.yield break
-//CHECK-NEXT:   },
+//CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
+//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT: }
+//CHECK:      case (equal, 4)
 //CHECK-NEXT:   cir.yield break
 //CHECK-NEXT: }
 
@@ -203,9 +209,9 @@ void sw10(int a) {
   {
   case 3:
     break;  
-  case 5:  
+  case 4:  
   default:
-  case 4:
+  case 5:
     break;
   }
 }
@@ -213,8 +219,42 @@ void sw10(int a) {
 //CHECK:    cir.func @_Z4sw10i
 //CHECK:      case (equal, 3)
 //CHECK-NEXT:   cir.yield break
-//CHECK-NEXT:   },
+//CHECK-NEXT: },
+//CHECK-NEXT: case (equal, 4) {
+//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
+//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT: }
+//CHECK-NEXT: case (equal, 5) {
+//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT: }
+
+void sw11(int a) {
+  switch (a)
+  {
+  case 3:
+    break;  
+  case 4:
+  case 5:    
+  default:
+  case 6:
+  case 7:
+    break;
+  }
+}
+
+//CHECK:    cir.func @_Z4sw11i
+//CHECK:      case (equal, 3)
+//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT: },
+//CHECK-NEXT: case (anyof, [4, 5] : !s32i) {
+//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT: }
+//CHECK-NEXT: case (default) {
+//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT: }
+//CHECK-NEXT: case (anyof, [6, 7] : !s32i)  {
 //CHECK-NEXT:   cir.yield break
 //CHECK-NEXT: }
 

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -15,7 +15,6 @@ void sw1(int a) {
   }
   }
 }
-
 // CHECK: cir.func @_Z3sw1i
 // CHECK: cir.switch (%3 : !s32i) [
 // CHECK-NEXT: case (equal, 0)  {
@@ -160,3 +159,62 @@ void sw7(int a) {
 // CHECK-NEXT: case (anyof, [3, 4, 5] : !s32i)  {
 // CHECK-NEXT:   cir.yield break
 // CHECK-NEXT: }
+
+void sw8(int a) {
+  switch (a)
+  {
+  case 3:
+    break;
+  case 4:
+  default:
+    break;
+  }
+}
+
+//CHECK:    cir.func @_Z3sw8i
+//CHECK:      case (equal, 3)
+//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   },
+//CHECK-NEXT: case (default) {
+//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT: }  
+
+void sw9(int a) {
+  switch (a)
+  {
+  case 3:
+    break;  
+  default:
+  case 4:
+    break;
+  }
+}
+
+//CHECK:    cir.func @_Z3sw9i
+//CHECK:      case (equal, 3)
+//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   },
+//CHECK-NEXT: case (default) {
+//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT: }
+
+void sw10(int a) {
+  switch (a)
+  {
+  case 3:
+    break;  
+  case 5:  
+  default:
+  case 4:
+    break;
+  }
+}
+
+//CHECK:    cir.func @_Z4sw10i
+//CHECK:      case (equal, 3)
+//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   },
+//CHECK-NEXT: case (default) {
+//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT: }
+


### PR DESCRIPTION
This PR fixes CIR generation for the `switch-case` cases like the following:
```
case 'a':
default:
 ... 
```
or
```
default:
case 'a':
...
```
i.e. when the `default` clause is sub-statement of the `case` one and vice versa. 