### PR TITLE
[CIR][Codegen] Destructor support for global variable initialization

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1277,19 +1277,19 @@ def GlobalOp : CIR_Op<"global", [Symbol, DeclareOpInterfaceMethods<RegionBranchO
                        OptionalAttr<I64Attr>:$alignment,
                        OptionalAttr<ASTVarDeclAttr>:$ast
                        );
-  let regions = (region AnyRegion:$ctorRegion);
+  let regions = (region AnyRegion:$ctorRegion, AnyRegion:$dtorRegion);
   let assemblyFormat = [{
        ($sym_visibility^)?
        (`constant` $constant^)?
        $linkage
        $sym_name
-       custom<GlobalOpTypeAndInitialValue>($sym_type, $initial_value, $ctorRegion)
+       custom<GlobalOpTypeAndInitialValue>($sym_type, $initial_value, $ctorRegion, $dtorRegion)
        attr-dict
   }];
 
   let extraClassDeclaration = [{
     bool isDeclaration() {
-      return !getInitialValue() && getCtorRegion().empty();
+      return !getInitialValue() && getCtorRegion().empty() && getDtorRegion().empty();
     }
     bool hasInitializer() { return !isDeclaration(); }
     bool hasAvailableExternallyLinkage() {
@@ -1317,7 +1317,9 @@ def GlobalOp : CIR_Op<"global", [Symbol, DeclareOpInterfaceMethods<RegionBranchO
       CArg<"cir::GlobalLinkageKind",
             "cir::GlobalLinkageKind::ExternalLinkage">:$linkage,
       CArg<"function_ref<void(OpBuilder &, Location)>",
-           "nullptr">:$ctorBuilder)>
+           "nullptr">:$ctorBuilder,
+      CArg<"function_ref<void(OpBuilder &, Location)>",
+           "nullptr">:$dtorBuilder)>
   ];
 
   let hasVerifier = 1;

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -12,10 +12,13 @@
 
 // We might split this into multiple files if it gets too unwieldy
 
+#include "CIRGenCXXABI.h"
 #include "CIRGenFunction.h"
 #include "CIRGenModule.h"
 
 #include "clang/AST/GlobalDecl.h"
+#include "llvm/Support/ErrorHandling.h"
+#include <cassert>
 
 using namespace clang;
 using namespace cir;
@@ -48,6 +51,39 @@ static void buildDeclInit(CIRGenFunction &CGF, const VarDecl *D,
   }
 }
 
