### PR TITLE
[CIR] Implement cir.libc.fabs operation.

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2034,6 +2034,31 @@ def MemCpyOp : CIR_Op<"libc.memcpy"> {
 }
 
 //===----------------------------------------------------------------------===//
+// FAbsOp
+//===----------------------------------------------------------------------===//
+
+def FAbsOp : CIR_Op<"fabs", [Pure, SameOperandsAndResultType]> {
+  let arguments = (ins AnyFloat:$src);
+  let results = (outs AnyFloat:$result);
+  let summary = "Returns absolute value for floating-point input.";
+  let description = [{
+    Equivalent to libc's `fabs` and LLVM's intrinsic with the same name.
+
+    Examples:
+
+    ```mlir
+      %1 = cir.const(1.0 : f64) : f64
+      %2 = cir.fabs %1 : f64
+    ```
+  }];
+
+  let assemblyFormat = [{
+    $src `:` type($src) attr-dict
+  }];
+  let hasVerifier = 0;
+}
+
+//===----------------------------------------------------------------------===//
 // Variadic Operations
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -142,8 +142,13 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BI__builtin_fabsf:
     case Builtin::BI__builtin_fabsf16:
     case Builtin::BI__builtin_fabsl:
-    case Builtin::BI__builtin_fabsf128:
-      llvm_unreachable("NYI");
+    case Builtin::BI__builtin_fabsf128: {
+      mlir::Value Src0 = buildScalarExpr(E->getArg(0));
+      auto SrcType = Src0.getType();
+      auto Call =
+          builder.create<mlir::cir::FAbsOp>(Src0.getLoc(), SrcType, Src0);
+      return RValue::get(Call->getResult(0));
+    }
 
     case Builtin::BIfloor:
     case Builtin::BIfloorf:

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1808,6 +1808,19 @@ public:
   }
 };
 
+class CIRFAbsOpLowering : public mlir::OpConversionPattern<mlir::cir::FAbsOp> {
+public:
+  using OpConversionPattern<mlir::cir::FAbsOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::FAbsOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::FAbsOp>(
+        op, adaptor.getOperands().front());
+    return mlir::success();
+  }
+};
+
 void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter) {
   patterns.add<CIRReturnLowering>(patterns.getContext());
@@ -1820,7 +1833,8 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                CIRVAStartLowering, CIRVAEndLowering, CIRVACopyLowering,
                CIRVAArgLowering, CIRBrOpLowering, CIRTernaryOpLowering,
                CIRGetMemberOpLowering, CIRSwitchOpLowering,
-               CIRPtrDiffOpLowering, CIRCopyOpLowering, CIRMemCpyOpLowering>(
+               CIRPtrDiffOpLowering, CIRCopyOpLowering, CIRMemCpyOpLowering,
+               CIRFAbsOpLowering>(
       converter, patterns.getContext());
 }
 

--- a/clang/test/CIR/CodeGen/libc.c
+++ b/clang/test/CIR/CodeGen/libc.c
@@ -7,3 +7,15 @@ void testMemcpy(void *src, const void *dst, unsigned long size) {
   memcpy(dst, src, size);
   // CHECK: cir.libc.memcpy %{{.+}} bytes from %{{.+}} to %{{.+}} : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
 }
+
+double fabs(double);
+double testFabs(double x) {
+  return fabs(x);
+  // CHECK: cir.fabs %{{.+}} : f64
+}
+
+float fabsf(float);
+float testFabsf(float x) {
+  return fabsf(x);
+  // CHECK: cir.fabs %{{.+}} : f32
+}

--- a/clang/test/CIR/IR/libc-fabs.cir
+++ b/clang/test/CIR/IR/libc-fabs.cir
@@ -1,0 +1,9 @@
+// RUN: cir-opt %s
+
+!u32i = !cir.int<u, 32>
+module {
+  cir.func @foo(%arg0: f64) -> f64 {
+    %0 = cir.fabs %arg0 : f64
+    cir.return %0 : f64
+  }
+}

--- a/clang/test/CIR/Lowering/libc.cir
+++ b/clang/test/CIR/Lowering/libc.cir
@@ -9,4 +9,10 @@ module {
     // CHECK: "llvm.intr.memcpy"(%{{.+}}, %{{.+}}, %{{.+}}) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     cir.return
   }
+
+  cir.func @shouldLowerLibcFAbsBuiltin(%arg0: f64) -> f64 {
+    %0 = cir.fabs %arg0 : f64
+    // CHECK: %0 = llvm.intr.fabs(%arg0) : (f64) -> f64
+    cir.return %0 : f64
+  }
 }


### PR DESCRIPTION
Following discussion in #237 this adds support for `fabs` builtins which are used extensively in llvm-test-suite.