### PR TITLE
[CIR][CIRGen] CIR generation for bitfields. Fixes #13

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -377,6 +377,11 @@ public:
     return getConstInt(
         loc, t, isSigned ? intVal.getSExtValue() : intVal.getZExtValue());
   }
+  mlir::Value getConstAPInt(mlir::Location loc, mlir::Type typ,
+                            const llvm::APInt &val) {
+    return create<mlir::cir::ConstantOp>(loc, typ,
+                                         getAttr<mlir::cir::IntAttr>(typ, val));
+  }
   mlir::cir::ConstantOp getBool(bool state, mlir::Location loc) {
     return create<mlir::cir::ConstantOp>(loc, getBoolTy(),
                                          getCIRBoolAttr(state));
@@ -624,6 +629,24 @@ public:
 
   mlir::Value createBitcast(mlir::Value src, mlir::Type newTy) {
     return createCast(mlir::cir::CastKind::bitcast, src, newTy);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Misc
+  //===--------------------------------------------------------------------===//
+
+  mlir::Value createBinop(mlir::Value lhs, mlir::cir::BinOpKind kind,
+                          const llvm::APInt &rhs) {
+    return create<mlir::cir::BinOp>(
+        lhs.getLoc(), lhs.getType(), kind, lhs,
+        getConstAPInt(lhs.getLoc(), lhs.getType(), rhs));
+  }
+
+  mlir::Value createShift(mlir::Value lhs, const llvm::APInt &rhs,
+                          bool isShiftLeft) {
+    return create<mlir::cir::ShiftOp>(
+        lhs.getLoc(), lhs.getType(), lhs,
+        getConstAPInt(lhs.getLoc(), lhs.getType(), rhs), isShiftLeft);
   }
 };
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -212,11 +212,8 @@ public:
   /// Emits the address of the l-value, then loads and returns the result.
   mlir::Value buildLoadOfLValue(const Expr *E) {
     LValue LV = CGF.buildLValue(E);
-    auto load = Builder.create<mlir::cir::LoadOp>(CGF.getLoc(E->getExprLoc()),
-                                                  CGF.getCIRType(E->getType()),
-                                                  LV.getPointer());
     // FIXME: add some akin to EmitLValueAlignmentAssumption(E, V);
-    return load;
+    return CGF.buildLoadOfLValue(LV, E->getExprLoc()).getScalarVal();
   }
 
   mlir::Value buildLoadOfLValue(LValue LV, SourceLocation Loc) {
@@ -1863,7 +1860,7 @@ mlir::Value ScalarExprEmitter::VisitBinAssign(const BinaryOperator *E) {
     // 'An assignment expression has the value of the left operand after the
     // assignment...'.
     if (LHS.isBitField()) {
-      llvm_unreachable("NYI");
+      CGF.buildStoreThroughBitfieldLValue(RValue::get(RHS), LHS, &RHS);
     } else {
       CGF.buildNullabilityCheck(LHS, RHS, E->getExprLoc());
       CIRGenFunction::SourceLocRAIIObject loc{CGF,
@@ -1964,25 +1961,27 @@ mlir::Value ScalarExprEmitter::VisitAbstractConditionalOperator(
     auto condV = CGF.evaluateExprAsBool(condExpr);
     assert(!UnimplementedFeature::incrementProfileCounter());
 
-    return builder.create<mlir::cir::TernaryOp>(
-        loc, condV, /*thenBuilder=*/
-        [&](mlir::OpBuilder &b, mlir::Location loc) {
-          auto lhs = Visit(lhsExpr);
-          if (!lhs) {
-            lhs = builder.getNullValue(CGF.VoidTy, loc);
-            lhsIsVoid = true;
-          }
-          builder.create<mlir::cir::YieldOp>(loc, lhs);
-        },
-        /*elseBuilder=*/
-        [&](mlir::OpBuilder &b, mlir::Location loc) {
-          auto rhs = Visit(rhsExpr);
-          if (lhsIsVoid) {
-            assert(!rhs && "lhs and rhs types must match");
-            rhs = builder.getNullValue(CGF.VoidTy, loc);
-          }
-          builder.create<mlir::cir::YieldOp>(loc, rhs);
-        }).getResult();
+    return builder
+        .create<mlir::cir::TernaryOp>(
+            loc, condV, /*thenBuilder=*/
+            [&](mlir::OpBuilder &b, mlir::Location loc) {
+              auto lhs = Visit(lhsExpr);
+              if (!lhs) {
+                lhs = builder.getNullValue(CGF.VoidTy, loc);
+                lhsIsVoid = true;
+              }
+              builder.create<mlir::cir::YieldOp>(loc, lhs);
+            },
+            /*elseBuilder=*/
+            [&](mlir::OpBuilder &b, mlir::Location loc) {
+              auto rhs = Visit(rhsExpr);
+              if (lhsIsVoid) {
+                assert(!rhs && "lhs and rhs types must match");
+                rhs = builder.getNullValue(CGF.VoidTy, loc);
+              }
+              builder.create<mlir::cir::YieldOp>(loc, rhs);
+            })
+        .getResult();
   }
 
   mlir::Value condV = CGF.buildOpOnBoolExpr(condExpr, loc, lhsExpr, rhsExpr);
@@ -2012,51 +2011,53 @@ mlir::Value ScalarExprEmitter::VisitAbstractConditionalOperator(
     }
   };
 
-  return builder.create<mlir::cir::TernaryOp>(
-      loc, condV, /*trueBuilder=*/
-      [&](mlir::OpBuilder &b, mlir::Location loc) {
-        CIRGenFunction::LexicalScopeContext lexScope{loc,
-                                                     b.getInsertionBlock()};
-        CIRGenFunction::LexicalScopeGuard lexThenGuard{CGF, &lexScope};
-        CGF.currLexScope->setAsTernary();
+  return builder
+      .create<mlir::cir::TernaryOp>(
+          loc, condV, /*trueBuilder=*/
+          [&](mlir::OpBuilder &b, mlir::Location loc) {
+            CIRGenFunction::LexicalScopeContext lexScope{loc,
+                                                         b.getInsertionBlock()};
+            CIRGenFunction::LexicalScopeGuard lexThenGuard{CGF, &lexScope};
+            CGF.currLexScope->setAsTernary();
 
-        assert(!UnimplementedFeature::incrementProfileCounter());
-        eval.begin(CGF);
-        auto lhs = Visit(lhsExpr);
-        eval.end(CGF);
+            assert(!UnimplementedFeature::incrementProfileCounter());
+            eval.begin(CGF);
+            auto lhs = Visit(lhsExpr);
+            eval.end(CGF);
 
-        if (lhs) {
-          yieldTy = lhs.getType();
-          b.create<mlir::cir::YieldOp>(loc, lhs);
-          return;
-        }
-        // If LHS or RHS is a throw or void expression we need to patch arms
-        // as to properly match yield types.
-        insertPoints.push_back(b.saveInsertionPoint());
-      },
-      /*falseBuilder=*/
-      [&](mlir::OpBuilder &b, mlir::Location loc) {
-        CIRGenFunction::LexicalScopeContext lexScope{loc,
-                                                     b.getInsertionBlock()};
-        CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
-        CGF.currLexScope->setAsTernary();
+            if (lhs) {
+              yieldTy = lhs.getType();
+              b.create<mlir::cir::YieldOp>(loc, lhs);
+              return;
+            }
+            // If LHS or RHS is a throw or void expression we need to patch arms
+            // as to properly match yield types.
+            insertPoints.push_back(b.saveInsertionPoint());
+          },
+          /*falseBuilder=*/
+          [&](mlir::OpBuilder &b, mlir::Location loc) {
+            CIRGenFunction::LexicalScopeContext lexScope{loc,
+                                                         b.getInsertionBlock()};
+            CIRGenFunction::LexicalScopeGuard lexElseGuard{CGF, &lexScope};
+            CGF.currLexScope->setAsTernary();
 
-        assert(!UnimplementedFeature::incrementProfileCounter());
-        eval.begin(CGF);
-        auto rhs = Visit(rhsExpr);
-        eval.end(CGF);
+            assert(!UnimplementedFeature::incrementProfileCounter());
+            eval.begin(CGF);
+            auto rhs = Visit(rhsExpr);
+            eval.end(CGF);
 
-        if (rhs) {
-          yieldTy = rhs.getType();
-          b.create<mlir::cir::YieldOp>(loc, rhs);
-        } else {
-          // If LHS or RHS is a throw or void expression we need to patch arms
-          // as to properly match yield types.
-          insertPoints.push_back(b.saveInsertionPoint());
-        }
+            if (rhs) {
+              yieldTy = rhs.getType();
+              b.create<mlir::cir::YieldOp>(loc, rhs);
+            } else {
+              // If LHS or RHS is a throw or void expression we need to patch
+              // arms as to properly match yield types.
+              insertPoints.push_back(b.saveInsertionPoint());
+            }
 
-        patchVoidOrThrowSites();
-      }).getResult();
+            patchVoidOrThrowSites();
+          })
+      .getResult();
 }
 
 mlir::Value CIRGenFunction::buildScalarPrePostIncDec(const UnaryOperator *E,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -577,7 +577,8 @@ public:
   const CIRGenFunctionInfo *CurFnInfo;
   clang::QualType FnRetTy;
 
-  /// This is the current function or global initializer that is generated code for.
+  /// This is the current function or global initializer that is generated code
+  /// for.
   mlir::Operation *CurFn = nullptr;
 
   /// Save Parameter Decl for coroutine.
@@ -593,7 +594,7 @@ public:
 
   CIRGenModule &getCIRGenModule() { return CGM; }
 
-  mlir::Block* getCurFunctionEntryBlock() {
+  mlir::Block *getCurFunctionEntryBlock() {
     auto Fn = dyn_cast<mlir::cir::FuncOp>(CurFn);
     assert(Fn && "other callables NYI");
     return &Fn.getRegion().front();
@@ -868,6 +869,12 @@ public:
                                 clang::SourceLocation Loc,
                                 LValueBaseInfo BaseInfo,
                                 bool isNontemporal = false);
+  mlir::Value buildLoadOfScalar(Address Addr, bool Volatile, clang::QualType Ty,
+                                mlir::Location Loc, LValueBaseInfo BaseInfo,
+                                bool isNontemporal = false);
+
+  RValue buildLoadOfBitfieldLValue(LValue LV, SourceLocation Loc);
+
   /// Load a scalar value from an address, taking care to appropriately convert
   /// from the memory representation to CIR value representation.
   mlir::Value buildLoadOfScalar(Address Addr, bool Volatile, clang::QualType Ty,
@@ -882,6 +889,7 @@ public:
   /// form the memory representation to the CIR value representation. The
   /// l-value must be a simple l-value.
   mlir::Value buildLoadOfScalar(LValue lvalue, clang::SourceLocation Loc);
+  mlir::Value buildLoadOfScalar(LValue lvalue, mlir::Location Loc);
 
   Address buildLoadOfReference(LValue RefLVal, mlir::Location Loc,
                                LValueBaseInfo *PointeeBaseInfo = nullptr);
@@ -1198,6 +1206,9 @@ public:
   /// lvalue, where both are guaranteed to the have the same type, and that type
   /// is 'Ty'.
   void buildStoreThroughLValue(RValue Src, LValue Dst);
+
+  void buildStoreThroughBitfieldLValue(RValue Src, LValue Dst,
+                                       mlir::Value *Result);
 
   mlir::cir::BrOp buildBranchThroughCleanup(mlir::Location Loc, JumpDest Dest);
 

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
@@ -187,6 +187,16 @@ public:
   /// Check whether this struct can be C++ zero-initialized with a
   /// zeroinitializer.
   bool isZeroInitializable() const { return IsZeroInitializable; }
+
+  /// Return the BitFieldInfo that corresponds to the field FD.
+  const CIRGenBitFieldInfo &getBitFieldInfo(const clang::FieldDecl *FD) const {
+    FD = FD->getCanonicalDecl();
+    assert(FD->isBitField() && "Invalid call for non-bit-field decl!");
+    llvm::DenseMap<const clang::FieldDecl *, CIRGenBitFieldInfo>::const_iterator
+        it = BitFields.find(FD);
+    assert(it != BitFields.end() && "Unable to find bitfield info");
+    return it->second;
+  }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/CodeGen/CIRGenValue.h
+++ b/clang/lib/CIR/CodeGen/CIRGenValue.h
@@ -15,6 +15,7 @@
 #define LLVM_CLANG_LIB_CIR_CIRGENVALUE_H
 
 #include "Address.h"
+#include "CIRGenRecordLayout.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/CharUnits.h"
@@ -207,6 +208,7 @@ private:
   mlir::Value V;
   mlir::Type ElementType;
   LValueBaseInfo BaseInfo;
+  const CIRGenBitFieldInfo *BitFieldInfo{0};
 
 public:
   bool isSimple() const { return LVType == Simple; }
@@ -298,6 +300,38 @@ public:
 
   const clang::Qualifiers &getQuals() const { return Quals; }
   clang::Qualifiers &getQuals() { return Quals; }
+
+  // bitfield lvalue
+  Address getBitFieldAddress() const {
+    return Address(getBitFieldPointer(), ElementType, getAlignment());
+  }
+
+  mlir::Value getBitFieldPointer() const {
+    assert(isBitField());
+    return V;
+  }
+
+  const CIRGenBitFieldInfo &getBitFieldInfo() const {
+    assert(isBitField());
+    return *BitFieldInfo;
+  }
+
+  /// Create a new object to represent a bit-field access.
+  ///
+  /// \param Addr - The base address of the bit-field sequence this
+  /// bit-field refers to.
+  /// \param Info - The information describing how to perform the bit-field
+  /// access.
+  static LValue MakeBitfield(Address Addr, const CIRGenBitFieldInfo &Info,
+                             clang::QualType type, LValueBaseInfo BaseInfo) {
+    LValue R;
+    R.LVType = BitField;
+    R.V = Addr.getPointer();
+    R.ElementType = Addr.getElementType();
+    R.BitFieldInfo = &Info;
+    R.Initialize(type, type.getQualifiers(), Addr.getAlignment(), BaseInfo);
+    return R;
+  }
 };
 
 /// An aggregate value slot.

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -214,8 +214,8 @@ CIRRecordLowering::CIRRecordLowering(CIRGenTypes &cirGenTypes,
       cxxRecordDecl{llvm::dyn_cast<CXXRecordDecl>(recordDecl)},
       astRecordLayout{cirGenTypes.getContext().getASTRecordLayout(recordDecl)},
       dataLayout{cirGenTypes.getModule().getModule()},
-      IsZeroInitializable(true), IsZeroInitializableAsBase(true),
-      isPacked{isPacked} {}
+      IsZeroInitializable(true),
+      IsZeroInitializableAsBase(true), isPacked{isPacked} {}
 
 void CIRRecordLowering::setBitFieldInfo(const FieldDecl *FD,
                                         CharUnits StartOffset,
@@ -474,6 +474,8 @@ void CIRRecordLowering::accumulateBitFields(
   // with lower cost.
   auto IsBetterAsSingleFieldRun = [&](uint64_t OffsetInRecord,
                                       uint64_t StartBitOffset) {
+    if (OffsetInRecord >= 64) // See IntType::verify
+      return true;
     if (!cirGenTypes.getModule().getCodeGenOpts().FineGrainedBitfieldAccesses)
       return false;
     llvm_unreachable("NYI");


### PR DESCRIPTION
This PR introduces bitfelds support. I explicitly marked the PR  as a draft, since I foresee some discussion here. 
There is no tests so far - and I will add them once we agree on everything else (or won't do it if we disagree at all :) ) 

Probably, the  key  design decision is an extra pointer to `CIRGenBitFieldInfo`  in the `Value` class. Unfortunately, it can not be done - at least from my point of view - in the same way, as it is done in the original `CodeGen/CGValue.h`.  The rest of the code is a revision of the code generation in `CodeGen` .

Also, there are some changes due to `clang-format` application. Just noticed it(

Basically, the next toy example works.

```
#include <stdio.h>

typedef struct {
    int a1 : 4;
    int a2 : 28;
    int a3 : 16;
    int a4 : 3;
    int a5 : 17;
    int a6 : 25; 
} A;

void init(A* a) {
    a->a1 = 1;
    a->a2 = 321;
    a->a3 = 15;
    a->a4 = 2;
    a->a5 = 123;
    a->a6 = 1234;
}

void print(A* a) {
    printf("%d %d %d %d %d %d\n",
        a->a1,
        a->a2,
        a->a3,
        a->a4,
        a->a5,
        a->a6
    );
}

int main() {
    A a;
    init(&a);
    print(&a);
    return 0;
}

```
