### PR TITLE
[CIR][Lowering] use cir.int type in LIT tests

### DIFF
--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -65,54 +65,42 @@ struct ConvertCIRToMLIRPass
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::BuiltinDialect, mlir::func::FuncDialect,
                     mlir::affine::AffineDialect, mlir::memref::MemRefDialect,
-                    mlir::arith::ArithDialect>();
+                    mlir::arith::ArithDialect, mlir::cf::ControlFlowDialect>();
   }
   void runOnOperation() final;
 
   virtual StringRef getArgument() const override { return "cir-to-mlir"; }
 };
 
-class CIRCallLowering : public mlir::OpRewritePattern<mlir::cir::CallOp> {
+class CIRCallLowering : public mlir::OpConversionPattern<mlir::cir::CallOp> {
 public:
-  using OpRewritePattern<mlir::cir::CallOp>::OpRewritePattern;
+  using OpConversionPattern<mlir::cir::CallOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::CallOp op,
-                  mlir::PatternRewriter &rewriter) const override {
+  matchAndRewrite(mlir::cir::CallOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    SmallVector<mlir::Type> types;
+    if (mlir::failed(
+            getTypeConverter()->convertTypes(op.getResultTypes(), types)))
+      return mlir::failure();
     rewriter.replaceOpWithNewOp<mlir::func::CallOp>(
-        op, mlir::SymbolRefAttr::get(op), op.getResultTypes(),
-        op.getArgOperands());
+        op, mlir::SymbolRefAttr::get(op), types, adaptor.getOperands());
     return mlir::LogicalResult::success();
   }
 };
 
