### PR TITLE
[CIR] Forbid identified structs with empty names

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -116,6 +116,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
   );
 
   let skipDefaultBuilders = 1;
+  let genVerifyDecl = 1;
   let builders = [
     // Build an identified and complete struct.
     TypeBuilder<(ins

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -8,7 +8,7 @@ module {
   cir.global external @a = #cir.int<3> : !s32i
   cir.global external @rgb = #cir.const_array<[#cir.int<0> : !s8i, #cir.int<-23> : !s8i, #cir.int<33> : !s8i] : !cir.array<!s8i x 3>>
   cir.global external @b = #cir.const_array<"example\00" : !cir.array<!s8i x 8>>
-  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.ptr<null> : !cir.ptr<!s8i>}> : !cir.struct<struct "" {!s8i, !s64i, !cir.ptr<!s8i>}>
+  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.ptr<null> : !cir.ptr<!s8i>}> : !cir.struct<struct {!s8i, !s64i, !cir.ptr<!s8i>}>
   cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global "private" internal @c : !s32i
   cir.global "private" constant internal @".str2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
@@ -31,7 +31,7 @@ module {
     #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!s8i>,
     #cir.global_view<@type_info_name_B> : !cir.ptr<!s8i>,
     #cir.global_view<@type_info_A> : !cir.ptr<!s8i>}>
-  : !cir.struct<struct "" {!cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>}>
+  : !cir.struct<struct {!cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>}>
   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22Init22>, !s8i)
   cir.func private @_ZN4InitD1Ev(!cir.ptr<!ty_22Init22>)
   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22Init22 {

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -309,7 +309,7 @@ module {
 
   cir.global external @type_info_B = #cir.typeinfo<{ // expected-error {{element at index 0 has type '!cir.ptr<!cir.int<u, 8>>' but return type for this element is '!cir.ptr<!cir.int<u, 32>>'}}
     #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!u8i>}>
-    : !cir.struct<struct "" {!cir.ptr<!u32i>}>
+    : !cir.struct<struct {!cir.ptr<!u32i>}>
 } // expected-error {{'cir.global' expected constant attribute to match type}}
 
 // -----
@@ -549,9 +549,14 @@ module {
   }
 }
 
-
 // -----
 
 !u16i = !cir.int<u, 16>
 // expected-error@+1 {{anonymous structs must be complete}}
 !struct = !cir.struct<struct incomplete>
+
+// -----
+
+!u16i = !cir.int<u, 16>
+// expected-error@+1 {{identified structs cannot have an empty name}}
+!struct = !cir.struct<struct "" incomplete>

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -6,8 +6,8 @@
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-!ty_2222 = !cir.struct<struct "" {!cir.array<!cir.ptr<!u8i> x 5>}>
-!ty_22221 = !cir.struct<struct "" {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+!ty_2222 = !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
+!ty_22221 = !cir.struct<struct {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
 !ty_22A22 = !cir.struct<class "A" incomplete #cir.record.decl.ast>
 !ty_22i22 = !cir.struct<union "i" incomplete>
 !ty_22S22 = !cir.struct<struct "S" {!u8i, !u16i, !u32i}>

--- a/clang/test/CIR/IR/vtableAttr.cir
+++ b/clang/test/CIR/IR/vtableAttr.cir
@@ -4,5 +4,5 @@
 module {
     // Should parse VTable attribute.
     cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
-    // CHECK: cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
+    // CHECK: cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_anon_struct
 }

--- a/clang/test/CIR/IR/vtableAttr.cir
+++ b/clang/test/CIR/IR/vtableAttr.cir
@@ -1,9 +1,8 @@
 // RUN: cir-opt %s | FileCheck %s
 
 !u8i = !cir.int<u, 8>
-!ty_2222 = !cir.struct<struct "" {!cir.array<!cir.ptr<!u8i> x 1>}>
 module {
     // Should parse VTable attribute.
-    cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222
-    // CHECK: cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_2222
+    cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
+    // CHECK: cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
 }


### PR DESCRIPTION
There are instances of CIR where anonymous structs are generated as identified structs with an empty name. This patch Adds a verifier for StructType, which ensures structs have a non-empty name.

This will be required for properly uniqueing mutable CIR structs.