### PR TITLE
[CIR] Implement bool->int conversion

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1633,45 +1633,54 @@ mlir::Value ScalarExprEmitter::buildScalarCast(
     DstElementType = DstType;
   }
 
-  if (CGF.getBuilder().isInt(SrcElementTy)) {
-    if (SrcElementType->isBooleanType() && Opts.TreatBooleanAsSigned) {
-      llvm_unreachable("NYI");
-    }
+  if (SrcElementTy.isa<mlir::IntegerType>() ||
+      DstElementTy.isa<mlir::IntegerType>())
+    llvm_unreachable("Obsolete code. Don't use mlir::IntegerType with CIR.");
 
-    if (CGF.getBuilder().isInt(DstElementTy))
+  if (SrcElementType->isBooleanType()) {
+    if (Opts.TreatBooleanAsSigned)
+      llvm_unreachable("NYI: signed bool");
+    if (CGF.getBuilder().isInt(DstElementTy)) {
+      return Builder.create<mlir::cir::CastOp>(
+          Src.getLoc(), DstTy, mlir::cir::CastKind::bool_to_int, Src);
+    } else if (DstTy.isa<mlir::FloatType>()) {
+      llvm_unreachable("NYI: bool->float cast");
+    } else {
+      llvm_unreachable("Unexpected destination type for scalar cast");
+    }
+  } else if (CGF.getBuilder().isInt(SrcElementTy)) {
+    if (CGF.getBuilder().isInt(DstElementTy)) {
       return Builder.create<mlir::cir::CastOp>(
           Src.getLoc(), DstTy, mlir::cir::CastKind::integral, Src);
-    if (DstElementTy.isa<mlir::FloatType>())
+    } else if (DstElementTy.isa<mlir::FloatType>()) {
       return Builder.create<mlir::cir::CastOp>(
           Src.getLoc(), DstTy, mlir::cir::CastKind::int_to_float, Src);
-    llvm_unreachable("Unknown type cast");
+    } else {
+      llvm_unreachable("Unexpected destination type for scalar cast");
+    }
+  } else if (SrcElementTy.isa<mlir::FloatType>()) {
+    if (CGF.getBuilder().isInt(DstElementTy)) {
+      // If wwe can't recognize overflow as undefined behavior, assume that
+      // overflow saturates.  This protects against normal optimizations if we
+      // are compiling with non-standard FP semantics.
+      if (!CGF.CGM.getCodeGenOpts().StrictFloatCastOverflow)
+        llvm_unreachable("NYI");
+      if (Builder.getIsFPConstrained())
+        llvm_unreachable("NYI");
+      return Builder.create<mlir::cir::CastOp>(
+          Src.getLoc(), DstTy, mlir::cir::CastKind::float_to_int, Src);
+    } else if (DstElementTy.isa<mlir::FloatType>()) {
+      auto FloatDstTy = DstTy.cast<mlir::FloatType>();
+      auto FloatSrcTy = SrcTy.cast<mlir::FloatType>();
+      if (FloatDstTy.getWidth() < FloatSrcTy.getWidth())
+        llvm_unreachable("NYI: narrowing floating-point cast");
+      return Builder.createFPExt(Src, DstTy);
+    } else {
+      llvm_unreachable("Unexpected destination type for scalar cast");
+    }
+  } else {
+    llvm_unreachable("Unexpected source type for scalar cast");
   }
-
-  // Leaving mlir::IntegerType around incase any old user lingers
-  if (DstElementTy.isa<mlir::IntegerType>()) {
-    llvm_unreachable("NYI");
-  }
-
-  if (DstElementTy.isa<mlir::cir::IntType>()) {
-    assert(SrcElementTy.isa<mlir::FloatType>() && "Unknown real conversion");
-
-    // If we can't recognize overflow as undefined behavior, assume that
-    // overflow saturates. This protects against normal optimizations if we are
-    // compiling with non-standard FP semantics.
-    if (!CGF.CGM.getCodeGenOpts().StrictFloatCastOverflow)
-      llvm_unreachable("NYI");
-
-    if (Builder.getIsFPConstrained())
-      llvm_unreachable("NYI");
-    return Builder.create<mlir::cir::CastOp>(
-        Src.getLoc(), DstTy, mlir::cir::CastKind::float_to_int, Src);
-  }
-
-  auto FloatDstTy = DstElementTy.cast<mlir::FloatType>();
-  auto FloatSrcTy = SrcElementTy.cast<mlir::FloatType>();
-  if (FloatDstTy.getWidth() < FloatSrcTy.getWidth())
-    llvm_unreachable("truncation NYI");
-  return Builder.createFPExt(Src, DstTy);
 }
 
 LValue

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1660,8 +1660,8 @@ mlir::Value ScalarExprEmitter::buildScalarCast(
     }
   } else if (SrcElementTy.isa<mlir::FloatType>()) {
     if (CGF.getBuilder().isInt(DstElementTy)) {
-      // If wwe can't recognize overflow as undefined behavior, assume that
-      // overflow saturates.  This protects against normal optimizations if we
+      // If we can't recognize overflow as undefined behavior, assume that
+      // overflow saturates. This protects against normal optimizations if we
       // are compiling with non-standard FP semantics.
       if (!CGF.CGM.getCodeGenOpts().StrictFloatCastOverflow)
         llvm_unreachable("NYI");

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -68,6 +68,11 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4) {
   unsigned fptoui = (unsigned)x3; // Floating point to unsigned integer
   // CHECK: %{{.+}} = cir.cast(float_to_int, %{{[0-9]+}} : f32), !u32i
 
+  bool x5 = (bool)x1; // No checking, because this isn't a cast.
+
+  int bi = (int)x5; // bool to int
+  // CHECK: %{{[0-9]+}} = cir.cast(bool_to_int, %{{[0-9]+}} : !cir.bool), !s32i
+
   return 0;
 }
 


### PR DESCRIPTION
In the CIR CodeGen function `ScalarExprEmitter::buildScalarCast`, implement conversions from bool to an integral type.  This was inadvertently left out in earlier changes.

Reorganize the code in the function to be more clear, with better assertion failure messages when encountering an unimplemented construct.

This is a partial fix for issue #290