### PR TITLE
[CIR][NFC] Refactor StructType body attribute

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -109,7 +109,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
   let parameters = (ins
     ArrayRefParameter<"mlir::Type", "members">:$members,
     "mlir::StringAttr":$name,
-    "bool":$body,
+    "bool":$incomplete,
     "bool":$packed,
     "mlir::cir::StructType::RecordKind":$kind,
     "std::optional<ASTRecordDeclInterface>":$ast
@@ -134,7 +134,8 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
   public:
     void dropAst();
     size_t getNumElements() const { return getMembers().size(); }
-    bool isOpaque() const { return !getBody(); }
+    bool isIncomplete() const { return getIncomplete(); }
+    bool isComplete() const { return !getIncomplete(); }
     bool isPadded(const ::mlir::DataLayout &dataLayout) const;
 
     std::string getPrefixedName() {

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -178,8 +178,8 @@ public:
     if (!structTy)
       structTy = getType<mlir::cir::StructType>(
           members, mlir::StringAttr::get(getContext()),
-          /*body=*/true, packed, mlir::cir::StructType::Struct,
-          /*ast=*/std::nullopt);
+          /*incomplete=*/false, packed, mlir::cir::StructType::Struct,
+          /*ast=*/nullptr);
 
     // Return zero or anonymous constant struct.
     if (isZero)
@@ -199,7 +199,7 @@ public:
     }
 
     if (!ty)
-      ty = getAnonStructTy(members, /*body=*/true, packed);
+      ty = getAnonStructTy(members, /*incomplete=*/false, packed);
 
     auto sTy = ty.dyn_cast<mlir::cir::StructType>();
     assert(sTy && "expected struct type");
@@ -396,9 +396,9 @@ public:
 
   /// Get a CIR anonymous struct type.
   mlir::cir::StructType
-  getAnonStructTy(llvm::ArrayRef<mlir::Type> members, bool body,
+  getAnonStructTy(llvm::ArrayRef<mlir::Type> members, bool incomplete,
                   bool packed = false, const clang::RecordDecl *ast = nullptr) {
-    return getStructTy(members, "", body, packed, ast);
+    return getStructTy(members, "", incomplete, packed, ast);
   }
 
   /// Get a CIR record kind from a AST declaration tag.
@@ -420,7 +420,7 @@ public:
 
   /// Get a CIR named struct type.
   mlir::cir::StructType getStructTy(llvm::ArrayRef<mlir::Type> members,
-                                    llvm::StringRef name, bool body,
+                                    llvm::StringRef name, bool incomplete,
                                     bool packed, const clang::RecordDecl *ast) {
     const auto nameAttr = getStringAttr(name);
     std::optional<mlir::cir::ASTRecordDeclAttr> astAttr = std::nullopt;
@@ -429,8 +429,8 @@ public:
       astAttr = getAttr<mlir::cir::ASTRecordDeclAttr>(ast);
       kind = getRecordKind(ast->getTagKind());
     }
-    return mlir::cir::StructType::get(getContext(), members, nameAttr, body,
-                                      packed, kind, astAttr);
+    return mlir::cir::StructType::get(getContext(), members, nameAttr,
+                                      incomplete, packed, kind, astAttr);
   }
 
   //

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -63,7 +63,7 @@ mlir::Type CIRGenVTables::getVTableType(const VTableLayout &layout) {
 
   // FIXME(cir): should VTableLayout be encoded like we do for some
   // AST nodes?
-  return CGM.getBuilder().getAnonStructTy(tys, /*body=*/true);
+  return CGM.getBuilder().getAnonStructTy(tys, /*incomplete=*/false);
 }
 
 /// At this point in the translation unit, does it appear that can we

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -609,7 +609,7 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *D,
       CIRRecordLowering baseBuilder(*this, D, /*Packed=*/builder.isPacked);
       auto baseIdentifier = getRecordTypeName(D, ".base");
       *BaseTy = Builder.getStructTy(baseBuilder.fieldTypes, baseIdentifier,
-                                    /*body=*/true, /*packed=*/false, D);
+                                    /*incomplete=*/false, /*packed=*/false, D);
       // TODO(cir): add something like addRecordTypeName
 
       // BaseTy and Ty must agree on their packedness for getCIRFieldNo to work
@@ -623,7 +623,7 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *D,
   // signifies that the type is no longer opaque and record layout is complete,
   // but we may need to recursively layout D while laying D out as a base type.
   *Ty = Builder.getStructTy(builder.fieldTypes, getRecordTypeName(D, ""),
-                            /*body=*/true, /*packed=*/false, D);
+                            /*incomplete=*/false, /*packed=*/false, D);
 
   auto RL = std::make_unique<CIRGenRecordLayout>(
       Ty ? *Ty : mlir::cir::StructType{},

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2404,7 +2404,7 @@ static bool isIncompleteType(mlir::Type typ) {
   if (auto ptr = typ.dyn_cast<PointerType>())
     return isIncompleteType(ptr.getPointee());
   else if (auto rec = typ.dyn_cast<StructType>())
-    return !rec.getBody();
+    return rec.isIncomplete();
   return false;
 }
 


### PR DESCRIPTION
The `body` attribute is used to identify if a struct type has a body or not. In other words, it separates complete from incomplete structs. For this reason, the `body` attribute was renamed to `incomplete`, matching its keyword in the CIR language.