### PR TITLE
[CIR][Codegen] VTT support for virtual class inheritance

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -188,6 +188,11 @@ public:
   /// Emits the VTable definitions required for the given record type.
   virtual void emitVTableDefinitions(CIRGenVTables &CGVT,
                                      const CXXRecordDecl *RD) = 0;
+
+  /// Emit any tables needed to implement virtual inheritance.  For Itanium,
+  /// this emits virtual table tables.
+  virtual void emitVirtualInheritanceTables(const CXXRecordDecl *RD) = 0;
+
   virtual mlir::Attribute getAddrOfRTTIDescriptor(mlir::Location loc,
                                                   QualType Ty) = 0;
   virtual CatchTypeInfo
@@ -279,6 +284,12 @@ public:
   // Determine if references to thread_local global variables can be made
   // directly or require access through a thread wrapper function.
   virtual bool usesThreadWrapperFunction(const VarDecl *VD) const = 0;
+
+  /// Emit the code to initialize hidden members required to handle virtual
+  /// inheritance, if needed by the ABI.
+  virtual void
+  initializeHiddenVirtualInheritanceMembers(CIRGenFunction &CGF,
+                                            const CXXRecordDecl *RD) {}
 
   /// Emit a single constructor/destructor with the gien type from a C++
   /// constructor Decl.

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -39,9 +39,8 @@ bool CIRGenFunction::IsConstructorDelegationValid(
   //   };
   // ...although even this example could in principle be emitted as a delegation
   // since the address of the parameter doesn't escape.
-  if (Ctor->getParent()->getNumVBases()) {
-    llvm_unreachable("NYI");
-  }
+  if (Ctor->getParent()->getNumVBases())
+    return false;
 
   // We also disable the optimization for variadic functions because it's
   // impossible to "re-pass" varargs.
@@ -235,7 +234,7 @@ static void buildMemberInitializer(CIRGenFunction &CGF,
   if (CGF.CurGD.getCtorType() == Ctor_Base)
     LHS = CGF.MakeNaturalAlignPointeeAddrLValue(ThisPtr, RecordTy);
   else
-    llvm_unreachable("NYI");
+    LHS = CGF.MakeNaturalAlignAddrLValue(ThisPtr, RecordTy);
 
   buildLValueForAnyFieldInitialization(CGF, MemberInit, LHS);
 
@@ -523,9 +522,10 @@ Address CIRGenFunction::getAddressOfDirectBaseInCompleteClass(
   // TODO: for complete types, this should be possible with a GEP.
   Address V = This;
   if (!Offset.isZero()) {
-    // TODO(cir): probably create a new operation to account for
-    // down casting when the offset isn't zero.
-    llvm_unreachable("NYI");
+    mlir::Value OffsetVal = builder.getSInt32(Offset.getQuantity(), loc);
+    mlir::Value VBaseThisPtr = builder.create<mlir::cir::PtrStrideOp>(
+        loc, This.getPointer().getType(), This.getPointer(), OffsetVal);
+    V = Address(VBaseThisPtr, CXXABIThisAlignment);
   }
   V = builder.createElementBitCast(loc, V, ConvertType(Base));
   return V;
@@ -604,7 +604,11 @@ void CIRGenFunction::buildCtorPrologue(const CXXConstructorDecl *CD,
   for (; B != E && (*B)->isBaseInitializer() && (*B)->isBaseVirtual(); B++) {
     if (!ConstructVBases)
       continue;
-    llvm_unreachable("NYI");
+    if (CGM.getCodeGenOpts().StrictVTablePointers &&
+        CGM.getCodeGenOpts().OptimizationLevel > 0 &&
+        isInitializerOfDynamicClass(*B))
+      llvm_unreachable("NYI");
+    buildBaseInitializer(getLoc(CD->getBeginLoc()), *this, ClassDecl, *B);
   }
 
   if (BaseCtorContinueBB) {
@@ -698,7 +702,7 @@ void CIRGenFunction::initializeVTablePointers(mlir::Location loc,
       initializeVTablePointer(loc, Vptr);
 
   if (RD->getNumVBases())
-    llvm_unreachable("NYI");
+    CGM.getCXXABI().initializeHiddenVirtualInheritanceMembers(*this, RD);
 }
 
 CIRGenFunction::VPtrsVector

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -358,8 +358,8 @@ void CIRGenFunction::buildCXXConstructExpr(const CXXConstructExpr *E,
     llvm_unreachable("NYI");
     break;
   case CXXConstructExpr::CK_VirtualBase:
-    llvm_unreachable("NYI");
-    break;
+    ForVirtualBase = true;
+    [[fallthrough]];
   case CXXConstructExpr::CK_NonVirtualBase:
     Type = Ctor_Base;
     break;

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -197,6 +197,7 @@ public:
       const CXXRecordDecl *NearestVBase) override;
   void emitVTableDefinitions(CIRGenVTables &CGVT,
                              const CXXRecordDecl *RD) override;
+  void emitVirtualInheritanceTables(const CXXRecordDecl *RD) override;
   mlir::Attribute getAddrOfRTTIDescriptor(mlir::Location loc,
                                           QualType Ty) override;
   bool useThunkForDtorVariant(const CXXDestructorDecl *Dtor,
@@ -821,10 +822,10 @@ class CIRGenItaniumRTTIBuilder {
   /// to the Itanium C++ ABI, 2.9.5p6b.
   void BuildSIClassTypeInfo(mlir::Location loc, const CXXRecordDecl *RD);
 
-  // /// Build an abi::__vmi_class_type_info, used for
-  // /// classes with bases that do not satisfy the abi::__si_class_type_info
-  // /// constraints, according ti the Itanium C++ ABI, 2.9.5p5c.
-  // void BuildVMIClassTypeInfo(const CXXRecordDecl *RD);
+  /// Build an abi::__vmi_class_type_info, used for
+  /// classes with bases that do not satisfy the abi::__si_class_type_info
+  /// constraints, according ti the Itanium C++ ABI, 2.9.5p5c.
+  void BuildVMIClassTypeInfo(const CXXRecordDecl *RD);
 
   // /// Build an abi::__pointer_type_info struct, used
   // /// for pointer types.
@@ -1432,6 +1433,10 @@ void CIRGenItaniumRTTIBuilder::BuildSIClassTypeInfo(mlir::Location loc,
   Fields.push_back(BaseTypeInfo);
 }
 
+void CIRGenItaniumRTTIBuilder::BuildVMIClassTypeInfo(const CXXRecordDecl *RD) {
+  // TODO: Implement this function.
+}
+
 mlir::Attribute
 CIRGenItaniumRTTIBuilder::GetAddrOfExternalRTTIDescriptor(mlir::Location loc,
                                                           QualType Ty) {
@@ -1554,8 +1559,7 @@ mlir::Attribute CIRGenItaniumRTTIBuilder::BuildTypeInfo(
     if (CanUseSingleInheritance(RD)) {
       BuildSIClassTypeInfo(loc, RD);
     } else {
-      llvm_unreachable("NYI");
-      // BuildVMIClassTypeInfo(RD);
+      BuildVMIClassTypeInfo(RD);
     }
 
     break;
@@ -1722,6 +1726,13 @@ void CIRGenItaniumCXXABI::emitVTableDefinitions(CIRGenVTables &CGVT,
 
   if (VTContext.isRelativeLayout())
     llvm_unreachable("NYI");
+}
+
+void CIRGenItaniumCXXABI::emitVirtualInheritanceTables(
+    const CXXRecordDecl *RD) {
+  CIRGenVTables &VTables = CGM.getVTables();
+  auto VTT = VTables.getAddrOfVTT(RD);
+  VTables.buildVTTDefinition(VTT, CGM.getVTableLinkage(RD), RD);
 }
 
 /// What sort of uniqueness rules should we use for the RTTI for the

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.h
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.h
@@ -138,13 +138,13 @@ public:
   //                              llvm::GlobalVariable::LinkageTypes Linkage,
   //                              VTableAddressPointsMapTy &AddressPoints);
 
-  //   /// GetAddrOfVTT - Get the address of the VTT for the given record decl.
-  //   llvm::GlobalVariable *GetAddrOfVTT(const CXXRecordDecl *RD);
+  /// Get the address of the VTT for the given record decl.
+  mlir::cir::GlobalOp getAddrOfVTT(const CXXRecordDecl *RD);
 
-  //   /// EmitVTTDefinition - Emit the definition of the given vtable.
-  //   void EmitVTTDefinition(llvm::GlobalVariable *VTT,
-  //                          llvm::GlobalVariable::LinkageTypes Linkage,
-  //                          const CXXRecordDecl *RD);
+  /// Emit the definition of the given vtable.
+  void buildVTTDefinition(mlir::cir::GlobalOp VTT,
+                          mlir::cir::GlobalLinkageKind Linkage,
+                          const CXXRecordDecl *RD);
 
   /// Emit the associated thunks for the given global decl.
   void buildThunks(GlobalDecl GD);

--- a/clang/test/CIR/CodeGen/vbase.cpp
+++ b/clang/test/CIR/CodeGen/vbase.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+struct A {
+  int a;
+};
+
+struct B:  virtual A {
+  int b;
+};
+
+void ppp() { B b; }
+
+
+// CHECK:  cir.global linkonce_odr @_ZTV1B = #cir.vtable<{#cir.const_array<[#cir.ptr<12> : !cir.ptr<!u8i>, #cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1B> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}>
+// CHECK:  cir.global linkonce_odr @_ZTT1B = #cir.const_array<[#cir.global_view<@_ZTV1B, [0 : i32, 0 : i32, 3 : i32]> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>
+// CHECK:  cir.global "private" external @_ZTVN10__cxxabiv121__vmi_class_type_infoE
+// CHECK:  cir.global linkonce_odr @_ZTS1B = #cir.const_array<"1B" : !cir.array<!s8i x 2>> : !cir.array<!s8i x 2>
+// CHECK:  cir.global constant external @_ZTI1B = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv121__vmi_class_type_infoE, [#cir.int<2> : !s64i]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS1B> : !cir.ptr<!u8i>}>


### PR DESCRIPTION
This patch brings up the basic support for C++  virtual inheritance. VTT (virtual table table) now can be laid out as expected for simple program with single virtual inheritance. RTTI support is on the way.

This patch does not include LLVM lowering support.  