### PR TITLE
[CIR] Rename StructType "typeName" attribute to "name"

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -108,7 +108,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
 
   let parameters = (ins
     ArrayRefParameter<"mlir::Type", "members">:$members,
-    "mlir::StringAttr":$typeName,
+    "mlir::StringAttr":$name,
     "bool":$body,
     "bool":$packed,
     "mlir::cir::StructType::RecordKind":$kind,
@@ -138,7 +138,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
     bool isPadded(const ::mlir::DataLayout &dataLayout) const;
 
     std::string getPrefixedName() {
-      const auto name = getTypeName().getValue().str();
+      const auto name = getName().getValue().str();
       switch (getKind()) {
       case RecordKind::Class:
         return "class." + name;

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -53,7 +53,10 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
 
   AliasResult getAlias(Type type, raw_ostream &os) const final {
     if (auto structType = type.dyn_cast<StructType>()) {
-      os << "ty_" << structType.getTypeName();
+      // TODO(cir): generate unique alias names for anonymous records.
+      if (!structType.getName())
+        return AliasResult::NoAlias;
+      os << "ty_" << structType.getName();
       return AliasResult::OverridableAlias;
     }
     if (auto intType = type.dyn_cast<IntType>()) {

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -107,7 +107,6 @@ Type StructType::getLargestMember(const ::mlir::DataLayout &dataLayout) const {
 Type StructType::parse(mlir::AsmParser &parser) {
   const auto loc = parser.getCurrentLocation();
   llvm::SmallVector<mlir::Type> members;
-  mlir::StringAttr id;
   bool body = false;
   bool packed = false;
   mlir::cir::ASTRecordDeclAttr ast = nullptr;
@@ -129,8 +128,8 @@ Type StructType::parse(mlir::AsmParser &parser) {
     return {};
   }
 
-  if (parser.parseAttribute(id))
-    return {};
+  mlir::StringAttr name;
+  parser.parseOptionalAttribute(name);
 
   if (parser.parseOptionalKeyword("packed").succeeded())
     packed = true;
@@ -155,7 +154,7 @@ Type StructType::parse(mlir::AsmParser &parser) {
   if (parser.parseGreater())
     return {};
 
-  return StructType::get(parser.getContext(), members, id, body, packed, kind,
+  return StructType::get(parser.getContext(), members, name, body, packed, kind,
                          std::nullopt);
 }
 
@@ -174,7 +173,8 @@ void StructType::print(mlir::AsmPrinter &printer) const {
     break;
   }
 
-  printer << getTypeName() << " ";
+  if (getName())
+    printer << getName() << " ";
 
   if (getPacked())
     printer << "packed ";

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1909,7 +1909,7 @@ mlir::LLVMTypeConverter prepareTypeConverter(mlir::MLIRContext *ctx,
 
     // Struct has a name: lower as an identified struct.
     mlir::LLVM::LLVMStructType llvmStruct;
-    if (type.getTypeName().size() != 0) {
+    if (type.getName().size() != 0) {
       llvmStruct = mlir::LLVM::LLVMStructType::getIdentified(
           type.getContext(), type.getPrefixedName());
       if (llvmStruct.setBody(llvmMembers, /*isPacked=*/type.getPacked())

--- a/clang/test/CIR/IR/aliases.cir
+++ b/clang/test/CIR/IR/aliases.cir
@@ -1,0 +1,10 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+!s32i = !cir.int<s, 32>
+module {
+  // CHECK: cir.func @shouldNotUseAliasWithAnonStruct(%arg0: !cir.struct<struct {!s32i}>)
+  cir.func @shouldNotUseAliasWithAnonStruct(%arg0 : !cir.struct<struct {!s32i}>) {
+    cir.return
+  }
+}


### PR DESCRIPTION
Rename `typeName` to just `name`, also use `StringAttr`'s nullability to identify if the record is identified or anonymous. Unnamed structs are also no longer aliased, as they have no unique name to be used in the alias.