### PR TITLE
[CIR] Introduce ConstPtrAttr for absolute pointer value initialization.

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -221,6 +221,25 @@ def IntAttr : CIR_Attr<"Int", "int", [TypedAttrInterface]> {
 }
 
 //===----------------------------------------------------------------------===//
+// ConstPointerAttr
+//===----------------------------------------------------------------------===//
+
+def ConstPtrAttr : CIR_Attr<"ConstPtr", "ptr", [TypedAttrInterface]> {
+  let summary = "An Attribute containing a pointer value";
+  let parameters = (ins AttributeSelfTypeParameter<"">:$type, "uint64_t":$value);
+  let description = [{
+    A pointer attribute is a literal attribute that represents an integral
+    value of a pointer type.
+  }];
+  let assemblyFormat = [{
+    `<` $value `>`
+  }];
+  let extraClassDeclaration = [{
+    bool isNullValue() const { return getValue() == 0; }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // SignedOverflowBehaviorAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -70,27 +70,6 @@ def LangAttr : CIR_Attr<"Lang", "lang"> {
 }
 
 //===----------------------------------------------------------------------===//
-// NullAttr
-//===----------------------------------------------------------------------===//
-
-def NullAttr : CIR_Attr<"Null", "null", [TypedAttrInterface]> {
-  let summary = "A simple attr to represent nullptr";
-  let description = [{
-    The NullAttr represents the value of nullptr within cir.
-  }];
-
-  let parameters = (ins AttributeSelfTypeParameter<"">:$type);
-
-  let builders = [
-    AttrBuilderWithInferredContext<(ins "Type":$type), [{
-      return $_get(type.getContext(), type);
-    }]>
-  ];
-
-  let assemblyFormat = [{}];
-}
-
-//===----------------------------------------------------------------------===//
 // BoolAttr
 //===----------------------------------------------------------------------===//
 
@@ -225,18 +204,21 @@ def IntAttr : CIR_Attr<"Int", "int", [TypedAttrInterface]> {
 //===----------------------------------------------------------------------===//
 
 def ConstPtrAttr : CIR_Attr<"ConstPtr", "ptr", [TypedAttrInterface]> {
-  let summary = "An Attribute containing a pointer value";
+  let summary = "Holds a constant pointer value";
   let parameters = (ins AttributeSelfTypeParameter<"">:$type, "uint64_t":$value);
   let description = [{
     A pointer attribute is a literal attribute that represents an integral
     value of a pointer type.
   }];
-  let assemblyFormat = [{
-    `<` $value `>`
-  }];
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "Type":$type, "uint64_t":$value), [{
+      return $_get(type.getContext(), type, value);
+    }]>,
+  ];
   let extraClassDeclaration = [{
     bool isNullValue() const { return getValue() == 0; }
   }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -237,7 +237,9 @@ def ConstantOp : CIR_Op<"const",
 
   let extraClassDeclaration = [{
      bool isNullPtr() {
-       return getValue().isa<mlir::cir::NullAttr>();
+      if (const auto ptrAttr = getValue().dyn_cast<mlir::cir::ConstPtrAttr>())
+       return ptrAttr.isNullValue();
+      return false;
      }
   }];
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -138,6 +138,11 @@ public:
     return mlir::cir::NullAttr::get(getContext(), t);
   }
 
+  mlir::TypedAttr getConstPtrAttr(mlir::Type t, uint64_t v) {
+    assert(t.isa<mlir::cir::PointerType>() && "expected cir.ptr");
+    return mlir::cir::ConstPtrAttr::get(getContext(), t, v);
+  }
+
   mlir::cir::ConstArrayAttr getString(llvm::StringRef str, mlir::Type eltTy,
                                       unsigned size = 0) {
     unsigned finalSize = size ? size : str.size();

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -133,11 +133,6 @@ public:
     return mlir::cir::BoolAttr::get(getContext(), getBoolTy(), state);
   }
 
-  mlir::TypedAttr getNullPtrAttr(mlir::Type t) {
-    assert(t.isa<mlir::cir::PointerType>() && "expected cir.ptr");
-    return mlir::cir::NullAttr::get(getContext(), t);
-  }
-
   mlir::TypedAttr getConstPtrAttr(mlir::Type t, uint64_t v) {
     assert(t.isa<mlir::cir::PointerType>() && "expected cir.ptr");
     return mlir::cir::ConstPtrAttr::get(getContext(), t, v);
@@ -216,7 +211,7 @@ public:
     if (auto arrTy = ty.dyn_cast<mlir::cir::ArrayType>())
       return getZeroAttr(arrTy);
     if (auto ptrTy = ty.dyn_cast<mlir::cir::PointerType>())
-      return getNullPtrAttr(ptrTy);
+      return getConstPtrAttr(ptrTy, 0);
     if (auto structTy = ty.dyn_cast<mlir::cir::StructType>())
       return getZeroAttr(structTy);
     llvm_unreachable("Zero initializer for given type is NYI");
@@ -225,8 +220,10 @@ public:
   // TODO(cir): Once we have CIR float types, replace this by something like a
   // NullableValueInterface to allow for type-independent queries.
   bool isNullValue(mlir::Attribute attr) const {
-    if (attr.isa<mlir::cir::ZeroAttr, mlir::cir::NullAttr>())
+    if (attr.isa<mlir::cir::ZeroAttr>())
       return true;
+    if (const auto ptrVal = attr.dyn_cast<mlir::cir::ConstPtrAttr>())
+      return ptrVal.isNullValue();
 
     if (attr.isa<mlir::cir::GlobalViewAttr>())
       return false;
@@ -476,7 +473,7 @@ public:
 
   // Creates constant nullptr for pointer type ty.
   mlir::cir::ConstantOp getNullPtr(mlir::Type ty, mlir::Location loc) {
-    return create<mlir::cir::ConstantOp>(loc, ty, getNullPtrAttr(ty));
+    return create<mlir::cir::ConstantOp>(loc, ty, getConstPtrAttr(ty, 0));
   }
 
   // Creates constant null value for integral type ty.
@@ -732,5 +729,4 @@ public:
 };
 
 } // namespace cir
-
 #endif

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1112,12 +1112,8 @@ mlir::Attribute ConstantLValueEmitter::tryEmitAbsolute(mlir::Type destTy) {
   // If we're producing a pointer, this is easy.
   auto destPtrTy = destTy.dyn_cast<mlir::cir::PointerType>();
   assert(destPtrTy && "expected !cir.ptr type");
-  if (Value.isNullPointer()) {
-    return CGM.getBuilder().getNullPtrAttr(destPtrTy);
-  } else {
-    return CGM.getBuilder().getConstPtrAttr(
-        destPtrTy, Value.getLValueOffset().getQuantity());
-  }
+  return CGM.getBuilder().getConstPtrAttr(
+      destPtrTy, Value.getLValueOffset().getQuantity());
 }
 
 ConstantLValue

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1113,10 +1113,11 @@ mlir::Attribute ConstantLValueEmitter::tryEmitAbsolute(mlir::Type destTy) {
   auto destPtrTy = destTy.dyn_cast<mlir::cir::PointerType>();
   assert(destPtrTy && "expected !cir.ptr type");
   if (Value.isNullPointer()) {
-    // FIXME: integer offsets from non-zero null pointers.
     return CGM.getBuilder().getNullPtrAttr(destPtrTy);
+  } else {
+    return CGM.getBuilder().getConstPtrAttr(
+        destPtrTy, Value.getLValueOffset().getQuantity());
   }
-  llvm_unreachable("NYI");
 }
 
 ConstantLValue

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1395,7 +1395,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     mlir::Type Ty = CGF.getCIRType(DestTy);
     return Builder.create<mlir::cir::ConstantOp>(
         CGF.getLoc(E->getExprLoc()), Ty,
-        mlir::cir::NullAttr::get(Builder.getContext(), Ty));
+        mlir::cir::ConstPtrAttr::get(Builder.getContext(), Ty, 0));
   }
 
   case CK_NullToMemberPointer:

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -17,6 +17,7 @@
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/Basic/CodeGenOptions.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CodeGen/CGFunctionInfo.h"
 #include "clang/CodeGen/ConstantInitBuilder.h"
