### PR TITLE
[CIR][Lowering] Deprecate typed LLVM dialect pointers

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -200,6 +200,13 @@ def PtrStrideOp : CIR_Op<"ptr_stride",
     `,` type($result) attr-dict
   }];
 
+  let extraClassDeclaration = [{
+    // Get type pointed by the base pointer.
+    mlir::Type getElementTy() {
+      return getBase().getType().cast<mlir::cir::PointerType>().getPointee();
+    }
+  }];
+
   // SameFirstOperandAndResultType already checks all we need.
   let hasVerifier = 0;
 }

--- a/clang/test/CIR/Lowering/array.cir
+++ b/clang/test/CIR/Lowering/array.cir
@@ -13,7 +13,7 @@ module {
 //      MLIR: module {
 // MLIR-NEXT: func @foo()
 // MLIR-NEXT:  %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:  %1 = llvm.alloca %0 x !llvm.array<10 x i32> {alignment = 16 : i64} : (i64) -> !llvm.ptr<array<10 x i32>>
+// MLIR-NEXT:  %1 = llvm.alloca %0 x !llvm.array<10 x i32> {alignment = 16 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:    llvm.return
 // MLIR-NEXT:  }
 // MLIR-NEXT: }

--- a/clang/test/CIR/Lowering/binop-fp.cir
+++ b/clang/test/CIR/Lowering/binop-fp.cir
@@ -45,8 +45,8 @@ module {
   }
 }
 
-// MLIR: = llvm.alloca {{.*}} f32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<f32>
-// MLIR: = llvm.alloca {{.*}} f64 {alignment = 8 : i64} : (i64) -> !llvm.ptr<f64>
+// MLIR: = llvm.alloca {{.*}} f32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
+// MLIR: = llvm.alloca {{.*}} f64 {alignment = 8 : i64} : (i64) -> !llvm.ptr
 // MLIR: = llvm.fmul {{.*}} : f32
 // MLIR: = llvm.fdiv
 // MLIR: = llvm.fadd

