### PR TITLE
[CIR][CIRGen][Lowering] Generate GlobalViewAttr for string literals (#242).

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -223,6 +223,9 @@ public:
     if (attr.isa<mlir::cir::ZeroAttr, mlir::cir::NullAttr>())
       return true;
 
+    if (attr.isa<mlir::cir::GlobalViewAttr>())
+      return false;
+
     // TODO(cir): introduce char type in CIR and check for that instead.
     if (const auto intVal = attr.dyn_cast<mlir::cir::IntAttr>())
       return intVal.isNullValue();

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1324,7 +1324,7 @@ LValue CIRGenFunction::buildArraySubscriptExpr(const ArraySubscriptExpr *E,
 }
 
 LValue CIRGenFunction::buildStringLiteralLValue(const StringLiteral *E) {
-  auto sym = CGM.getAddrOfConstantStringFromLiteral(E);
+  auto sym = CGM.getAddrOfConstantStringFromLiteral(E).getSymbol();
 
   auto cstGlobal = mlir::SymbolTable::lookupSymbolIn(CGM.getModule(), sym);
   assert(cstGlobal && "Expected global");

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1001,7 +1001,7 @@ struct ConstantLValue {
   /*implicit*/ ConstantLValue(mlir::Value value, bool hasOffsetApplied = false)
       : Value(value), HasOffsetApplied(hasOffsetApplied) {}
 
-  /*implicit*/ ConstantLValue(mlir::SymbolRefAttr address) : Value(address) {}
+  /*implicit*/ ConstantLValue(mlir::cir::GlobalViewAttr address) : Value(address) {}
 
   ConstantLValue(std::nullptr_t) : ConstantLValue({}, false) {}
   ConstantLValue(mlir::Attribute value) : Value(value) {}

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -304,7 +304,7 @@ public:
 
   /// Return a global symbol reference to a constant array for the given string
   /// literal.
-  mlir::SymbolRefAttr
+  mlir::cir::GlobalViewAttr
   getAddrOfConstantStringFromLiteral(const StringLiteral *S,
                                      StringRef Name = ".str");
   unsigned StringLiteralCnt = 0;

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1189,8 +1189,6 @@ static void printGlobalOpTypeAndInitialValue(OpAsmPrinter &p, GlobalOp op,
       // This also prints the type...
       if (initAttr)
         printConstant(p, initAttr);
-      if (initAttr.isa<SymbolRefAttr>())
-        printType();
     }
 
     if (!dtorRegion.empty()) {
@@ -1241,16 +1239,10 @@ static ParseResult parseGlobalOpTypeAndInitialValue(OpAsmParser &parser,
       if (parseConstantValue(parser, initialValueAttr).failed())
         return failure();
 
-      if (auto sra = initialValueAttr.dyn_cast<SymbolRefAttr>()) {
-        if (parser.parseColonType(opTy))
-          return failure();
-      } else {
-        // Handle StringAttrs
-        assert(initialValueAttr.isa<mlir::TypedAttr>() &&
-               "Non-typed attrs shouldn't appear here.");
-        auto typedAttr = initialValueAttr.cast<mlir::TypedAttr>();
-        opTy = typedAttr.getType();
-      }
+      assert(initialValueAttr.isa<mlir::TypedAttr>() &&
+             "Non-typed attrs shouldn't appear here.");
+      auto typedAttr = initialValueAttr.cast<mlir::TypedAttr>();
+      opTy = typedAttr.getType();
     }
 
     // Parse destructor, example:

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -79,57 +79,62 @@ namespace direct {
 
 /// Switches on the type of attribute and calls the appropriate conversion.
 inline mlir::Value
-lowerCirAttrAsValue(mlir::Attribute attr, mlir::Location loc,
+lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::Attribute attr,
                     mlir::ConversionPatternRewriter &rewriter,
                     mlir::TypeConverter *converter);
 
 /// IntAttr visitor.
 inline mlir::Value
-lowerCirAttrAsValue(mlir::cir::IntAttr intAttr, mlir::Location loc,
+lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::cir::IntAttr intAttr,
                     mlir::ConversionPatternRewriter &rewriter,
                     mlir::TypeConverter *converter) {
+  auto loc = parentOp->getLoc();
   return rewriter.create<mlir::LLVM::ConstantOp>(
       loc, converter->convertType(intAttr.getType()), intAttr.getValue());
 }
 
 /// NullAttr visitor.
 inline mlir::Value
-lowerCirAttrAsValue(mlir::cir::NullAttr nullAttr, mlir::Location loc,
+lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::cir::NullAttr nullAttr,
                     mlir::ConversionPatternRewriter &rewriter,
                     mlir::TypeConverter *converter) {
+  auto loc = parentOp->getLoc();
   return rewriter.create<mlir::LLVM::NullOp>(
       loc, converter->convertType(nullAttr.getType()));
 }
 
 /// FloatAttr visitor.
 inline mlir::Value
-lowerCirAttrAsValue(mlir::FloatAttr fltAttr, mlir::Location loc,
+lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::FloatAttr fltAttr,
                     mlir::ConversionPatternRewriter &rewriter,
                     mlir::TypeConverter *converter) {
+  auto loc = parentOp->getLoc();
   return rewriter.create<mlir::LLVM::ConstantOp>(
       loc, converter->convertType(fltAttr.getType()), fltAttr.getValue());
 }
 
 /// ZeroAttr visitor.
 inline mlir::Value
-lowerCirAttrAsValue(mlir::cir::ZeroAttr zeroAttr, mlir::Location loc,
+lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::cir::ZeroAttr zeroAttr,
                     mlir::ConversionPatternRewriter &rewriter,
                     mlir::TypeConverter *converter) {
+  auto loc = parentOp->getLoc();
   return rewriter.create<mlir::cir::ZeroInitConstOp>(
       loc, converter->convertType(zeroAttr.getType()));
 }
 
 /// ConstStruct visitor.
-mlir::Value lowerCirAttrAsValue(mlir::cir::ConstStructAttr constStruct,
-                                mlir::Location loc,
+mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
+                                mlir::cir::ConstStructAttr constStruct,
                                 mlir::ConversionPatternRewriter &rewriter,
                                 mlir::TypeConverter *converter) {
   auto llvmTy = converter->convertType(constStruct.getType());
+  auto loc = parentOp->getLoc();
   mlir::Value result = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
 
   // Iteratively lower each constant element of the struct.
   for (auto [idx, elt] : llvm::enumerate(constStruct.getMembers())) {
-    mlir::Value init = lowerCirAttrAsValue(elt, loc, rewriter, converter);
+    mlir::Value init = lowerCirAttrAsValue(parentOp, elt, rewriter, converter);
     result = rewriter.create<mlir::LLVM::InsertValueOp>(loc, result, init, idx);
   }
 
@@ -137,17 +142,19 @@ mlir::Value lowerCirAttrAsValue(mlir::cir::ConstStructAttr constStruct,
 }
 
 // ArrayAttr visitor.
-mlir::Value lowerCirAttrAsValue(mlir::cir::ConstArrayAttr constArr,
-                                mlir::Location loc,
+mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
+                                mlir::cir::ConstArrayAttr constArr,
                                 mlir::ConversionPatternRewriter &rewriter,
                                 mlir::TypeConverter *converter) {
   auto llvmTy = converter->convertType(constArr.getType());
+  auto loc = parentOp->getLoc();
   mlir::Value result = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
 
   // Iteratively lower each constant element of the array.
   if (auto arrayAttr = constArr.getElts().dyn_cast<mlir::ArrayAttr>()) {
     for (auto [idx, elt] : llvm::enumerate(arrayAttr)) {
-      mlir::Value init = lowerCirAttrAsValue(elt, loc, rewriter, converter);
+      mlir::Value init =
+          lowerCirAttrAsValue(parentOp, elt, rewriter, converter);
       result =
           rewriter.create<mlir::LLVM::InsertValueOp>(loc, result, init, idx);
     }
@@ -171,25 +178,56 @@ mlir::Value lowerCirAttrAsValue(mlir::cir::ConstArrayAttr constArr,
   return result;
 }
 
+// GlobalViewAttr visitor.
+mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
+                                mlir::cir::GlobalViewAttr globalAttr,
+                                mlir::ConversionPatternRewriter &rewriter,
+                                mlir::TypeConverter *converter) {
+  auto module = parentOp->getParentOfType<mlir::ModuleOp>();
+  auto sourceSymbol = dyn_cast<mlir::LLVM::GlobalOp>(
+      mlir::SymbolTable::lookupSymbolIn(module, globalAttr.getSymbol()));
+  assert(sourceSymbol && "Unlowered GlobalOp");
+  auto loc = parentOp->getLoc();
+
+  auto addressOfOp = rewriter.create<mlir::LLVM::AddressOfOp>(
+      loc, mlir::LLVM::LLVMPointerType::get(sourceSymbol.getType()),
+      sourceSymbol.getSymName());
+
+  assert(!globalAttr.getIndices() && "TODO");
+
+  auto ptrTy = globalAttr.getType().dyn_cast<mlir::cir::PointerType>();
+  assert(ptrTy && "Expecting pointer type in GlobalViewAttr");
+  auto llvmEltTy = converter->convertType(ptrTy.getPointee());
+
+  if (llvmEltTy == sourceSymbol.getType())
+    return addressOfOp;
+
+  auto llvmDstTy = converter->convertType(globalAttr.getType());
+  return rewriter.create<mlir::LLVM::BitcastOp>(parentOp->getLoc(), llvmDstTy,
+                                                addressOfOp.getResult());
+}
+
 /// Switches on the type of attribute and calls the appropriate conversion.
 inline mlir::Value
-lowerCirAttrAsValue(mlir::Attribute attr, mlir::Location loc,
+lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::Attribute attr,
                     mlir::ConversionPatternRewriter &rewriter,
                     mlir::TypeConverter *converter) {
   if (const auto intAttr = attr.dyn_cast<mlir::cir::IntAttr>())
-    return lowerCirAttrAsValue(intAttr, loc, rewriter, converter);
+    return lowerCirAttrAsValue(parentOp, intAttr, rewriter, converter);
   if (const auto fltAttr = attr.dyn_cast<mlir::FloatAttr>())
-    return lowerCirAttrAsValue(fltAttr, loc, rewriter, converter);
+    return lowerCirAttrAsValue(parentOp, fltAttr, rewriter, converter);
   if (const auto nullAttr = attr.dyn_cast<mlir::cir::NullAttr>())
-    return lowerCirAttrAsValue(nullAttr, loc, rewriter, converter);
+    return lowerCirAttrAsValue(parentOp, nullAttr, rewriter, converter);
   if (const auto constStruct = attr.dyn_cast<mlir::cir::ConstStructAttr>())
-    return lowerCirAttrAsValue(constStruct, loc, rewriter, converter);
+    return lowerCirAttrAsValue(parentOp, constStruct, rewriter, converter);
   if (const auto constArr = attr.dyn_cast<mlir::cir::ConstArrayAttr>())
-    return lowerCirAttrAsValue(constArr, loc, rewriter, converter);
+    return lowerCirAttrAsValue(parentOp, constArr, rewriter, converter);
   if (const auto boolAttr = attr.dyn_cast<mlir::cir::BoolAttr>())
     llvm_unreachable("bool attribute is NYI");
   if (const auto zeroAttr = attr.dyn_cast<mlir::cir::ZeroAttr>())
-    return lowerCirAttrAsValue(zeroAttr, loc, rewriter, converter);
+    return lowerCirAttrAsValue(parentOp, zeroAttr, rewriter, converter);
+  if (const auto globalAttr = attr.dyn_cast<mlir::cir::GlobalViewAttr>())
+    return lowerCirAttrAsValue(parentOp, globalAttr, rewriter, converter);
 
   llvm_unreachable("unhandled attribute type");
 }
@@ -945,7 +983,7 @@ public:
       // define a local constant with llvm.undef that will be stored into the
       // stack.
       auto initVal =
-          lowerCirAttrAsValue(structAttr, op.getLoc(), rewriter, typeConverter);
+          lowerCirAttrAsValue(op, structAttr, rewriter, typeConverter);
       rewriter.replaceAllUsesWith(op, initVal);
       rewriter.eraseOp(op);
       return mlir::success();
@@ -1281,8 +1319,8 @@ public:
         if (!(init = lowerConstArrayAttr(constArr, getTypeConverter()))) {
           setupRegionInitializedLLVMGlobalOp(op, rewriter);
           rewriter.create<mlir::LLVM::ReturnOp>(
-              op->getLoc(), lowerCirAttrAsValue(constArr, op->getLoc(),
-                                                rewriter, typeConverter));
+              op->getLoc(),
+              lowerCirAttrAsValue(op, constArr, rewriter, typeConverter));
           return mlir::success();
         }
       } else {
@@ -1297,49 +1335,26 @@ public:
     // Initializer is a constant integer: convert to MLIR builtin constant.
     else if (auto intAttr = init.value().dyn_cast<mlir::cir::IntAttr>()) {
       init = rewriter.getIntegerAttr(llvmType, intAttr.getValue());
-    }
-    // Initializer is a global: load global value in initializer block.
-    else if (auto attr = init.value().dyn_cast<mlir::FlatSymbolRefAttr>()) {
-      setupRegionInitializedLLVMGlobalOp(op, rewriter);
-
-      // Fetch global used as initializer.
-      auto sourceSymbol =
-          dyn_cast<mlir::LLVM::GlobalOp>(mlir::SymbolTable::lookupSymbolIn(
-              op->getParentOfType<mlir::ModuleOp>(), attr.getValue()));
-
-      // Load and return the initializer value.
-      auto addressOfOp = rewriter.create<mlir::LLVM::AddressOfOp>(
-          loc, mlir::LLVM::LLVMPointerType::get(sourceSymbol.getType()),
-          sourceSymbol.getSymName());
-      llvm::SmallVector<mlir::LLVM::GEPArg> offset{0};
-      auto gepOp = rewriter.create<mlir::LLVM::GEPOp>(
-          loc, llvmType, addressOfOp.getResult(), offset);
-      rewriter.create<mlir::LLVM::ReturnOp>(loc, gepOp.getResult());
-      return mlir::success();
     } else if (isa<mlir::cir::ZeroAttr, mlir::cir::NullAttr>(init.value())) {
       // TODO(cir): once LLVM's dialect has a proper zeroinitializer attribute
       // this should be updated. For now, we use a custom op to initialize
       // globals to zero.
       setupRegionInitializedLLVMGlobalOp(op, rewriter);
       auto value =
-          lowerCirAttrAsValue(init.value(), loc, rewriter, typeConverter);
+          lowerCirAttrAsValue(op, init.value(), rewriter, typeConverter);
       rewriter.create<mlir::LLVM::ReturnOp>(loc, value);
       return mlir::success();
     } else if (const auto structAttr =
                    init.value().dyn_cast<mlir::cir::ConstStructAttr>()) {
       setupRegionInitializedLLVMGlobalOp(op, rewriter);
       rewriter.create<mlir::LLVM::ReturnOp>(
-          op->getLoc(), lowerCirAttrAsValue(structAttr, op->getLoc(), rewriter,
-                                            typeConverter));
+          op->getLoc(),
+          lowerCirAttrAsValue(op, structAttr, rewriter, typeConverter));
       return mlir::success();
     } else if (auto attr = init.value().dyn_cast<mlir::cir::GlobalViewAttr>()) {
       setupRegionInitializedLLVMGlobalOp(op, rewriter);
-
-      // Return the address of the global symbol.
-      auto elementType = typeConverter->convertType(attr.getType());
-      auto addrOfOp = rewriter.create<mlir::LLVM::AddressOfOp>(
-          op->getLoc(), elementType, attr.getSymbol());
-      rewriter.create<mlir::LLVM::ReturnOp>(op->getLoc(), addrOfOp.getResult());
+      rewriter.create<mlir::LLVM::ReturnOp>(
+          loc, lowerCirAttrAsValue(op, attr, rewriter, typeConverter));
       return mlir::success();
     } else {
       op.emitError() << "usupported initializer '" << init.value() << "'";

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -42,6 +42,11 @@ struct {
 } nestedString = {"1", "", "\0"};
 // CHECK: cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>}>
 
+struct {
+  char *name;
+} nestedStringPtr = {"1"};
+// CHECK: cir.global external @nestedStringPtr = #cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>}>
+
 // TODO: test tentatives with internal linkage.
 
 // Tentative definition is THE definition. Should be zero-initialized.

--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -39,12 +39,12 @@ int use_func() { return func<int>(); }
 // CHECK-NEXT: cir.global external @alpha = #cir.const_array<[#cir.int<97> : !s8i, #cir.int<98> : !s8i, #cir.int<99> : !s8i, #cir.int<0> : !s8i]> : !cir.array<!s8i x 4>
 
 // CHECK-NEXT: cir.global "private" constant internal @".str" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
-// CHECK-NEXT: cir.global external @s = @".str": !cir.ptr<!s8i>
+// CHECK-NEXT: cir.global external @s = #cir.global_view<@".str"> : !cir.ptr<!s8i>
 
 // CHECK-NEXT: cir.global "private" constant internal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
-// CHECK-NEXT: cir.global external @s1 = @".str1": !cir.ptr<!s8i>
+// CHECK-NEXT: cir.global external @s1 = #cir.global_view<@".str1"> : !cir.ptr<!s8i>
 
-// CHECK-NEXT: cir.global external @s2 = @".str": !cir.ptr<!s8i>
+// CHECK-NEXT: cir.global external @s2 = #cir.global_view<@".str"> : !cir.ptr<!s8i>
 
 //      CHECK: cir.func @_Z10use_globalv()
 // CHECK-NEXT:     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["li", init] {alignment = 4 : i64}

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -12,7 +12,7 @@ module {
   cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global "private" internal @c : !s32i
   cir.global "private" constant internal @".str2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
-  cir.global external @s = @".str2": !cir.ptr<!s8i>
+  cir.global external @s = #cir.global_view<@".str2"> : !cir.ptr<!s8i>
   cir.func @use_global() {
     %0 = cir.get_global @a : cir.ptr <!s32i>
     cir.return
@@ -50,7 +50,8 @@ module {
 // CHECK: cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
 // CHECK: cir.global "private" internal @c : !s32i
 // CHECK: cir.global "private" constant internal @".str2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
-// CHECK: cir.global external @s = @".str2": !cir.ptr<!s8i>
+// CHECK: cir.global external @s = #cir.global_view<@".str2"> : !cir.ptr<!s8i>
+
 
 // CHECK: cir.func @use_global()
 // CHECK-NEXT: %0 = cir.get_global @a : cir.ptr <!s32i>

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -13,6 +13,7 @@
 !ty_22A22 = !cir.struct<struct "A" {!s32i, !cir.array<!cir.array<!s32i x 2> x 2>} #cir.recdecl.ast>
 !ty_22Bar22 = !cir.struct<struct "Bar" {!s32i, !s8i} #cir.recdecl.ast>
 !ty_22StringStruct22 = !cir.struct<struct "StringStruct" {!cir.array<!s8i x 3>, !cir.array<!s8i x 3>, !cir.array<!s8i x 3>} #cir.recdecl.ast>
+!ty_22StringStructPtr22 = !cir.struct<struct "StringStructPtr" {!cir.ptr<!s8i>} #cir.recdecl.ast>
 
 module {
   cir.global external @a = #cir.int<3> : !s32i
@@ -23,11 +24,11 @@ module {
   cir.global external @rgb = #cir.const_array<[#cir.int<0> : !u8i, #cir.int<233> : !u8i, #cir.int<33> : !u8i]> : !cir.array<!u8i x 3>
   cir.global external @alpha = #cir.const_array<[#cir.int<97> : !s8i, #cir.int<98> : !s8i, #cir.int<99> : !s8i, #cir.int<0> : !s8i]> : !cir.array<!s8i x 4>
   cir.global "private" constant internal @".str" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
-  cir.global external @s = @".str": !cir.ptr<!s8i>
+  cir.global external @s = #cir.global_view<@".str"> : !cir.ptr<!s8i>
   // MLIR: llvm.mlir.global internal constant @".str"("example\00") {addr_space = 0 : i32}
   // MLIR: llvm.mlir.global external @s() {addr_space = 0 : i32} : !llvm.ptr<i8> {
   // MLIR:   %0 = llvm.mlir.addressof @".str" : !llvm.ptr<array<8 x i8>>
-  // MLIR:   %1 = llvm.getelementptr %0[0] : (!llvm.ptr<array<8 x i8>>) -> !llvm.ptr<i8>
+  // MLIR:   %1 = llvm.bitcast %0 : !llvm.ptr<array<8 x i8>> to !llvm.ptr<i8>
   // MLIR:   llvm.return %1 : !llvm.ptr<i8>
   // MLIR: }
   // LLVM: @.str = internal constant [8 x i8] c"example\00"
@@ -38,8 +39,8 @@ module {
   // MLIR:   llvm.return %0 : !llvm.ptr<i32>
   // MLIR: }
   cir.global "private" constant internal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
-  cir.global external @s1 = @".str1": !cir.ptr<!s8i>
-  cir.global external @s2 = @".str": !cir.ptr<!s8i>
+  cir.global external @s1 = #cir.global_view<@".str1"> : !cir.ptr<!s8i>
+  cir.global external @s2 = #cir.global_view<@".str"> : !cir.ptr<!s8i>
   cir.func @_Z10use_globalv() {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["li", init] {alignment = 4 : i64}
     %1 = cir.get_global @a : cir.ptr <!s32i>
@@ -94,6 +95,8 @@ module {
   // LLVM: @nestedTwoDim = global %struct.A { i32 1, [2 x [2 x i32{{\]\] \[\[}}2 x i32] [i32 2, i32 3], [2 x i32] [i32 4, i32 5{{\]\]}} }
   cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>}> : !ty_22StringStruct22
   // LLVM: @nestedString = global %struct.StringStruct { [3 x i8] c"1\00\00", [3 x i8] zeroinitializer, [3 x i8] zeroinitializer }
+  cir.global external @nestedStringPtr = #cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>}> : !ty_22StringStructPtr22
+  // LLVM: @nestedStringPtr = global %struct.StringStructPtr { ptr @.str }
   cir.func @_Z11get_globalsv() {
     %0 = cir.alloca !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>, ["s", init] {alignment = 8 : i64}
     %1 = cir.alloca !cir.ptr<!u32i>, cir.ptr <!cir.ptr<!u32i>>, ["u", init] {alignment = 8 : i64}


### PR DESCRIPTION
This PR replaces `SymbolRefAttr`'s generated for string literals with `GlobalViewAttr`'s to get rid of the
```
this should always be typed
UNREACHABLE executed at /home/huawei/src/clangir/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp:1428!
```
error in
```
typedef struct {
  char *name;
} A;

A foo = {"1"};
```
I'm not sure that my usage of `GlobalViewAttr`'s `indices` matches its intentions so marking this as draft.