### PR TITLE
[CIR][IR] Bypass get_member verifier for incomplete types

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2461,12 +2461,17 @@ LogicalResult GetMemberOp::verify() {
   if (!recordTy)
     return emitError() << "expected pointer to a record type";
 
+  // FIXME: currently we bypass typechecking of incomplete types due to errors
+  // in the codegen process. This should be removed once the codegen is fixed.
+  if (!recordTy.getBody())
+    return mlir::success();
+
   if (recordTy.getMembers().size() <= getIndex())
     return emitError() << "member index out of bounds";
 
-  // FIXME(cir): Member type check is disabled for classes and incomplete types
-  // as the codegen for these still need to be patched.
-  if (!recordTy.isClass() && !recordTy.getBody() &&
+  // FIXME(cir): member type check is disabled for classes as the codegen for
+  // these still need to be patched.
+  if (!recordTy.isClass() &&
       recordTy.getMembers()[getIndex()] != getResultTy().getPointee())
     return emitError() << "member type mismatch";
 

--- a/clang/test/CIR/IR/getmember.cir
+++ b/clang/test/CIR/IR/getmember.cir
@@ -1,0 +1,31 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+
+!ty_22Class22 = !cir.struct<class "Class" {!u16i, !u32i}>
+!ty_22Incomplete22 = !cir.struct<struct "Incomplete" incomplete>
+!ty_22Struct22 = !cir.struct<struct "Struct" {!u16i, !u32i}>
+
+module  {
+  cir.func @shouldGetStructMember(%arg0 : !cir.ptr<!ty_22Struct22>) {
+    // CHECK: cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Struct22> -> !cir.ptr<!u32i>
+    %0 = cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Struct22> -> !cir.ptr<!u32i>
+    cir.return
+  }
+
+  // FIXME: remove bypass once codegen for CIR records is patched.
+  cir.func @shouldBypassMemberIndexCheckForIncompleteRecords(%arg0 : !cir.ptr<!ty_22Incomplete22>) {
+    // CHECK: cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Incomplete22> -> !cir.ptr<!u32i>
+    %0 = cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Incomplete22> -> !cir.ptr<!u32i>
+    cir.return
+  }
+
+  // FIXME: remove bypass once codegen for CIR class records is patched.
+  cir.func @shouldBypassMemberTypeCheckForClassRecords(%arg0 : !cir.ptr<!ty_22Class22>) {
+    // CHECK: cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Class22> -> !cir.ptr<!cir.ptr<!u32i>> 
+    %0 = cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Class22> -> !cir.ptr<!cir.ptr<!u32i>>
+    cir.return
+  }
+}

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -522,3 +522,29 @@ module {
     cir.throw(%11 : !cir.ptr<!cir.ptr<!u8i>>) // expected-error {{'type_info' symbol attribute missing}}
   }
 }
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!struct = !cir.struct<struct "Struct" {!u16i, !u32i}>
+module {
+  cir.func @memeber_index_out_of_bounds(%arg0 : !cir.ptr<!struct>) {
+    // expected-error@+1 {{member index out of bounds}}
+    %0 = cir.get_member %arg0[2] {name = "test"} : !cir.ptr<!struct> -> !cir.ptr<!u32i>
+    cir.return
+  }
+}
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!struct = !cir.struct<struct "Struct" {!u16i, !u32i}>
+module {
+  cir.func @memeber_type_mismatch(%arg0 : !cir.ptr<!struct>) {
+    // expected-error@+1 {{member type mismatch}}
+    %0 = cir.get_member %arg0[0] {name = "test"} : !cir.ptr<!struct> -> !cir.ptr<!u32i>
+    cir.return
+  }
+}


### PR DESCRIPTION
Temporary workaround until we patch the codegen for record types.