### PR TITLE
Removes hasBooleanRepresentation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -9,7 +9,6 @@
 // This contains code to emit Expr nodes as CIR code.
 //
 //===----------------------------------------------------------------------===//
-#include <iostream>
 #include "CIRGenBuilder.h"
 #include "CIRGenCXXABI.h"
 #include "CIRGenCall.h"
@@ -2209,8 +2208,7 @@ mlir::Value CIRGenFunction::buildLoadOfScalar(LValue lvalue,
                            lvalue.isNontemporal());
 }
 
-mlir::Value CIRGenFunction::buildFromMemory(mlir::Value Value, QualType Ty) {
-  std::cout << "buildFromMemory" << std::endl;
+mlir::Value CIRGenFunction::buildFromMemory(mlir::Value Value, QualType Ty) {  
   return Value;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2208,7 +2208,11 @@ mlir::Value CIRGenFunction::buildLoadOfScalar(LValue lvalue,
                            lvalue.isNontemporal());
 }
 
-mlir::Value CIRGenFunction::buildFromMemory(mlir::Value Value, QualType Ty) {  
+mlir::Value CIRGenFunction::buildFromMemory(mlir::Value Value, QualType Ty) {
+  if (!Ty->isBooleanType() && hasBooleanRepresentation(Ty)) {
+    llvm_unreachable("NIY");
+  }
+
   return Value;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -9,7 +9,7 @@
 // This contains code to emit Expr nodes as CIR code.
 //
 //===----------------------------------------------------------------------===//
-
+#include <iostream>
 #include "CIRGenBuilder.h"
 #include "CIRGenCXXABI.h"
 #include "CIRGenCall.h"
@@ -2210,11 +2210,7 @@ mlir::Value CIRGenFunction::buildLoadOfScalar(LValue lvalue,
 }
 
 mlir::Value CIRGenFunction::buildFromMemory(mlir::Value Value, QualType Ty) {
-  // Bool has a different representation in memory than in registers.
-  if (hasBooleanRepresentation(Ty)) {
-    llvm_unreachable("NYI");
-  }
-
+  std::cout << "buildFromMemory" << std::endl;
   return Value;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -212,12 +212,8 @@ public:
   /// Emits the address of the l-value, then loads and returns the result.
   mlir::Value buildLoadOfLValue(const Expr *E) {
     LValue LV = CGF.buildLValue(E);
-    auto load = Builder.create<mlir::cir::LoadOp>(CGF.getLoc(E->getExprLoc()),
-                                                  CGF.getCIRType(E->getType()),
-                                                  LV.getPointer());
-    return CGF.buildLoadOfLValue(LV, E->getExprLoc()).getScalarVal();
     // FIXME: add some akin to EmitLValueAlignmentAssumption(E, V);
-    //return load;
+    return CGF.buildLoadOfLValue(LV, E->getExprLoc()).getScalarVal();    
   }
 
   mlir::Value buildLoadOfLValue(LValue LV, SourceLocation Loc) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -215,8 +215,9 @@ public:
     auto load = Builder.create<mlir::cir::LoadOp>(CGF.getLoc(E->getExprLoc()),
                                                   CGF.getCIRType(E->getType()),
                                                   LV.getPointer());
+    return CGF.buildLoadOfLValue(LV, E->getExprLoc()).getScalarVal();
     // FIXME: add some akin to EmitLValueAlignmentAssumption(E, V);
-    return load;
+    //return load;
   }
 
   mlir::Value buildLoadOfLValue(LValue LV, SourceLocation Loc) {

--- a/clang/test/CIR/CodeGen/bool.c
+++ b/clang/test/CIR/CodeGen/bool.c
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 typedef struct {    
-    bool x;
+  bool x;
 } S;
 
 // CHECK:  cir.func @store_bool
@@ -16,7 +16,7 @@ typedef struct {
 // CHECK:    [[TMP4:%.*]] = cir.get_member [[TMP3]][0] {name = "x"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!cir.bool> 
 // CHECK:    cir.store [[TMP2]], [[TMP4]] : !cir.bool, cir.ptr <!cir.bool> 
 void store_bool(S *s) {
-    s->x = false;
+  s->x = false;
 }
 
 // CHECK:  cir.func @load_bool
@@ -27,5 +27,5 @@ void store_bool(S *s) {
 // CHECK:    [[TMP3:%.*]] = cir.get_member [[TMP2]][0] {name = "x"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!cir.bool> 
 // CHECK:    [[TMP4:%.*]] = cir.load [[TMP3]] : cir.ptr <!cir.bool>, !cir.bool 
 void load_bool(S *s) {
-    bool x = s->x;
+  bool x = s->x;
 }

--- a/clang/test/CIR/CodeGen/bool.c
+++ b/clang/test/CIR/CodeGen/bool.c
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+#include <stdbool.h>
+
+typedef struct {
+    int a;
+    bool x;
+} S;
+
+// CHECK:  cir.func @store_bool
+// CHECK:    [[TMP0:%.*]] = cir.alloca !cir.ptr<!ty_22S22>, cir.ptr <!cir.ptr<!ty_22S22>>
+// CHECK:    cir.store %arg0, [[TMP0]] : !cir.ptr<!ty_22S22>, cir.ptr <!cir.ptr<!ty_22S22>> 
+// CHECK:    [[TMP1:%.*]] = cir.const(#cir.int<0> : !s32i) : !s32i 
+// CHECK:    [[TMP2:%.*]] = cir.cast(int_to_bool, [[TMP1]] : !s32i), !cir.bool 
+// CHECK:    [[TMP3:%.*]] = cir.load [[TMP0]] : cir.ptr <!cir.ptr<!ty_22S22>>, !cir.ptr<!ty_22S22> 
+// CHECK:    [[TMP4:%.*]] = cir.get_member [[TMP3]][0] {name = "x"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!cir.bool> 
+// CHECK:    cir.store [[TMP2]], [[TMP4]] : !cir.bool, cir.ptr <!cir.bool> 
+void store_bool(S *s) {
+    s->x = false;
+}
+
+// CHECK:  cir.func @load_bool
+// CHECK:    [[TMP0:%.*]] = cir.alloca !cir.ptr<!ty_22S22>, cir.ptr <!cir.ptr<!ty_22S22>>, ["s", init] {alignment = 8 : i64} 
+// CHECK:    [[TMP1:%.*]] = cir.alloca !cir.bool, cir.ptr <!cir.bool>, ["x", init] {alignment = 1 : i64} 
+// CHECK:    cir.store %arg0, [[TMP0]] : !cir.ptr<!ty_22S22>, cir.ptr <!cir.ptr<!ty_22S22>> 
+// CHECK:    [[TMP2:%.*]] = cir.load [[TMP0]] : cir.ptr <!cir.ptr<!ty_22S22>>, !cir.ptr<!ty_22S22> 
+// CHECK:    [[TMP3:%.*]] = cir.get_member [[TMP2]][0] {name = "x"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!cir.bool> 
+// CHECK:    [[TMP4:%.*]] = cir.load [[TMP3]] : cir.ptr <!cir.bool>, !cir.bool 
+void load_bool(S *s) {
+    bool x = s->x;
+}

--- a/clang/test/CIR/CodeGen/bool.c
+++ b/clang/test/CIR/CodeGen/bool.c
@@ -3,8 +3,7 @@
 
 #include <stdbool.h>
 
-typedef struct {
-    int a;
+typedef struct {    
     bool x;
 } S;
 


### PR DESCRIPTION
This PR removes the method `hasBooleanRepresentation` as was discussed in [PR#233](https://github.com/llvm/clangir/pull/233)
Briefly, the `cir.bool` has the same representation in memory and after load. The LLVM IR differs, that's why the  check is there, in the origin `CodeGen`.

Also, in order to trigger the path and make the implementation to be conform with the original `CodeGen`,  there are changes in the `CIRGenExprScalar`: call the common `buildFromLValue`  instead of manaul `load` creation.

Also, a couple of tests for the bool load/store added