### PR TITLE
[CIR][CIRGen] Ensure unique names for template specializations

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -16,6 +16,8 @@
 #include "clang/AST/GlobalDecl.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace clang;
@@ -54,6 +56,19 @@ std::string CIRGenTypes::getRecordTypeName(const clang::RecordDecl *recordDecl,
       recordDecl->printQualifiedName(outStream, policy);
     else
       recordDecl->printName(outStream, policy);
+
+    // Ensure each template specialization has a unique name.
+    if (auto *templateSpecialization =
+            llvm::dyn_cast<ClassTemplateSpecializationDecl>(recordDecl)) {
+      outStream << '<';
+      const auto args = templateSpecialization->getTemplateArgs().asArray();
+      const auto printer = [&policy, &outStream](const TemplateArgument &arg) {
+        arg.getAsType().print(outStream, policy);
+      };
+      llvm::interleaveComma(args, outStream, printer);
+      outStream << '>';
+    }
+
   } else if (auto *typedefNameDecl = recordDecl->getTypedefNameForAnonDecl()) {
     if (typedefNameDecl->getDeclContext())
       typedefNameDecl->printQualifiedName(outStream, policy);

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -126,13 +126,13 @@ co_invoke_fn co_invoke;
 
 }} // namespace folly::coro
 
-// CHECK: ![[VoidTask:ty_.*]] = !cir.struct<struct "folly::coro::Task" {!u8i}>
-// CHECK: ![[IntTask:ty_.*]] = !cir.struct<struct "folly::coro::Task" {!u8i}>
-// CHECK: ![[VoidPromisse:ty_.*]] = !cir.struct<struct "folly::coro::Task<void>::promise_type" {!u8i}>
-// CHECK: ![[CoroHandleVoid:ty_.*]] = !cir.struct<struct "std::coroutine_handle" {!u8i}>
-// CHECK: ![[CoroHandlePromise:ty_.*]] = !cir.struct<struct "std::coroutine_handle" {!u8i}>
-// CHECK: ![[StdString:ty_.*]] = !cir.struct<struct "std::string" {!u8i}
-// CHECK: ![[SuspendAlways:ty_.*]] = !cir.struct<struct "std::suspend_always" {!u8i}>
+// CHECK-DAG: ![[IntTask:.*]] = !cir.struct<struct "folly::coro::Task<int>" {!u8i}>
+// CHECK-DAG: ![[VoidTask:.*]] = !cir.struct<struct "folly::coro::Task<void>" {!u8i}>
+// CHECK-DAG: ![[VoidPromisse:.*]] = !cir.struct<struct "folly::coro::Task<void>::promise_type" {!u8i}>
+// CHECK-DAG: ![[CoroHandleVoid:.*]] = !cir.struct<struct "std::coroutine_handle<void>" {!u8i}>
+// CHECK-DAG: ![[CoroHandlePromise:ty_.*]]  = !cir.struct<struct "std::coroutine_handle<folly::coro::Task<void>::promise_type>" {!u8i}>
+// CHECK-DAG: ![[StdString:.*]] = !cir.struct<struct "std::string" {!u8i}>
+// CHECK-DAG: ![[SuspendAlways:.*]] = !cir.struct<struct "std::suspend_always" {!u8i}>
 
 // CHECK: module {{.*}} {
 // CHECK-NEXT: cir.global external @_ZN5folly4coro9co_invokeE = #cir.zero : !ty_22folly3A3Acoro3A3Aco_invoke_fn22