--- a/clang/test/CIR/Lowering/bool.cir
+++ b/clang/test/CIR/Lowering/bool.cir
@@ -16,8 +16,8 @@ module {
 //      MLIR: llvm.func @foo()
 //  MLIR-DAG: = llvm.mlir.constant(1 : i8) : i8
 //  MLIR-DAG: [[Value:%[a-z0-9]+]] = llvm.mlir.constant(1 : index) : i64
-//  MLIR-DAG: = llvm.alloca [[Value]] x i8 {alignment = 1 : i64} : (i64) -> !llvm.ptr<i8>
-//  MLIR-DAG: llvm.store %0, %2 : !llvm.ptr<i8>
+//  MLIR-DAG: = llvm.alloca [[Value]] x i8 {alignment = 1 : i64} : (i64) -> !llvm.ptr
+//  MLIR-DAG: llvm.store %0, %2 : i8, !llvm.ptr
 // MLIR-NEXT: llvm.return
 
 //      LLVM: define void @foo()

--- a/clang/test/CIR/Lowering/call.cir
+++ b/clang/test/CIR/Lowering/call.cir
@@ -28,11 +28,11 @@ module {
 
   // check operands and results type lowering
   cir.func @callee(!cir.ptr<i32>) -> !cir.ptr<i32> attributes {sym_visibility = "private"}
-  // MLIR: llvm.func @callee(!llvm.ptr<i32>) -> !llvm.ptr<i32>
+  // MLIR: llvm.func @callee(!llvm.ptr) -> !llvm.ptr
   cir.func @caller(%arg0: !cir.ptr<i32>) -> !cir.ptr<i32> {
-  // MLIR: llvm.func @caller(%arg0: !llvm.ptr<i32>) -> !llvm.ptr<i32>
+  // MLIR: llvm.func @caller(%arg0: !llvm.ptr) -> !llvm.ptr
     %0 = cir.call @callee(%arg0) : (!cir.ptr<i32>) -> !cir.ptr<i32>
-    // MLIR: %{{[0-9]+}} = llvm.call @callee(%arg0) : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
+    // MLIR: %{{[0-9]+}} = llvm.call @callee(%arg0) : (!llvm.ptr) -> !llvm.ptr
     cir.return %0 : !cir.ptr<i32>
   }
 

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -71,11 +71,11 @@ module {
     cir.store %16, %6 : !s64i, cir.ptr <!s64i>
     %17 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
     cir.store %17, %8 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr<array<3 x i32>>) -> !llvm.ptr<i32>
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
     %23 = cir.cast(int_to_ptr, %22 : !u64i), !cir.ptr<!u8i>
-    // MLIR: %[[TMP2:[0-9]+]] = llvm.inttoptr %[[TMP]] : i64 to !llvm.ptr<i8>
+    // MLIR: %[[TMP2:[0-9]+]] = llvm.inttoptr %[[TMP]] : i64 to !llvm.ptr
     %24 = cir.cast(ptr_to_int, %23 : !cir.ptr<!u8i>), !s32i
-    // MLIR: %{{[0-9]+}} = llvm.ptrtoint %[[TMP2]] : !llvm.ptr<i8> to i32
+    // MLIR: %{{[0-9]+}} = llvm.ptrtoint %[[TMP2]] : !llvm.ptr to i32
     %29 = cir.cast(ptr_to_bool, %23 : !cir.ptr<!u8i>), !cir.bool
 
     // Floating point casts.

--- a/clang/test/CIR/Lowering/dot.cir
+++ b/clang/test/CIR/Lowering/dot.cir
@@ -57,32 +57,32 @@ module {
 }
 
 //      MLIR: module {
-// MLIR-NEXT:   llvm.func @dot(%arg0: !llvm.ptr<f64>, %arg1: !llvm.ptr<f64>, %arg2: i32) -> f64
+// MLIR-NEXT:   llvm.func @dot(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: i32) -> f64
 // MLIR-NEXT:     %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %1 = llvm.alloca %0 x !llvm.ptr<f64> {alignment = 8 : i64} : (i64) -> !llvm.ptr<ptr<f64>>
+// MLIR-NEXT:     %1 = llvm.alloca %0 x !llvm.ptr {alignment = 8 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:     %2 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %3 = llvm.alloca %2 x !llvm.ptr<f64> {alignment = 8 : i64} : (i64) -> !llvm.ptr<ptr<f64>>
+// MLIR-NEXT:     %3 = llvm.alloca %2 x !llvm.ptr {alignment = 8 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:     %4 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %5 = llvm.alloca %4 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:     %5 = llvm.alloca %4 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:     %6 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %7 = llvm.alloca %6 x f64 {alignment = 8 : i64} : (i64) -> !llvm.ptr<f64>
+// MLIR-NEXT:     %7 = llvm.alloca %6 x f64 {alignment = 8 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:     %8 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %9 = llvm.alloca %8 x f64 {alignment = 8 : i64} : (i64) -> !llvm.ptr<f64>
-// MLIR-NEXT:     llvm.store %arg0, %1 : !llvm.ptr<ptr<f64>>
-// MLIR-NEXT:     llvm.store %arg1, %3 : !llvm.ptr<ptr<f64>>
-// MLIR-NEXT:     llvm.store %arg2, %5 : !llvm.ptr<i32>
+// MLIR-NEXT:     %9 = llvm.alloca %8 x f64 {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// MLIR-NEXT:     llvm.store %arg0, %1 : !llvm.ptr, !llvm.ptr
+// MLIR-NEXT:     llvm.store %arg1, %3 : !llvm.ptr, !llvm.ptr
+// MLIR-NEXT:     llvm.store %arg2, %5 : i32, !llvm.ptr
 // MLIR-NEXT:     %10 = llvm.mlir.constant(0.000000e+00 : f64) : f64
-// MLIR-NEXT:     llvm.store %10, %9 : !llvm.ptr<f64>
+// MLIR-NEXT:     llvm.store %10, %9 : f64, !llvm.ptr
 // MLIR-NEXT:     llvm.br ^bb1
 // MLIR-NEXT:   ^bb1:  // pred: ^bb0
 // MLIR-NEXT:     %11 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %12 = llvm.alloca %11 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:     %12 = llvm.alloca %11 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:     %13 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:     llvm.store %13, %12 : !llvm.ptr<i32>
+// MLIR-NEXT:     llvm.store %13, %12 : i32, !llvm.ptr
 // MLIR-NEXT:     llvm.br ^bb2
 // MLIR-NEXT:   ^bb2:  // 2 preds: ^bb1, ^bb6
-// MLIR-NEXT:     %14 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:     %15 = llvm.load %5 : !llvm.ptr<i32>
+// MLIR-NEXT:     %14 = llvm.load %12 : !llvm.ptr -> i32
+// MLIR-NEXT:     %15 = llvm.load %5 : !llvm.ptr -> i32
 // MLIR-NEXT:     %16 = llvm.icmp "slt" %14, %15 : i32
 // MLIR-NEXT:     %17 = llvm.zext %16 : i1 to i32
 // MLIR-NEXT:     %18 = llvm.mlir.constant(0 : i32) : i32
@@ -95,31 +95,31 @@ module {
 // MLIR-NEXT:   ^bb4:  // pred: ^bb2
 // MLIR-NEXT:     llvm.br ^bb7
 // MLIR-NEXT:   ^bb5:  // pred: ^bb3
-// MLIR-NEXT:     %22 = llvm.load %1 : !llvm.ptr<ptr<f64>>
-// MLIR-NEXT:     %23 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:     %24 = llvm.getelementptr %22[%23] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-// MLIR-NEXT:     %25 = llvm.load %24 : !llvm.ptr<f64>
-// MLIR-NEXT:     %26 = llvm.load %3 : !llvm.ptr<ptr<f64>>
-// MLIR-NEXT:     %27 = llvm.load %12 : !llvm.ptr<i32>
-// MLIR-NEXT:     %28 = llvm.getelementptr %26[%27] : (!llvm.ptr<f64>, i32) -> !llvm.ptr<f64>
-// MLIR-NEXT:     %29 = llvm.load %28 : !llvm.ptr<f64>
+// MLIR-NEXT:     %22 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+// MLIR-NEXT:     %23 = llvm.load %12 : !llvm.ptr -> i32
+// MLIR-NEXT:     %24 = llvm.getelementptr %22[%23] : (!llvm.ptr, i32) -> !llvm.ptr
+// MLIR-NEXT:     %25 = llvm.load %24 : !llvm.ptr -> f64
+// MLIR-NEXT:     %26 = llvm.load %3 : !llvm.ptr -> !llvm.ptr
+// MLIR-NEXT:     %27 = llvm.load %12 : !llvm.ptr -> i32
+// MLIR-NEXT:     %28 = llvm.getelementptr %26[%27] : (!llvm.ptr, i32) -> !llvm.ptr
+// MLIR-NEXT:     %29 = llvm.load %28 : !llvm.ptr -> f64
 // MLIR-NEXT:     %30 = llvm.fmul %25, %29  : f64
-// MLIR-NEXT:     %31 = llvm.load %9 : !llvm.ptr<f64>
+// MLIR-NEXT:     %31 = llvm.load %9 : !llvm.ptr -> f64
 // MLIR-NEXT:     %32 = llvm.fadd %31, %30  : f64
-// MLIR-NEXT:     llvm.store %32, %9 : !llvm.ptr<f64>
+// MLIR-NEXT:     llvm.store %32, %9 : f64, !llvm.ptr
 // MLIR-NEXT:     llvm.br ^bb6
 // MLIR-NEXT:   ^bb6:  // pred: ^bb5
-// MLIR-NEXT:     %33 = llvm.load %12 : !llvm.ptr<i32>
+// MLIR-NEXT:     %33 = llvm.load %12 : !llvm.ptr -> i32
 // MLIR-NEXT:     %34 = llvm.mlir.constant(1 : i32) : i32
 // MLIR-NEXT:     %35 = llvm.add %33, %34  : i32
-// MLIR-NEXT:     llvm.store %35, %12 : !llvm.ptr<i32>
+// MLIR-NEXT:     llvm.store %35, %12 : i32, !llvm.ptr
 // MLIR-NEXT:     llvm.br ^bb2
 // MLIR-NEXT:   ^bb7:  // pred: ^bb4
 // MLIR-NEXT:     llvm.br ^bb8
 // MLIR-NEXT:   ^bb8:  // pred: ^bb7
-// MLIR-NEXT:     %36 = llvm.load %9 : !llvm.ptr<f64>
-// MLIR-NEXT:     llvm.store %36, %7 : !llvm.ptr<f64>
-// MLIR-NEXT:     %37 = llvm.load %7 : !llvm.ptr<f64>
+// MLIR-NEXT:     %36 = llvm.load %9 : !llvm.ptr -> f64
+// MLIR-NEXT:     llvm.store %36, %7 : f64, !llvm.ptr
+// MLIR-NEXT:     %37 = llvm.load %7 : !llvm.ptr -> f64
 // MLIR-NEXT:     llvm.return %37 : f64
 // MLIR-NEXT:   }
 // MLIR-NEXT: }

--- a/clang/test/CIR/Lowering/func.cir
+++ b/clang/test/CIR/Lowering/func.cir
@@ -7,11 +7,11 @@ module {
   // MLIR: llvm.func @noProto3(...) -> i32
   cir.func @test3(%arg0: !s32i) {
     %3 = cir.get_global @noProto3 : cir.ptr <!cir.func<!s32i (...)>>
-    // MLIR: %[[#FN_PTR:]] = llvm.mlir.addressof @noProto3 : !llvm.ptr<func<i32 (...)>>
+    // MLIR: %[[#FN_PTR:]] = llvm.mlir.addressof @noProto3 : !llvm.ptr
     %4 = cir.cast(bitcast, %3 : !cir.ptr<!cir.func<!s32i (...)>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
-    // MLIR: %[[#FUNC:]] = llvm.bitcast %[[#FN_PTR]] : !llvm.ptr<func<i32 (...)>> to !llvm.ptr<func<i32 (i32)>>
+    // MLIR: %[[#FUNC:]] = llvm.bitcast %[[#FN_PTR]] : !llvm.ptr to !llvm.ptr
     %5 = cir.call %4(%arg0) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
-    // MLIR: %{{.+}} = llvm.call %[[#FUNC]](%{{.+}}) : !llvm.ptr<func<i32 (i32)>>, (i32) -> i32
+    // MLIR: %{{.+}} = llvm.call %[[#FUNC]](%{{.+}}) : !llvm.ptr, (i32) -> i32
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -26,17 +26,17 @@ module {
   cir.global "private" constant internal @".str" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global external @s = #cir.global_view<@".str"> : !cir.ptr<!s8i>
   // MLIR: llvm.mlir.global internal constant @".str"("example\00") {addr_space = 0 : i32}
-  // MLIR: llvm.mlir.global external @s() {addr_space = 0 : i32} : !llvm.ptr<i8> {
-  // MLIR:   %0 = llvm.mlir.addressof @".str" : !llvm.ptr<array<8 x i8>>
-  // MLIR:   %1 = llvm.bitcast %0 : !llvm.ptr<array<8 x i8>> to !llvm.ptr<i8>
-  // MLIR:   llvm.return %1 : !llvm.ptr<i8>
+  // MLIR: llvm.mlir.global external @s() {addr_space = 0 : i32} : !llvm.ptr {
+  // MLIR:   %0 = llvm.mlir.addressof @".str" : !llvm.ptr
+  // MLIR:   %1 = llvm.bitcast %0 : !llvm.ptr to !llvm.ptr
+  // MLIR:   llvm.return %1 : !llvm.ptr
   // MLIR: }
   // LLVM: @.str = internal constant [8 x i8] c"example\00"
   // LLVM: @s = global ptr @.str
   cir.global external @aPtr = #cir.global_view<@a> : !cir.ptr<!s32i>
-  // MLIR: llvm.mlir.global external @aPtr() {addr_space = 0 : i32} : !llvm.ptr<i32> {
-  // MLIR:   %0 = llvm.mlir.addressof @a : !llvm.ptr<i32>
-  // MLIR:   llvm.return %0 : !llvm.ptr<i32>
+  // MLIR: llvm.mlir.global external @aPtr() {addr_space = 0 : i32} : !llvm.ptr {
+  // MLIR:   %0 = llvm.mlir.addressof @a : !llvm.ptr
+  // MLIR:   llvm.return %0 : !llvm.ptr
   // MLIR: }
   cir.global "private" constant internal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
   cir.global external @s1 = #cir.global_view<@".str1"> : !cir.ptr<!s8i>
@@ -75,28 +75,26 @@ module {
   }
   cir.global external @string = #cir.const_array<[#cir.int<119> : !s8i, #cir.int<104> : !s8i, #cir.int<97> : !s8i, #cir.int<116> : !s8i, #cir.int<110> : !s8i, #cir.int<111> : !s8i, #cir.int<119> : !s8i, #cir.int<0> : !s8i]> : !cir.array<!s8i x 8>
   // MLIR: llvm.mlir.global external @string(dense<[119, 104, 97, 116, 110, 111, 119, 0]> : tensor<8xi8>) {addr_space = 0 : i32} : !llvm.array<8 x i8>
-  // LLVM: @string = global [8 x i8] c"whatnow\00"
   cir.global external @uint = #cir.const_array<[#cir.int<255> : !u32i]> : !cir.array<!u32i x 1>
   // MLIR: llvm.mlir.global external @uint(dense<255> : tensor<1xi32>) {addr_space = 0 : i32} : !llvm.array<1 x i32>
-  // LLVM: @uint = global [1 x i32] [i32 255]
   cir.global external @sshort = #cir.const_array<[#cir.int<11111> : !s16i, #cir.int<22222> : !s16i]> : !cir.array<!s16i x 2>
   // MLIR: llvm.mlir.global external @sshort(dense<[11111, 22222]> : tensor<2xi16>) {addr_space = 0 : i32} : !llvm.array<2 x i16>
-  // LLVM: @sshort = global [2 x i16] [i16 11111, i16 22222]
   cir.global external @sint = #cir.const_array<[#cir.int<123> : !s32i, #cir.int<456> : !s32i, #cir.int<789> : !s32i]> : !cir.array<!s32i x 3>
   // MLIR: llvm.mlir.global external @sint(dense<[123, 456, 789]> : tensor<3xi32>) {addr_space = 0 : i32} : !llvm.array<3 x i32>
-  // LLVM: @sint = global [3 x i32] [i32 123, i32 456, i32 789]
   cir.global external @ll = #cir.const_array<[#cir.int<999999999> : !s64i, #cir.int<0> : !s64i, #cir.int<0> : !s64i, #cir.int<0> : !s64i]> : !cir.array<!s64i x 4>
   // MLIR: llvm.mlir.global external @ll(dense<[999999999, 0, 0, 0]> : tensor<4xi64>) {addr_space = 0 : i32} : !llvm.array<4 x i64>
-  // LLVM: @ll = global [4 x i64] [i64 999999999, i64 0, i64 0, i64 0]
   cir.global external @twoDim = #cir.const_array<[#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>
   // MLIR: llvm.mlir.global external @twoDim(dense<{{\[\[}}1, 2], [3, 4{{\]\]}}> : tensor<2x2xi32>) {addr_space = 0 : i32} : !llvm.array<2 x array<2 x i32>>
-  // LLVM: @twoDim = global [2 x [2 x i32{{\]\] \[\[}}2 x i32] [i32 1, i32 2], [2 x i32] [i32 3, i32 4{{\]\]}}
+
+  // The following tests check direclty the resulting LLVM IR because the MLIR
+  // version is two long. Always prefer the MLIR prefix when possible.
   cir.global external @nestedTwoDim = #cir.const_struct<{#cir.int<1> : !s32i, #cir.const_array<[#cir.const_array<[#cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>}> : !ty_22A22
   // LLVM: @nestedTwoDim = global %struct.A { i32 1, [2 x [2 x i32{{\]\] \[\[}}2 x i32] [i32 2, i32 3], [2 x i32] [i32 4, i32 5{{\]\]}} }
   cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>}> : !ty_22StringStruct22
   // LLVM: @nestedString = global %struct.StringStruct { [3 x i8] c"1\00\00", [3 x i8] zeroinitializer, [3 x i8] zeroinitializer }
   cir.global external @nestedStringPtr = #cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>}> : !ty_22StringStructPtr22
   // LLVM: @nestedStringPtr = global %struct.StringStructPtr { ptr @.str }
+
   cir.func @_Z11get_globalsv() {
     %0 = cir.alloca !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>, ["s", init] {alignment = 8 : i64}
     %1 = cir.alloca !cir.ptr<!u32i>, cir.ptr <!cir.ptr<!u32i>>, ["u", init] {alignment = 8 : i64}
@@ -105,33 +103,28 @@ module {
     %4 = cir.alloca !cir.ptr<!s64i>, cir.ptr <!cir.ptr<!s64i>>, ["l", init] {alignment = 8 : i64}
     %5 = cir.get_global @string : cir.ptr <!cir.array<!s8i x 8>>
     %6 = cir.cast(array_to_ptrdecay, %5 : !cir.ptr<!cir.array<!s8i x 8>>), !cir.ptr<!s8i>
-    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @string : !llvm.ptr<array<8 x i8>>
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<8 x i8>>) -> !llvm.ptr<i8>
-    // LLVM: store ptr @string, ptr %{{[0-9]+}}
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @string : !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
     cir.store %6, %0 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
     %7 = cir.get_global @uint : cir.ptr <!cir.array<!u32i x 1>>
     %8 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<!u32i x 1>>), !cir.ptr<!u32i>
-    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @uint : !llvm.ptr<array<1 x i32>>
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<1 x i32>>) -> !llvm.ptr<i32>
-    // LLVM: store ptr @uint, ptr %{{[0-9]+}}
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @uint : !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
     cir.store %8, %1 : !cir.ptr<!u32i>, cir.ptr <!cir.ptr<!u32i>>
     %9 = cir.get_global @sshort : cir.ptr <!cir.array<!s16i x 2>>
     %10 = cir.cast(array_to_ptrdecay, %9 : !cir.ptr<!cir.array<!s16i x 2>>), !cir.ptr<!s16i>
-    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sshort : !llvm.ptr<array<2 x i16>>
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<2 x i16>>) -> !llvm.ptr<i16>
-    // LLVM: store ptr @sshort, ptr %{{[0-9]+}}
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sshort : !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
     cir.store %10, %2 : !cir.ptr<!s16i>, cir.ptr <!cir.ptr<!s16i>>
     %11 = cir.get_global @sint : cir.ptr <!cir.array<!s32i x 3>>
     %12 = cir.cast(array_to_ptrdecay, %11 : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
-    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sint : !llvm.ptr<array<3 x i32>>
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<3 x i32>>) -> !llvm.ptr<i32>
-    // LLVM: store ptr @sint, ptr %{{[0-9]+}}
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sint : !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
     cir.store %12, %3 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
     %13 = cir.get_global @ll : cir.ptr <!cir.array<!s64i x 4>>
     %14 = cir.cast(array_to_ptrdecay, %13 : !cir.ptr<!cir.array<!s64i x 4>>), !cir.ptr<!s64i>
-    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @ll : !llvm.ptr<array<4 x i64>>
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr<array<4 x i64>>) -> !llvm.ptr<i64>
-    // LLVM: store ptr @ll, ptr %{{[0-9]+}}
+    // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @ll : !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
     cir.store %14, %4 : !cir.ptr<!s64i>, cir.ptr <!cir.ptr<!s64i>>
     cir.return
   }
@@ -143,8 +136,8 @@ module {
   // MLIR: llvm.mlir.global internal @staticVar(0 : i32) {addr_space = 0 : i32} : i32
   cir.global external @nullPtr = #cir.ptr<null> : !cir.ptr<!s32i>
   // MLIR: llvm.mlir.global external @nullPtr()
-  // MLIR:   %0 = llvm.mlir.null : !llvm.ptr<i32>
-  // MLIR:   llvm.return %0 : !llvm.ptr<i32>
+  // MLIR:   %0 = llvm.mlir.null : !llvm.ptr
+  // MLIR:   llvm.return %0 : !llvm.ptr
   // MLIR: }
   cir.global external @zeroStruct = #cir.zero : !ty_22Bar22
   // MLIR: llvm.mlir.global external @zeroStruct()

--- a/clang/test/CIR/Lowering/hello.cir
+++ b/clang/test/CIR/Lowering/hello.cir
@@ -19,16 +19,16 @@ module @"/tmp/test.raw" attributes {cir.lang = #cir.lang<c>, cir.sob = #cir.sign
   }
 }
 
-// CHECK:  llvm.func @printf(!llvm.ptr<i8>, ...) -> i32
+// CHECK:  llvm.func @printf(!llvm.ptr, ...) -> i32
 // CHECK:  llvm.mlir.global internal constant @".str"("Hello, world!\0A\00") {addr_space = 0 : i32}
 // CHECK:  llvm.func @main() -> i32
 // CHECK:    %0 = llvm.mlir.constant(1 : index) : i64
-// CHECK:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// CHECK:    %2 = llvm.mlir.addressof @".str" : !llvm.ptr<array<15 x i8>>
-// CHECK:    %3 = llvm.getelementptr %2[0] : (!llvm.ptr<array<15 x i8>>) -> !llvm.ptr<i8>
-// CHECK:    %4 = llvm.call @printf(%3) : (!llvm.ptr<i8>) -> i32
+// CHECK:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
+// CHECK:    %2 = llvm.mlir.addressof @".str" : !llvm.ptr
+// CHECK:    %3 = llvm.getelementptr %2[0] : (!llvm.ptr) -> !llvm.ptr
+// CHECK:    %4 = llvm.call @printf(%3) : (!llvm.ptr) -> i32
 // CHECK:    %5 = llvm.mlir.constant(0 : i32) : i32
-// CHECK:    llvm.store %5, %1 : !llvm.ptr<i32>
-// CHECK:    %6 = llvm.load %1 : !llvm.ptr<i32>
+// CHECK:    llvm.store %5, %1 : i32, !llvm.ptr
+// CHECK:    %6 = llvm.load %1 : !llvm.ptr -> i32
 // CHECK:    llvm.return %6 : i32
 // CHECK:  }

--- a/clang/test/CIR/Lowering/loadstorealloca.cir
+++ b/clang/test/CIR/Lowering/loadstorealloca.cir
@@ -1,5 +1,5 @@
-// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s -cir-to-llvm -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir -check-prefix=MLIR
 !u32i = !cir.int<u, 32>
 
 module {
@@ -15,14 +15,8 @@ module {
 //      MLIR: module {
 // MLIR-NEXT:   func @foo() -> i32
 // MLIR-NEXT:     %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:     %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:     %2 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:     llvm.store %2, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:     %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:     llvm.store %2, %1 : i32, !llvm.ptr
+// MLIR-NEXT:     %3 = llvm.load %1 : !llvm.ptr -> i32
 // MLIR-NEXT:     return %3 : i32
-
-//      LLVM: define i32 @foo()
-// LLVM-NEXT:   %1 = alloca i32, i64 1, align 4
-// LLVM-NEXT:   store i32 1, ptr %1, align 4
-// LLVM-NEXT:   %2 = load i32, ptr %1, align 4
-// LLVM-NEXT:   ret i32 %2

--- a/clang/test/CIR/Lowering/loop.cir
+++ b/clang/test/CIR/Lowering/loop.cir
@@ -31,13 +31,13 @@ module {
 //      MLIR: module {
 // MLIR-NEXT:   llvm.func @testFor()
 // MLIR-NEXT:     %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:     %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:     %2 = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:     llvm.store %2, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:     llvm.store %2, %1 : i32, !llvm.ptr
 // MLIR-NEXT:     llvm.br ^bb1
 // ============= Condition block =============
 // MLIR-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb5
-// MLIR-NEXT:     %3 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:    %3 = llvm.load %1 : !llvm.ptr -> i32
 // MLIR-NEXT:     %4 = llvm.mlir.constant(10 : i32) : i32
 // MLIR-NEXT:     %5 = llvm.icmp "slt" %3, %4 : i32
 // MLIR-NEXT:     %6 = llvm.zext %5 : i1 to i32
@@ -55,10 +55,10 @@ module {
 // MLIR-NEXT:     llvm.br ^bb5
 // ============= Step block =============
 // MLIR-NEXT:   ^bb5:  // pred: ^bb4
-// MLIR-NEXT:     %11 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:    %11 = llvm.load %1 : !llvm.ptr -> i32
 // MLIR-NEXT:     %12 = llvm.mlir.constant(1 : i32) : i32
 // MLIR-NEXT:     %13 = llvm.add %11, %12  : i32
-// MLIR-NEXT:     llvm.store %13, %1 : !llvm.ptr<i32>
+// MLIR-NEXT:     llvm.store %13, %1 : i32, !llvm.ptr
 // MLIR-NEXT:     llvm.br ^bb1
 // ============= Exit block =============
 // MLIR-NEXT:   ^bb6:  // pred: ^bb3
@@ -94,14 +94,14 @@ module {
 
   //      MLIR:  llvm.func @testWhile(%arg0: i32)
   // MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
-  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-  // MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
+  // MLIR-NEXT:    llvm.store %arg0, %1 : i32, !llvm.ptr
   // MLIR-NEXT:    llvm.br ^bb1
   // MLIR-NEXT:  ^bb1:
   // MLIR-NEXT:    llvm.br ^bb2
   // ============= Condition block =============
   // MLIR-NEXT:  ^bb2:  // 2 preds: ^bb1, ^bb5
-  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr -> i32
   // MLIR-NEXT:    %3 = llvm.mlir.constant(10 : i32) : i32
   // MLIR-NEXT:    %4 = llvm.icmp "slt" %2, %3 : i32
   // MLIR-NEXT:    %5 = llvm.zext %4 : i1 to i32
@@ -116,10 +116,10 @@ module {
   // MLIR-NEXT:    llvm.br ^bb6
   // ============= Body block =============
   // MLIR-NEXT:  ^bb5:  // pred: ^bb3
-  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr -> i32
   // MLIR-NEXT:    %11 = llvm.mlir.constant(1 : i32) : i32
   // MLIR-NEXT:    %12 = llvm.add %10, %11  : i32
-  // MLIR-NEXT:    llvm.store %12, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.store %12, %1 : i32, !llvm.ptr
   // MLIR-NEXT:    llvm.br ^bb2
   // ============= Exit block =============
   // MLIR-NEXT:  ^bb6:  // pred: ^bb4
@@ -154,14 +154,14 @@ module {
 
   //      MLIR:  llvm.func @testDoWhile(%arg0: i32)
   // MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
-  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-  // MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
+  // MLIR-NEXT:    llvm.store %arg0, %1 : i32, !llvm.ptr
   // MLIR-NEXT:    llvm.br ^bb1
   // MLIR-NEXT:  ^bb1:
   // MLIR-NEXT:    llvm.br ^bb5
   // ============= Condition block =============
   // MLIR-NEXT:  ^bb2:
-  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr -> i32
   // MLIR-NEXT:    %3 = llvm.mlir.constant(10 : i32) : i32
   // MLIR-NEXT:    %4 = llvm.icmp "slt" %2, %3 : i32
   // MLIR-NEXT:    %5 = llvm.zext %4 : i1 to i32
@@ -176,10 +176,10 @@ module {
   // MLIR-NEXT:    llvm.br ^bb6
   // ============= Body block =============
   // MLIR-NEXT:  ^bb5:
-  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    %10 = llvm.load %1 : !llvm.ptr -> i32
   // MLIR-NEXT:    %11 = llvm.mlir.constant(1 : i32) : i32
   // MLIR-NEXT:    %12 = llvm.add %10, %11  : i32
-  // MLIR-NEXT:    llvm.store %12, %1 : !llvm.ptr<i32>
+  // MLIR-NEXT:    llvm.store %12, %1 : i32, !llvm.ptr
   // MLIR-NEXT:    llvm.br ^bb2
   // ============= Exit block =============
   // MLIR-NEXT:  ^bb6:

--- a/clang/test/CIR/Lowering/ptrstride.cir
+++ b/clang/test/CIR/Lowering/ptrstride.cir
@@ -14,14 +14,14 @@ module {
 }
 
 //      MLIR: module {
-// MLIR-NEXT:   llvm.func @f(%arg0: !llvm.ptr<i32>)
+// MLIR-NEXT:   llvm.func @f(%arg0: !llvm.ptr)
 // MLIR-NEXT:     %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:     %1 = llvm.alloca %0 x !llvm.ptr<i32> {alignment = 8 : i64} : (i64) -> !llvm.ptr<ptr<i32>>
-// MLIR-NEXT:     llvm.store %arg0, %1 : !llvm.ptr<ptr<i32>>
-// MLIR-NEXT:     %2 = llvm.load %1 : !llvm.ptr<ptr<i32>>
+// MLIR-NEXT:     %1 = llvm.alloca %0 x !llvm.ptr {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// MLIR-NEXT:     llvm.store %arg0, %1 : !llvm.ptr
+// MLIR-NEXT:     %2 = llvm.load %1 : !llvm.ptr
 // MLIR-NEXT:     %3 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:     %4 = llvm.getelementptr %2[%3] : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
-// MLIR-NEXT:     %5 = llvm.load %4 : !llvm.ptr<i32>
+// MLIR-NEXT:     %4 = llvm.getelementptr %2[%3] : (!llvm.ptr, i32) -> !llvm.ptr
+// MLIR-NEXT:     %5 = llvm.load %4 : !llvm.ptr
 // MLIR-NEXT:     llvm.return
 // MLIR-NEXT:   }
 // MLIR-NEXT: }

--- a/clang/test/CIR/Lowering/scope.cir
+++ b/clang/test/CIR/Lowering/scope.cir
@@ -1,4 +1,5 @@
-// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-opt %s -cir-to-llvm -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir -check-prefix=MLIR
 // RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
 !u32i = !cir.int<u, 32>
 
@@ -17,8 +18,8 @@ module {
 // MLIR-NEXT: ^bb1:
 //  MLIR-DAG:   [[v1:%[0-9]]] = llvm.mlir.constant(4 : i32) : i32
 //  MLIR-DAG:   [[v2:%[0-9]]] = llvm.mlir.constant(1 : index) : i64
-//  MLIR-DAG:   [[v3:%[0-9]]] = llvm.alloca [[v2]] x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:   llvm.store [[v1]], [[v3]] : !llvm.ptr<i32>
+//  MLIR-DAG:   [[v3:%[0-9]]] = llvm.alloca [[v2]] x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
+// MLIR-NEXT:   llvm.store [[v1]], [[v3]] : i32, !llvm.ptr
 // MLIR-NEXT:   llvm.br ^bb2
 // MLIR-NEXT: ^bb2:
 // MLIR-NEXT:   llvm.return

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -16,9 +16,9 @@ module {
     // CHECK: %[[#ARRSIZE:]] = llvm.mlir.constant(1 : index) : i64
     // CHECK: %[[#STRUCT:]] = llvm.alloca %[[#ARRSIZE]] x !llvm.struct<"struct.S", (i8, i32)>
     %3 = cir.get_member %1[0] {name = "c"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!u8i>
-    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 0] : (!llvm.ptr<struct<"struct.S", (i8, i32)>>) -> !llvm.ptr<i8>
+    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 0] : (!llvm.ptr) -> !llvm.ptr
     %5 = cir.get_member %1[1] {name = "i"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!s32i>
-    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 1] : (!llvm.ptr<struct<"struct.S", (i8, i32)>>) -> !llvm.ptr<i32>
+    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 1] : (!llvm.ptr) -> !llvm.ptr
     cir.return
   }
 
@@ -30,25 +30,25 @@ module {
   }
   // CHECK: llvm.func @shouldConstInitLocalStructsWithConstStructAttr()
   // CHECK:   %0 = llvm.mlir.constant(1 : index) : i64
-  // CHECK:   %1 = llvm.alloca %0 x !llvm.struct<"struct.S2A", (i32)> {alignment = 4 : i64} : (i64) -> !llvm.ptr<struct<"struct.S2A", (i32)>>
+  // CHECK:   %1 = llvm.alloca %0 x !llvm.struct<"struct.S2A", (i32)> {alignment = 4 : i64} : (i64) -> !llvm.ptr
   // CHECK:   %2 = llvm.mlir.undef : !llvm.struct<"struct.S2A", (i32)>
   // CHECK:   %3 = llvm.mlir.constant(1 : i32) : i32
   // CHECK:   %4 = llvm.insertvalue %3, %2[0] : !llvm.struct<"struct.S2A", (i32)>
-  // CHECK:   llvm.store %4, %1 : !llvm.ptr<struct<"struct.S2A", (i32)>>
+  // CHECK:   llvm.store %4, %1 : !llvm.struct<"struct.S2A", (i32)>, !llvm.ptr
   // CHECK:   llvm.return
   // CHECK: }
 
   // Should lower basic #cir.const_struct initializer.
   cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, 1.000000e-01 : f32, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_22S122
-  // CHECK: llvm.mlir.global external @s1() {addr_space = 0 : i32} : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)> {
-  // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
+  // CHECK: llvm.mlir.global external @s1() {addr_space = 0 : i32} : !llvm.struct<"struct.S1", (i32, f32, ptr)> {
+  // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"struct.S1", (i32, f32, ptr)>
   // CHECK:   %1 = llvm.mlir.constant(1 : i32) : i32
-  // CHECK:   %2 = llvm.insertvalue %1, %0[0] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
+  // CHECK:   %2 = llvm.insertvalue %1, %0[0] : !llvm.struct<"struct.S1", (i32, f32, ptr)>
   // CHECK:   %3 = llvm.mlir.constant(1.000000e-01 : f32) : f32
-  // CHECK:   %4 = llvm.insertvalue %3, %2[1] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
-  // CHECK:   %5 = llvm.mlir.null : !llvm.ptr<i32>
-  // CHECK:   %6 = llvm.insertvalue %5, %4[2] : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
-  // CHECK:   llvm.return %6 : !llvm.struct<"struct.S1", (i32, f32, ptr<i32>)>
+  // CHECK:   %4 = llvm.insertvalue %3, %2[1] : !llvm.struct<"struct.S1", (i32, f32, ptr)>
+  // CHECK:   %5 = llvm.mlir.null : !llvm.ptr
+  // CHECK:   %6 = llvm.insertvalue %5, %4[2] : !llvm.struct<"struct.S1", (i32, f32, ptr)>
+  // CHECK:   llvm.return %6 : !llvm.struct<"struct.S1", (i32, f32, ptr)>
   // CHECK: }
 
   // Should lower nested #cir.const_struct initializer.
@@ -84,13 +84,13 @@ module {
   // CHECK: llvm.func @shouldLowerStructCopies()
     %1 = cir.alloca !ty_22S22, cir.ptr <!ty_22S22>, ["a"] {alignment = 4 : i64}
     // CHECK: %[[#ONE:]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK: %[[#SA:]] = llvm.alloca %[[#ONE]] x !llvm.struct<"struct.S", (i8, i32)> {alignment = 4 : i64} : (i64) -> !llvm.ptr<struct<"struct.S", (i8, i32)>>
+    // CHECK: %[[#SA:]] = llvm.alloca %[[#ONE]] x !llvm.struct<"struct.S", (i8, i32)> {alignment = 4 : i64} : (i64) -> !llvm.ptr
     %2 = cir.alloca !ty_22S22, cir.ptr <!ty_22S22>, ["b", init] {alignment = 4 : i64}
     // CHECK: %[[#ONE:]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK: %[[#SB:]] = llvm.alloca %[[#ONE]] x !llvm.struct<"struct.S", (i8, i32)> {alignment = 4 : i64} : (i64) -> !llvm.ptr<struct<"struct.S", (i8, i32)>>
+    // CHECK: %[[#SB:]] = llvm.alloca %[[#ONE]] x !llvm.struct<"struct.S", (i8, i32)> {alignment = 4 : i64} : (i64) -> !llvm.ptr
     cir.copy %1 to %2 : !cir.ptr<!ty_22S22>
     // CHECK: %[[#SIZE:]] = llvm.mlir.constant(8 : i32) : i32
-    // CHECK: "llvm.intr.memcpy"(%[[#SB]], %[[#SA]], %[[#SIZE]]) <{isVolatile = false}> : (!llvm.ptr<struct<"struct.S", (i8, i32)>>, !llvm.ptr<struct<"struct.S", (i8, i32)>>, i32) -> ()
+    // CHECK: "llvm.intr.memcpy"(%[[#SB]], %[[#SA]], %[[#SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/tenary.cir
+++ b/clang/test/CIR/Lowering/tenary.cir
@@ -1,4 +1,5 @@
-// RUN: cir-opt %s -cir-to-llvm -reconcile-unrealized-casts -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-opt %s -cir-to-llvm -reconcile-unrealized-casts -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir -check-prefix=MLIR
 
 !s32i = !cir.int<s, 32>
 
@@ -25,11 +26,11 @@ cir.func @_Z1xi(%arg0: !s32i) -> !s32i {
 
 //      MLIR:  llvm.func @_Z1xi(%arg0: i32) -> i32
 // MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
+// MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
 // MLIR-NEXT:    %2 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:    %3 = llvm.alloca %2 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr<i32>
-// MLIR-NEXT:    llvm.store %arg0, %1 : !llvm.ptr<i32>
-// MLIR-NEXT:    %4 = llvm.load %1 : !llvm.ptr<i32>
+// MLIR-NEXT:    %3 = llvm.alloca %2 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
+// MLIR-NEXT:    llvm.store %arg0, %1 : i32, !llvm.ptr
+// MLIR-NEXT:    %4 = llvm.load %1 : !llvm.ptr -> i32
 // MLIR-NEXT:    %5 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:    %6 = llvm.icmp "sgt" %4, %5 : i32
 // MLIR-NEXT:    %7 = llvm.zext %6 : i1 to i8
@@ -44,7 +45,7 @@ cir.func @_Z1xi(%arg0: !s32i) -> !s32i {
 // MLIR-NEXT:  ^bb3(%11: i32):  // 2 preds: ^bb1, ^bb2
 // MLIR-NEXT:    llvm.br ^bb4
 // MLIR-NEXT:  ^bb4:  // pred: ^bb3
-// MLIR-NEXT:    llvm.store %11, %3 : !llvm.ptr<i32>
-// MLIR-NEXT:    %12 = llvm.load %3 : !llvm.ptr<i32>
+// MLIR-NEXT:    llvm.store %11, %3 : i32, !llvm.ptr
+// MLIR-NEXT:    %12 = llvm.load %3 : !llvm.ptr -> i32
 // MLIR-NEXT:    llvm.return %12 : i32
 // MLIR-NEXT:  }

--- a/clang/test/CIR/Lowering/types.cir
+++ b/clang/test/CIR/Lowering/types.cir
@@ -8,7 +8,7 @@ module {
     %0 = cir.const(#cir.ptr<null> : !cir.ptr<!void>) : !cir.ptr<!void>
     // CHECK: llvm.mlir.null : !llvm.ptr
     %1 = cir.const(#cir.ptr<null> : !cir.ptr<!cir.ptr<!void>>) : !cir.ptr<!cir.ptr<!void>>
-    // CHECK: llvm.mlir.null : !llvm.ptr<ptr>
+    // CHECK: llvm.mlir.null : !llvm.ptr
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/unary-not.cir
+++ b/clang/test/CIR/Lowering/unary-not.cir
@@ -57,7 +57,7 @@ module {
         %6 = cir.cast(int_to_bool, %5 : !s32i), !cir.bool
         %7 = cir.unary(not, %6) : !cir.bool, !cir.bool
         %8 = cir.cast(bool_to_int, %7 : !cir.bool), !s32i
-        // MLIR: %[[#INT:]] = llvm.load %{{.+}} : !llvm.ptr<i32>
+        // MLIR: %[[#INT:]] = llvm.load %{{.+}} : !llvm.ptr
         // MLIR: %[[#IZERO:]] = llvm.mlir.constant(0 : i32) : i32
         // MLIR: %[[#ICMP:]] = llvm.icmp "ne" %[[#INT]], %[[#IZERO]] : i32
         // MLIR: %[[#IEXT:]] = llvm.zext %[[#ICMP]] : i1 to i8
@@ -69,7 +69,7 @@ module {
         %18 = cir.cast(float_to_bool, %17 : f32), !cir.bool
         %19 = cir.unary(not, %18) : !cir.bool, !cir.bool
         %20 = cir.cast(bool_to_int, %19 : !cir.bool), !s32i
-        // MLIR: %[[#FLOAT:]] = llvm.load %{{.+}} : !llvm.ptr<f32>
+        // MLIR: %[[#FLOAT:]] = llvm.load %{{.+}} : !llvm.ptr
         // MLIR: %[[#FZERO:]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
         // MLIR: %[[#FCMP:]] = llvm.fcmp "une" %[[#FLOAT]], %[[#FZERO]] : f32
         // MLIR: %[[#FEXT:]] = llvm.zext %[[#FCMP]] : i1 to i8

--- a/clang/test/CIR/Lowering/unary-plus-minus.cir
+++ b/clang/test/CIR/Lowering/unary-plus-minus.cir
@@ -1,5 +1,6 @@
-// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s -cir-to-llvm -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir -check-prefix=MLIR
+
 !s32i = !cir.int<s, 32>
 module {
   cir.func @foo() {
@@ -25,20 +26,17 @@ module {
 // MLIR: %[[ZERO:[a-z0-9_]+]] = llvm.mlir.constant(0 : i32)
 // MLIR: llvm.sub %[[ZERO]], %[[#INPUT_MINUS]]
 
-// LLVM: = sub i32 0, %[[#]]
-
-
   cir.func @floatingPoints(%arg0: f64) {
   // MLIR: llvm.func @floatingPoints(%arg0: f64)
     %0 = cir.alloca f64, cir.ptr <f64>, ["X", init] {alignment = 8 : i64}
     cir.store %arg0, %0 : f64, cir.ptr <f64>
     %1 = cir.load %0 : cir.ptr <f64>, f64
     %2 = cir.unary(plus, %1) : f64, f64
-    // MLIR: llvm.store %arg0, %[[#F_PLUS:]] : !llvm.ptr<f64>
-    // MLIR: %{{[0-9]}} = llvm.load %[[#F_PLUS]] : !llvm.ptr<f64>
+    // MLIR: llvm.store %arg0, %[[#F_PLUS:]] : f64, !llvm.ptr
+    // MLIR: %{{[0-9]}} = llvm.load %[[#F_PLUS]] : !llvm.ptr -> f64
     %3 = cir.load %0 : cir.ptr <f64>, f64
     %4 = cir.unary(minus, %3) : f64, f64
-    // MLIR: %[[#F_MINUS:]] = llvm.load %{{[0-9]}} : !llvm.ptr<f64>
+    // MLIR: %[[#F_MINUS:]] = llvm.load %{{[0-9]}} : !llvm.ptr -> f64
     // MLIR: %[[#F_NEG_ONE:]] = llvm.mlir.constant(-1.000000e+00 : f64) : f64
     // MLIR: %5 = llvm.fmul %[[#F_NEG_ONE]], %[[#F_MINUS]]  : f64
     cir.return

--- a/clang/test/CIR/Lowering/unions.cir
+++ b/clang/test/CIR/Lowering/unions.cir
@@ -27,15 +27,15 @@ module {
     cir.store %5, %6 : !cir.bool, cir.ptr <!cir.bool>
     // CHECK: %[[#VAL:]] = llvm.mlir.constant(1 : i8) : i8
     // The bitcast it just to bypass the type checker. It will be replaced by an opaque pointer.
-    // CHECK: %[[#ADDR:]] = llvm.bitcast %{{.+}} : !llvm.ptr<struct<"union.U1", (i32)>> to !llvm.ptr<i8>
-    // CHECK: llvm.store %[[#VAL]], %[[#ADDR]] : !llvm.ptr<i8>
+    // CHECK: %[[#ADDR:]] = llvm.bitcast %{{.+}} : !llvm.ptr
+    // CHECK: llvm.store %[[#VAL]], %[[#ADDR]] : i8, !llvm.ptr
 
     // Should load direclty from the union's base address.
     %7 = cir.get_member %arg0[0] {name = "b"} : !cir.ptr<!ty_22U122> -> !cir.ptr<!cir.bool>
     %8 = cir.load %7 : cir.ptr <!cir.bool>, !cir.bool
     // The bitcast it just to bypass the type checker. It will be replaced by an opaque pointer.
-    // CHECK: %[[#BASE:]] = llvm.bitcast %{{.+}} : !llvm.ptr<struct<"union.U1", (i32)>> to !llvm.ptr<i8>
-    // CHECK: %{{.+}} = llvm.load %[[#BASE]] : !llvm.ptr<i8>
+    // CHECK: %[[#BASE:]] = llvm.bitcast %{{.+}} : !llvm.ptr
+    // CHECK: %{{.+}} = llvm.load %[[#BASE]] : !llvm.ptr -> i8
 
     cir.return
   }

--- a/clang/test/CIR/Lowering/variadics.cir
+++ b/clang/test/CIR/Lowering/variadics.cir
@@ -16,22 +16,22 @@ module {
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     %4 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!ty_22__va_list_tag22 x 1>>), !cir.ptr<!ty_22__va_list_tag22>
     cir.va.start %4 : !cir.ptr<!ty_22__va_list_tag22>
-    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr<array<1 x struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>>>) -> !llvm.ptr<struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>>
-    // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr<struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>> to !llvm.ptr<i8>
-    // MLIR-NEXT: llvm.intr.vastart %{{[0-9]+}} : !llvm.ptr<i8>
+    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr to !llvm.ptr
+    // MLIR-NEXT: llvm.intr.vastart %{{[0-9]+}} : !llvm.ptr
     %5 = cir.cast(array_to_ptrdecay, %3 : !cir.ptr<!cir.array<!ty_22__va_list_tag22 x 1>>), !cir.ptr<!ty_22__va_list_tag22>
     %6 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!ty_22__va_list_tag22 x 1>>), !cir.ptr<!ty_22__va_list_tag22>
     cir.va.copy %6 to %5 : !cir.ptr<!ty_22__va_list_tag22>, !cir.ptr<!ty_22__va_list_tag22>
-    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr<array<1 x struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>>>) -> !llvm.ptr<struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>>
-    // MLIR-NEXT: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr<array<1 x struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>>>) -> !llvm.ptr<struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>>
-    // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr<struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>> to !llvm.ptr<i8>
-    // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr<struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>> to !llvm.ptr<i8>
-    // MLIR-NEXT: llvm.intr.vacopy %13 to %{{[0-9]+}} : !llvm.ptr<i8>, !llvm.ptr<i8>
+    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR-NEXT: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr to !llvm.ptr
+    // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr to !llvm.ptr
+    // MLIR-NEXT: llvm.intr.vacopy %13 to %{{[0-9]+}} : !llvm.ptr, !llvm.ptr
     %7 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!ty_22__va_list_tag22 x 1>>), !cir.ptr<!ty_22__va_list_tag22>
     cir.va.end %7 : !cir.ptr<!ty_22__va_list_tag22>
-    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr<array<1 x struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>>>) -> !llvm.ptr<struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>>
-    // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr<struct<"struct.__va_list_tag", (i32, i32, ptr<i8>, ptr<i8>)>> to !llvm.ptr<i8>
-    // MLIR-NEXT: llvm.intr.vaend %{{[0-9]+}} : !llvm.ptr<i8>
+    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr to !llvm.ptr
+    // MLIR-NEXT: llvm.intr.vaend %{{[0-9]+}} : !llvm.ptr
     %8 = cir.const(#cir.int<0> : !s32i) : !s32i
     cir.store %8, %1 : !s32i, cir.ptr <!s32i>
     %9 = cir.load %1 : cir.ptr <!s32i>, !s32i


### PR DESCRIPTION
Updates the lowering pass to use only opaque pointers. This essentially involves updating the type converter to drop pointee types and explicitly defining the types loaded/stored/GEPed by LLVM operations.

The reasons for this are twofold:

 - LLVM dialect is currently transitioning to deprecate typed pointers, allowing only opaque pointers. The sooner we transition the fewer changes we will have to make.
 - Opaque pointers greatly simplify lowering self-references, since all self-references in records are wrapped in a pointer.