### PR TITLE
[CIR][CodeGen][Bugfix] supports local structs decl

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -727,10 +727,12 @@ void CIRGenFunction::buildDecl(const Decl &D) {
     llvm_unreachable("Declaration should not be in declstmts!");
   case Decl::Record:    // struct/union/class X;
   case Decl::CXXRecord: // struct/union/class X; [C++]
-    llvm_unreachable("NYI");
+    if (auto *DI = getDebugInfo())
+      llvm_unreachable("NYI");
     return;
   case Decl::Enum: // enum X;
-    llvm_unreachable("NYI");
+    if (auto *DI = getDebugInfo())
+      llvm_unreachable("NYI");
     return;
   case Decl::Function:     // void X();
   case Decl::EnumConstant: // enum ? { X = ? }

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -78,3 +78,12 @@ struct Bar shouldGenerateAndAccessStructArrays(void) {
 // CHECK-DAG: %[[#DARR:]] = cir.cast(array_to_ptrdecay, %{{.+}} : !cir.ptr<!cir.array<!ty_22Bar22 x 1>>), !cir.ptr<!ty_22Bar22>
 // CHECK-DAG: %[[#ELT:]] = cir.ptr_stride(%[[#DARR]] : !cir.ptr<!ty_22Bar22>, %[[#STRIDE]] : !s32i), !cir.ptr<!ty_22Bar22>
 // CHECK-DAG: cir.copy %[[#ELT]] to %{{.+}} : !cir.ptr<!ty_22Bar22>
+
+// CHECK-DAG: cir.func @local_decl
+// CHECK-DAG: {{%.}} = cir.alloca !ty_22Local22, cir.ptr <!ty_22Local22>, ["a"] 
+void local_decl(void) {
+  struct Local {
+    int i;
+  };
+  struct Local a;
+}


### PR DESCRIPTION
Just a trivial fix that enables declaration of local structs. 
Basically, there it's a copy-pasta from the original `CodeGen`, without debug info handling. 