### PR TITLE
[CIR][CIRGen] Ensure unique IDs for anonymous records

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -32,6 +32,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <optional>
@@ -48,10 +49,17 @@ class CIRGenBuilderTy : public mlir::OpBuilder {
   llvm::RoundingMode DefaultConstrainedRounding = llvm::RoundingMode::Dynamic;
 
   llvm::StringMap<unsigned> GlobalsVersioning;
+  llvm::StringSet<> anonRecordNames;
 
 public:
   CIRGenBuilderTy(mlir::MLIRContext &C, const CIRGenTypeCache &tc)
       : mlir::OpBuilder(&C), typeCache(tc) {}
+
+  std::string getUniqueAnonRecordName() {
+    std::string name = "anon." + std::to_string(anonRecordNames.size());
+    anonRecordNames.insert(name);
+    return name;
+  }
 
   //
   // Floating point specific helpers

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -60,7 +60,7 @@ std::string CIRGenTypes::getRecordTypeName(const clang::RecordDecl *recordDecl,
     else
       typedefNameDecl->printName(outStream);
   } else {
-    outStream << "anon";
+    outStream << Builder.getUniqueAnonRecordName();
   }
 
   if (!suffix.empty())

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -29,8 +29,8 @@ typedef struct {
 } T; 
 // CHECK: !ty_22S22 = !cir.struct<struct "S" {!u32i, !u32i, !u16i, !u32i}>
 // CHECK: !ty_22T22 = !cir.struct<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK: !ty_22anon22 = !cir.struct<struct "anon" {!u32i} #cir.record.decl.ast>
-// CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!ty_22anon22, !u32i, !cir.ptr<!u32i>}>
+// CHECK: !ty_22anon2E122 = !cir.struct<struct "anon.1" {!u32i} #cir.record.decl.ast>
+// CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!ty_22anon2E122, !u32i, !cir.ptr<!u32i>}>
 
 // CHECK: cir.func {{.*@store_field}}
 // CHECK:   [[TMP0:%.*]] = cir.alloca !ty_22S22, cir.ptr <!ty_22S22>

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -27,10 +27,11 @@ typedef struct {
   int a : 3;  // one bitfield with size < 8
   unsigned b;
 } T; 
+
 // CHECK: !ty_22S22 = !cir.struct<struct "S" {!u32i, !u32i, !u16i, !u32i}>
 // CHECK: !ty_22T22 = !cir.struct<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK: !ty_22anon22 = !cir.struct<struct "anon" {!u32i} #cir.record.decl.ast>
-// CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!ty_22anon22, !u32i, !cir.ptr<!u32i>}>
+// CHECK: !ty_22anon2E122 = !cir.struct<struct "anon.1" {!u32i} #cir.record.decl.ast>
+// CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!ty_22anon2E122, !u32i, !cir.ptr<!u32i>}>
 
 // CHECK: cir.func @_Z11store_field
 // CHECK:   [[TMP0:%.*]] = cir.alloca !ty_22S22, cir.ptr <!ty_22S22>,

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -359,10 +359,10 @@ folly::coro::Task<int> go4() {
 // CHECK: }
 
 // CHECK: %12 = cir.scope {
-// CHECK:   %17 = cir.alloca !ty_22anon221, cir.ptr <!ty_22anon221>, ["ref.tmp1"] {alignment = 1 : i64}
+// CHECK:   %17 = cir.alloca !ty_22anon2E522, cir.ptr <!ty_22anon2E522>, ["ref.tmp1"] {alignment = 1 : i64}
 
 // Get the lambda invoker ptr via `lambda operator folly::coro::Task<int> (*)(int const&)()`
-// CHECK:   %18 = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%17) : (!cir.ptr<!ty_22anon221>) -> !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
+// CHECK:   %18 = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%17) : (!cir.ptr<!ty_22anon2E522>) -> !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
 // CHECK:   %19 = cir.unary(plus, %18) : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
 // CHECK:   cir.yield %19 : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
 // CHECK: }

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -6,13 +6,13 @@ void fn() {
   a();
 }
 
-//      CHECK: !ty_22anon22 = !cir.struct<class "anon" {!u8i}>
+//      CHECK: !ty_22anon2E222 = !cir.struct<class "anon.2" {!u8i}>
 //  CHECK-DAG: module
 
 //      CHECK: cir.func lambda internal private @_ZZ2fnvENK3$_0clEv
 
 //      CHECK:   cir.func @_Z2fnv()
-// CHECK-NEXT:     %0 = cir.alloca !ty_22anon22, cir.ptr <!ty_22anon22>, ["a"]
+// CHECK-NEXT:     %0 = cir.alloca !ty_22anon2E222, cir.ptr <!ty_22anon2E222>, ["a"]
 //      CHECK:   cir.call @_ZZ2fnvENK3$_0clEv
 
 void l0() {
@@ -23,15 +23,15 @@ void l0() {
 
 // CHECK: cir.func lambda internal private @_ZZ2l0vENK3$_0clEv(
 
-// CHECK: %0 = cir.alloca !cir.ptr<!ty_22anon222>, cir.ptr <!cir.ptr<!ty_22anon222>>, ["this", init] {alignment = 8 : i64}
-// CHECK: cir.store %arg0, %0 : !cir.ptr<!ty_22anon222>, cir.ptr <!cir.ptr<!ty_22anon222>>
-// CHECK: %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22anon222>>, !cir.ptr<!ty_22anon222>
-// CHECK: %2 = cir.get_member %1[0] {name = "i"} : !cir.ptr<!ty_22anon222> -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %0 = cir.alloca !cir.ptr<!ty_22anon2E422>, cir.ptr <!cir.ptr<!ty_22anon2E422>>, ["this", init] {alignment = 8 : i64}
+// CHECK: cir.store %arg0, %0 : !cir.ptr<!ty_22anon2E422>, cir.ptr <!cir.ptr<!ty_22anon2E422>>
+// CHECK: %1 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22anon2E422>>, !cir.ptr<!ty_22anon2E422>
+// CHECK: %2 = cir.get_member %1[0] {name = "i"} : !cir.ptr<!ty_22anon2E422> -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: %3 = cir.load %2 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: %4 = cir.load %3 : cir.ptr <!s32i>, !s32i
 // CHECK: %5 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK: %6 = cir.binop(add, %4, %5) : !s32i
-// CHECK: %7 = cir.get_member %1[0] {name = "i"} : !cir.ptr<!ty_22anon222> -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %7 = cir.get_member %1[0] {name = "i"} : !cir.ptr<!ty_22anon2E422> -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: %8 = cir.load %7 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: cir.store %6, %8 : !s32i, cir.ptr <!s32i>
 
@@ -45,15 +45,15 @@ auto g() {
   };
 }
 
-// CHECK: cir.func @_Z1gv() -> !ty_22anon223
-// CHECK: %0 = cir.alloca !ty_22anon223, cir.ptr <!ty_22anon223>, ["__retval"] {alignment = 8 : i64}
+// CHECK: cir.func @_Z1gv() -> !ty_22anon2E622
+// CHECK: %0 = cir.alloca !ty_22anon2E622, cir.ptr <!ty_22anon2E622>, ["__retval"] {alignment = 8 : i64}
 // CHECK: %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK: %2 = cir.const(#cir.int<12> : !s32i) : !s32i
 // CHECK: cir.store %2, %1 : !s32i, cir.ptr <!s32i>
-// CHECK: %3 = cir.get_member %0[0] {name = "i"} : !cir.ptr<!ty_22anon223> -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK: %3 = cir.get_member %0[0] {name = "i"} : !cir.ptr<!ty_22anon2E622> -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: cir.store %1, %3 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
-// CHECK: %4 = cir.load %0 : cir.ptr <!ty_22anon223>, !ty_22anon223
-// CHECK: cir.return %4 : !ty_22anon223
+// CHECK: %4 = cir.load %0 : cir.ptr <!ty_22anon2E622>, !ty_22anon2E622
+// CHECK: cir.return %4 : !ty_22anon2E622
 
 auto g2() {
   int i = 12;
@@ -65,15 +65,15 @@ auto g2() {
 }
 
 // Should be same as above because of NRVO
-// CHECK: cir.func @_Z2g2v() -> !ty_22anon224
-// CHECK-NEXT: %0 = cir.alloca !ty_22anon224, cir.ptr <!ty_22anon224>, ["__retval", init] {alignment = 8 : i64}
+// CHECK: cir.func @_Z2g2v() -> !ty_22anon2E822
+// CHECK-NEXT: %0 = cir.alloca !ty_22anon2E822, cir.ptr <!ty_22anon2E822>, ["__retval", init] {alignment = 8 : i64}
 // CHECK-NEXT: %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK-NEXT: %2 = cir.const(#cir.int<12> : !s32i) : !s32i
 // CHECK-NEXT: cir.store %2, %1 : !s32i, cir.ptr <!s32i>
-// CHECK-NEXT: %3 = cir.get_member %0[0] {name = "i"} : !cir.ptr<!ty_22anon224> -> !cir.ptr<!cir.ptr<!s32i>>
+// CHECK-NEXT: %3 = cir.get_member %0[0] {name = "i"} : !cir.ptr<!ty_22anon2E822> -> !cir.ptr<!cir.ptr<!s32i>>
 // CHECK-NEXT: cir.store %1, %3 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
-// CHECK-NEXT: %4 = cir.load %0 : cir.ptr <!ty_22anon224>, !ty_22anon224
-// CHECK-NEXT: cir.return %4 : !ty_22anon224
+// CHECK-NEXT: %4 = cir.load %0 : cir.ptr <!ty_22anon2E822>, !ty_22anon2E822
+// CHECK-NEXT: cir.return %4 : !ty_22anon2E822
 
 int f() {
   return g2()();
@@ -82,10 +82,10 @@ int f() {
 //      CHECK: cir.func @_Z1fv() -> !s32i
 // CHECK-NEXT:   %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:     %2 = cir.alloca !ty_22anon224, cir.ptr <!ty_22anon224>, ["ref.tmp0"] {alignment = 8 : i64}
-// CHECK-NEXT:     %3 = cir.call @_Z2g2v() : () -> !ty_22anon224
-// CHECK-NEXT:     cir.store %3, %2 : !ty_22anon224, cir.ptr <!ty_22anon224>
-// CHECK-NEXT:     %4 = cir.call @_ZZ2g2vENK3$_0clEv(%2) : (!cir.ptr<!ty_22anon224>) -> !s32i
+// CHECK-NEXT:     %2 = cir.alloca !ty_22anon2E822, cir.ptr <!ty_22anon2E822>, ["ref.tmp0"] {alignment = 8 : i64}
+// CHECK-NEXT:     %3 = cir.call @_Z2g2v() : () -> !ty_22anon2E822
+// CHECK-NEXT:     cir.store %3, %2 : !ty_22anon2E822, cir.ptr <!ty_22anon2E822>
+// CHECK-NEXT:     %4 = cir.call @_ZZ2g2vENK3$_0clEv(%2) : (!cir.ptr<!ty_22anon2E822>) -> !s32i
 // CHECK-NEXT:     cir.store %4, %0 : !s32i, cir.ptr <!s32i>
 // CHECK-NEXT:   }
 // CHECK-NEXT:   %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
@@ -114,8 +114,8 @@ int g3() {
 
 // 1. Use `operator int (*)(int const&)()` to retrieve the fnptr to `__invoke()`.
 // CHECK:     %3 = cir.scope {
-// CHECK:       %7 = cir.alloca !ty_22anon221, cir.ptr <!ty_22anon221>, ["ref.tmp0"] {alignment = 1 : i64}
-// CHECK:       %8 = cir.call @_ZZ2g3vENK3$_0cvPFiRKiEEv(%7) : (!cir.ptr<!ty_22anon221>) -> !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
+// CHECK:       %7 = cir.alloca !ty_22anon2E1122, cir.ptr <!ty_22anon2E1122>, ["ref.tmp0"] {alignment = 1 : i64}
+// CHECK:       %8 = cir.call @_ZZ2g3vENK3$_0cvPFiRKiEEv(%7) : (!cir.ptr<!ty_22anon2E1122>) -> !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
 // CHECK:       %9 = cir.unary(plus, %8) : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
 // CHECK:       cir.yield %9 : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
 // CHECK:     }

--- a/clang/test/CIR/CodeGen/union.cpp
+++ b/clang/test/CIR/CodeGen/union.cpp
@@ -7,13 +7,13 @@ typedef union { yolo y; struct { int *lifecnt; int genpad; }; } yolm2;
 typedef union { yolo y; struct { bool life; int genpad; }; } yolm3;
 
 // CHECK-DAG: !ty_22U23A3ADummy22 = !cir.struct<struct "U2::Dummy" {!s16i, f32} #cir.record.decl.ast>
-// CHECK-DAG: !ty_22anon221 = !cir.struct<struct "anon" {!cir.bool, !s32i} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22anon2E522 = !cir.struct<struct "anon.5" {!cir.bool, !s32i} #cir.record.decl.ast>
 // CHECK-DAG: !ty_22yolo22 = !cir.struct<struct "yolo" {!s32i} #cir.record.decl.ast>
-// CHECK-DAG: !ty_22anon222 = !cir.struct<struct "anon" {!cir.ptr<!s32i>, !s32i} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22anon2E322 = !cir.struct<struct "anon.3" {!cir.ptr<!s32i>, !s32i} #cir.record.decl.ast>
 
-// CHECK-DAG: !ty_22yolm22 = !cir.struct<union "yolm" {!ty_22yolo22, !ty_22anon22}>
-// CHECK-DAG: !ty_22yolm322 = !cir.struct<union "yolm3" {!ty_22yolo22, !ty_22anon221}>
-// CHECK-DAG: !ty_22yolm222 = !cir.struct<union "yolm2" {!ty_22yolo22, !ty_22anon222}>
+// CHECK-DAG: !ty_22yolm22 = !cir.struct<union "yolm" {!ty_22yolo22, !ty_22anon2E122}>
+// CHECK-DAG: !ty_22yolm322 = !cir.struct<union "yolm3" {!ty_22yolo22, !ty_22anon2E522}>
+// CHECK-DAG: !ty_22yolm222 = !cir.struct<union "yolm2" {!ty_22yolo22, !ty_22anon2E322}>
 
 // Should generate a union type with all members preserved.
 union U {


### PR DESCRIPTION
Traditional Clang's codegen generates IDs for anonymous records (e.g. "struct.anon.1") and ensures that they are unique. This patch does the same for CIRGen, which, until now, would just identify any anonymous record as "anon".

This will be required to support mutable structs uniquely identified by their names.