### PR TITLE
[CIR][Bugfix] adds missing clangAST dependency

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -16,4 +16,5 @@ add_clang_library(MLIRCIR
   MLIRFuncDialect
   MLIRDataLayoutInterfaces
   MLIRSideEffectInterfaces
+  clangAST
   )


### PR DESCRIPTION
Looks like that after [AST attributes PR](https://github.com/llvm/clangir/pull/250)  the build with shared libs (`-DBUILD_SHARED_LIBS=ON `) is broken. This PR fix it