### PR TITLE
[CIR][Codegen][Bugfix] use record layout to generate index for a field

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -206,8 +206,7 @@ static void buildLValueForAnyFieldInitialization(CIRGenFunction &CGF,
   if (MemberInit->isIndirectMemberInitializer()) {
     llvm_unreachable("NYI");
   } else {
-    LHS = CGF.buildLValueForFieldInitialization(LHS, Field, Field->getName(),
-                                                Field->getFieldIndex());
+    LHS = CGF.buildLValueForFieldInitialization(LHS, Field, Field->getName());
   }
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -318,13 +318,15 @@ LValue CIRGenFunction::buildLValueForField(LValue base,
 }
 
 LValue CIRGenFunction::buildLValueForFieldInitialization(
-    LValue Base, const clang::FieldDecl *Field, llvm::StringRef FieldName,
-    unsigned FieldIndex) {
+    LValue Base, const clang::FieldDecl *Field, llvm::StringRef FieldName) {
   QualType FieldType = Field->getType();
 
   if (!FieldType->isReferenceType())
     return buildLValueForField(Base, Field);
 
+  auto& layout = CGM.getTypes().getCIRGenRecordLayout(Field->getParent());
+  unsigned FieldIndex = layout.getCIRFieldNo(Field);
+  
   Address V = buildAddrOfFieldStorage(*this, Base.getAddress(), Field,
                                       FieldName, FieldIndex);
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -9,7 +9,6 @@
 // This contains code to emit Aggregate Expr nodes as CIR code.
 //
 //===----------------------------------------------------------------------===//
-
 #include "CIRGenCall.h"
 #include "CIRGenFunction.h"
 #include "CIRGenModule.h"
@@ -551,7 +550,7 @@ void AggExprEmitter::VisitLambdaExpr(LambdaExpr *E) {
 
     // Emit initialization
     LValue LV = CGF.buildLValueForFieldInitialization(
-        SlotLV, *CurField, fieldName, CurField->getFieldIndex());
+        SlotLV, *CurField, fieldName);
     if (CurField->hasCapturedVLAType()) {
       llvm_unreachable("NYI");
     }
@@ -816,9 +815,8 @@ void AggExprEmitter::VisitCXXParenListOrInitListExpr(
     if (curInitIndex == NumInitElements && Dest.isZeroed() &&
         CGF.getTypes().isZeroInitializable(ExprToVisit->getType()))
       break;
-
     LValue LV = CGF.buildLValueForFieldInitialization(
-        DestLV, field, field->getName(), field->getFieldIndex());
+        DestLV, field, field->getName());
     // We never generate write-barries for initialized fields.
     assert(!UnimplementedFeature::setNonGC());
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1520,8 +1520,7 @@ public:
   /// stored in the reference.
   LValue buildLValueForFieldInitialization(LValue Base,
                                            const clang::FieldDecl *Field,
-                                           llvm::StringRef FieldName,
-                                           unsigned FieldIndex);
+                                           llvm::StringRef FieldName);
 
   void buildInitializerForField(clang::FieldDecl *Field, LValue LHS,
                                 clang::Expr *Init);

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -156,3 +156,16 @@ void t() {
   B b;
   b.foo();
 }
+
+struct C : public A {
+  int& ref;
+  C(int& x) : ref(x) {}
+};
+
+// CHECK: cir.func @_Z8test_refv()
+// CHECK: cir.get_member %2[1] {name = "ref"} 
+int test_ref() {
+  int x = 42;
+  C c(x);
+  return c.ref;
+}


### PR DESCRIPTION
This is a minor fix similar to the one introduced in #263.
Basically, all calls to the `buildLValueForFieldInitialization`  are even with  the origin codegen `emitLValueForFieldInitialization` calls, i.e. the field index is calculated from the record layout, but not from the decl `field->getFieldIndex()`.

Added just one test, because looks like we need to implement some `NYI` features first  to test another places e.g. in `CIRGenExprAgg.cpp`, though I could miss something. 

Anyway, given the original codegen doesn't use `getFieldIndex` in these places, we also should not.

All the remaining usages of `getFieldIndex` are ok.