### PR TITLE
[CIR][NFC] Remove std::optional from StructType ast attribute

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -112,7 +112,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
     "bool":$incomplete,
     "bool":$packed,
     "mlir::cir::StructType::RecordKind":$kind,
-    "std::optional<ASTRecordDeclInterface>":$ast
+    "ASTRecordDeclInterface":$ast
   );
 
   let hasCustomAssemblyFormat = 1;
@@ -165,7 +165,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
 
   let extraClassDefinition = [{
     void $cppClass::dropAst() {
-      getImpl()->ast = std::nullopt;
+      getImpl()->ast = nullptr;
     }
   }];
 }

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -423,7 +423,7 @@ public:
                                     llvm::StringRef name, bool incomplete,
                                     bool packed, const clang::RecordDecl *ast) {
     const auto nameAttr = getStringAttr(name);
-    std::optional<mlir::cir::ASTRecordDeclAttr> astAttr = std::nullopt;
+    mlir::cir::ASTRecordDeclAttr astAttr = nullptr;
     auto kind = mlir::cir::StructType::RecordKind::Struct;
     if (ast) {
       astAttr = getAttr<mlir::cir::ASTRecordDeclAttr>(ast);

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -107,7 +107,6 @@ Type StructType::getLargestMember(const ::mlir::DataLayout &dataLayout) const {
 Type StructType::parse(mlir::AsmParser &parser) {
   const auto loc = parser.getCurrentLocation();
   bool packed = false;
-  mlir::cir::ASTRecordDeclAttr ast = nullptr;
   RecordKind kind;
 
   if (parser.parseLess())
@@ -145,13 +144,16 @@ Type StructType::parse(mlir::AsmParser &parser) {
       return {};
   }
 
+  // Parse optional AST attribute. This is just a formality for now, since CIR
+  // cannot yet read serialized AST.
+  mlir::cir::ASTRecordDeclAttr ast = nullptr;
   parser.parseOptionalAttribute(ast);
 
   if (parser.parseGreater())
     return {};
 
   return StructType::get(parser.getContext(), members, name, incomplete, packed,
-                         kind, std::nullopt);
+                         kind, nullptr);
 }
 
 void StructType::print(mlir::AsmPrinter &printer) const {
@@ -183,9 +185,9 @@ void StructType::print(mlir::AsmPrinter &printer) const {
     printer << "}";
   }
 
-  if (getAst().has_value()) {
+  if (getAst()) {
     printer << " ";
-    printer.printAttribute(getAst().value());
+    printer.printAttribute(getAst());
   }
 
   printer << '>';

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -891,7 +891,7 @@ void LifetimeCheckPass::checkIf(IfOp ifOp) {
 template <class T> bool isStructAndHasAttr(mlir::Type ty) {
   if (!ty.isa<mlir::cir::StructType>())
     return false;
-  return hasAttr<T>(*mlir::cast<mlir::cir::StructType>(ty).getAst());
+  return hasAttr<T>(ty.cast<mlir::cir::StructType>().getAst());
 }
 
 static bool isOwnerType(mlir::Type ty) {
@@ -1757,7 +1757,7 @@ bool LifetimeCheckPass::isLambdaType(mlir::Type ty) {
   auto taskTy = ty.dyn_cast<mlir::cir::StructType>();
   if (!taskTy)
     return false;
-  if (taskTy.getAst()->isLambda())
+  if (taskTy.getAst().isLambda())
     IsLambdaTyCache[ty] = true;
 
   return IsLambdaTyCache[ty];
@@ -1772,7 +1772,7 @@ bool LifetimeCheckPass::isTaskType(mlir::Value taskVal) {
     auto taskTy = taskVal.getType().dyn_cast<mlir::cir::StructType>();
     if (!taskTy)
       return false;
-    return taskTy.getAst()->hasPromiseType();
+    return taskTy.getAst().hasPromiseType();
   }();
 
   IsTaskTyCache[ty] = result;


### PR DESCRIPTION
MLIR's attributes are inherently nullable, so there is no need to use std::optional to represent a nullable attribute. This patch removes std::optional from StructType's ast attribute to simplify its usage.