+static void buildDeclDestory(CIRGenFunction &CGF, const VarDecl *D,
+                             Address DeclPtr) {
+  // Honor __attribute__((no_destroy)) and bail instead of attempting
+  // to emit a reference to a possibly nonexistent destructor, which
+  // in turn can cause a crash. This will result in a global constructor
+  // that isn't balanced out by a destructor call as intended by the
+  // attribute. This also checks for -fno-c++-static-destructors and
+  // bails even if the attribute is not present.
+  assert(D->needsDestruction(CGF.getContext()) == QualType::DK_cxx_destructor);
+
+  auto &CGM = CGF.CGM;
+
+  // If __cxa_atexit is disabled via a flag, a different helper function is
+  // generated elsewhere which uses atexit instead, and it takes the destructor
+  // directly.
+  auto UsingExternalHelper = CGM.getCodeGenOpts().CXAAtExit;
+  QualType type = D->getType();
+  const CXXRecordDecl *Record = type->getAsCXXRecordDecl();
+  bool CanRegisterDestructor =
+      Record && (!CGM.getCXXABI().HasThisReturn(
+                     GlobalDecl(Record->getDestructor(), Dtor_Complete)) ||
+                 CGM.getCXXABI().canCallMismatchedFunctionType());
+  if (Record && (CanRegisterDestructor || UsingExternalHelper)) {
+    assert(!D->getTLSKind() && "TLS NYI");
+    CXXDestructorDecl *Dtor = Record->getDestructor();
+    CGM.getCXXABI().buildDestructorCall(CGF, Dtor, Dtor_Complete,
+                                        /*ForVirtualBase=*/false,
+                                        /*Delegating=*/false, DeclPtr, type);
+  } else {
+    llvm_unreachable("array destructors not yet supported!");
+  }
+}
+
 mlir::cir::FuncOp CIRGenModule::codegenCXXStructor(GlobalDecl GD) {
   const auto &FnInfo = getTypes().arrangeCXXStructorDeclaration(GD);
   auto Fn = getAddrOfCXXStructor(GD, &FnInfo, /*FnType=*/nullptr,
@@ -68,11 +104,16 @@ mlir::cir::FuncOp CIRGenModule::codegenCXXStructor(GlobalDecl GD) {
 }
 
 void CIRGenModule::codegenGlobalInitCxxStructor(const VarDecl *D,
-                                                mlir::cir::GlobalOp Addr) {
+                                                mlir::cir::GlobalOp Addr,
+                                                bool NeedsCtor,
+                                                bool NeedsDtor) {
+  assert(D && " Expected a global declaration!");
   CIRGenFunction CGF{*this, builder, true};
   CurCGF = &CGF;
   CurCGF->CurFn = Addr;
-  {
+  Addr.setAstAttr(mlir::cir::ASTVarDeclAttr::get(builder.getContext(), D));
+
+  if (NeedsCtor) {
     mlir::OpBuilder::InsertionGuard guard(builder);
     auto block = builder.createBlock(&Addr.getCtorRegion());
     builder.setInsertionPointToStart(block);
@@ -80,7 +121,17 @@ void CIRGenModule::codegenGlobalInitCxxStructor(const VarDecl *D,
     buildDeclInit(CGF, D, DeclAddr);
     builder.setInsertionPointToEnd(block);
     builder.create<mlir::cir::YieldOp>(Addr->getLoc());
-    Addr.setAstAttr(mlir::cir::ASTVarDeclAttr::get(builder.getContext(), D));
   }
+
+  if (NeedsDtor) {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    auto block = builder.createBlock(&Addr.getDtorRegion());
+    builder.setInsertionPointToStart(block);
+    Address DeclAddr(getAddrOfGlobalVar(D), getASTContext().getDeclAlign(D));
+    buildDeclDestory(CGF, D, DeclAddr);
+    builder.setInsertionPointToEnd(block);
+    builder.create<mlir::cir::YieldOp>(Addr->getLoc());
+  }
+
   CurCGF = nullptr;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -258,6 +258,16 @@ public:
     return false;
   }
 
+  /// Returns true if the target allows calling a function through a pointer
+  /// with a different signature than the actual function (or equivalently,
+  /// bitcasting a function or function pointer to a different function type).
+  /// In principle in the most general case this could depend on the target, the
+  /// calling convention, and the actual types of the arguments and return
+  /// value. Here it just means whether the signature mismatch could *ever* be
+  /// allowed; in other words, does the target do strict checking of signatures
+  /// for all calls.
+  virtual bool canCallMismatchedFunctionType() const { return true; }
+
   virtual ~CIRGenCXXABI();
 
   void setCXXABIThisValue(CIRGenFunction &CGF, mlir::Value ThisPtr);

--- a/clang/lib/CIR/CodeGen/CIRGenDeclCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDeclCXX.cpp
@@ -73,7 +73,13 @@ void CIRGenModule::buildGlobalVarDeclInit(const VarDecl *D,
     assert(!UnimplementedFeature::addressSpace());
 
     if (!T->isReferenceType()) {
-      codegenGlobalInitCxxStructor(D, Addr);
+      bool NeedsDtor =
+          D->needsDestruction(getASTContext()) == QualType::DK_cxx_destructor;
+      assert(!isTypeConstant(D->getType(), true, !NeedsDtor) &&
+             "invaraint-typed initialization NYI");
+
+      if (PerformInit || NeedsDtor)
+        codegenGlobalInitCxxStructor(D, Addr, PerformInit, NeedsDtor);
       return;
     }
   }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -514,7 +514,8 @@ public:
 
   // Produce code for this constructor/destructor for global initialzation.
   void codegenGlobalInitCxxStructor(const clang::VarDecl *D,
-                                    mlir::cir::GlobalOp Addr);
+                                    mlir::cir::GlobalOp Addr, bool NeedsCtor,
+                                    bool NeedsDtor);
 
   bool lookupRepresentativeDecl(llvm::StringRef MangledName,
                                 clang::GlobalDecl &Result) const;

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1153,7 +1153,8 @@ LogicalResult LoopOp::verify() {
 
 static void printGlobalOpTypeAndInitialValue(OpAsmPrinter &p, GlobalOp op,
                                              TypeAttr type, Attribute initAttr,
-                                             mlir::Region &ctorRegion) {
+                                             mlir::Region &ctorRegion,
+                                             mlir::Region &dtorRegion) {
   auto printType = [&]() { p << ": " << type; };
   if (!op.isDeclaration()) {
     p << "= ";
@@ -1172,6 +1173,12 @@ static void printGlobalOpTypeAndInitialValue(OpAsmPrinter &p, GlobalOp op,
         printType();
     }
 
+    if (!dtorRegion.empty()) {
+      p << " dtor ";
+      p.printRegion(dtorRegion,
+                    /*printEntryBlockArgs=*/false,
+                    /*printBlockTerminators=*/false);
+    }
   } else {
     printType();
   }
@@ -1180,7 +1187,8 @@ static void printGlobalOpTypeAndInitialValue(OpAsmPrinter &p, GlobalOp op,
 static ParseResult parseGlobalOpTypeAndInitialValue(OpAsmParser &parser,
                                                     TypeAttr &typeAttr,
                                                     Attribute &initialValueAttr,
-                                                    mlir::Region &ctorRegion) {
+                                                    mlir::Region &ctorRegion,
+                                                    mlir::Region &dtorRegion) {
   mlir::Type opTy;
   if (parser.parseOptionalEqual().failed()) {
     // Absence of equal means a declaration, so we need to parse the type.
@@ -1224,6 +1232,24 @@ static ParseResult parseGlobalOpTypeAndInitialValue(OpAsmParser &parser,
         opTy = typedAttr.getType();
       }
     }
+
+    // Parse destructor, example:
+    //   dtor { ... }
+    if (!parser.parseOptionalKeyword("dtor")) {
+      auto parseLoc = parser.getCurrentLocation();
+      if (parser.parseRegion(dtorRegion, /*arguments=*/{}, /*argTypes=*/{}))
+        return failure();
+      if (!dtorRegion.hasOneBlock())
+        return parser.emitError(parser.getCurrentLocation(),
+                                "dtor region must have exactly one block");
+      if (dtorRegion.back().empty())
+        return parser.emitError(parser.getCurrentLocation(),
+                                "dtor region shall not be empty");
+      if (checkBlockTerminator(parser, parseLoc,
+                               dtorRegion.back().back().getLoc(), &dtorRegion)
+              .failed())
+        return failure();
+    }
   }
 
   typeAttr = TypeAttr::get(opTy);
@@ -1250,6 +1276,20 @@ LogicalResult GlobalOp::verify() {
     auto &block = ctorRegion.front();
     if (block.empty()) {
       return emitError() << "ctor region shall not be empty.";
+    }
+  }
+
+  // Verify that the destructor region, if present, has only one block which is
+  // not empty.
+  auto &dtorRegion = getDtorRegion();
+  if (!dtorRegion.empty()) {
+    if (!dtorRegion.hasOneBlock()) {
+      return emitError() << "dtor region must have exactly one block.";
+    }
+
+    auto &block = dtorRegion.front();
+    if (block.empty()) {
+      return emitError() << "dtor region shall not be empty.";
     }
   }
 
@@ -1293,7 +1333,8 @@ LogicalResult GlobalOp::verify() {
 void GlobalOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                      StringRef sym_name, Type sym_type, bool isConstant,
                      cir::GlobalLinkageKind linkage,
-                     function_ref<void(OpBuilder &, Location)> ctorBuilder) {
+                     function_ref<void(OpBuilder &, Location)> ctorBuilder,
+                     function_ref<void(OpBuilder &, Location)> dtorBuilder) {
   odsState.addAttribute(getSymNameAttrName(odsState.name),
                         odsBuilder.getStringAttr(sym_name));
   odsState.addAttribute(getSymTypeAttrName(odsState.name),
@@ -1311,6 +1352,12 @@ void GlobalOp::build(OpBuilder &odsBuilder, OperationState &odsState,
     odsBuilder.createBlock(ctorRegion);
     ctorBuilder(odsBuilder, odsState.location);
   }
+
+  Region *dtorRegion = odsState.addRegion();
+  if (dtorBuilder) {
+    odsBuilder.createBlock(dtorRegion);
+    dtorBuilder(odsBuilder, odsState.location);
+  }
 }
 
 /// Given the region at `index`, or the parent operation if `index` is None,
@@ -1321,7 +1368,7 @@ void GlobalOp::build(OpBuilder &odsBuilder, OperationState &odsState,
 void GlobalOp::getSuccessorRegions(std::optional<unsigned> index,
                                    ArrayRef<Attribute> operands,
                                    SmallVectorImpl<RegionSuccessor> &regions) {
-  // The only region always branch back to the parent operation.
+  // The `ctor` and `dtor` regions always branch back to the parent operation.
   if (index.has_value()) {
     regions.push_back(RegionSuccessor());
     return;
@@ -1332,9 +1379,16 @@ void GlobalOp::getSuccessorRegions(std::optional<unsigned> index,
   if (ctorRegion->empty())
     ctorRegion = nullptr;
 
+  // Don't consider the dtor region if it is empty.
+  Region *dtorRegion = &this->getCtorRegion();
+  if (dtorRegion->empty())
+    dtorRegion = nullptr;
+
   // If the condition isn't constant, both regions may be executed.
   if (ctorRegion)
     regions.push_back(RegionSuccessor(ctorRegion));
+  if (dtorRegion)
+    regions.push_back(RegionSuccessor(dtorRegion));
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
 
 using namespace mlir;
@@ -129,6 +130,13 @@ void LoweringPreparePass::lowerGlobalOp(GlobalOp op) {
     assert(!op.getAst()->getAstDecl()->getAttr<clang::InitPriorityAttr>() &&
            "custom initialization priority NYI");
     dynamicInitializers.push_back(f);
+  }
+
+  auto &dtorRegion = op.getDtorRegion();
+  if (!dtorRegion.empty()) {
+    // TODO: handle destructor
+    // Clear the dtor region
+    dtorRegion.getBlocks().clear();
   }
 }
 

--- a/clang/test/CIR/CodeGen/static.cpp
+++ b/clang/test/CIR/CodeGen/static.cpp
@@ -7,7 +7,7 @@ class Init {
 
 public:
   Init(bool a) ;
-
+  ~Init();
 private:
   static bool _S_synced_with_stdio;
 };
@@ -18,21 +18,29 @@ static Init __ioinit2(false);
 
 // BEFORE:      module {{.*}} {
 // BEFORE-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22Init22>, !cir.bool)
+// BEFORE-NEXT:   cir.func private @_ZN4InitD1Ev(!cir.ptr<!ty_22Init22>)
 // BEFORE-NEXT:   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22Init22 {
 // BEFORE-NEXT:     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22Init22>
 // BEFORE-NEXT:     %1 = cir.const(#true) : !cir.bool
 // BEFORE-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22Init22>, !cir.bool) -> ()
+// BEFORE-NEXT:   } dtor {
+// BEFORE-NEXT:      %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22Init22>
+// BEFORE-NEXT:      cir.call @_ZN4InitD1Ev(%0) : (!cir.ptr<!ty_22Init22>) -> ()
 // BEFORE-NEXT:   } {ast = #cir.vardecl.ast}
 // BEFORE:        cir.global "private" internal @_ZL9__ioinit2 = ctor : !ty_22Init22 {
 // BEFORE-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : cir.ptr <!ty_22Init22>
 // BEFORE-NEXT:     %1 = cir.const(#false) : !cir.bool
 // BEFORE-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22Init22>, !cir.bool) -> ()
+// BEFORE-NEXT:   } dtor  {
+// BEFORE-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : cir.ptr <!ty_22Init22>
+// BEFORE-NEXT:     cir.call @_ZN4InitD1Ev(%0) : (!cir.ptr<!ty_22Init22>) -> ()
 // BEFORE-NEXT:   } {ast = #cir.vardecl.ast}
 // BEFORE-NEXT: }
 
 
 // AFTER:      module {{.*}} attributes {{.*}}cir.globalCtors = [#cir.globalCtor<"__cxx_global_var_init">, #cir.globalCtor<"__cxx_global_var_init.1">]
 // AFTER-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22Init22>, !cir.bool)
+// AFTER-NEXT:   cir.func private @_ZN4InitD1Ev(!cir.ptr<!ty_22Init22>)
 // AFTER-NEXT:   cir.global "private" internal @_ZL8__ioinit =  #cir.zero : !ty_22Init22 {ast = #cir.vardecl.ast}
 // AFTER-NEXT:   cir.func internal private @__cxx_global_var_init()
 // AFTER-NEXT:     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22Init22>

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -33,10 +33,14 @@ module {
     #cir.global_view<@type_info_A> : !cir.ptr<!s8i>}>
   : !cir.struct<struct "" {!cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>}>
   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22Init22>, !s8i)
+  cir.func private @_ZN4InitD1Ev(!cir.ptr<!ty_22Init22>)
   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22Init22 {
     %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22Init22>
     %1 = cir.const(#cir.int<3> : !s8i) : !s8i
     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22Init22>, !s8i) -> ()
+  } dtor {
+    %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22Init22>
+    cir.call @_ZN4InitD1Ev(%0) : (!cir.ptr<!ty_22Init22>) -> ()
   }
 }
 

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -485,3 +485,25 @@ module {
     cir.return
   }
 }
+
+// -----
+!s8i = !cir.int<s, 8>
+!ty_22Init22 = !cir.struct<class "Init" {!s8i} #cir.recdecl.ast>
+module {
+  cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22Init22 {
+  }
+  // expected-error@+1 {{custom op 'cir.global' ctor region must have exactly one block}}
+}
+
+// -----
+!s8i = !cir.int<s, 8>
+#true = #cir.bool<true> : !cir.bool
+!ty_22Init22 = !cir.struct<class "Init" {!s8i} #cir.recdecl.ast>
+module {
+  cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22Init22>)
+  cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22Init22 {
+    %0 = cir.get_global @_ZL8__ioinit : cir.ptr <!ty_22Init22>
+    cir.call @_ZN4InitC1Eb(%0) : (!cir.ptr<!ty_22Init22>) -> ()
+  } dtor {}
+  // expected-error@+1 {{custom op 'cir.global' dtor region must have exactly one block}}
+}


### PR DESCRIPTION
Similar with the previous ctor support, I'm bringing up the dtor support for global var initialization.

This change only contains the CIR early codegen work. The upcoming lowering prepare work will be in a separate change.