### PR TITLE
[CIR][Lowering] Support endless loops (gh-161)

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -330,7 +330,7 @@ public:
     }
 
     // Succeed only if both yields are found.
-    if (!yieldToBody || !yieldToCont)
+    if (!yieldToBody)
       return mlir::failure();
     return mlir::success();
   }
@@ -419,8 +419,10 @@ public:
     rewriter.create<mlir::cir::BrOp>(loopOp.getLoc(), &entry);
 
     // Set loop exit point to continue block.
-    rewriter.setInsertionPoint(yieldToCont);
-    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldToCont, continueBlock);
+    if (yieldToCont) {
+      rewriter.setInsertionPoint(yieldToCont);
+      rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldToCont, continueBlock);
+    }
 
     // Branch from condition to body.
     rewriter.setInsertionPoint(yieldToBody);

--- a/clang/test/CIR/Lowering/loop.cir
+++ b/clang/test/CIR/Lowering/loop.cir
@@ -185,4 +185,36 @@ module {
   // MLIR-NEXT:  ^bb6:
   // MLIR-NEXT:    llvm.br ^bb7
 
+  // Test endless cir.loop lowering.
+  cir.func @testEndless() {
+    cir.scope {
+      cir.loop for(cond : {
+        cir.yield continue
+      }, step : {
+        cir.yield
+      }) {
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  //      MLIR: llvm.func @testEndless()
+  // MLIR-NEXT:   llvm.br ^bb1
+  // MLIR-NEXT:   ^bb1:
+  // MLIR-NEXT:     llvm.br ^bb2
+  // ============= Condition block =============
+  // MLIR-NEXT:   ^bb2:
+  // MLIR-NEXT:     llvm.br ^bb3
+  // ============= Body block =============
+  // MLIR-NEXT:   ^bb3:
+  // MLIR-NEXT:     llvm.br ^bb4
+  // ============= Step block =============
+  // MLIR-NEXT:   ^bb4:
+  // MLIR-NEXT:     llvm.br ^bb2
+  // ============= Exit block =============
+  // MLIR-NEXT:   ^bb5:
+  // MLIR-NEXT:     llvm.br ^bb6
+  // MLIR-NEXT:   ^bb6:
+  // MLIR-NEXT:     llvm.return
 }


### PR DESCRIPTION
This is a dumb fix for #161 which fixes crashes on endless loops like `for(;;)`. A better long-term approach could be to resurrect the reverted #178.