### PR TITLE
[CIR][Lowering] Emit llvm.global_ctors list

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -452,4 +452,18 @@ def OptNoneAttr : CIRUnitAttr<"OptNone", "optnone"> {
   let storageType = [{ OptNoneAttr }];
 }
 
+def GlobalCtorAttr : CIR_Attr<"GlobalCtor", "globalCtor"> {
+  let summary = "Indicates a function is a global constructor.";
+  let description = [{
+    Describing a global constructor with a priority.
+  }];
+  let parameters = (ins "int":$value);
+  let assemblyFormat = [{
+    `<` $value `>`
+  }];
+
+  let extraClassDeclaration = [{
+    int getPriority() const { return getValue(); }
+  }];
+}
 #endif // MLIR_CIR_DIALECT_CIR_ATTRS

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -455,15 +455,17 @@ def OptNoneAttr : CIRUnitAttr<"OptNone", "optnone"> {
 def GlobalCtorAttr : CIR_Attr<"GlobalCtor", "globalCtor"> {
   let summary = "Indicates a function is a global constructor.";
   let description = [{
-    Describing a global constructor with a priority.
+    Describing a global constructor with a priority (default 65536).
   }];
-  let parameters = (ins "int":$value);
+  let parameters = (ins "StringAttr":$name, "int":$priority);
   let assemblyFormat = [{
-    `<` $value `>`
+    `<` $name  `,` $priority `>`
   }];
-
-  let extraClassDeclaration = [{
-    int getPriority() const { return getValue(); }
-  }];
+  let builders = [
+    AttrBuilder<(ins "StringRef":$name, CArg<"int", "65536">:$priority), [{
+      return $_get($_ctxt, StringAttr::get($_ctxt, name), priority);
+    }]>
+  ];
+  let skipDefaultBuilders = 1;
 }
 #endif // MLIR_CIR_DIALECT_CIR_ATTRS

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -455,14 +455,19 @@ def OptNoneAttr : CIRUnitAttr<"OptNone", "optnone"> {
 def GlobalCtorAttr : CIR_Attr<"GlobalCtor", "globalCtor"> {
   let summary = "Indicates a function is a global constructor.";
   let description = [{
-    Describing a global constructor with a priority (default 65536).
+    Describing a global constructor with an optional priority.
   }];
-  let parameters = (ins "StringAttr":$name, "int":$priority);
+  let parameters = (ins "StringAttr":$name,
+                        OptionalParameter<"std::optional<int>">:$priority);
   let assemblyFormat = [{
-    `<` $name  `,` $priority `>`
+    `<`
+      $name
+      (`,` $priority^)?
+    `>`
   }];
   let builders = [
-    AttrBuilder<(ins "StringRef":$name, CArg<"int", "65536">:$priority), [{
+    AttrBuilder<(ins "StringRef":$name,
+                      CArg<"std::optional<int>", "{}">:$priority), [{
       return $_get($_ctxt, StringAttr::get($_ctxt, name), priority);
     }]>
   ];

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -162,6 +162,10 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
   mlir::SymbolTable::setSymbolVisibility(
       f, mlir::SymbolTable::Visibility::Private);
   mlir::NamedAttrList attrs;
+  // 65535 is the default priority, i.e, the lowest priority.
+  // TODO: handle globals with a user-specified initialzation priority.
+  auto ctorAttr = mlir::cir::GlobalCtorAttr::get(builder.getContext(), 65535);
+  attrs.set(ctorAttr.getMnemonic(), ctorAttr);
   f.setExtraAttrsAttr(mlir::cir::ExtraFuncAttributesAttr::get(
       builder.getContext(), attrs.getDictionary(builder.getContext())));
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -126,6 +126,8 @@ void LoweringPreparePass::lowerGlobalOp(GlobalOp op) {
     ctorRegion.getBlocks().clear();
 
     // Add a function call to the variable initialization function.
+    assert(!op.getAst()->getAstDecl()->getAttr<clang::InitPriorityAttr>() &&
+           "custom initialization priority NYI");
     dynamicInitializers.push_back(f);
   }
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1838,8 +1838,13 @@ static void buildCtorList(mlir::ModuleOp module) {
       for (auto attr : namedAttr.getValue().cast<mlir::ArrayAttr>()) {
         assert(attr.isa<mlir::cir::GlobalCtorAttr>() &&
                "must be a GlobalCtorAttr");
-        if (auto ctorAttr = attr.cast<mlir::cir::GlobalCtorAttr>())
-          globalCtors.emplace_back(ctorAttr.getName(), ctorAttr.getPriority());
+        if (auto ctorAttr = attr.cast<mlir::cir::GlobalCtorAttr>()) {
+           // default priority is 65536
+          int priority = 65536;
+          if (ctorAttr.getPriority())
+            priority = *ctorAttr.getPriority();
+          globalCtors.emplace_back(ctorAttr.getName(), priority);
+        }
       }
       break;
     }

--- a/clang/test/CIR/CodeGen/static.cpp
+++ b/clang/test/CIR/CodeGen/static.cpp
@@ -31,7 +31,7 @@ static Init __ioinit2(false);
 // BEFORE-NEXT: }
 
 
-// AFTER:      module {{.*}} attributes {{.*}}cir.globalCtors = [#cir.globalCtor<"__cxx_global_var_init", 65536>, #cir.globalCtor<"__cxx_global_var_init.1", 65536>]
+// AFTER:      module {{.*}} attributes {{.*}}cir.globalCtors = [#cir.globalCtor<"__cxx_global_var_init">, #cir.globalCtor<"__cxx_global_var_init.1">]
 // AFTER-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !cir.bool)
 // AFTER-NEXT:   cir.global "private" internal @_ZL8__ioinit =  #cir.zero : !ty_22class2EInit22 {ast = #cir.vardecl.ast}
 // AFTER-NEXT:   cir.func internal private @__cxx_global_var_init()

--- a/clang/test/CIR/CodeGen/static.cpp
+++ b/clang/test/CIR/CodeGen/static.cpp
@@ -45,14 +45,14 @@ static Init __ioinit2(false);
 // AFTER-NEXT:     %1 = cir.const(#false) : !cir.bool
 // AFTER-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
 // AFTER-NEXT:     cir.return
-// AFTER:        cir.func private @_GLOBAL__sub_I_static.cpp()
+// AFTER:        cir.func private @_GLOBAL__sub_I_static.cpp() extra( {globalCtor = #cir.globalCtor<65535>} )
 // AFTER-NEXT:     cir.call @__cxx_global_var_init() : () -> ()
 // AFTER-NEXT:     cir.call @__cxx_global_var_init.1() : () -> ()
 // AFTER-NEXT:     cir.return
 
-
 // LLVM:      @_ZL8__ioinit = internal global %class.Init zeroinitializer
 // LLVM:      @_ZL9__ioinit2 = internal global %class.Init zeroinitializer
+// LLVM:      @llvm.global_ctors = appending constant [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @_GLOBAL__sub_I_static.cpp, ptr null }]
 // LLVM:      define internal void @__cxx_global_var_init()
 // LLVM-NEXT:   call void @_ZN4InitC1Eb(ptr @_ZL8__ioinit, i8 1)
 // LLVM-NEXT:   ret void

--- a/clang/test/CIR/CodeGen/static.cpp
+++ b/clang/test/CIR/CodeGen/static.cpp
@@ -31,7 +31,7 @@ static Init __ioinit2(false);
 // BEFORE-NEXT: }
 
 
-// AFTER:      module {{.*}} {
+// AFTER:      module {{.*}} attributes {{.*}}cir.globalCtors = [#cir.globalCtor<"__cxx_global_var_init", 65536>, #cir.globalCtor<"__cxx_global_var_init.1", 65536>]
 // AFTER-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !cir.bool)
 // AFTER-NEXT:   cir.global "private" internal @_ZL8__ioinit =  #cir.zero : !ty_22class2EInit22 {ast = #cir.vardecl.ast}
 // AFTER-NEXT:   cir.func internal private @__cxx_global_var_init()
@@ -45,14 +45,14 @@ static Init __ioinit2(false);
 // AFTER-NEXT:     %1 = cir.const(#false) : !cir.bool
 // AFTER-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
 // AFTER-NEXT:     cir.return
-// AFTER:        cir.func private @_GLOBAL__sub_I_static.cpp() extra( {globalCtor = #cir.globalCtor<65535>} )
+// AFTER:        cir.func private @_GLOBAL__sub_I_static.cpp()
 // AFTER-NEXT:     cir.call @__cxx_global_var_init() : () -> ()
 // AFTER-NEXT:     cir.call @__cxx_global_var_init.1() : () -> ()
 // AFTER-NEXT:     cir.return
 
 // LLVM:      @_ZL8__ioinit = internal global %class.Init zeroinitializer
 // LLVM:      @_ZL9__ioinit2 = internal global %class.Init zeroinitializer
-// LLVM:      @llvm.global_ctors = appending constant [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @_GLOBAL__sub_I_static.cpp, ptr null }]
+// LLVM:      @llvm.global_ctors = appending constant [2 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65536, ptr @__cxx_global_var_init, ptr null }, { i32, ptr, ptr } { i32 65536, ptr @__cxx_global_var_init.1, ptr null }]
 // LLVM:      define internal void @__cxx_global_var_init()
 // LLVM-NEXT:   call void @_ZN4InitC1Eb(ptr @_ZL8__ioinit, i8 1)
 // LLVM-NEXT:   ret void

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -3,6 +3,7 @@
 // RUN: cir-translate %s -cir-to-llvmir -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
+#false = #cir.bool<false> : !cir.bool
 !s16i = !cir.int<s, 16>
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
@@ -12,6 +13,8 @@
 !u8i = !cir.int<u, 8>
 !ty_22struct2EA22 = !cir.struct<"struct.A", !s32i, !cir.array<!cir.array<!s32i x 2> x 2>, #cir.recdecl.ast>
 !ty_22struct2EBar22 = !cir.struct<"struct.Bar", !s32i, !s8i, #cir.recdecl.ast>
+!ty_22class2EInit22 = !cir.struct<"class.Init", !u8i>
+
 
 module {
   cir.global external @a = #cir.int<3> : !s32i
@@ -145,4 +148,27 @@ module {
   // MLIR:   %0 = cir.llvmir.zeroinit : !llvm.struct<"struct.Bar", (i32, i8)>
   // MLIR:   llvm.return %0 : !llvm.struct<"struct.Bar", (i32, i8)>
   // MLIR: }
+  cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !cir.bool) extra( {inline = #cir.inline<no>} )
+  cir.global "private" internal @_ZL9__ioinit2 = #cir.zero : !ty_22class2EInit22
+  cir.func internal private @__cxx_global_var_init() {
+    %0 = cir.get_global @_ZL9__ioinit2 : cir.ptr <!ty_22class2EInit22>
+    %1 = cir.const(#false) : !cir.bool
+    cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
+    cir.return
+  }
+  cir.func private @_GLOBAL__sub_I_static.cpp() extra( {globalCtor = #cir.globalCtor<65535>} ){
+    cir.call @__cxx_global_var_init() : () -> ()
+    cir.return
+  }
+  // MLIR:       llvm.mlir.global appending constant @llvm.global_ctors() {addr_space = 0 : i32} : !llvm.array<1 x struct<(i32, ptr, ptr)>>
+  // MLIR-NEXT:    %0 = llvm.mlir.undef : !llvm.array<1 x struct<(i32, ptr, ptr)>>
+  // MLIR-NEXT:    %1 = llvm.mlir.undef : !llvm.struct<(i32, ptr, ptr)>
+  // MLIR-NEXT:    %2 = llvm.mlir.constant(65535 : i32) : i32
+  // MLIR-NEXT:    %3 = llvm.mlir.addressof @_GLOBAL__sub_I_static.cpp : !llvm.ptr
+  // MLIR-NEXT:    %4 = llvm.mlir.null : !llvm.ptr
+  // MLIR-NEXT:    %5 = llvm.insertvalue %2, %1[0] : !llvm.struct<(i32, ptr, ptr)>
+  // MLIR-NEXT:    %6 = llvm.insertvalue %3, %5[1] : !llvm.struct<(i32, ptr, ptr)>
+  // MLIR-NEXT:    %7 = llvm.insertvalue %4, %6[2] : !llvm.struct<(i32, ptr, ptr)>
+  // MLIR-NEXT:    %8 = llvm.insertvalue %7, %0[0] : !llvm.array<1 x struct<(i32, ptr, ptr)>>
+  // MLIR-NEXT:    llvm.return %8 : !llvm.array<1 x struct<(i32, ptr, ptr)>>
 }

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -3,7 +3,6 @@
 // RUN: cir-translate %s -cir-to-llvmir -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
-#false = #cir.bool<false> : !cir.bool
 !s16i = !cir.int<s, 16>
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
@@ -13,8 +12,6 @@
 !u8i = !cir.int<u, 8>
 !ty_22struct2EA22 = !cir.struct<"struct.A", !s32i, !cir.array<!cir.array<!s32i x 2> x 2>, #cir.recdecl.ast>
 !ty_22struct2EBar22 = !cir.struct<"struct.Bar", !s32i, !s8i, #cir.recdecl.ast>
-!ty_22class2EInit22 = !cir.struct<"class.Init", !u8i>
-
 
 module {
   cir.global external @a = #cir.int<3> : !s32i
@@ -148,27 +145,4 @@ module {
   // MLIR:   %0 = cir.llvmir.zeroinit : !llvm.struct<"struct.Bar", (i32, i8)>
   // MLIR:   llvm.return %0 : !llvm.struct<"struct.Bar", (i32, i8)>
   // MLIR: }
-  cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22class2EInit22>, !cir.bool) extra( {inline = #cir.inline<no>} )
-  cir.global "private" internal @_ZL9__ioinit2 = #cir.zero : !ty_22class2EInit22
-  cir.func internal private @__cxx_global_var_init() {
-    %0 = cir.get_global @_ZL9__ioinit2 : cir.ptr <!ty_22class2EInit22>
-    %1 = cir.const(#false) : !cir.bool
-    cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22class2EInit22>, !cir.bool) -> ()
-    cir.return
-  }
-  cir.func private @_GLOBAL__sub_I_static.cpp() extra( {globalCtor = #cir.globalCtor<65535>} ){
-    cir.call @__cxx_global_var_init() : () -> ()
-    cir.return
-  }
-  // MLIR:       llvm.mlir.global appending constant @llvm.global_ctors() {addr_space = 0 : i32} : !llvm.array<1 x struct<(i32, ptr, ptr)>>
-  // MLIR-NEXT:    %0 = llvm.mlir.undef : !llvm.array<1 x struct<(i32, ptr, ptr)>>
-  // MLIR-NEXT:    %1 = llvm.mlir.undef : !llvm.struct<(i32, ptr, ptr)>
-  // MLIR-NEXT:    %2 = llvm.mlir.constant(65535 : i32) : i32
-  // MLIR-NEXT:    %3 = llvm.mlir.addressof @_GLOBAL__sub_I_static.cpp : !llvm.ptr
-  // MLIR-NEXT:    %4 = llvm.mlir.null : !llvm.ptr
-  // MLIR-NEXT:    %5 = llvm.insertvalue %2, %1[0] : !llvm.struct<(i32, ptr, ptr)>
-  // MLIR-NEXT:    %6 = llvm.insertvalue %3, %5[1] : !llvm.struct<(i32, ptr, ptr)>
-  // MLIR-NEXT:    %7 = llvm.insertvalue %4, %6[2] : !llvm.struct<(i32, ptr, ptr)>
-  // MLIR-NEXT:    %8 = llvm.insertvalue %7, %0[0] : !llvm.array<1 x struct<(i32, ptr, ptr)>>
-  // MLIR-NEXT:    llvm.return %8 : !llvm.array<1 x struct<(i32, ptr, ptr)>>
 }


### PR DESCRIPTION
Creating the `llvm.global_ctors` list to hold all global dynamic initializers. The list has the following format:

```
%0 = type { i32, ptr, ptr }
@llvm.global_ctors = appending global [1 x %0] [%0 { i32 65535, ptr @ctor, ptr @data }]
```

The list will be converted to `.init_array` for ELF by LLVM which will be loaded and executed by the C++ runtime.