### PR TITLE
[CIR][Lowering][Bugfix] Fix GetMemberOp lowering

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1770,8 +1770,7 @@ public:
       // Since the base address is a pointer to an aggregate, the first offset
       // is always zero. The second offset tell us which member it will access.
       llvm::SmallVector<mlir::LLVM::GEPArg, 2> offset{0, op.getIndex()};
-      const auto elementTy =
-          getTypeConverter()->convertType(structTy.getMembers()[op.getIndex()]);
+      const auto elementTy = getTypeConverter()->convertType(structTy);
       rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(op, llResTy, elementTy,
                                                      adaptor.getAddr(), offset);
       return mlir::success();

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -1,5 +1,6 @@
-// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s -cir-to-llvm -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir
+
 !s16i = !cir.int<s, 16>
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
@@ -9,27 +10,8 @@
 !u64i = !cir.int<u, 64>
 
 module {
-  cir.func @foo(%arg0: !s32i) -> !s32i {
-    %4 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
-    cir.return %arg0 : !s32i
-  }
-
-//      MLIR:  llvm.func @foo(%arg0: i32) -> i32
-// MLIR-NEXT:    [[v0:%[0-9]]] = llvm.mlir.constant(0 : i32) : i32
-// MLIR-NEXT:    [[v1:%[0-9]]] = llvm.icmp "ne" %arg0, %0 : i32
-// MLIR-NEXT:    [[v2:%[0-9]]] = llvm.zext %1 : i1 to i8
-// MLIR-NEXT:    llvm.return %arg0 : i32
-// MLIR-NEXT:  }
-
-
-//      LLVM: define i32 @foo(i32 %0)
-// LLVM-NEXT:   %2 = icmp ne i32 %0, 0
-// LLVM-NEXT:   %3 = zext i1 %2 to i8
-// LLVM-NEXT:   ret i32 %0
-// LLVM-NEXT: }
-
   cir.func @cStyleCasts(%arg0: !u32i, %arg1: !s32i, %arg2: f32) -> !s32i {
-  // MLIR: llvm.func @cStyleCasts
+  // CHECK: llvm.func @cStyleCasts
     %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["x1", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["x2", init] {alignment = 4 : i64}
     %20 = cir.alloca !s16i, cir.ptr <!s16i>, ["x4", init] {alignment = 2 : i64}
@@ -46,47 +28,51 @@ module {
     // Integer casts.
     %9 = cir.load %0 : cir.ptr <!u32i>, !u32i
     %10 = cir.cast(integral, %9 : !u32i), !s8i
-    // MLIR: %{{[0-9]+}} = llvm.trunc %{{[0-9]+}} : i32 to i8
+    // CHECK: %{{[0-9]+}} = llvm.trunc %{{[0-9]+}} : i32 to i8
     cir.store %10, %3 : !s8i, cir.ptr <!s8i>
     %11 = cir.load %1 : cir.ptr <!s32i>, !s32i
     %12 = cir.cast(integral, %11 : !s32i), !s16i
-    // MLIR: %{{[0-9]+}} = llvm.trunc %{{[0-9]+}} : i32 to i16
+    // CHECK: %{{[0-9]+}} = llvm.trunc %{{[0-9]+}} : i32 to i16
     cir.store %12, %4 : !s16i, cir.ptr <!s16i>
     %13 = cir.load %0 : cir.ptr <!u32i>, !u32i
     %14 = cir.cast(integral, %13 : !u32i), !s64i
-    // MLIR: %{{[0-9]+}} = llvm.zext %{{[0-9]+}} : i32 to i64
+    // CHECK: %{{[0-9]+}} = llvm.zext %{{[0-9]+}} : i32 to i64
     cir.store %14, %5 : !s64i, cir.ptr <!s64i>
     %15 = cir.load %1 : cir.ptr <!s32i>, !s32i
     %16 = cir.cast(integral, %15 : !s32i), !s64i
-    // MLIR: %{{[0-9]+}} = llvm.sext %{{[0-9]+}} : i32 to i64
+    // CHECK: %{{[0-9]+}} = llvm.sext %{{[0-9]+}} : i32 to i64
     %30 = cir.cast(integral, %arg1 : !s32i), !u32i
     // Should not produce a cast.
     %32 = cir.cast(integral, %arg0 : !u32i), !s32i
     // Should not produce a cast.
     %21 = cir.load %20 : cir.ptr <!s16i>, !s16i
     %22 = cir.cast(integral, %21 : !s16i), !u64i
-    // MLIR: %[[TMP:[0-9]+]] = llvm.sext %{{[0-9]+}} : i16 to i64
+    // CHECK: %[[TMP:[0-9]+]] = llvm.sext %{{[0-9]+}} : i16 to i64
+    %33 = cir.cast(int_to_bool, %arg1 : !s32i), !cir.bool
+    // CHECK: %[[#ZERO:]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[#CMP:]] = llvm.icmp "ne" %arg1, %[[#ZERO]] : i32
+    // CHECK: %{{.+}} = llvm.zext %[[#CMP]] : i1 to i8
 
     // Pointer casts.
     cir.store %16, %6 : !s64i, cir.ptr <!s64i>
     %17 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
     cir.store %17, %8 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
+    // CHECK: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr, i32
     %23 = cir.cast(int_to_ptr, %22 : !u64i), !cir.ptr<!u8i>
-    // MLIR: %[[TMP2:[0-9]+]] = llvm.inttoptr %[[TMP]] : i64 to !llvm.ptr
+    // CHECK: %[[TMP2:[0-9]+]] = llvm.inttoptr %[[TMP]] : i64 to !llvm.ptr
     %24 = cir.cast(ptr_to_int, %23 : !cir.ptr<!u8i>), !s32i
-    // MLIR: %{{[0-9]+}} = llvm.ptrtoint %[[TMP2]] : !llvm.ptr to i32
+    // CHECK: %{{[0-9]+}} = llvm.ptrtoint %[[TMP2]] : !llvm.ptr to i32
     %29 = cir.cast(ptr_to_bool, %23 : !cir.ptr<!u8i>), !cir.bool
 
     // Floating point casts.
     %25 = cir.cast(int_to_float, %arg1 : !s32i), f32
-    // MLIR: %{{.+}} = llvm.sitofp %{{.+}} : i32 to f32
+    // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : i32 to f32
     %26 = cir.cast(int_to_float, %arg0 : !u32i), f32
-    // MLIR: %{{.+}} = llvm.uitofp %{{.+}} : i32 to f32
+    // CHECK: %{{.+}} = llvm.uitofp %{{.+}} : i32 to f32
     %27 = cir.cast(float_to_int, %arg2 : f32), !s32i
-    // MLIR: %{{.+}} = llvm.fptosi %{{.+}} : f32 to i32
+    // CHECK: %{{.+}} = llvm.fptosi %{{.+}} : f32 to i32
     %28 = cir.cast(float_to_int, %arg2 : f32), !u32i
-    // MLIR: %{{.+}} = llvm.fptoui %{{.+}} : f32 to i32
+    // CHECK: %{{.+}} = llvm.fptoui %{{.+}} : f32 to i32
     %18 = cir.const(#cir.int<0> : !s32i) : !s32i
 
     cir.store %18, %2 : !s32i, cir.ptr <!s32i>

--- a/clang/test/CIR/Lowering/dot.cir
+++ b/clang/test/CIR/Lowering/dot.cir
@@ -97,11 +97,11 @@ module {
 // MLIR-NEXT:   ^bb5:  // pred: ^bb3
 // MLIR-NEXT:     %22 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
 // MLIR-NEXT:     %23 = llvm.load %12 : !llvm.ptr -> i32
-// MLIR-NEXT:     %24 = llvm.getelementptr %22[%23] : (!llvm.ptr, i32) -> !llvm.ptr
+// MLIR-NEXT:     %24 = llvm.getelementptr %22[%23] : (!llvm.ptr, i32) -> !llvm.ptr, f64
 // MLIR-NEXT:     %25 = llvm.load %24 : !llvm.ptr -> f64
 // MLIR-NEXT:     %26 = llvm.load %3 : !llvm.ptr -> !llvm.ptr
 // MLIR-NEXT:     %27 = llvm.load %12 : !llvm.ptr -> i32
-// MLIR-NEXT:     %28 = llvm.getelementptr %26[%27] : (!llvm.ptr, i32) -> !llvm.ptr
+// MLIR-NEXT:     %28 = llvm.getelementptr %26[%27] : (!llvm.ptr, i32) -> !llvm.ptr, f64
 // MLIR-NEXT:     %29 = llvm.load %28 : !llvm.ptr -> f64
 // MLIR-NEXT:     %30 = llvm.fmul %25, %29  : f64
 // MLIR-NEXT:     %31 = llvm.load %9 : !llvm.ptr -> f64

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -104,27 +104,27 @@ module {
     %5 = cir.get_global @string : cir.ptr <!cir.array<!s8i x 8>>
     %6 = cir.cast(array_to_ptrdecay, %5 : !cir.ptr<!cir.array<!s8i x 8>>), !cir.ptr<!s8i>
     // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @string : !llvm.ptr
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr, i8
     cir.store %6, %0 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
     %7 = cir.get_global @uint : cir.ptr <!cir.array<!u32i x 1>>
     %8 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<!u32i x 1>>), !cir.ptr<!u32i>
     // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @uint : !llvm.ptr
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr, i32
     cir.store %8, %1 : !cir.ptr<!u32i>, cir.ptr <!cir.ptr<!u32i>>
     %9 = cir.get_global @sshort : cir.ptr <!cir.array<!s16i x 2>>
     %10 = cir.cast(array_to_ptrdecay, %9 : !cir.ptr<!cir.array<!s16i x 2>>), !cir.ptr<!s16i>
     // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sshort : !llvm.ptr
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr, i16
     cir.store %10, %2 : !cir.ptr<!s16i>, cir.ptr <!cir.ptr<!s16i>>
     %11 = cir.get_global @sint : cir.ptr <!cir.array<!s32i x 3>>
     %12 = cir.cast(array_to_ptrdecay, %11 : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
     // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @sint : !llvm.ptr
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr, i32
     cir.store %12, %3 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
     %13 = cir.get_global @ll : cir.ptr <!cir.array<!s64i x 4>>
     %14 = cir.cast(array_to_ptrdecay, %13 : !cir.ptr<!cir.array<!s64i x 4>>), !cir.ptr<!s64i>
     // MLIR: %[[RES:[0-9]+]] = llvm.mlir.addressof @ll : !llvm.ptr
-    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr
+    // MLIR: %{{[0-9]+}} = llvm.getelementptr %[[RES]][0] : (!llvm.ptr) -> !llvm.ptr, i64
     cir.store %14, %4 : !cir.ptr<!s64i>, cir.ptr <!cir.ptr<!s64i>>
     cir.return
   }

--- a/clang/test/CIR/Lowering/hello.cir
+++ b/clang/test/CIR/Lowering/hello.cir
@@ -25,7 +25,7 @@ module @"/tmp/test.raw" attributes {cir.lang = #cir.lang<c>, cir.sob = #cir.sign
 // CHECK:    %0 = llvm.mlir.constant(1 : index) : i64
 // CHECK:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
 // CHECK:    %2 = llvm.mlir.addressof @".str" : !llvm.ptr
-// CHECK:    %3 = llvm.getelementptr %2[0] : (!llvm.ptr) -> !llvm.ptr
+// CHECK:    %3 = llvm.getelementptr %2[0] : (!llvm.ptr) -> !llvm.ptr, i8
 // CHECK:    %4 = llvm.call @printf(%3) : (!llvm.ptr) -> i32
 // CHECK:    %5 = llvm.mlir.constant(0 : i32) : i32
 // CHECK:    llvm.store %5, %1 : i32, !llvm.ptr

--- a/clang/test/CIR/Lowering/ptrstride.cir
+++ b/clang/test/CIR/Lowering/ptrstride.cir
@@ -1,5 +1,6 @@
-// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s -cir-to-llvm -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir -check-prefix=MLIR
+
 !s32i = !cir.int<s, 32>
 module {
   cir.func @f(%arg0: !cir.ptr<!s32i>) {
@@ -17,20 +18,11 @@ module {
 // MLIR-NEXT:   llvm.func @f(%arg0: !llvm.ptr)
 // MLIR-NEXT:     %0 = llvm.mlir.constant(1 : index) : i64
 // MLIR-NEXT:     %1 = llvm.alloca %0 x !llvm.ptr {alignment = 8 : i64} : (i64) -> !llvm.ptr
-// MLIR-NEXT:     llvm.store %arg0, %1 : !llvm.ptr
-// MLIR-NEXT:     %2 = llvm.load %1 : !llvm.ptr
+// MLIR-NEXT:     llvm.store %arg0, %1 : !llvm.ptr, !llvm.ptr
+// MLIR-NEXT:     %2 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
 // MLIR-NEXT:     %3 = llvm.mlir.constant(1 : i32) : i32
-// MLIR-NEXT:     %4 = llvm.getelementptr %2[%3] : (!llvm.ptr, i32) -> !llvm.ptr
-// MLIR-NEXT:     %5 = llvm.load %4 : !llvm.ptr
+// MLIR-NEXT:     %4 = llvm.getelementptr %2[%3] : (!llvm.ptr, i32) -> !llvm.ptr, i32
+// MLIR-NEXT:     %5 = llvm.load %4 : !llvm.ptr -> i32
 // MLIR-NEXT:     llvm.return
 // MLIR-NEXT:   }
 // MLIR-NEXT: }
-
-//      LLVM: define void @f(ptr %0)
-// LLVM-NEXT:   %2 = alloca ptr, i64 1, align 8
-// LLVM-NEXT:   store ptr %0, ptr %2, align 8
-// LLVM-NEXT:   %3 = load ptr, ptr %2, align 8
-// LLVM-NEXT:   %4 = getelementptr i32, ptr %3, i32 1
-// LLVM-NEXT:   %5 = load i32, ptr %4, align 4
-// LLVM-NEXT:   ret void
-// LLVM-NEXT: }

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -16,9 +16,9 @@ module {
     // CHECK: %[[#ARRSIZE:]] = llvm.mlir.constant(1 : index) : i64
     // CHECK: %[[#STRUCT:]] = llvm.alloca %[[#ARRSIZE]] x !llvm.struct<"struct.S", (i8, i32)>
     %3 = cir.get_member %1[0] {name = "c"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!u8i>
-    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 0] : (!llvm.ptr) -> !llvm.ptr
+    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"struct.S", (i8, i32)>
     %5 = cir.get_member %1[1] {name = "i"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!s32i>
-    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 1] : (!llvm.ptr) -> !llvm.ptr
+    // CHECK: = llvm.getelementptr %[[#STRUCT]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"struct.S", (i8, i32)>
     cir.return
   }
 

--- a/clang/test/CIR/Lowering/variadics.cir
+++ b/clang/test/CIR/Lowering/variadics.cir
@@ -16,20 +16,20 @@ module {
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     %4 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!ty_22__va_list_tag22 x 1>>), !cir.ptr<!ty_22__va_list_tag22>
     cir.va.start %4 : !cir.ptr<!ty_22__va_list_tag22>
-    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
+    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"struct.__va_list_tag", (i32, i32, ptr, ptr)>
     // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr to !llvm.ptr
     // MLIR-NEXT: llvm.intr.vastart %{{[0-9]+}} : !llvm.ptr
     %5 = cir.cast(array_to_ptrdecay, %3 : !cir.ptr<!cir.array<!ty_22__va_list_tag22 x 1>>), !cir.ptr<!ty_22__va_list_tag22>
     %6 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!ty_22__va_list_tag22 x 1>>), !cir.ptr<!ty_22__va_list_tag22>
     cir.va.copy %6 to %5 : !cir.ptr<!ty_22__va_list_tag22>, !cir.ptr<!ty_22__va_list_tag22>
-    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
-    // MLIR-NEXT: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
+    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"struct.__va_list_tag", (i32, i32, ptr, ptr)>
+    // MLIR-NEXT: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"struct.__va_list_tag", (i32, i32, ptr, ptr)>
     // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr to !llvm.ptr
     // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr to !llvm.ptr
     // MLIR-NEXT: llvm.intr.vacopy %13 to %{{[0-9]+}} : !llvm.ptr, !llvm.ptr
     %7 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!ty_22__va_list_tag22 x 1>>), !cir.ptr<!ty_22__va_list_tag22>
     cir.va.end %7 : !cir.ptr<!ty_22__va_list_tag22>
-    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr
+    //      MLIR: %{{[0-9]+}} = llvm.getelementptr %{{[0-9]+}}[0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"struct.__va_list_tag", (i32, i32, ptr, ptr)>
     // MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : !llvm.ptr to !llvm.ptr
     // MLIR-NEXT: llvm.intr.vaend %{{[0-9]+}} : !llvm.ptr
     %8 = cir.const(#cir.int<0> : !s32i) : !s32i


### PR DESCRIPTION
The wrong element type was being passed to LLVM's GEP op, generating an invalid IR. Tests were also updated to properly validate the `llvm.getelementptr` element type.

Fixes #272