### PR TITLE
[CIR][CIRGen] fixes explicit cast and minor bug in unary & operator

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -133,8 +133,21 @@ static Address buildPointerWithAlignment(const Expr *E,
         if (BaseInfo)
           *BaseInfo = InnerBaseInfo;
 
-        if (isa<ExplicitCastExpr>(CE)) {
-          llvm_unreachable("NYI");
+        if (isa<ExplicitCastExpr>(CE)) {          
+          assert(!UnimplementedFeature::tbaa());          
+          LValueBaseInfo TargetTypeBaseInfo;
+
+          CharUnits Align = CGF.CGM.getNaturalPointeeTypeAlignment(
+              E->getType(), &TargetTypeBaseInfo);
+
+          // If the source l-value is opaque, honor the alignment of the
+          // casted-to type.
+          if (InnerBaseInfo.getAlignmentSource() != AlignmentSource::Decl) {
+            if (BaseInfo)
+              BaseInfo->mergeForCast(TargetTypeBaseInfo);
+            Addr = Address(Addr.getPointer(), Addr.getElementType(), Align,
+                           IsKnownNonNull);
+          }
         }
 
         if (CGF.SanOpts.has(SanitizerKind::CFIUnrelatedCast) &&
@@ -185,7 +198,7 @@ static Address buildPointerWithAlignment(const Expr *E,
       LValue LV = CGF.buildLValue(UO->getSubExpr());
       if (BaseInfo)
         *BaseInfo = LV.getBaseInfo();
-      assert(UnimplementedFeature::tbaa());
+      assert(!UnimplementedFeature::tbaa());
       return LV.getAddress();
     }
   }
@@ -354,8 +367,7 @@ static CIRGenCallee buildDirectCallee(CIRGenModule &CGM, GlobalDecl GD) {
     // When directing calling an inline builtin, call it through it's mangled
     // name to make it clear it's not the actual builtin.
     auto Fn = cast<mlir::cir::FuncOp>(CGF.CurFn);
-    if (Fn.getName() != FDInlineName &&
-        onlyHasInlineBuiltinDeclaration(FD)) {
+    if (Fn.getName() != FDInlineName && onlyHasInlineBuiltinDeclaration(FD)) {
       assert(0 && "NYI");
     }
 

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -95,3 +95,12 @@ void call_cptr(void *d) {
 // CHECK:     %2 = cir.call @_Z4cptrPv(%1) : (!cir.ptr<!void>) -> !cir.bool
 // CHECK:     %3 = cir.unary(not, %2) : !cir.bool, !cir.bool
 // CHECK:     cir.if %3 {
+
+void lvalue_cast(int x) {    
+  *(int *)&x = 42;
+}  
+
+// CHECK: cir.func @_Z11lvalue_cast
+// CHECK:   %1 = cir.const(#cir.int<42> : !s32i) : !s32i 
+// CHECK:   cir.store %1, %0 : !s32i, cir.ptr <!s32i> 
+


### PR DESCRIPTION
This a small  PR  that is a sort of copy-pasta from the original `Codegen` and handles expressions like `(int *) &a `.
Also, a small bug was fixed - no `!` in assert for the `&` operator