### PR TITLE
[CIR] Enable per-pass IR printing

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -1907,15 +1907,13 @@ void LifetimeCheckPass::checkOperation(Operation *op) {
 }
 
 void LifetimeCheckPass::runOnOperation() {
+  assert(astCtx && "Missing ASTContext, please construct with the right ctor");
   opts.parseOptions(*this);
   Operation *op = getOperation();
   checkOperation(op);
 }
 
 std::unique_ptr<Pass> mlir::createLifetimeCheckPass() {
-  // FIXME: MLIR requres a default "constructor", but should never
-  // be used.
-  llvm_unreachable("Check requires clang::ASTContext, use the other ctor");
   return std::make_unique<LifetimeCheckPass>();
 }
 

--- a/clang/lib/FrontendTool/CMakeLists.txt
+++ b/clang/lib/FrontendTool/CMakeLists.txt
@@ -17,6 +17,7 @@ set(deps)
 if(CLANG_ENABLE_CIR)
   list(APPEND link_libs
     clangCIRFrontendAction
+    MLIRCIRTransforms
     MLIRIR
     MLIRPass
     )

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -36,6 +36,7 @@
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Pass/PassManager.h"
+#include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIRFrontendAction/CIRGenAction.h"
 #endif
 
@@ -317,6 +318,7 @@ bool ExecuteCompilerInvocation(CompilerInstance *Clang) {
 #endif
 #if CLANG_ENABLE_CIR
   if (!Clang->getFrontendOpts().MLIRArgs.empty()) {
+    mlir::registerCIRPasses();
     mlir::registerMLIRContextCLOptions();
     mlir::registerPassManagerCLOptions();
     mlir::registerAsmPrinterCLOptions();

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR
 // RUN: %clang_cc1 -fclangir-enable -emit-llvm -mmlir --mlir-print-ir-after-all -mllvm -print-after-all  %s -o %t.ll 2>&1 | FileCheck %s -check-prefix=CIR -check-prefix=LLVM
+// RUN: %clang_cc1 -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after=cir-drop-ast %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRPASS
 
 int foo(void) {
   int i = 3;
@@ -15,3 +16,6 @@ int foo(void) {
 // LLVM: llvm.func @foo() -> i32
 // LLVM: IR Dump After VerifierPass on [module] ***
 // LLVM: define i32 @foo()
+
+// CIRPASS-NOT:  IR Dump After MergeCleanups
+// CIRPASS:      IR Dump After DropAST


### PR DESCRIPTION

Enabling IR printing with --mlir-print-ir-after=passName1, passName2. This requires all CIR passes to be registered at startup time.