### PR TITLE
[CIR][Lowering] Add LoweringPrepare pass to pre-lower global initializers

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1274,7 +1274,9 @@ def GlobalOp : CIR_Op<"global", [Symbol, DeclareOpInterfaceMethods<RegionBranchO
                        // Note this can also be a FlatSymbolRefAttr
                        OptionalAttr<AnyAttr>:$initial_value,
                        UnitAttr:$constant,
-                       OptionalAttr<I64Attr>:$alignment);
+                       OptionalAttr<I64Attr>:$alignment,
+                       OptionalAttr<ASTVarDeclAttr>:$ast
+                       );
   let regions = (region AnyRegion:$ctorRegion);
   let assemblyFormat = [{
        ($sym_visibility^)?

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -80,6 +80,7 @@ void CIRGenModule::codegenGlobalInitCxxStructor(const VarDecl *D,
     buildDeclInit(CGF, D, DeclAddr);
     builder.setInsertionPointToEnd(block);
     builder.create<mlir::cir::YieldOp>(Addr->getLoc());
+    Addr.setAstAttr(mlir::cir::ASTVarDeclAttr::get(builder.getContext(), D));
   }
   CurCGF = nullptr;
 }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1237,6 +1237,20 @@ LogicalResult GlobalOp::verify() {
       return failure();
   }
 
+  // Verify that the constructor region, if present, has only one block which is
+  // not empty.
+  auto &ctorRegion = getCtorRegion();
+  if (!ctorRegion.empty()) {
+    if (!ctorRegion.hasOneBlock()) {
+      return emitError() << "ctor region must have exactly one block.";
+    }
+
+    auto &block = ctorRegion.front();
+    if (block.empty()) {
+      return emitError() << "ctor region shall not be empty.";
+    }
+  }
+
   if (std::optional<uint64_t> alignAttr = getAlignment()) {
     uint64_t alignment = alignAttr.value();
     if (!llvm::isPowerOf2_64(alignment))

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@ add_clang_library(MLIRCIRTransforms
 
   LINK_LIBS PUBLIC
   clangAST
+  clangBasic
 
   MLIRAnalysis
   MLIRIR

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -7,17 +7,54 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Region.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Mangle.h"
+#include "clang/Basic/Module.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/Path.h"
 
 using namespace mlir;
 using namespace cir;
+
+static SmallString<128> getTransformedFileName(ModuleOp theModule) {
+  SmallString<128> FileName;
+
+  if (theModule.getSymName()) {
+    FileName = llvm::sys::path::filename(theModule.getSymName()->str());
+  }
+
+  if (FileName.empty())
+    FileName = "<null>";
+
+  for (size_t i = 0; i < FileName.size(); ++i) {
+    // Replace everything that's not [a-zA-Z0-9._] with a _. This set happens
+    // to be the set of C preprocessing numbers.
+    if (!clang::isPreprocessingNumberBody(FileName[i]))
+      FileName[i] = '_';
+  }
+
+  return FileName;
+}
 
 namespace {
 struct LoweringPreparePass : public LoweringPrepareBase<LoweringPreparePass> {
   LoweringPreparePass() = default;
   void runOnOperation() override;
+
+  void runOnOp(Operation *op);
+  void lowerGlobalOp(GlobalOp op);
+
+  /// Build the function that initializes the specified global
+  cir::FuncOp buildCXXGlobalVarDeclInitFunc(GlobalOp op);
+
+  /// Build a module init function that calls all the dynamic initializers.
+  void buildCXXGlobalInitFunc();
 
   ///
   /// AST related
@@ -28,9 +65,120 @@ struct LoweringPreparePass : public LoweringPrepareBase<LoweringPreparePass> {
 
   /// Tracks current module.
   ModuleOp theModule;
+
+  /// Tracks existing dynamic initializers.
+  llvm::StringMap<uint32_t> dynamicInitializerNames;
+  llvm::SmallVector<FuncOp, 4> dynamicInitializers;
 };
 } // namespace
 
+cir::FuncOp LoweringPreparePass::buildCXXGlobalVarDeclInitFunc(GlobalOp op) {
+  SmallString<256> fnName;
+  {
+    std::unique_ptr<clang::MangleContext> MangleCtx(
+        astCtx->createMangleContext());
+    llvm::raw_svector_ostream Out(fnName);
+    auto varDecl = op.getAst()->getAstDecl();
+    MangleCtx->mangleDynamicInitializer(varDecl, Out);
+    // Name numbering
+    uint32_t cnt = dynamicInitializerNames[fnName]++;
+    if (cnt)
+      fnName += "." + llvm::Twine(cnt).str();
+  }
+
+  // Create a variable initialization function.
+  mlir::OpBuilder builder(&getContext());
+  builder.setInsertionPointAfter(op);
+  auto fnType = mlir::cir::FuncType::get(
+      {}, mlir::cir::VoidType::get(builder.getContext()));
+  FuncOp f = builder.create<mlir::cir::FuncOp>(op.getLoc(), fnName, fnType);
+  f.setLinkageAttr(mlir::cir::GlobalLinkageKindAttr::get(
+      builder.getContext(), mlir::cir::GlobalLinkageKind::InternalLinkage));
+  mlir::SymbolTable::setSymbolVisibility(
+      f, mlir::SymbolTable::Visibility::Private);
+  mlir::NamedAttrList attrs;
+  f.setExtraAttrsAttr(mlir::cir::ExtraFuncAttributesAttr::get(
+      builder.getContext(), attrs.getDictionary(builder.getContext())));
+
+  // move over the initialzation code of the ctor region.
+  auto &block = op.getCtorRegion().front();
+  mlir::Block *EntryBB = f.addEntryBlock();
+  EntryBB->getOperations().splice(EntryBB->begin(), block.getOperations(),
+                                  block.begin(), std::prev(block.end()));
+
+  // Replace cir.yield with cir.return
+  builder.setInsertionPointToEnd(EntryBB);
+  auto &yieldOp = block.getOperations().back();
+  assert(isa<YieldOp>(yieldOp));
+  builder.create<ReturnOp>(yieldOp.getLoc());
+  return f;
+}
+
+void LoweringPreparePass::lowerGlobalOp(GlobalOp op) {
+  auto &ctorRegion = op.getCtorRegion();
+  if (!ctorRegion.empty()) {
+    // Build a variable initialization function and move the initialzation code
+    // in the ctor region over.
+    auto f = buildCXXGlobalVarDeclInitFunc(op);
+
+    // Clear the ctor region
+    ctorRegion.getBlocks().clear();
+
+    // Add a function call to the variable initialization function.
+    dynamicInitializers.push_back(f);
+  }
+}
+
+void LoweringPreparePass::buildCXXGlobalInitFunc() {
+  if (dynamicInitializers.empty())
+    return;
+
+  SmallString<256> fnName;
+  // Include the filename in the symbol name. Including "sub_" matches gcc
+  // and makes sure these symbols appear lexicographically behind the symbols
+  // with priority emitted above.  Module implementation units behave the same
+  // way as a non-modular TU with imports.
+  // TODO: check CXX20ModuleInits
+  if (astCtx->getCurrentNamedModule() &&
+      !astCtx->getCurrentNamedModule()->isModuleImplementation()) {
+    llvm::raw_svector_ostream Out(fnName);
+    std::unique_ptr<clang::MangleContext> MangleCtx(
+        astCtx->createMangleContext());
+    cast<clang::ItaniumMangleContext>(*MangleCtx)
+        .mangleModuleInitializer(astCtx->getCurrentNamedModule(), Out);
+  } else {
+    fnName += "_GLOBAL__sub_I_";
+    fnName += getTransformedFileName(theModule);
+  }
+
+  mlir::OpBuilder builder(&getContext());
+  builder.setInsertionPointToEnd(&theModule.getBodyRegion().back());
+  auto fnType = mlir::cir::FuncType::get(
+      {}, mlir::cir::VoidType::get(builder.getContext()));
+  FuncOp f =
+      builder.create<mlir::cir::FuncOp>(theModule.getLoc(), fnName, fnType);
+  f.setLinkageAttr(mlir::cir::GlobalLinkageKindAttr::get(
+      builder.getContext(), mlir::cir::GlobalLinkageKind::ExternalLinkage));
+  mlir::SymbolTable::setSymbolVisibility(
+      f, mlir::SymbolTable::Visibility::Private);
+  mlir::NamedAttrList attrs;
+  f.setExtraAttrsAttr(mlir::cir::ExtraFuncAttributesAttr::get(
+      builder.getContext(), attrs.getDictionary(builder.getContext())));
+
+  builder.setInsertionPointToStart(f.addEntryBlock());
+  for (auto &f : dynamicInitializers) {
+    builder.create<mlir::cir::CallOp>(f.getLoc(), f);
+  }
+
+  builder.create<ReturnOp>(f.getLoc());
+}
+
+void LoweringPreparePass::runOnOp(Operation *op) {
+  if (GlobalOp globalOp = cast<GlobalOp>(op)) {
+    lowerGlobalOp(globalOp);
+    return;
+  }
+}
 
 void LoweringPreparePass::runOnOperation() {
   assert(astCtx && "Missing ASTContext, please construct with the right ctor");
@@ -38,6 +186,18 @@ void LoweringPreparePass::runOnOperation() {
   if (isa<::mlir::ModuleOp>(op)) {
     theModule = cast<::mlir::ModuleOp>(op);
   }
+
+  SmallVector<Operation *> opsToTransform;
+  op->walk([&](Operation *op) {
+    if (isa<GlobalOp>(op))
+      opsToTransform.push_back(op);
+  });
+
+  for (auto *o : opsToTransform) {
+    runOnOp(o);
+  }
+
+  buildCXXGlobalInitFunc();
 }
 
 std::unique_ptr<Pass> mlir::createLoweringPreparePass() {

--- a/clang/test/CIR/CodeGen/static.cpp
+++ b/clang/test/CIR/CodeGen/static.cpp
@@ -1,6 +1,7 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: cir-opt %t.cir -o - | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=BEFORE
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
+// RUN: cir-opt %t.cir -o - | FileCheck %s -check-prefix=AFTER
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
 
 class Init {
 
@@ -13,12 +14,52 @@ private:
 
 
 static Init __ioinit(true);
+static Init __ioinit2(false);
 
-// CIR:      module {{.*}} {
-// CIR-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !cir.bool)
-// CIR-NEXT:   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22class2EInit22 {
-// CIR-NEXT:     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22>
-// CIR-NEXT:     %1 = cir.const(#true) : !cir.bool
-// CIR-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
-// CIR-NEXT:   }
-// CIR-NEXT: }
+// BEFORE:      module {{.*}} {
+// BEFORE-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !cir.bool)
+// BEFORE-NEXT:   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22class2EInit22 {
+// BEFORE-NEXT:     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22>
+// BEFORE-NEXT:     %1 = cir.const(#true) : !cir.bool
+// BEFORE-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
+// BEFORE-NEXT:   } {ast = #cir.vardecl.ast}
+// BEFORE:        cir.global "private" internal @_ZL9__ioinit2 = ctor : !ty_22class2EInit22 {
+// BEFORE-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : cir.ptr <!ty_22class2EInit22>
+// BEFORE-NEXT:     %1 = cir.const(#false) : !cir.bool
+// BEFORE-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
+// BEFORE-NEXT:   } {ast = #cir.vardecl.ast}
+// BEFORE-NEXT: }
+
+
+// AFTER:      module {{.*}} {
+// AFTER-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !cir.bool)
+// AFTER-NEXT:   cir.global "private" internal @_ZL8__ioinit =  #cir.zero : !ty_22class2EInit22 {ast = #cir.vardecl.ast}
+// AFTER-NEXT:   cir.func internal private @__cxx_global_var_init()
+// AFTER-NEXT:     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22>
+// AFTER-NEXT:     %1 = cir.const(#true) : !cir.bool
+// AFTER-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
+// AFTER-NEXT:     cir.return
+// AFTER:        cir.global "private" internal @_ZL9__ioinit2 =  #cir.zero : !ty_22class2EInit22 {ast = #cir.vardecl.ast}
+// AFTER-NEXT:   cir.func internal private @__cxx_global_var_init.1()
+// AFTER-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : cir.ptr <!ty_22class2EInit22>
+// AFTER-NEXT:     %1 = cir.const(#false) : !cir.bool
+// AFTER-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
+// AFTER-NEXT:     cir.return
+// AFTER:        cir.func private @_GLOBAL__sub_I_static.cpp()
+// AFTER-NEXT:     cir.call @__cxx_global_var_init() : () -> ()
+// AFTER-NEXT:     cir.call @__cxx_global_var_init.1() : () -> ()
+// AFTER-NEXT:     cir.return
+
+
+// LLVM:      @_ZL8__ioinit = internal global %class.Init zeroinitializer
+// LLVM:      @_ZL9__ioinit2 = internal global %class.Init zeroinitializer
+// LLVM:      define internal void @__cxx_global_var_init()
+// LLVM-NEXT:   call void @_ZN4InitC1Eb(ptr @_ZL8__ioinit, i8 1)
+// LLVM-NEXT:   ret void
+// LLVM:      define internal void @__cxx_global_var_init.1()
+// LLVM-NEXT:   call void @_ZN4InitC1Eb(ptr @_ZL9__ioinit2, i8 0)
+// LLVM-NEXT:   ret void
+// LLVM:      define void @_GLOBAL__sub_I_static.cpp()
+// LLVM-NEXT:  call void @__cxx_global_var_init()
+// LLVM-NEXT:  call void @__cxx_global_var_init.1()
+// LLVM-NEXT:  ret void


### PR DESCRIPTION
As a follow up to https://github.com/llvm/clangir/pull/197, this change pre-lowers high-level CIR for global initializers.

High-level CIR:

```
  cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22class2EInit22 {
    %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22> loc(#loc8)
    %1 = cir.const(#true) : !cir.bool loc(#loc5)
    cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> () loc(#loc6)
 }
```

After pre-lowering:

```
   cir.global "private" internal @_ZL8__ioinit =  #cir.zero : !ty_22class2EInit22 {ast = #cir.vardecl.ast}

   cir.func internal private @__cxx_global_var_init() {
     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22class2EInit22>
     %1 = cir.const(#true) : !cir.bool
     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
     cir.return
  }

   cir.func private @_GLOBAL__sub_I_static.cpp() {
     cir.call @__cxx_global_var_init() : () -> ()
     cir.return
  }
```


There is still work to be done to fully lower to LLVM. E.g, add `llvm.global_ctors` global to list all module initializers like `_GLOBAL__sub_I_static`. This will be handled in a separate change.