@@ -362,20 +362,20 @@ folly::coro::Task<int> go4() {
 // CHECK:   %17 = cir.alloca !ty_22anon2E522, cir.ptr <!ty_22anon2E522>, ["ref.tmp1"] {alignment = 1 : i64}
 
 // Get the lambda invoker ptr via `lambda operator folly::coro::Task<int> (*)(int const&)()`
-// CHECK:   %18 = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%17) : (!cir.ptr<!ty_22anon2E522>) -> !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
-// CHECK:   %19 = cir.unary(plus, %18) : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
-// CHECK:   cir.yield %19 : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
+// CHECK:   %18 = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%17) : (!cir.ptr<!ty_22anon2E522>) -> !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>
+// CHECK:   %19 = cir.unary(plus, %18) : !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>
+// CHECK:   cir.yield %19 : !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>
 // CHECK: }
-// CHECK: cir.store %12, %3 : !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>, cir.ptr <!cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>>
+// CHECK: cir.store %12, %3 : !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>, cir.ptr <!cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>>
 // CHECK: cir.scope {
 // CHECK:   %17 = cir.alloca !s32i, cir.ptr <!s32i>, ["ref.tmp2", init] {alignment = 4 : i64}
-// CHECK:   %18 = cir.load %3 : cir.ptr <!cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>>, !cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>
+// CHECK:   %18 = cir.load %3 : cir.ptr <!cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>>, !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>
 // CHECK:   %19 = cir.const(#cir.int<3> : !s32i) : !s32i
 // CHECK:   cir.store %19, %17 : !s32i, cir.ptr <!s32i>
 
 // Call invoker, which calls operator() indirectly.
-// CHECK:   %20 = cir.call %18(%17) : (!cir.ptr<!cir.func<!ty_22folly3A3Acoro3A3ATask221 (!cir.ptr<!s32i>)>>, !cir.ptr<!s32i>) -> !ty_22folly3A3Acoro3A3ATask221
-// CHECK:   cir.store %20, %4 : !ty_22folly3A3Acoro3A3ATask221, cir.ptr <!ty_22folly3A3Acoro3A3ATask221>
+// CHECK:   %20 = cir.call %18(%17) : (!cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>, !cir.ptr<!s32i>) -> ![[IntTask]]
+// CHECK:   cir.store %20, %4 : ![[IntTask]], cir.ptr <![[IntTask]]>
 // CHECK: }
 
 // CHECK:   cir.await(user, ready : {

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -14,7 +14,7 @@ void m(int a, int b) {
 // CHECK: cir.func linkonce_odr @_ZSt11make_sharedI1SJRiS1_EESt10shared_ptrIT_EDpOT0_(
 // CHECK:   %0 = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["args", init] {alignment = 8 : i64}
 // CHECK:   %1 = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["args", init] {alignment = 8 : i64}
-// CHECK:   %2 = cir.alloca !ty_22std3A3Ashared_ptr22, cir.ptr <!ty_22std3A3Ashared_ptr22>, ["__retval"] {alignment = 1 : i64}
+// CHECK:   %2 = cir.alloca !ty_22std3A3Ashared_ptr3CS3E22, cir.ptr <!ty_22std3A3Ashared_ptr3CS3E22>, ["__retval"] {alignment = 1 : i64}
 // CHECK:   cir.store %arg0, %0 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK:   cir.store %arg1, %1 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK:   cir.scope {
@@ -26,7 +26,7 @@ void m(int a, int b) {
 // CHECK:     %9 = cir.load %1 : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK:     %10 = cir.load %9 : cir.ptr <!s32i>, !s32i
 // CHECK:     cir.call @_ZN1SC1Eii(%6, %8, %10) : (!cir.ptr<!ty_22S22>, !s32i, !s32i) -> ()
-// CHECK:     cir.call @_ZNSt10shared_ptrI1SEC1EPS0_(%2, %6) : (!cir.ptr<!ty_22std3A3Ashared_ptr22>, !cir.ptr<!ty_22S22>) -> ()
+// CHECK:     cir.call @_ZNSt10shared_ptrI1SEC1EPS0_(%2, %6) : (!cir.ptr<!ty_22std3A3Ashared_ptr3CS3E22>, !cir.ptr<!ty_22S22>) -> ()
 // CHECK:   }
 
 class B {

--- a/clang/test/CIR/CodeGen/nrvo.cpp
+++ b/clang/test/CIR/CodeGen/nrvo.cpp
@@ -9,23 +9,23 @@ std::vector<const char*> test_nrvo() {
   return result;
 }
 
-// CHECK: !ty_22std3A3Avector22 = !cir.struct<class "std::vector" {!cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>}>
+// CHECK: ![[VEC:.*]] = !cir.struct<class "std::vector<const char *>" {!cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>}>
 
-// CHECK: cir.func @_Z9test_nrvov() -> !ty_22std3A3Avector22
-// CHECK:   %0 = cir.alloca !ty_22std3A3Avector22, cir.ptr <!ty_22std3A3Avector22>, ["__retval", init] {alignment = 8 : i64}
+// CHECK: cir.func @_Z9test_nrvov() -> ![[VEC]]
+// CHECK:   %0 = cir.alloca ![[VEC]], cir.ptr <![[VEC]]>, ["__retval", init] {alignment = 8 : i64}
 // CHECK:   %1 = cir.alloca !cir.bool, cir.ptr <!cir.bool>, ["nrvo"] {alignment = 1 : i64}
 // CHECK:   %2 = cir.const(#false) : !cir.bool
 // CHECK:   cir.store %2, %1 : !cir.bool, cir.ptr <!cir.bool>
-// CHECK:   cir.call @_ZNSt6vectorIPKcEC1Ev(%0) : (!cir.ptr<!ty_22std3A3Avector22>) -> ()
+// CHECK:   cir.call @_ZNSt6vectorIPKcEC1Ev(%0) : (!cir.ptr<![[VEC]]>) -> ()
 // CHECK:   cir.scope {
 // CHECK:     %5 = cir.alloca !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>, ["ref.tmp0"] {alignment = 8 : i64}
 // CHECK:     %6 = cir.get_global @".str" : cir.ptr <!cir.array<!s8i x 59>>
 // CHECK:     %7 = cir.cast(array_to_ptrdecay, %6 : !cir.ptr<!cir.array<!s8i x 59>>), !cir.ptr<!s8i>
 // CHECK:     cir.store %7, %5 : !cir.ptr<!s8i>, cir.ptr <!cir.ptr<!s8i>>
-// CHECK:     cir.call @_ZNSt6vectorIPKcE9push_backEOS1_(%0, %5) : (!cir.ptr<!ty_22std3A3Avector22>, !cir.ptr<!cir.ptr<!s8i>>) -> ()
+// CHECK:     cir.call @_ZNSt6vectorIPKcE9push_backEOS1_(%0, %5) : (!cir.ptr<![[VEC]]>, !cir.ptr<!cir.ptr<!s8i>>) -> ()
 // CHECK:   }
 // CHECK:   %3 = cir.const(#true) : !cir.bool
 // CHECK:   cir.store %3, %1 : !cir.bool, cir.ptr <!cir.bool>
-// CHECK:   %4 = cir.load %0 : cir.ptr <!ty_22std3A3Avector22>, !ty_22std3A3Avector22
-// CHECK:   cir.return %4 : !ty_22std3A3Avector22
+// CHECK:   %4 = cir.load %0 : cir.ptr <![[VEC]]>, ![[VEC]]
+// CHECK:   cir.return %4 : ![[VEC]]
 // CHECK: }

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -22,40 +22,40 @@ void init(unsigned numImages) {
 }
 
 // CHECK-DAG: !ty_22triple22 = !cir.struct<struct "triple" {!u32i, !cir.ptr<!void>, !u32i}>
-// CHECK-DAG: !ty_22std3A3Avector22 = !cir.struct<class "std::vector" {!cir.ptr<!ty_22triple22>, !cir.ptr<!ty_22triple22>, !cir.ptr<!ty_22triple22>}>
-// CHECK-DAG: !ty_22__vector_iterator22 = !cir.struct<struct "__vector_iterator" {!cir.ptr<!ty_22triple22>}>
+// CHECK-DAG: ![[VEC:.*]] = !cir.struct<class "std::vector<triple>" {!cir.ptr<!ty_22triple22>, !cir.ptr<!ty_22triple22>, !cir.ptr<!ty_22triple22>}>
+// CHECK-DAG: ![[VEC_IT:.*]] = !cir.struct<struct "__vector_iterator<triple, triple *, triple &>" {!cir.ptr<!ty_22triple22>}>
 
 // CHECK: cir.func @_Z4initj(%arg0: !u32i
 // CHECK:   %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["numImages", init] {alignment = 4 : i64}
-// CHECK:   %1 = cir.alloca !ty_22std3A3Avector22, cir.ptr <!ty_22std3A3Avector22>, ["images", init] {alignment = 8 : i64}
+// CHECK:   %1 = cir.alloca ![[VEC]], cir.ptr <![[VEC]]>, ["images", init] {alignment = 8 : i64}
 // CHECK:   cir.store %arg0, %0 : !u32i, cir.ptr <!u32i>
 // CHECK:   %2 = cir.load %0 : cir.ptr <!u32i>, !u32i
 // CHECK:   %3 = cir.cast(integral, %2 : !u32i), !u64i
-// CHECK:   cir.call @_ZNSt6vectorI6tripleEC1Em(%1, %3) : (!cir.ptr<!ty_22std3A3Avector22>, !u64i) -> ()
+// CHECK:   cir.call @_ZNSt6vectorI6tripleEC1Em(%1, %3) : (!cir.ptr<![[VEC]]>, !u64i) -> ()
 // CHECK:   cir.scope {
-// CHECK:     %4 = cir.alloca !cir.ptr<!ty_22std3A3Avector22>, cir.ptr <!cir.ptr<!ty_22std3A3Avector22>>, ["__range1", init] {alignment = 8 : i64}
-// CHECK:     %5 = cir.alloca !ty_22__vector_iterator22, cir.ptr <!ty_22__vector_iterator22>, ["__begin1", init] {alignment = 8 : i64}
-// CHECK:     %6 = cir.alloca !ty_22__vector_iterator22, cir.ptr <!ty_22__vector_iterator22>, ["__end1", init] {alignment = 8 : i64}
+// CHECK:     %4 = cir.alloca !cir.ptr<![[VEC]]>, cir.ptr <!cir.ptr<![[VEC]]>>, ["__range1", init] {alignment = 8 : i64}
+// CHECK:     %5 = cir.alloca ![[VEC_IT]], cir.ptr <![[VEC_IT]]>, ["__begin1", init] {alignment = 8 : i64}
+// CHECK:     %6 = cir.alloca ![[VEC_IT]], cir.ptr <![[VEC_IT]]>, ["__end1", init] {alignment = 8 : i64}
 // CHECK:     %7 = cir.alloca !cir.ptr<!ty_22triple22>, cir.ptr <!cir.ptr<!ty_22triple22>>, ["image", init] {alignment = 8 : i64}
-// CHECK:     cir.store %1, %4 : !cir.ptr<!ty_22std3A3Avector22>, cir.ptr <!cir.ptr<!ty_22std3A3Avector22>>
-// CHECK:     %8 = cir.load %4 : cir.ptr <!cir.ptr<!ty_22std3A3Avector22>>, !cir.ptr<!ty_22std3A3Avector22>
-// CHECK:     %9 = cir.call @_ZNSt6vectorI6tripleE5beginEv(%8) : (!cir.ptr<!ty_22std3A3Avector22>) -> !ty_22__vector_iterator22
-// CHECK:     cir.store %9, %5 : !ty_22__vector_iterator22, cir.ptr <!ty_22__vector_iterator22>
-// CHECK:     %10 = cir.load %4 : cir.ptr <!cir.ptr<!ty_22std3A3Avector22>>, !cir.ptr<!ty_22std3A3Avector22>
-// CHECK:     %11 = cir.call @_ZNSt6vectorI6tripleE3endEv(%10) : (!cir.ptr<!ty_22std3A3Avector22>) -> !ty_22__vector_iterator22
-// CHECK:     cir.store %11, %6 : !ty_22__vector_iterator22, cir.ptr <!ty_22__vector_iterator22>
+// CHECK:     cir.store %1, %4 : !cir.ptr<![[VEC]]>, cir.ptr <!cir.ptr<![[VEC]]>>
+// CHECK:     %8 = cir.load %4 : cir.ptr <!cir.ptr<![[VEC]]>>, !cir.ptr<![[VEC]]>
+// CHECK:     %9 = cir.call @_ZNSt6vectorI6tripleE5beginEv(%8) : (!cir.ptr<![[VEC]]>) -> ![[VEC_IT]]
+// CHECK:     cir.store %9, %5 : ![[VEC_IT]], cir.ptr <![[VEC_IT]]>
+// CHECK:     %10 = cir.load %4 : cir.ptr <!cir.ptr<![[VEC]]>>, !cir.ptr<![[VEC]]>
+// CHECK:     %11 = cir.call @_ZNSt6vectorI6tripleE3endEv(%10) : (!cir.ptr<![[VEC]]>) -> ![[VEC_IT]]
+// CHECK:     cir.store %11, %6 : ![[VEC_IT]], cir.ptr <![[VEC_IT]]>
 // CHECK:     cir.loop for(cond : {
-// CHECK:       %12 = cir.call @_ZNK17__vector_iteratorI6triplePS0_RS0_EneERKS3_(%5, %6) : (!cir.ptr<!ty_22__vector_iterator22>, !cir.ptr<!ty_22__vector_iterator22>) -> !cir.bool
+// CHECK:       %12 = cir.call @_ZNK17__vector_iteratorI6triplePS0_RS0_EneERKS3_(%5, %6) : (!cir.ptr<![[VEC_IT]]>, !cir.ptr<![[VEC_IT]]>) -> !cir.bool
 // CHECK:       cir.brcond %12 ^bb1, ^bb2
 // CHECK:     ^bb1:  // pred: ^bb0
 // CHECK:       cir.yield continue
 // CHECK:     ^bb2:  // pred: ^bb0
 // CHECK:       cir.yield
 // CHECK:     }, step : {
-// CHECK:       %12 = cir.call @_ZN17__vector_iteratorI6triplePS0_RS0_EppEv(%5) : (!cir.ptr<!ty_22__vector_iterator22>) -> !cir.ptr<!ty_22__vector_iterator22>
+// CHECK:       %12 = cir.call @_ZN17__vector_iteratorI6triplePS0_RS0_EppEv(%5) : (!cir.ptr<![[VEC_IT]]>) -> !cir.ptr<![[VEC_IT]]>
 // CHECK:       cir.yield
 // CHECK:     }) {
-// CHECK:       %12 = cir.call @_ZNK17__vector_iteratorI6triplePS0_RS0_EdeEv(%5) : (!cir.ptr<!ty_22__vector_iterator22>) -> !cir.ptr<!ty_22triple22>
+// CHECK:       %12 = cir.call @_ZNK17__vector_iteratorI6triplePS0_RS0_EdeEv(%5) : (!cir.ptr<![[VEC_IT]]>) -> !cir.ptr<!ty_22triple22>
 // CHECK:       cir.store %12, %7 : !cir.ptr<!ty_22triple22>, cir.ptr <!cir.ptr<!ty_22triple22>>
 // CHECK:       cir.scope {
 // CHECK:         %13 = cir.alloca !ty_22triple22, cir.ptr <!ty_22triple22>, ["ref.tmp0"] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/vector.cpp
+++ b/clang/test/CIR/CodeGen/vector.cpp
@@ -12,13 +12,13 @@ namespace std {
 } // namespace std
 
 // CHECK: cir.func linkonce_odr @_ZNSt6vectorIyE6resizeEm(
-// CHECK:   %0 = cir.alloca !cir.ptr<!ty_22std3A3Avector22>, cir.ptr <!cir.ptr<!ty_22std3A3Avector22>>, ["this", init] {alignment = 8 : i64}
+// CHECK:   %0 = cir.alloca !cir.ptr<!ty_22std3A3Avector3Cunsigned_long_long3E22>, cir.ptr <!cir.ptr<!ty_22std3A3Avector3Cunsigned_long_long3E22>>, ["this", init] {alignment = 8 : i64}
 // CHECK:   %1 = cir.alloca !u64i, cir.ptr <!u64i>, ["__sz", init] {alignment = 8 : i64}
 // CHECK:   %2 = cir.alloca !u64i, cir.ptr <!u64i>, ["__cs", init] {alignment = 8 : i64}
-// CHECK:   cir.store %arg0, %0 : !cir.ptr<!ty_22std3A3Avector22>, cir.ptr <!cir.ptr<!ty_22std3A3Avector22>>
+// CHECK:   cir.store %arg0, %0 : !cir.ptr<!ty_22std3A3Avector3Cunsigned_long_long3E22>, cir.ptr <!cir.ptr<!ty_22std3A3Avector3Cunsigned_long_long3E22>>
 // CHECK:   cir.store %arg1, %1 : !u64i, cir.ptr <!u64i>
-// CHECK:   %3 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22std3A3Avector22>>, !cir.ptr<!ty_22std3A3Avector22>
-// CHECK:   %4 = cir.call @_ZNKSt6vectorIyE4sizeEv(%3) : (!cir.ptr<!ty_22std3A3Avector22>) -> !u64i
+// CHECK:   %3 = cir.load %0 : cir.ptr <!cir.ptr<!ty_22std3A3Avector3Cunsigned_long_long3E22>>, !cir.ptr<!ty_22std3A3Avector3Cunsigned_long_long3E22>
+// CHECK:   %4 = cir.call @_ZNKSt6vectorIyE4sizeEv(%3) : (!cir.ptr<!ty_22std3A3Avector3Cunsigned_long_long3E22>) -> !u64i
 // CHECK:   cir.store %4, %2 : !u64i, cir.ptr <!u64i>
 // CHECK:   cir.scope {
 // CHECK:     %5 = cir.load %2 : cir.ptr <!u64i>, !u64i


### PR DESCRIPTION
Currently, different specializations of a template will generate distinct types with the same name. To properly differentiate each specialization, this patch includes the template arguments in the name of the type.

This will be required to support mutable structs uniquely identified by their names.