-class CIRAllocaLowering : public mlir::OpRewritePattern<mlir::cir::AllocaOp> {
+class CIRAllocaLowering
+    : public mlir::OpConversionPattern<mlir::cir::AllocaOp> {
 public:
-  using OpRewritePattern<mlir::cir::AllocaOp>::OpRewritePattern;
+  using OpConversionPattern<mlir::cir::AllocaOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::AllocaOp op,
-                  mlir::PatternRewriter &rewriter) const override {
-    auto type = op.getAllocaType();
-    mlir::MemRefType memreftype;
+  matchAndRewrite(mlir::cir::AllocaOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto type = adaptor.getAllocaType();
+    auto mlirType = getTypeConverter()->convertType(type);
 
-    if (type.isa<mlir::cir::BoolType>()) {
-      auto integerType =
-          mlir::IntegerType::get(getContext(), 8, mlir::IntegerType::Signless);
-      memreftype = mlir::MemRefType::get({}, integerType);
-    } else if (type.isa<mlir::cir::ArrayType>()) {
-      mlir::cir::ArrayType arraytype = type.dyn_cast<mlir::cir::ArrayType>();
-      memreftype =
-          mlir::MemRefType::get(arraytype.getSize(), arraytype.getEltType());
-    } else if (type.isa<mlir::IntegerType>() || type.isa<mlir::FloatType>()) {
-      memreftype = mlir::MemRefType::get({}, op.getAllocaType());
-    } else if (type.isa<mlir::cir::PointerType>()) {
-      auto ptrType = type.cast<mlir::cir::PointerType>();
-      auto innerMemref = mlir::MemRefType::get({-1}, ptrType.getPointee());
-      memreftype = mlir::MemRefType::get({}, innerMemref);
-    } else {
-      llvm_unreachable("type to be allocated not supported yet");
-    }
+    auto memreftype = mlir::MemRefType::get({}, mlirType);
     rewriter.replaceOpWithNewOp<mlir::memref::AllocaOp>(op, memreftype,
                                                         op.getAlignmentAttr());
     return mlir::LogicalResult::success();
@@ -131,44 +119,39 @@ public:
   }
 };
 
-class CIRStoreLowering : public mlir::ConversionPattern {
+class CIRStoreLowering : public mlir::OpConversionPattern<mlir::cir::StoreOp> {
 public:
-  CIRStoreLowering(mlir::MLIRContext *ctx)
-      : mlir::ConversionPattern(mlir::cir::StoreOp::getOperationName(), 1,
-                                ctx) {}
+  using OpConversionPattern<mlir::cir::StoreOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::Operation *op, ArrayRef<mlir::Value> operands,
+  matchAndRewrite(mlir::cir::StoreOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<mlir::memref::StoreOp>(op, operands[0],
-                                                       operands[1]);
+    rewriter.replaceOpWithNewOp<mlir::memref::StoreOp>(op, adaptor.getValue(),
+                                                       adaptor.getAddr());
     return mlir::LogicalResult::success();
   }
 };
 
 class CIRConstantLowering
-    : public mlir::OpRewritePattern<mlir::cir::ConstantOp> {
+    : public mlir::OpConversionPattern<mlir::cir::ConstantOp> {
 public:
-  using OpRewritePattern<mlir::cir::ConstantOp>::OpRewritePattern;
+  using OpConversionPattern<mlir::cir::ConstantOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::ConstantOp op,
-                  mlir::PatternRewriter &rewriter) const override {
-    if (op.getType().isa<mlir::cir::BoolType>()) {
-      mlir::Type type =
-          mlir::IntegerType::get(getContext(), 8, mlir::IntegerType::Signless);
-      mlir::TypedAttr IntegerAttr;
-      if (op.getValue() ==
-          mlir::cir::BoolAttr::get(
-              getContext(), ::mlir::cir::BoolType::get(getContext()), true))
-        IntegerAttr = mlir::IntegerAttr::get(type, 1);
-      else
-        IntegerAttr = mlir::IntegerAttr::get(type, 0);
-      rewriter.replaceOpWithNewOp<mlir::arith::ConstantOp>(op, type,
-                                                           IntegerAttr);
-    } else
-      rewriter.replaceOpWithNewOp<mlir::arith::ConstantOp>(op, op.getType(),
-                                                           op.getValue());
+  matchAndRewrite(mlir::cir::ConstantOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto ty = getTypeConverter()->convertType(op.getType());
+    mlir::TypedAttr value;
+    if (mlir::isa<mlir::cir::BoolType>(op.getType())) {
+      auto boolValue = mlir::cast<mlir::cir::BoolAttr>(op.getValue());
+      value = rewriter.getIntegerAttr(ty, boolValue.getValue());
+    } else {
+      auto cirIntAttr = mlir::dyn_cast<mlir::cir::IntAttr>(op.getValue());
+      assert(cirIntAttr && "NYI non cir.int attr");
+      value = rewriter.getIntegerAttr(
+          ty, cast<mlir::cir::IntAttr>(op.getValue()).getValue());
+    }
+    rewriter.replaceOpWithNewOp<mlir::arith::ConstantOp>(op, ty, value);
     return mlir::LogicalResult::success();
   }
 };
@@ -211,29 +194,28 @@ public:
   }
 };
 
-class CIRUnaryOpLowering : public mlir::OpRewritePattern<mlir::cir::UnaryOp> {
+class CIRUnaryOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::UnaryOp> {
 public:
-  using OpRewritePattern<mlir::cir::UnaryOp>::OpRewritePattern;
+  using OpConversionPattern<mlir::cir::UnaryOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::UnaryOp op,
-                  mlir::PatternRewriter &rewriter) const override {
-    mlir::Type type = op.getInput().getType();
-    assert(type.isa<mlir::IntegerType>() && "operand type not supported yet");
+  matchAndRewrite(mlir::cir::UnaryOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto input = adaptor.getInput();
+    auto type = getTypeConverter()->convertType(op.getType());
 
     switch (op.getKind()) {
     case mlir::cir::UnaryOpKind::Inc: {
       auto One = rewriter.create<mlir::arith::ConstantOp>(
           op.getLoc(), type, mlir::IntegerAttr::get(type, 1));
-      rewriter.replaceOpWithNewOp<mlir::arith::AddIOp>(op, op.getType(),
-                                                       op.getInput(), One);
+      rewriter.replaceOpWithNewOp<mlir::arith::AddIOp>(op, type, input, One);
       break;
     }
     case mlir::cir::UnaryOpKind::Dec: {
       auto One = rewriter.create<mlir::arith::ConstantOp>(
           op.getLoc(), type, mlir::IntegerAttr::get(type, 1));
-      rewriter.replaceOpWithNewOp<mlir::arith::SubIOp>(op, op.getType(),
-                                                       op.getInput(), One);
+      rewriter.replaceOpWithNewOp<mlir::arith::SubIOp>(op, type, input, One);
       break;
     }
     case mlir::cir::UnaryOpKind::Plus: {
@@ -243,15 +225,14 @@ public:
     case mlir::cir::UnaryOpKind::Minus: {
       auto Zero = rewriter.create<mlir::arith::ConstantOp>(
           op.getLoc(), type, mlir::IntegerAttr::get(type, 0));
-      rewriter.replaceOpWithNewOp<mlir::arith::SubIOp>(op, op.getType(), Zero,
-                                                       op.getInput());
+      rewriter.replaceOpWithNewOp<mlir::arith::SubIOp>(op, type, Zero, input);
       break;
     }
     case mlir::cir::UnaryOpKind::Not: {
       auto MinusOne = rewriter.create<mlir::arith::ConstantOp>(
           op.getLoc(), type, mlir::IntegerAttr::get(type, -1));
-      rewriter.replaceOpWithNewOp<mlir::arith::XOrIOp>(op, op.getType(),
-                                                       MinusOne, op.getInput());
+      rewriter.replaceOpWithNewOp<mlir::arith::XOrIOp>(op, type, MinusOne,
+                                                       input);
       break;
     }
     }
@@ -260,77 +241,78 @@ public:
   }
 };
 
-class CIRBinOpLowering : public mlir::OpRewritePattern<mlir::cir::BinOp> {
+class CIRBinOpLowering : public mlir::OpConversionPattern<mlir::cir::BinOp> {
 public:
-  using OpRewritePattern<mlir::cir::BinOp>::OpRewritePattern;
+  using OpConversionPattern<mlir::cir::BinOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::BinOp op,
-                  mlir::PatternRewriter &rewriter) const override {
-    assert((op.getLhs().getType() == op.getRhs().getType()) &&
+  matchAndRewrite(mlir::cir::BinOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    assert((adaptor.getLhs().getType() == adaptor.getRhs().getType()) &&
            "inconsistent operands' types not supported yet");
-    mlir::Type type = op.getRhs().getType();
-    assert((type.isa<mlir::IntegerType>() || type.isa<mlir::FloatType>()) &&
+    mlir::Type mlirType = getTypeConverter()->convertType(op.getType());
+    assert((mlirType.isa<mlir::IntegerType>() ||
+            mlirType.isa<mlir::FloatType>()) &&
            "operand type not supported yet");
 
     switch (op.getKind()) {
     case mlir::cir::BinOpKind::Add:
-      if (type.isa<mlir::IntegerType>())
+      if (mlirType.isa<mlir::IntegerType>())
         rewriter.replaceOpWithNewOp<mlir::arith::AddIOp>(
-            op, op.getType(), op.getLhs(), op.getRhs());
+            op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       else
         rewriter.replaceOpWithNewOp<mlir::arith::AddFOp>(
-            op, op.getType(), op.getLhs(), op.getRhs());
+            op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Sub:
-      if (type.isa<mlir::IntegerType>())
+      if (mlirType.isa<mlir::IntegerType>())
         rewriter.replaceOpWithNewOp<mlir::arith::SubIOp>(
-            op, op.getType(), op.getLhs(), op.getRhs());
+            op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       else
         rewriter.replaceOpWithNewOp<mlir::arith::SubFOp>(
-            op, op.getType(), op.getLhs(), op.getRhs());
+            op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Mul:
-      if (type.isa<mlir::IntegerType>())
+      if (mlirType.isa<mlir::IntegerType>())
         rewriter.replaceOpWithNewOp<mlir::arith::MulIOp>(
-            op, op.getType(), op.getLhs(), op.getRhs());
+            op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       else
         rewriter.replaceOpWithNewOp<mlir::arith::MulFOp>(
-            op, op.getType(), op.getLhs(), op.getRhs());
+            op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Div:
-      if (type.isa<mlir::IntegerType>()) {
-        if (type.isSignlessInteger())
+      if (mlirType.isa<mlir::IntegerType>()) {
+        if (mlirType.isSignlessInteger())
           rewriter.replaceOpWithNewOp<mlir::arith::DivUIOp>(
-              op, op.getType(), op.getLhs(), op.getRhs());
+              op, mlirType, adaptor.getLhs(), adaptor.getRhs());
         else
-          llvm_unreachable("integer type not supported in CIR yet");
+          llvm_unreachable("integer mlirType not supported in CIR yet");
       } else
         rewriter.replaceOpWithNewOp<mlir::arith::DivFOp>(
-            op, op.getType(), op.getLhs(), op.getRhs());
+            op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Rem:
-      if (type.isa<mlir::IntegerType>()) {
-        if (type.isSignlessInteger())
+      if (mlirType.isa<mlir::IntegerType>()) {
+        if (mlirType.isSignlessInteger())
           rewriter.replaceOpWithNewOp<mlir::arith::RemUIOp>(
-              op, op.getType(), op.getLhs(), op.getRhs());
+              op, mlirType, adaptor.getLhs(), adaptor.getRhs());
         else
-          llvm_unreachable("integer type not supported in CIR yet");
+          llvm_unreachable("integer mlirType not supported in CIR yet");
       } else
         rewriter.replaceOpWithNewOp<mlir::arith::RemFOp>(
-            op, op.getType(), op.getLhs(), op.getRhs());
+            op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::And:
       rewriter.replaceOpWithNewOp<mlir::arith::AndIOp>(
-          op, op.getType(), op.getLhs(), op.getRhs());
+          op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Or:
-      rewriter.replaceOpWithNewOp<mlir::arith::OrIOp>(op, op.getType(),
-                                                      op.getLhs(), op.getRhs());
+      rewriter.replaceOpWithNewOp<mlir::arith::OrIOp>(
+          op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Xor:
       rewriter.replaceOpWithNewOp<mlir::arith::XOrIOp>(
-          op, op.getType(), op.getLhs(), op.getRhs());
+          op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     }
 
@@ -338,17 +320,18 @@ public:
   }
 };
 
-class CIRCmpOpLowering : public mlir::OpRewritePattern<mlir::cir::CmpOp> {
+class CIRCmpOpLowering : public mlir::OpConversionPattern<mlir::cir::CmpOp> {
 public:
-  using OpRewritePattern<mlir::cir::CmpOp>::OpRewritePattern;
+  using OpConversionPattern<mlir::cir::CmpOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::CmpOp op,
-                  mlir::PatternRewriter &rewriter) const override {
-    auto type = op.getLhs().getType();
+  matchAndRewrite(mlir::cir::CmpOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto type = adaptor.getLhs().getType();
     auto integerType =
         mlir::IntegerType::get(getContext(), 1, mlir::IntegerType::Signless);
 
+    mlir::Value mlirResult;
     switch (op.getKind()) {
     case mlir::cir::CmpOpKind::gt: {
       if (type.isa<mlir::IntegerType>()) {
@@ -356,16 +339,16 @@ public:
         if (!type.isSignlessInteger())
           llvm_unreachable("integer type not supported in CIR yet");
         cmpIType = mlir::arith::CmpIPredicate::ugt;
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpIOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpIOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpIPredicateAttr::get(getContext(), cmpIType),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else if (type.isa<mlir::FloatType>()) {
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpFOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpFOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpFPredicateAttr::get(
                 getContext(), mlir::arith::CmpFPredicate::UGT),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else {
         llvm_unreachable("Unknown Operand Type");
       }
@@ -377,16 +360,16 @@ public:
         if (!type.isSignlessInteger())
           llvm_unreachable("integer type not supported in CIR yet");
         cmpIType = mlir::arith::CmpIPredicate::uge;
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpIOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpIOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpIPredicateAttr::get(getContext(), cmpIType),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else if (type.isa<mlir::FloatType>()) {
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpFOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpFOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpFPredicateAttr::get(
                 getContext(), mlir::arith::CmpFPredicate::UGE),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else {
         llvm_unreachable("Unknown Operand Type");
       }
@@ -398,16 +381,16 @@ public:
         if (!type.isSignlessInteger())
           llvm_unreachable("integer type not supported in CIR yet");
         cmpIType = mlir::arith::CmpIPredicate::ult;
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpIOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpIOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpIPredicateAttr::get(getContext(), cmpIType),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else if (type.isa<mlir::FloatType>()) {
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpFOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpFOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpFPredicateAttr::get(
                 getContext(), mlir::arith::CmpFPredicate::ULT),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else {
         llvm_unreachable("Unknown Operand Type");
       }
@@ -419,16 +402,16 @@ public:
         if (!type.isSignlessInteger())
           llvm_unreachable("integer type not supported in CIR yet");
         cmpIType = mlir::arith::CmpIPredicate::ule;
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpIOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpIOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpIPredicateAttr::get(getContext(), cmpIType),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else if (type.isa<mlir::FloatType>()) {
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpFOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpFOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpFPredicateAttr::get(
                 getContext(), mlir::arith::CmpFPredicate::ULE),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else {
         llvm_unreachable("Unknown Operand Type");
       }
@@ -436,17 +419,17 @@ public:
     }
     case mlir::cir::CmpOpKind::eq: {
       if (type.isa<mlir::IntegerType>()) {
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpIOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpIOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpIPredicateAttr::get(getContext(),
                                                 mlir::arith::CmpIPredicate::eq),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else if (type.isa<mlir::FloatType>()) {
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpFOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpFOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpFPredicateAttr::get(
                 getContext(), mlir::arith::CmpFPredicate::UEQ),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else {
         llvm_unreachable("Unknown Operand Type");
       }
@@ -454,23 +437,30 @@ public:
     }
     case mlir::cir::CmpOpKind::ne: {
       if (type.isa<mlir::IntegerType>()) {
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpIOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpIOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpIPredicateAttr::get(getContext(),
                                                 mlir::arith::CmpIPredicate::ne),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else if (type.isa<mlir::FloatType>()) {
-        rewriter.replaceOpWithNewOp<mlir::arith::CmpFOp>(
-            op, integerType,
+        mlirResult = rewriter.create<mlir::arith::CmpFOp>(
+            op.getLoc(), integerType,
             mlir::arith::CmpFPredicateAttr::get(
                 getContext(), mlir::arith::CmpFPredicate::UNE),
-            op.getLhs(), op.getRhs());
+            adaptor.getLhs(), adaptor.getRhs());
       } else {
         llvm_unreachable("Unknown Operand Type");
       }
       break;
     }
     }
+
+    // MLIR comparison ops return i1, but cir::CmpOp returns the same type as
+    // the LHS value. Since this return value can be used later, we need to
+    // restore the type with the extension below.
+    auto mlirResultTy = getTypeConverter()->convertType(op.getType());
+    rewriter.replaceOpWithNewOp<mlir::arith::ExtUIOp>(op, mlirResultTy,
+                                                      mlirResult);
 
     return mlir::LogicalResult::success();
   }
@@ -488,12 +478,13 @@ public:
   }
 };
 
-class CIRScopeOpLowering : public mlir::OpRewritePattern<mlir::cir::ScopeOp> {
-  using mlir::OpRewritePattern<mlir::cir::ScopeOp>::OpRewritePattern;
+class CIRScopeOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::ScopeOp> {
+  using mlir::OpConversionPattern<mlir::cir::ScopeOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::ScopeOp scopeOp,
-                  mlir::PatternRewriter &rewriter) const override {
+  matchAndRewrite(mlir::cir::ScopeOp scopeOp, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
     // Empty scope: just remove it.
     if (scopeOp.getRegion().empty()) {
       rewriter.eraseOp(scopeOp);
@@ -507,9 +498,14 @@ class CIRScopeOpLowering : public mlir::OpRewritePattern<mlir::cir::ScopeOp> {
           terminator, terminator->getOperands());
     }
 
+    SmallVector<mlir::Type> mlirResultTypes;
+    if (mlir::failed(getTypeConverter()->convertTypes(scopeOp->getResultTypes(),
+                                                      mlirResultTypes)))
+      return mlir::LogicalResult::failure();
+
     rewriter.setInsertionPoint(scopeOp);
     auto newScopeOp = rewriter.create<mlir::memref::AllocaScopeOp>(
-        scopeOp.getLoc(), scopeOp.getResultTypes());
+        scopeOp.getLoc(), mlirResultTypes);
     rewriter.inlineRegionBefore(scopeOp.getScopeRegion(),
                                 newScopeOp.getBodyRegion(),
                                 newScopeOp.getBodyRegion().end());
@@ -521,17 +517,19 @@ class CIRScopeOpLowering : public mlir::OpRewritePattern<mlir::cir::ScopeOp> {
 
 void populateCIRToMLIRConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter) {
-  patterns.add<CIRAllocaLowering, CIRLoadLowering, CIRStoreLowering,
-               CIRConstantLowering, CIRUnaryOpLowering, CIRBinOpLowering,
-               CIRCmpOpLowering, CIRBrOpLowering, CIRCallLowering,
-               CIRReturnLowering, CIRScopeOpLowering>(patterns.getContext());
-  patterns.add<CIRFuncLowering>(converter, patterns.getContext());
+  patterns.add<CIRReturnLowering, CIRBrOpLowering>(patterns.getContext());
+
+  patterns.add<CIRCmpOpLowering, CIRCallLowering, CIRUnaryOpLowering,
+               CIRBinOpLowering, CIRLoadLowering, CIRConstantLowering,
+               CIRStoreLowering, CIRAllocaLowering, CIRFuncLowering,
+               CIRScopeOpLowering>(converter, patterns.getContext());
 }
 
 static mlir::TypeConverter prepareTypeConverter() {
   mlir::TypeConverter converter;
   converter.addConversion([&](mlir::cir::PointerType type) -> mlir::Type {
-    return mlir::MemRefType::get({-1}, type.getPointee());
+    auto ty = converter.convertType(type.getPointee());
+    return mlir::MemRefType::get({}, ty);
   });
   converter.addConversion(
       [&](mlir::IntegerType type) -> mlir::Type { return type; });
@@ -539,6 +537,19 @@ static mlir::TypeConverter prepareTypeConverter() {
       [&](mlir::FloatType type) -> mlir::Type { return type; });
   converter.addConversion(
       [&](mlir::cir::VoidType type) -> mlir::Type { return {}; });
+  converter.addConversion([&](mlir::cir::IntType type) -> mlir::Type {
+    // arith dialect ops doesn't take signed integer -- drop cir sign here
+    return mlir::IntegerType::get(
+        type.getContext(), type.getWidth(),
+        mlir::IntegerType::SignednessSemantics::Signless);
+  });
+  converter.addConversion([&](mlir::cir::BoolType type) -> mlir::Type {
+    return mlir::IntegerType::get(type.getContext(), 8);
+  });
+  converter.addConversion([&](mlir::cir::ArrayType type) -> mlir::Type {
+    auto elementType = converter.convertType(type.getEltType());
+    return mlir::MemRefType::get(type.getSize(), elementType);
+  });
 
   return converter;
 }

--- a/clang/test/CIR/Lowering/ThroughMLIR/binop-unsigned-int.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/binop-unsigned-int.cir
@@ -1,55 +1,56 @@
 // RUN: cir-opt %s -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
+!u32i = !cir.int<u, 32>
 
 module {
   cir.func @foo() {
-    %0 = cir.alloca i32, cir.ptr <i32>, ["a", init] {alignment = 4 : i64}
-    %1 = cir.alloca i32, cir.ptr <i32>, ["b", init] {alignment = 4 : i64}
-    %2 = cir.alloca i32, cir.ptr <i32>, ["x", init] {alignment = 4 : i64}
-    %3 = cir.const(2 : i32) : i32    cir.store %3, %0 : i32, cir.ptr <i32>
-    %4 = cir.const(1 : i32) : i32    cir.store %4, %1 : i32, cir.ptr <i32>
-    %5 = cir.load %0 : cir.ptr <i32>, i32
-    %6 = cir.load %1 : cir.ptr <i32>, i32
-    %7 = cir.binop(mul, %5, %6) : i32
-    cir.store %7, %2 : i32, cir.ptr <i32>
-    %8 = cir.load %2 : cir.ptr <i32>, i32
-    %9 = cir.load %1 : cir.ptr <i32>, i32
-    %10 = cir.binop(div, %8, %9) : i32
-    cir.store %10, %2 : i32, cir.ptr <i32>
-    %11 = cir.load %2 : cir.ptr <i32>, i32
-    %12 = cir.load %1 : cir.ptr <i32>, i32
-    %13 = cir.binop(rem, %11, %12) : i32
-    cir.store %13, %2 : i32, cir.ptr <i32>
-    %14 = cir.load %2 : cir.ptr <i32>, i32
-    %15 = cir.load %1 : cir.ptr <i32>, i32
-    %16 = cir.binop(add, %14, %15) : i32
-    cir.store %16, %2 : i32, cir.ptr <i32>
-    %17 = cir.load %2 : cir.ptr <i32>, i32
-    %18 = cir.load %1 : cir.ptr <i32>, i32
-    %19 = cir.binop(sub, %17, %18) : i32
-    cir.store %19, %2 : i32, cir.ptr <i32>
+    %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["a", init] {alignment = 4 : i64}
+    %1 = cir.alloca !u32i, cir.ptr <!u32i>, ["b", init] {alignment = 4 : i64}
+    %2 = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init] {alignment = 4 : i64}
+    %3 = cir.const(#cir.int<2> : !u32i) : !u32i    cir.store %3, %0 : !u32i, cir.ptr <!u32i>
+    %4 = cir.const(#cir.int<1> : !u32i) : !u32i    cir.store %4, %1 : !u32i, cir.ptr <!u32i>
+    %5 = cir.load %0 : cir.ptr <!u32i>, !u32i
+    %6 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    %7 = cir.binop(mul, %5, %6) : !u32i
+    cir.store %7, %2 : !u32i, cir.ptr <!u32i>
+    %8 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    %9 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    %10 = cir.binop(div, %8, %9) : !u32i
+    cir.store %10, %2 : !u32i, cir.ptr <!u32i>
+    %11 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    %12 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    %13 = cir.binop(rem, %11, %12) : !u32i
+    cir.store %13, %2 : !u32i, cir.ptr <!u32i>
+    %14 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    %15 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    %16 = cir.binop(add, %14, %15) : !u32i
+    cir.store %16, %2 : !u32i, cir.ptr <!u32i>
+    %17 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    %18 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    %19 = cir.binop(sub, %17, %18) : !u32i
+    cir.store %19, %2 : !u32i, cir.ptr <!u32i>
     // should move to cir.shift, which only accepts
     // CIR types.
-    // %20 = cir.load %2 : cir.ptr <i32>, i32
-    // %21 = cir.load %1 : cir.ptr <i32>, i32
-    // %22 = cir.binop(shr, %20, %21) : i32
-    // cir.store %22, %2 : i32, cir.ptr <i32>
-    // %23 = cir.load %2 : cir.ptr <i32>, i32
-    // %24 = cir.load %1 : cir.ptr <i32>, i32
-    // %25 = cir.binop(shl, %23, %24) : i32
-    // cir.store %25, %2 : i32, cir.ptr <i32>
-    %26 = cir.load %2 : cir.ptr <i32>, i32
-    %27 = cir.load %1 : cir.ptr <i32>, i32
-    %28 = cir.binop(and, %26, %27) : i32
-    cir.store %28, %2 : i32, cir.ptr <i32>
-    %29 = cir.load %2 : cir.ptr <i32>, i32
-    %30 = cir.load %1 : cir.ptr <i32>, i32
-    %31 = cir.binop(xor, %29, %30) : i32
-    cir.store %31, %2 : i32, cir.ptr <i32>
-    %32 = cir.load %2 : cir.ptr <i32>, i32
-    %33 = cir.load %1 : cir.ptr <i32>, i32
-    %34 = cir.binop(or, %32, %33) : i32
-    cir.store %34, %2 : i32, cir.ptr <i32>
+    // %20 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    // %21 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    // %22 = cir.binop(shr, %20, %21) : !u32i
+    // cir.store %22, %2 : !u32i, cir.ptr <!u32i>
+    // %23 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    // %24 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    // %25 = cir.binop(shl, %23, %24) : !u32i
+    // cir.store %25, %2 : !u32i, cir.ptr <!u32i>
+    %26 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    %27 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    %28 = cir.binop(and, %26, %27) : !u32i
+    cir.store %28, %2 : !u32i, cir.ptr <!u32i>
+    %29 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    %30 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    %31 = cir.binop(xor, %29, %30) : !u32i
+    cir.store %31, %2 : !u32i, cir.ptr <!u32i>
+    %32 = cir.load %2 : cir.ptr <!u32i>, !u32i
+    %33 = cir.load %1 : cir.ptr <!u32i>, !u32i
+    %34 = cir.binop(or, %32, %33) : !u32i
+    cir.store %34, %2 : !u32i, cir.ptr <!u32i>
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/ThroughMLIR/cmp.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/cmp.cir
@@ -1,31 +1,32 @@
 // RUN: cir-opt %s -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
 
+!s32i = !cir.int<s, 32>
 module {
   cir.func @foo() {
-    %0 = cir.alloca i32, cir.ptr <i32>, ["a"] {alignment = 4 : i64}
-    %1 = cir.alloca i32, cir.ptr <i32>, ["b"] {alignment = 4 : i64}
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a"] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["b"] {alignment = 4 : i64}
     %2 = cir.alloca f32, cir.ptr <f32>, ["c"] {alignment = 4 : i64}
     %3 = cir.alloca f32, cir.ptr <f32>, ["d"] {alignment = 4 : i64}
     %4 = cir.alloca !cir.bool, cir.ptr <!cir.bool>, ["e"] {alignment = 1 : i64}
-    %5 = cir.load %0 : cir.ptr <i32>, i32
-    %6 = cir.load %1 : cir.ptr <i32>, i32
-    %7 = cir.cmp(gt, %5, %6) : i32, !cir.bool
-    %8 = cir.load %0 : cir.ptr <i32>, i32
-    %9 = cir.load %1 : cir.ptr <i32>, i32
-    %10 = cir.cmp(eq, %8, %9) : i32, !cir.bool
-    %11 = cir.load %0 : cir.ptr <i32>, i32
-    %12 = cir.load %1 : cir.ptr <i32>, i32
-    %13 = cir.cmp(lt, %11, %12) : i32, !cir.bool
-    %14 = cir.load %0 : cir.ptr <i32>, i32
-    %15 = cir.load %1 : cir.ptr <i32>, i32
-    %16 = cir.cmp(ge, %14, %15) : i32, !cir.bool
-    %17 = cir.load %0 : cir.ptr <i32>, i32
-    %18 = cir.load %1 : cir.ptr <i32>, i32
-    %19 = cir.cmp(ne, %17, %18) : i32, !cir.bool
-    %20 = cir.load %0 : cir.ptr <i32>, i32
-    %21 = cir.load %1 : cir.ptr <i32>, i32
-    %22 = cir.cmp(le, %20, %21) : i32, !cir.bool
+    %5 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %7 = cir.cmp(gt, %5, %6) : !s32i, !cir.bool
+    %8 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %9 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %10 = cir.cmp(eq, %8, %9) : !s32i, !cir.bool
+    %11 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %12 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %13 = cir.cmp(lt, %11, %12) : !s32i, !cir.bool
+    %14 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %15 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %16 = cir.cmp(ge, %14, %15) : !s32i, !cir.bool
+    %17 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %18 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %19 = cir.cmp(ne, %17, %18) : !s32i, !cir.bool
+    %20 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %21 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %22 = cir.cmp(le, %20, %21) : !s32i, !cir.bool
     %23 = cir.load %2 : cir.ptr <f32>, f32
     %24 = cir.load %3 : cir.ptr <f32>, f32
     %25 = cir.cmp(gt, %23, %24) : f32, !cir.bool

--- a/clang/test/CIR/Lowering/ThroughMLIR/goto.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/goto.cir
@@ -1,24 +1,24 @@
 // RUN: cir-opt %s -canonicalize -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-opt %s -canonicalize -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
-// XFAIL: *
 
+!u32i = !cir.int<u, 32>
 module {
   cir.func @foo() {
-    %0 = cir.alloca i32, cir.ptr <i32>, ["b", init] {alignment = 4 : i64}
-    %1 = cir.const(1 : i32) : i32
-    cir.store %1, %0 : i32, cir.ptr <i32>
+    %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["b", init] {alignment = 4 : i64}
+    %1 = cir.const(#cir.int<1> : !u32i) : !u32i
+    cir.store %1, %0 : !u32i, cir.ptr <!u32i>
     cir.br ^bb2
   ^bb1:  // no predecessors
-    %2 = cir.load %0 : cir.ptr <i32>, i32
-    %3 = cir.const(1 : i32) : i32
-    %4 = cir.binop(add, %2, %3) : i32
-    cir.store %4, %0 : i32, cir.ptr <i32>
+    %2 = cir.load %0 : cir.ptr <!u32i>, !u32i
+    %3 = cir.const(#cir.int<1> : !u32i) : !u32i
+    %4 = cir.binop(add, %2, %3) : !u32i
+    cir.store %4, %0 : !u32i, cir.ptr <!u32i>
     cir.br ^bb2
   ^bb2:  // 2 preds: ^bb0, ^bb1
-    %5 = cir.load %0 : cir.ptr <i32>, i32
-    %6 = cir.const(2 : i32) : i32
-    %7 = cir.binop(add, %5, %6) : i32
-    cir.store %7, %0 : i32, cir.ptr <i32>
+    %5 = cir.load %0 : cir.ptr <!u32i>, !u32i
+    %6 = cir.const(#cir.int<2> : !u32i) : !u32i
+    %7 = cir.binop(add, %5, %6) : !u32i
+    cir.store %7, %0 : !u32i, cir.ptr <!u32i>
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/ThroughMLIR/memref.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/memref.cir
@@ -1,13 +1,14 @@
 // RUN: cir-opt %s -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
 
+!u32i = !cir.int<u, 32>
 module {
-  cir.func @foo() -> i32 {
-    %0 = cir.alloca i32, cir.ptr <i32>, ["x", init] {alignment = 4 : i64}
-    %1 = cir.const(1 : i32) : i32
-    cir.store %1, %0 : i32, cir.ptr <i32>
-    %2 = cir.load %0 : cir.ptr <i32>, i32
-    cir.return %2 : i32
+  cir.func @foo() -> !u32i {
+    %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init] {alignment = 4 : i64}
+    %1 = cir.const(#cir.int<1> : !u32i) : !u32i
+    cir.store %1, %0 : !u32i, cir.ptr <!u32i>
+    %2 = cir.load %0 : cir.ptr <!u32i>, !u32i
+    cir.return %2 : !u32i
   }
 }
 

--- a/clang/test/CIR/Lowering/ThroughMLIR/scope.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/scope.cir
@@ -1,12 +1,13 @@
 // RUN: cir-opt %s -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
 
+!u32i = !cir.int<u, 32>
 module {
   cir.func @foo() {
     cir.scope {
-      %0 = cir.alloca i32, cir.ptr <i32>, ["a", init] {alignment = 4 : i64}
-      %1 = cir.const(4 : i32) : i32
-      cir.store %1, %0 : i32, cir.ptr <i32>
+      %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["a", init] {alignment = 4 : i64}
+      %1 = cir.const(#cir.int<4> : !u32i) : !u32i
+      cir.store %1, %0 : !u32i, cir.ptr <!u32i>
     }
     cir.return
   }

--- a/clang/test/CIR/Lowering/ThroughMLIR/unary-inc-dec.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/unary-inc-dec.cir
@@ -1,21 +1,22 @@
 // RUN: cir-opt %s -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
 
+!s32i = !cir.int<s, 32>
 module {
   cir.func @foo() {
-    %0 = cir.alloca i32, cir.ptr <i32>, ["a", init] {alignment = 4 : i64}
-    %1 = cir.alloca i32, cir.ptr <i32>, ["b", init] {alignment = 4 : i64}
-    %2 = cir.const(2 : i32) : i32
-    cir.store %2, %0 : i32, cir.ptr <i32>
-    cir.store %2, %1 : i32, cir.ptr <i32>
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["b", init] {alignment = 4 : i64}
+    %2 = cir.const(#cir.int<2> : !s32i) : !s32i
+    cir.store %2, %0 : !s32i, cir.ptr <!s32i>
+    cir.store %2, %1 : !s32i, cir.ptr <!s32i>
 
-    %3 = cir.load %0 : cir.ptr <i32>, i32
-    %4 = cir.unary(inc, %3) : i32, i32
-    cir.store %4, %0 : i32, cir.ptr <i32>
+    %3 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %4 = cir.unary(inc, %3) : !s32i, !s32i
+    cir.store %4, %0 : !s32i, cir.ptr <!s32i>
 
-    %5 = cir.load %1 : cir.ptr <i32>, i32
-    %6 = cir.unary(dec, %5) : i32, i32
-    cir.store %6, %1 : i32, cir.ptr <i32>
+    %5 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %6 = cir.unary(dec, %5) : !s32i, !s32i
+    cir.store %6, %1 : !s32i, cir.ptr <!s32i>
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/ThroughMLIR/unary-plus-minus.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/unary-plus-minus.cir
@@ -1,21 +1,22 @@
 // RUN: cir-opt %s -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
 // RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
 
+!s32i = !cir.int<s, 32>
 module {
   cir.func @foo() {
-    %0 = cir.alloca i32, cir.ptr <i32>, ["a", init] {alignment = 4 : i64}
-    %1 = cir.alloca i32, cir.ptr <i32>, ["b", init] {alignment = 4 : i64}
-    %2 = cir.const(2 : i32) : i32
-    cir.store %2, %0 : i32, cir.ptr <i32>
-    cir.store %2, %1 : i32, cir.ptr <i32>
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["b", init] {alignment = 4 : i64}
+    %2 = cir.const(#cir.int<2> : !s32i) : !s32i
+    cir.store %2, %0 : !s32i, cir.ptr <!s32i>
+    cir.store %2, %1 : !s32i, cir.ptr <!s32i>
 
-    %3 = cir.load %0 : cir.ptr <i32>, i32
-    %4 = cir.unary(plus, %3) : i32, i32
-    cir.store %4, %0 : i32, cir.ptr <i32>
+    %3 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %4 = cir.unary(plus, %3) : !s32i, !s32i
+    cir.store %4, %0 : !s32i, cir.ptr <!s32i>
 
-    %5 = cir.load %1 : cir.ptr <i32>, i32
-    %6 = cir.unary(minus, %5) : i32, i32
-    cir.store %6, %1 : i32, cir.ptr <i32>
+    %5 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    %6 = cir.unary(minus, %5) : !s32i, !s32i
+    cir.store %6, %1 : !s32i, cir.ptr <!s32i>
     cir.return
   }
 }


### PR DESCRIPTION
Here is the promised patch that adds proper type conversion to CIR -> MLIR conversion. I tried to keep the changes minimum but the existing implementation doesn't use `TypeConverter`. 

This should not have any functional changes except for one tiny fix that registers the `cf` dialect, which should allow `goto.mlir` to pass. Happy to break the PR into two if requested.