### PR TITLE
[CIR][CIRGen][NFC] Fix post-rebase errors and warnings

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -232,6 +232,7 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
   case Stmt::OMPInteropDirectiveClass:
   case Stmt::OMPDispatchDirectiveClass:
   case Stmt::OMPGenericLoopDirectiveClass:
+  case Stmt::OMPScopeDirectiveClass:
   case Stmt::OMPMaskedDirectiveClass: {
     llvm::errs() << "CIR codegen for '" << S->getStmtClassName()
                  << "' not implemented\n";

--- a/clang/test/CIR/Lowering/ThroughMLIR/scope.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/scope.cir
@@ -1,6 +1,7 @@
-// RUN: cir-opt %s -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
-// XFAIL: *
+// RUN: cir-opt %s -cir-to-mlir -o %t.mlir
+// RUN: FileCheck %s -input-file=%t.mlir -check-prefix=MLIR
+// RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm -o %t.mlir
+// RUN: FileCheck %s -input-file=%t.mlir -check-prefix=LLVM
 
 !u32i = !cir.int<u, 32>
 module {
@@ -21,25 +22,16 @@ module {
 // MLIR-NEXT:   }
 // MLIR-NEXT:   return
 
-
-//       LLVM: define void @foo()
-//  LLVM-NEXT:   %1 = call ptr @llvm.stacksave()
-//  LLVM-NEXT:   br label %2
-// LLVM-EMPTY:
-//  LLVM-NEXT: 2:
-//  LLVM-NEXT:   %3 = alloca i32, i64 1, align 4
-//  LLVM-NEXT:   %4 = insertvalue { ptr, ptr, i64 } undef, ptr %3, 0
-//  LLVM-NEXT:   %5 = insertvalue { ptr, ptr, i64 } %4, ptr %3, 1
-//  LLVM-NEXT:   %6 = insertvalue { ptr, ptr, i64 } %5, i64 0, 2
-//  LLVM-NEXT:   %7 = extractvalue { ptr, ptr, i64 } %6, 1
-//  LLVM-NEXT:   store i32 4, ptr %7, align 4
-//  LLVM-NEXT:   call void @llvm.stackrestore(ptr %1)
-//  LLVM-NEXT:   br label %8
-// LLVM-EMPTY:
-//  LLVM-NEXT: 8:
-//  LLVM-NEXT:   ret void
-//  LLVM-NEXT: }
-
+// LLVM:  llvm.func @foo() {
+// LLVM:    %0 = llvm.intr.stacksave : !llvm.ptr
+// LLVM:    llvm.br ^bb1
+// LLVM:  ^bb1:
+//          [...]
+// LLVM:    llvm.intr.stackrestore %0 : !llvm.ptr
+// LLVM:    llvm.br ^bb2
+// LLVM:  ^bb2:
+// LLVM:    llvm.return
+// LLVM:  }
 
   // Should drop empty scopes.
   cir.func @empty_scope() {
@@ -51,4 +43,6 @@ module {
   // MLIR-NEXT:   return
   // MLIR-NEXT: }
 
+  // LLVM: llvm.func @empty_scope()
+  // LLVM:   llvm.return
 }


### PR DESCRIPTION
Fixes a switch case warning in which not all cases were being handled. And also fixes an incorrect XFAIL in the tests.