@@ -159,8 +160,8 @@ static void AddPointerLayoutOffset(CIRGenModule &CGM,
                                    ConstantArrayBuilder &builder,
                                    CharUnits offset) {
   assert(offset.getQuantity() == 0 && "NYI");
-  builder.add(mlir::cir::NullAttr::get(CGM.getBuilder().getContext(),
-                                       CGM.getBuilder().getUInt8PtrTy()));
+  builder.add(mlir::cir::ConstPtrAttr::get(
+      CGM.getBuilder().getContext(), CGM.getBuilder().getUInt8PtrTy(), 0));
 }
 
 static void AddRelativeLayoutOffset(CIRGenModule &CGM,

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
@@ -23,6 +23,7 @@
 #include "CIRGenBuilder.h"
 #include "ConstantInitFuture.h"
 
+#include <cstdint>
 #include <vector>
 
 using namespace clang;
@@ -194,9 +195,9 @@ public:
                                llvm::APInt{intTy.getWidth(), value, isSigned}));
   }
 
-  /// Add a null pointer of a specific type.
-  void addNullPointer(mlir::cir::PointerType ptrTy) {
-    add(mlir::cir::NullAttr::get(ptrTy.getContext(), ptrTy));
+  /// Add a pointer of a specific type.
+  void addPointer(mlir::cir::PointerType ptrTy, uint64_t value) {
+    add(mlir::cir::ConstPtrAttr::get(ptrTy.getContext(), ptrTy, value));
   }
 
   /// Add a bitcast of a value to a specific type.

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -156,6 +156,43 @@ void LangAttr::print(AsmPrinter &printer) const {
 }
 
 //===----------------------------------------------------------------------===//
+// ConstPtrAttr definitions
+//===----------------------------------------------------------------------===//
+
+Attribute ConstPtrAttr::parse(AsmParser &parser, Type odsType) {
+  uint64_t value;
+
+  if (!odsType.isa<cir::PointerType>())
+    return {};
+
+  // Consume the '<' symbol.
+  if (parser.parseLess())
+    return {};
+
+  if (parser.parseKeyword("null").succeeded()) {
+    value = 0;
+  } else {
+    if (parser.parseInteger(value))
+      parser.emitError(parser.getCurrentLocation(), "expected integer value");
+  }
+
+  // Consume the '>' symbol.
+  if (parser.parseGreater())
+    return {};
+
+  return ConstPtrAttr::get(odsType, value);
+}
+
+void ConstPtrAttr::print(AsmPrinter &printer) const {
+  printer << '<';
+  if (isNullValue())
+      printer << "null";
+  else
+      printer << getValue();
+  printer << '>';
+}
+
+//===----------------------------------------------------------------------===//
 // IntAttr definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -166,7 +166,7 @@ void AllocaOp::build(::mlir::OpBuilder &odsBuilder,
 
 static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
                                         mlir::Attribute attrType) {
-  if (attrType.isa<NullAttr>()) {
+  if (attrType.isa<NullAttr>() || attrType.isa<ConstPtrAttr>()) {
     if (opType.isa<::mlir::cir::PointerType>())
       return success();
     return op->emitOpError("nullptr expects pointer type");

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -166,7 +166,7 @@ void AllocaOp::build(::mlir::OpBuilder &odsBuilder,
 
 static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
                                         mlir::Attribute attrType) {
-  if (attrType.isa<NullAttr>() || attrType.isa<ConstPtrAttr>()) {
+  if (attrType.isa<ConstPtrAttr>()) {
     if (opType.isa<::mlir::cir::PointerType>())
       return success();
     return op->emitOpError("nullptr expects pointer type");
@@ -2406,7 +2406,7 @@ VTableAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
   if (auto arrayElts = constArrayAttr.getElts().dyn_cast<ArrayAttr>()) {
     arrayElts.walkImmediateSubElements(
         [&](Attribute attr) {
-          if (attr.isa<GlobalViewAttr>() || attr.isa<NullAttr>())
+          if (attr.isa<GlobalViewAttr>() || attr.isa<ConstPtrAttr>())
             return;
           emitError() << "expected GlobalViewAttr attribute";
           eltTypeCheck = failure();

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
 
@@ -1172,7 +1173,7 @@ void LifetimeCheckPass::updatePointsToForConstStruct(
     auto fieldAddr = aggregates[addr][memberIdx];
     // Unseen fields are not tracked.
     if (fieldAddr && ta.getType().isa<mlir::cir::PointerType>()) {
-      assert(ta.isa<mlir::cir::NullAttr>() &&
+      assert(ta.isa<mlir::cir::ConstPtrAttr>() &&
              "other than null not implemented");
       markPsetNull(fieldAddr, loc);
     }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -93,25 +93,21 @@ lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::cir::IntAttr intAttr,
       loc, converter->convertType(intAttr.getType()), intAttr.getValue());
 }
 
-/// NullAttr visitor.
+/// ConstPtrAttr visitor.
 inline mlir::Value
-lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::cir::NullAttr nullAttr,
+lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::cir::ConstPtrAttr ptrAttr,
                     mlir::ConversionPatternRewriter &rewriter,
                     mlir::TypeConverter *converter) {
   auto loc = parentOp->getLoc();
-  return rewriter.create<mlir::LLVM::NullOp>(
-      loc, converter->convertType(nullAttr.getType()));
-}
-
-/// ConstPtrAttr visitor.
-inline mlir::Value
-lowerCirAttrAsValue(mlir::cir::ConstPtrAttr ptrAttr, mlir::Location loc,
-                    mlir::ConversionPatternRewriter &rewriter,
-                    mlir::TypeConverter *converter) {
-  mlir::Value ptrVal = rewriter.create<mlir::LLVM::ConstantOp>(
-      loc, rewriter.getI64Type(), ptrAttr.getValue());
-  return rewriter.create<mlir::LLVM::IntToPtrOp>(
-      loc, converter->convertType(ptrAttr.getType()), ptrVal);
+  if (ptrAttr.isNullValue()) {
+    return rewriter.create<mlir::LLVM::NullOp>(
+        loc, converter->convertType(ptrAttr.getType()));
+  } else {
+    mlir::Value ptrVal = rewriter.create<mlir::LLVM::ConstantOp>(
+        loc, rewriter.getI64Type(), ptrAttr.getValue());
+    return rewriter.create<mlir::LLVM::IntToPtrOp>(
+        loc, converter->convertType(ptrAttr.getType()), ptrVal);
+  }
 }
 
 /// FloatAttr visitor.
@@ -227,8 +223,6 @@ lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::Attribute attr,
     return lowerCirAttrAsValue(parentOp, intAttr, rewriter, converter);
   if (const auto fltAttr = attr.dyn_cast<mlir::FloatAttr>())
     return lowerCirAttrAsValue(parentOp, fltAttr, rewriter, converter);
-  if (const auto nullAttr = attr.dyn_cast<mlir::cir::NullAttr>())
-    return lowerCirAttrAsValue(nullAttr, loc, rewriter, converter);
   if (const auto ptrAttr = attr.dyn_cast<mlir::cir::ConstPtrAttr>())
     return lowerCirAttrAsValue(parentOp, ptrAttr, rewriter, converter);
   if (const auto constStruct = attr.dyn_cast<mlir::cir::ConstStructAttr>())
@@ -621,7 +615,8 @@ public:
     case mlir::cir::CastKind::ptr_to_bool: {
       auto null = rewriter.create<mlir::cir::ConstantOp>(
           src.getLoc(), castOp.getSrc().getType(),
-          mlir::cir::NullAttr::get(castOp.getSrc().getType()));
+          mlir::cir::ConstPtrAttr::get(getContext(), castOp.getSrc().getType(),
+                                       0));
       rewriter.replaceOpWithNewOp<mlir::cir::CmpOp>(
           castOp, mlir::cir::BoolType::get(getContext()),
           mlir::cir::CmpOpKind::ne, castOp.getSrc(), null);
@@ -964,10 +959,12 @@ public:
       attr = op.getValue();
     } else if (op.getType().isa<mlir::cir::PointerType>()) {
       // Optimize with dedicated LLVM op for null pointers.
-      if (op.getValue().isa<mlir::cir::NullAttr>()) {
-        rewriter.replaceOpWithNewOp<mlir::LLVM::NullOp>(
-            op, typeConverter->convertType(op.getType()));
-        return mlir::success();
+      if (op.getValue().isa<mlir::cir::ConstPtrAttr>()) {
+        if (op.getValue().cast<mlir::cir::ConstPtrAttr>().isNullValue()) {
+          rewriter.replaceOpWithNewOp<mlir::LLVM::NullOp>(
+              op, typeConverter->convertType(op.getType()));
+          return mlir::success();
+        }
       }
       attr = op.getValue();
     }
@@ -1348,8 +1345,8 @@ public:
     // Initializer is a constant integer: convert to MLIR builtin constant.
     else if (auto intAttr = init.value().dyn_cast<mlir::cir::IntAttr>()) {
       init = rewriter.getIntegerAttr(llvmType, intAttr.getValue());
-    } else if (isa<mlir::cir::ZeroAttr, mlir::cir::NullAttr,
-                   mlir::cir::ConstPtrAttr>(init.value())) {
+    } else if (isa<mlir::cir::ZeroAttr, mlir::cir::ConstPtrAttr>(
+                   init.value())) {
       // TODO(cir): once LLVM's dialect has a proper zeroinitializer attribute
       // this should be updated. For now, we use a custom op to initialize
       // globals to zero.

--- a/clang/test/CIR/CodeGen/String.cpp
+++ b/clang/test/CIR/CodeGen/String.cpp
@@ -22,7 +22,7 @@ void test() {
 // CHECK-NEXT:   cir.store %arg0, %0
 // CHECK-NEXT:   %1 = cir.load %0
 // CHECK-NEXT:   %2 = cir.get_member %1[0] {name = "storage"}
-// CHECK-NEXT:   %3 = cir.const(#cir.null : !cir.ptr<!s8i>) : !cir.ptr<!s8i>
+// CHECK-NEXT:   %3 = cir.const(#cir.ptr<null> : !cir.ptr<!s8i>) : !cir.ptr<!s8i>
 // CHECK-NEXT:   cir.store %3, %2 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
 // CHECK-NEXT:   %4 = cir.get_member %1[1] {name = "size"} : !cir.ptr<!ty_22String22> -> !cir.ptr<!s64i>
 // CHECK-NEXT:   %5 = cir.const(#cir.int<0> : !s32i) : !s32i
@@ -37,7 +37,7 @@ void test() {
 // CHECK-NEXT:   cir.store %arg1, %1
 // CHECK-NEXT:   %2 = cir.load %0
 // CHECK-NEXT:   %3 = cir.get_member %2[0] {name = "storage"}
-// CHECK-NEXT:   %4 = cir.const(#cir.null : !cir.ptr<!s8i>)
+// CHECK-NEXT:   %4 = cir.const(#cir.ptr<null> : !cir.ptr<!s8i>)
 // CHECK-NEXT:   cir.store %4, %3
 // CHECK-NEXT:   %5 = cir.get_member %2[1] {name = "size"} : !cir.ptr<!ty_22String22> -> !cir.ptr<!s64i>
 // CHECK-NEXT:   %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
@@ -53,7 +53,7 @@ void test() {
 // CHECK-NEXT:   cir.store %arg1, %1 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
 // CHECK-NEXT:   %2 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22String22>>, !cir.ptr<!ty_22String22>
 // CHECK-NEXT:   %3 = cir.get_member %2[0] {name = "storage"} : !cir.ptr<!ty_22String22> -> !cir.ptr<!cir.ptr<!s8i>>
-// CHECK-NEXT:   %4 = cir.const(#cir.null : !cir.ptr<!s8i>) : !cir.ptr<!s8i>
+// CHECK-NEXT:   %4 = cir.const(#cir.ptr<null> : !cir.ptr<!s8i>) : !cir.ptr<!s8i>
 // CHECK-NEXT:   cir.store %4, %3 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
 // CHECK-NEXT:   cir.return
 

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -66,7 +66,7 @@ void yo() {
 // CHECK: cir.func @_Z2yov()
 // CHECK:   %0 = cir.alloca !ty_22Yo22, cir.ptr <!ty_22Yo22>, ["ext"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.alloca !ty_22Yo22, cir.ptr <!ty_22Yo22>, ["ext2", init] {alignment = 8 : i64}
-// CHECK:   %2 = cir.const(#cir.const_struct<{#cir.int<1000070000> : !u32i, #cir.null : !cir.ptr<!void>, #cir.int<0> : !u64i}> : !ty_22Yo22) : !ty_22Yo22
+// CHECK:   %2 = cir.const(#cir.const_struct<{#cir.int<1000070000> : !u32i, #cir.ptr<null> : !cir.ptr<!void>, #cir.int<0> : !u64i}> : !ty_22Yo22) : !ty_22Yo22
 // CHECK:   cir.store %2, %0 : !ty_22Yo22, cir.ptr <!ty_22Yo22>
 // CHECK:   %3 = cir.get_member %1[0] {name = "type"} : !cir.ptr<!ty_22Yo22> -> !cir.ptr<!u32i>
 // CHECK:   %4 = cir.const(#cir.int<1000066001> : !u32i) : !u32i

--- a/clang/test/CIR/CodeGen/basic.cpp
+++ b/clang/test/CIR/CodeGen/basic.cpp
@@ -8,7 +8,7 @@ int *p0() {
 
 // CHECK: cir.func @_Z2p0v() -> !cir.ptr<!s32i>
 // CHECK: %1 = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["p", init]
-// CHECK: %2 = cir.const(#cir.null : !cir.ptr<!s32i>) : !cir.ptr<!s32i>
+// CHECK: %2 = cir.const(#cir.ptr<null> : !cir.ptr<!s32i>) : !cir.ptr<!s32i>
 // CHECK: cir.store %2, %1 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 
 int *p1() {
@@ -19,7 +19,7 @@ int *p1() {
 
 // CHECK: cir.func @_Z2p1v() -> !cir.ptr<!s32i>
 // CHECK: %1 = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["p"]
-// CHECK: %2 = cir.const(#cir.null : !cir.ptr<!s32i>) : !cir.ptr<!s32i>
+// CHECK: %2 = cir.const(#cir.ptr<null> : !cir.ptr<!s32i>) : !cir.ptr<!s32i>
 // CHECK: cir.store %2, %1 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 
 int *p2() {
@@ -36,7 +36,7 @@ int *p2() {
 // CHECK: cir.func @_Z2p2v() -> !cir.ptr<!s32i>
 // CHECK-NEXT:  %0 = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["__retval"] {alignment = 8 : i64}
 // CHECK-NEXT:  %1 = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["p", init] {alignment = 8 : i64}
-// CHECK-NEXT:  %2 = cir.const(#cir.null : !cir.ptr<!s32i>) : !cir.ptr<!s32i>
+// CHECK-NEXT:  %2 = cir.const(#cir.ptr<null> : !cir.ptr<!s32i>) : !cir.ptr<!s32i>
 // CHECK-NEXT:  cir.store %2, %1 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK-NEXT:  cir.scope {
 // CHECK-NEXT:    %7 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/constptr.c
+++ b/clang/test/CIR/CodeGen/constptr.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o - | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
+
+int *p = (int*)0x1234;
+
+
+// CIR:  cir.global external @p = #cir.ptr<4660> : !cir.ptr<!s32i>
+// LLVM: @p = global ptr inttoptr (i64 4660 to ptr)

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -158,7 +158,7 @@ VoidTask silly_task() {
 
 // Get coroutine id with __builtin_coro_id.
 
-// CHECK: %[[#NullPtr:]] = cir.const(#cir.null : !cir.ptr<!void>) : !cir.ptr<!void>
+// CHECK: %[[#NullPtr:]] = cir.const(#cir.ptr<null> : !cir.ptr<!void>) : !cir.ptr<!void>
 // CHECK: %[[#Align:]] = cir.const(#cir.int<16> : !u32i) : !u32i
 // CHECK: %[[#CoroId:]] = cir.call @__builtin_coro_id(%[[#Align]], %[[#NullPtr]], %[[#NullPtr]], %[[#NullPtr]])
 
@@ -264,7 +264,7 @@ VoidTask silly_task() {
 
 // Call builtin coro end and return
 
-// CHECK-NEXT: %[[#CoroEndArg0:]] = cir.const(#cir.null : !cir.ptr<!void>)
+// CHECK-NEXT: %[[#CoroEndArg0:]] = cir.const(#cir.ptr<null> : !cir.ptr<!void>)
 // CHECK-NEXT: %[[#CoroEndArg1:]] = cir.const(#false) : !cir.bool
 // CHECK-NEXT: = cir.call @__builtin_coro_end(%[[#CoroEndArg0]], %[[#CoroEndArg1]])
 
@@ -363,7 +363,7 @@ folly::coro::Task<int> go4() {
 
 // Get the lambda invoker ptr via `lambda operator folly::coro::Task<int> (*)(int const&)()`
 // CHECK:   %18 = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%17) : (!cir.ptr<!ty_22anon221>) -> !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
-// CHECK:   %19 = cir.unary(plus, %18) : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>> 
+// CHECK:   %19 = cir.unary(plus, %18) : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
 // CHECK:   cir.yield %19 : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
 // CHECK: }
 // CHECK: cir.store %12, %3 : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>, cir.ptr <!cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>>

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -84,7 +84,7 @@ void C3::Layer::Initialize() {
 // CHECK:    %2 = cir.base_class_addr(%1 : cir.ptr <!ty_22C33A3ALayer22>) -> cir.ptr <!ty_22C23A3ALayer22>
 // CHECK:    %3 = cir.get_member %2[0] {name = "m_C1"} : !cir.ptr<!ty_22C23A3ALayer22> -> !cir.ptr<!cir.ptr<!ty_22C222>>
 // CHECK:    %4 = cir.load %3 : cir.ptr <!cir.ptr<!ty_22C222>>, !cir.ptr<!ty_22C222>
-// CHECK:    %5 = cir.const(#cir.null : !cir.ptr<!ty_22C222>) : !cir.ptr<!ty_22C222>
+// CHECK:    %5 = cir.const(#cir.ptr<null> : !cir.ptr<!ty_22C222>) : !cir.ptr<!ty_22C222>
 // CHECK:    %6 = cir.cmp(eq, %4, %5) : !cir.ptr<!ty_22C222>, !cir.bool
 
 enumy C3::Initialize() {

--- a/clang/test/CIR/CodeGen/pointer.cpp
+++ b/clang/test/CIR/CodeGen/pointer.cpp
@@ -3,4 +3,4 @@
 
 // Global pointer should be zero initialized by default.
 int *ptr;
-// CHECK: cir.global external @ptr = #cir.null : !cir.ptr<!s32i>
+// CHECK: cir.global external @ptr = #cir.ptr<null> : !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -46,7 +46,7 @@ struct S1 {
   float f;
   int *p;
 } s1 = {1, .1, 0};
-// CHECK-DAG: cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, 1.000000e-01 : f32, #cir.null : !cir.ptr<!s32i>}> : !ty_22S122
+// CHECK-DAG: cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, 1.000000e-01 : f32, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_22S122
 
 // Should initialize global nested structs.
 struct S2 {

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -103,7 +103,7 @@ void m() { Adv C; }
 // CHECK:     %4 = cir.const(#cir.int<1000024001> : !u32i) : !u32i
 // CHECK:     cir.store %4, %3 : !u32i, cir.ptr <!u32i>
 // CHECK:     %5 = cir.get_member %2[1] {name = "n"} : !cir.ptr<!ty_22Mandalore22> -> !cir.ptr<!cir.ptr<!void>>
-// CHECK:     %6 = cir.const(#cir.null : !cir.ptr<!void>) : !cir.ptr<!void>
+// CHECK:     %6 = cir.const(#cir.ptr<null> : !cir.ptr<!void>) : !cir.ptr<!void>
 // CHECK:     cir.store %6, %5 : !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>
 // CHECK:     %7 = cir.get_member %2[2] {name = "d"} : !cir.ptr<!ty_22Mandalore22> -> !cir.ptr<!s32i>
 // CHECK:     %8 = cir.const(#cir.int<0> : !s32i) : !s32i

--- a/clang/test/CIR/CodeGen/types-nullptr.cpp
+++ b/clang/test/CIR/CodeGen/types-nullptr.cpp
@@ -5,5 +5,5 @@ typedef decltype(nullptr) nullptr_t;
 void f() { nullptr_t t = nullptr; }
 
 // CHECK: %0 = cir.alloca !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>
-// CHECK: %1 = cir.const(#cir.null : !cir.ptr<!void>) : !cir.ptr<!void>
+// CHECK: %1 = cir.const(#cir.ptr<null> : !cir.ptr<!void>) : !cir.ptr<!void>
 // CHECK: cir.store %1, %0 : !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -73,7 +73,7 @@ public:
 // CHECK:  }
 
 // vtable for B
-// CHECK:   cir.global linkonce_odr @_ZTV1B = #cir.vtable<{#cir.const_array<[#cir.null : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1B> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1BD2Ev> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1BD0Ev> : !cir.ptr<!u8i>, #cir.global_view<@_ZNK1A5quackEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 5>}> : ![[VTableTypeA]]
+// CHECK:   cir.global linkonce_odr @_ZTV1B = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1B> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1BD2Ev> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1BD0Ev> : !cir.ptr<!u8i>, #cir.global_view<@_ZNK1A5quackEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 5>}> : ![[VTableTypeA]]
 
 // vtable for __cxxabiv1::__si_class_type_info
 // CHECK:   cir.global "private" external @_ZTVN10__cxxabiv120__si_class_type_infoE : !cir.ptr<!cir.ptr<!u8i>>

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -8,7 +8,7 @@ module {
   cir.global external @a = #cir.int<3> : !s32i
   cir.global external @rgb = #cir.const_array<[#cir.int<0> : !s8i, #cir.int<-23> : !s8i, #cir.int<33> : !s8i] : !cir.array<!s8i x 3>>
   cir.global external @b = #cir.const_array<"example\00" : !cir.array<!s8i x 8>>
-  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.null : !cir.ptr<!s8i>}> : !cir.struct<struct "" {!s8i, !s64i, !cir.ptr<!s8i>}>
+  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.ptr<null> : !cir.ptr<!s8i>}> : !cir.struct<struct "" {!s8i, !s64i, !cir.ptr<!s8i>}>
   cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global "private" internal @c : !s32i
   cir.global "private" constant internal @".str2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -5,7 +5,7 @@
 
 // expected-error@+2 {{'cir.const' op nullptr expects pointer type}}
 cir.func @p0() {
-  %1 = cir.const(#cir.null : !cir.ptr<!u32i>) : !u32i
+  %1 = cir.const(#cir.ptr<null> : !cir.ptr<!u32i>) : !u32i
   cir.return
 }
 

--- a/clang/test/CIR/IR/vtableAttr.cir
+++ b/clang/test/CIR/IR/vtableAttr.cir
@@ -4,6 +4,6 @@
 !ty_2222 = !cir.struct<struct "" {!cir.array<!cir.ptr<!u8i> x 1>}>
 module {
     // Should parse VTable attribute.
-    cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.null : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222
-    // CHECK: cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.null : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222
+    cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222
+    // CHECK: cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222
 }

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -141,7 +141,7 @@ module {
   // MLIR: llvm.mlir.global external @zeroInitFlt(dense<0.000000e+00> : tensor<2xf32>) {addr_space = 0 : i32} : !llvm.array<2 x f32>
   cir.global "private" internal @staticVar = #cir.int<0> : !s32i
   // MLIR: llvm.mlir.global internal @staticVar(0 : i32) {addr_space = 0 : i32} : i32
-  cir.global external @nullPtr = #cir.null : !cir.ptr<!s32i>
+  cir.global external @nullPtr = #cir.ptr<null> : !cir.ptr<!s32i>
   // MLIR: llvm.mlir.global external @nullPtr()
   // MLIR:   %0 = llvm.mlir.null : !llvm.ptr<i32>
   // MLIR:   llvm.return %0 : !llvm.ptr<i32>

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -33,21 +33,21 @@ module {
   // CHECK:   %1 = llvm.alloca %0 x !llvm.struct<"struct.S2A", (i32)> {alignment = 4 : i64} : (i64) -> !llvm.ptr<struct<"struct.S2A", (i32)>>
   // CHECK:   %2 = llvm.mlir.undef : !llvm.struct<"struct.S2A", (i32)>
   // CHECK:   %3 = llvm.mlir.constant(1 : i32) : i32
-  // CHECK:   %4 = llvm.insertvalue %3, %2[0] : !llvm.struct<"struct.S2A", (i32)> 
+  // CHECK:   %4 = llvm.insertvalue %3, %2[0] : !llvm.struct<"struct.S2A", (i32)>
   // CHECK:   llvm.store %4, %1 : !llvm.ptr<struct<"struct.S2A", (i32)>>
   // CHECK:   llvm.return
   // CHECK: }
 
   // Should lower basic #cir.const_struct initializer.
-  cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, 1.000000e-01 : f32, #cir.null : !cir.ptr<!s32i>}> : !ty_22S122
+  cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, 1.000000e-01 : f32, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_22S122
   // CHECK: llvm.mlir.global external @s1() {addr_space = 0 : i32} : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
   // CHECK:   %1 = llvm.mlir.constant(1 : i32) : i32
-  // CHECK:   %2 = llvm.insertvalue %1, %0[0] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> 
+  // CHECK:   %2 = llvm.insertvalue %1, %0[0] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
   // CHECK:   %3 = llvm.mlir.constant(1.000000e-01 : f32) : f32
-  // CHECK:   %4 = llvm.insertvalue %3, %2[1] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> 
+  // CHECK:   %4 = llvm.insertvalue %3, %2[1] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
   // CHECK:   %5 = llvm.mlir.null : !llvm.ptr<i32>
-  // CHECK:   %6 = llvm.insertvalue %5, %4[2] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> 
+  // CHECK:   %6 = llvm.insertvalue %5, %4[2] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
   // CHECK:   llvm.return %6 : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
   // CHECK: }
 
@@ -57,8 +57,8 @@ module {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)>
   // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"struct.S2A", (i32)>
   // CHECK:   %2 = llvm.mlir.constant(1 : i32) : i32
-  // CHECK:   %3 = llvm.insertvalue %2, %1[0] : !llvm.struct<"struct.S2A", (i32)> 
-  // CHECK:   %4 = llvm.insertvalue %3, %0[0] : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)> 
+  // CHECK:   %3 = llvm.insertvalue %2, %1[0] : !llvm.struct<"struct.S2A", (i32)>
+  // CHECK:   %4 = llvm.insertvalue %3, %0[0] : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)>
   // CHECK:   llvm.return %4 : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)>
   // CHECK: }
 
@@ -67,16 +67,16 @@ module {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.array<3 x struct<"struct.S3", (i32)>>
   // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"struct.S3", (i32)>
   // CHECK:   %2 = llvm.mlir.constant(1 : i32) : i32
-  // CHECK:   %3 = llvm.insertvalue %2, %1[0] : !llvm.struct<"struct.S3", (i32)> 
-  // CHECK:   %4 = llvm.insertvalue %3, %0[0] : !llvm.array<3 x struct<"struct.S3", (i32)>> 
+  // CHECK:   %3 = llvm.insertvalue %2, %1[0] : !llvm.struct<"struct.S3", (i32)>
+  // CHECK:   %4 = llvm.insertvalue %3, %0[0] : !llvm.array<3 x struct<"struct.S3", (i32)>>
   // CHECK:   %5 = llvm.mlir.undef : !llvm.struct<"struct.S3", (i32)>
   // CHECK:   %6 = llvm.mlir.constant(2 : i32) : i32
-  // CHECK:   %7 = llvm.insertvalue %6, %5[0] : !llvm.struct<"struct.S3", (i32)> 
-  // CHECK:   %8 = llvm.insertvalue %7, %4[1] : !llvm.array<3 x struct<"struct.S3", (i32)>> 
+  // CHECK:   %7 = llvm.insertvalue %6, %5[0] : !llvm.struct<"struct.S3", (i32)>
+  // CHECK:   %8 = llvm.insertvalue %7, %4[1] : !llvm.array<3 x struct<"struct.S3", (i32)>>
   // CHECK:   %9 = llvm.mlir.undef : !llvm.struct<"struct.S3", (i32)>
   // CHECK:   %10 = llvm.mlir.constant(3 : i32) : i32
-  // CHECK:   %11 = llvm.insertvalue %10, %9[0] : !llvm.struct<"struct.S3", (i32)> 
-  // CHECK:   %12 = llvm.insertvalue %11, %8[2] : !llvm.array<3 x struct<"struct.S3", (i32)>> 
+  // CHECK:   %11 = llvm.insertvalue %10, %9[0] : !llvm.struct<"struct.S3", (i32)>
+  // CHECK:   %12 = llvm.insertvalue %11, %8[2] : !llvm.array<3 x struct<"struct.S3", (i32)>>
   // CHECK:   llvm.return %12 : !llvm.array<3 x struct<"struct.S3", (i32)>>
   // CHECK: }
 

--- a/clang/test/CIR/Lowering/types.cir
+++ b/clang/test/CIR/Lowering/types.cir
@@ -5,9 +5,9 @@
 module {
   cir.func @testTypeLowering() {
     // Should lower void pointers as opaque pointers.
-    %0 = cir.const(#cir.null : !cir.ptr<!void>) : !cir.ptr<!void>
+    %0 = cir.const(#cir.ptr<0> : !cir.ptr<!void>) : !cir.ptr<!void>
     // CHECK: llvm.mlir.null : !llvm.ptr
-    %1 = cir.const(#cir.null : !cir.ptr<!cir.ptr<!void>>) : !cir.ptr<!cir.ptr<!void>>
+    %1 = cir.const(#cir.ptr<0> : !cir.ptr<!cir.ptr<!void>>) : !cir.ptr<!cir.ptr<!void>>
     // CHECK: llvm.mlir.null : !llvm.ptr<ptr>
     cir.return
   }

--- a/clang/test/CIR/Lowering/types.cir
+++ b/clang/test/CIR/Lowering/types.cir
@@ -5,9 +5,9 @@
 module {
   cir.func @testTypeLowering() {
     // Should lower void pointers as opaque pointers.
-    %0 = cir.const(#cir.ptr<0> : !cir.ptr<!void>) : !cir.ptr<!void>
+    %0 = cir.const(#cir.ptr<null> : !cir.ptr<!void>) : !cir.ptr<!void>
     // CHECK: llvm.mlir.null : !llvm.ptr
-    %1 = cir.const(#cir.ptr<0> : !cir.ptr<!cir.ptr<!void>>) : !cir.ptr<!cir.ptr<!void>>
+    %1 = cir.const(#cir.ptr<null> : !cir.ptr<!cir.ptr<!void>>) : !cir.ptr<!cir.ptr<!void>>
     // CHECK: llvm.mlir.null : !llvm.ptr<ptr>
     cir.return
   }


### PR DESCRIPTION
Introducing `cir.ConstPtrAttr` to represent arbitrary absolute pointer value initializations. Also incorporating previous `cir.nullptr` effort into this work.