### PR TITLE
[CIR][CIRGen] Support mutable and recursive named records

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -41,7 +41,8 @@ struct StructTypeStorage;
 
 class StructType
     : public Type::TypeBase<StructType, Type, detail::StructTypeStorage,
-                            DataLayoutTypeInterface::Trait> {
+                            DataLayoutTypeInterface::Trait,
+                            TypeTrait::IsMutable> {
 public:
   using Base::Base;
   using Base::getChecked;
@@ -117,6 +118,10 @@ public:
   std::string getPrefixedName() {
     return getKindAsStr() + "." + getName().getValue().str();
   }
+
+  /// Complete the struct type by mutating its members and attributes.
+  void complete(ArrayRef<Type> members, bool packed,
+                ASTRecordDeclInterface ast = {});
 
   /// DataLayoutTypeInterface methods.
   unsigned getTypeSizeInBits(const DataLayout &dataLayout,

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -596,7 +596,7 @@ std::unique_ptr<CIRGenRecordLayout>
 CIRGenTypes::computeRecordLayout(const RecordDecl *D,
                                  mlir::cir::StructType *Ty) {
   CIRRecordLowering builder(*this, D, /*packed=*/false);
-
+  assert(Ty->isIncomplete() && "recomputing record layout?");
   builder.lower(/*nonVirtualBaseType=*/false);
 
   // If we're in C++, compute the base subobject type.

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir-enable -Wno-unused-value -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-// CHECK: !ty_22yep_22 = !cir.struct<struct "yep_" {!u32i, !u32i}>
+// CHECK: !ty_22yep_22 = !cir.struct<struct "yep_" {!cir.int<u, 32>, !cir.int<u, 32>}>
 
 typedef enum xxy_ {
   xxy_Low = 0,

--- a/clang/test/CIR/CodeGen/atomic.cpp
+++ b/clang/test/CIR/CodeGen/atomic.cpp
@@ -7,4 +7,4 @@ typedef struct _a {
 
 void m() { at y; }
 
-// CHECK: !ty_22_a22 = !cir.struct<struct "_a" {!s32i}>
+// CHECK: !ty_22_a22 = !cir.struct<struct "_a" {!cir.int<s, 32>}>

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -27,10 +27,10 @@ typedef struct {
   int a : 3;  // one bitfield with size < 8
   unsigned b;
 } T; 
-// CHECK: !ty_22S22 = !cir.struct<struct "S" {!u32i, !u32i, !u16i, !u32i}>
-// CHECK: !ty_22T22 = !cir.struct<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK: !ty_22anon2E122 = !cir.struct<struct "anon.1" {!u32i} #cir.record.decl.ast>
-// CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!ty_22anon2E122, !u32i, !cir.ptr<!u32i>}>
+// CHECK: !ty_22S22 = !cir.struct<struct "S" {!cir.int<u, 32>, !cir.int<u, 32>, !cir.int<u, 16>, !cir.int<u, 32>}>
+// CHECK: !ty_22T22 = !cir.struct<struct "T" {!cir.int<u, 8>, !cir.int<u, 32>} #cir.record.decl.ast>
+// CHECK: !ty_22anon2E122 = !cir.struct<struct "anon.1" {!cir.int<u, 32>} #cir.record.decl.ast>
+// CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!cir.struct<struct "anon.1" {!cir.int<u, 32>} #cir.record.decl.ast>, !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>}>
 
 // CHECK: cir.func {{.*@store_field}}
 // CHECK:   [[TMP0:%.*]] = cir.alloca !ty_22S22, cir.ptr <!ty_22S22>

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -27,11 +27,10 @@ typedef struct {
   int a : 3;  // one bitfield with size < 8
   unsigned b;
 } T; 
-
-// CHECK: !ty_22S22 = !cir.struct<struct "S" {!u32i, !u32i, !u16i, !u32i}>
-// CHECK: !ty_22T22 = !cir.struct<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK: !ty_22anon2E122 = !cir.struct<struct "anon.1" {!u32i} #cir.record.decl.ast>
-// CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!ty_22anon2E122, !u32i, !cir.ptr<!u32i>}>
+// CHECK: !ty_22S22 = !cir.struct<struct "S" {!cir.int<u, 32>, !cir.int<u, 32>, !cir.int<u, 16>, !cir.int<u, 32>}>
+// CHECK: !ty_22T22 = !cir.struct<struct "T" {!cir.int<u, 8>, !cir.int<u, 32>} #cir.record.decl.ast>
+// CHECK: !ty_22anon2E122 = !cir.struct<struct "anon.1" {!cir.int<u, 32>} #cir.record.decl.ast>
+// CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!cir.struct<struct "anon.1" {!cir.int<u, 32>} #cir.record.decl.ast>, !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>}>
 
 // CHECK: cir.func @_Z11store_field
 // CHECK:   [[TMP0:%.*]] = cir.alloca !ty_22S22, cir.ptr <!ty_22S22>,

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -126,13 +126,13 @@ co_invoke_fn co_invoke;
 
 }} // namespace folly::coro
 
-// CHECK-DAG: ![[IntTask:.*]] = !cir.struct<struct "folly::coro::Task<int>" {!u8i}>
-// CHECK-DAG: ![[VoidTask:.*]] = !cir.struct<struct "folly::coro::Task<void>" {!u8i}>
-// CHECK-DAG: ![[VoidPromisse:.*]] = !cir.struct<struct "folly::coro::Task<void>::promise_type" {!u8i}>
-// CHECK-DAG: ![[CoroHandleVoid:.*]] = !cir.struct<struct "std::coroutine_handle<void>" {!u8i}>
-// CHECK-DAG: ![[CoroHandlePromise:ty_.*]]  = !cir.struct<struct "std::coroutine_handle<folly::coro::Task<void>::promise_type>" {!u8i}>
-// CHECK-DAG: ![[StdString:.*]] = !cir.struct<struct "std::string" {!u8i}>
-// CHECK-DAG: ![[SuspendAlways:.*]] = !cir.struct<struct "std::suspend_always" {!u8i}>
+// CHECK-DAG: ![[IntTask:.*]] = !cir.struct<struct "folly::coro::Task<int>" {!cir.int<u, 8>}>
+// CHECK-DAG: ![[VoidTask:.*]] = !cir.struct<struct "folly::coro::Task<void>" {!cir.int<u, 8>}>
+// CHECK-DAG: ![[VoidPromisse:.*]] = !cir.struct<struct "folly::coro::Task<void>::promise_type" {!cir.int<u, 8>}>
+// CHECK-DAG: ![[CoroHandleVoid:.*]] = !cir.struct<struct "std::coroutine_handle<void>" {!cir.int<u, 8>}>
+// CHECK-DAG: ![[CoroHandlePromise:ty_.*]]  = !cir.struct<struct "std::coroutine_handle<folly::coro::Task<void>::promise_type>" {!cir.int<u, 8>}>
+// CHECK-DAG: ![[StdString:.*]] = !cir.struct<struct "std::string" {!cir.int<u, 8>}>
+// CHECK-DAG: ![[SuspendAlways:.*]] = !cir.struct<struct "std::suspend_always" {!cir.int<u, 8>}>
 
 // CHECK: module {{.*}} {
 // CHECK-NEXT: cir.global external @_ZN5folly4coro9co_invokeE = #cir.zero : !ty_22folly3A3Acoro3A3Aco_invoke_fn22

--- a/clang/test/CIR/CodeGen/ctor.cpp
+++ b/clang/test/CIR/CodeGen/ctor.cpp
@@ -11,7 +11,7 @@ void baz() {
   Struk s;
 }
 
-// CHECK: !ty_22Struk22 = !cir.struct<struct "Struk" {!s32i}>
+// CHECK: !ty_22Struk22 = !cir.struct<struct "Struk" {!cir.int<s, 32>}>
 
 // CHECK:   cir.func linkonce_odr @_ZN5StrukC2Ev(%arg0: !cir.ptr<!ty_22Struk22>
 // CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!ty_22Struk22>, cir.ptr <!cir.ptr<!ty_22Struk22>>, ["this", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -75,8 +75,8 @@ void C3::Layer::Initialize() {
   }
 }
 
-// CHECK-DAG: !ty_22C23A3ALayer22 = !cir.struct<class "C2::Layer" {!ty_22C13A3ALayer22, !cir.ptr<!ty_22C222>
-// CHECK-DAG: !ty_22C33A3ALayer22 = !cir.struct<struct "C3::Layer" {!ty_22C23A3ALayer22
+// CHECK-DAG: !ty_22C23A3ALayer22 = !cir.struct<class "C2::Layer"
+// CHECK-DAG: !ty_22C33A3ALayer22 = !cir.struct<struct "C3::Layer"
 
 // CHECK: cir.func @_ZN2C35Layer10InitializeEv
 

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -37,10 +37,10 @@ public:
 };
 
 // Class A
-// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.record.decl.ast>
+// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>
 
 // Class B
-// CHECK: ![[ClassB:ty_.*]] = !cir.struct<class "B" {![[ClassA]]}>
+// CHECK: ![[ClassB:ty_.*]] = !cir.struct<class "B" {!cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>}>
 
 // CHECK: cir.func @_Z4bluev()
 // CHECK:   %0 = cir.alloca !ty_22PSEvent22, cir.ptr <!ty_22PSEvent22>, ["p", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/forward-decls.cpp
+++ b/clang/test/CIR/CodeGen/forward-decls.cpp
@@ -1,0 +1,89 @@
+// RUN: split-file %s %t
+
+
+//--- incomplete_struct
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %t/incomplete_struct -o %t/incomplete_struct.cir
+// RUN: FileCheck %s --input-file=%t/incomplete_struct.cir --check-prefix=CHECK1
+
+// Foward declaration of the record is never defeined, so it is defined
+// as incomplete and will remain as such.
+
+// CHECK1: ![[INC_STRUCT:.+]] = !cir.struct<struct "IncompleteStruct" incomplete>
+struct IncompleteStruct;
+// CHECK1: testIncompleteStruct(%arg0: !cir.ptr<![[INC_STRUCT]]>
+void testIncompleteStruct(struct IncompleteStruct *s) {};
+
+
+
+//--- mutated_struct
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %t/mutated_struct -o %t/mutated_struct.cir
+// RUN: FileCheck %s --input-file=%t/mutated_struct.cir --check-prefix=CHECK2
+
+// Foward declaration of the struct is followed by usage, then definition.
+// This means it will initially be created as incomplete, then completed.
+
+// CHECK2: ![[COMPLETE:.+]] = !cir.struct<struct "ForwardDeclaredStruct" {!cir.int<s, 32>} #cir.record.decl.ast>
+// CHECK2: testForwardDeclaredStruct(%arg0: !cir.ptr<![[COMPLETE]]>
+struct ForwardDeclaredStruct;
+void testForwardDeclaredStruct(struct ForwardDeclaredStruct *fds) {};
+struct ForwardDeclaredStruct {
+  int testVal;
+};
+
+
+
+//--- recursive_struct
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %t/recursive_struct -o %t/recursive_struct.cir
+// RUN: FileCheck --check-prefix=CHECK3 --input-file=%t/recursive_struct.cir %s
+
+// Struct is initially forward declared since the self-reference is generated
+// first. Then, once the type is fully generated, it is completed.
+
+// CHECK3: ![[STRUCT:.+]] = !cir.struct<struct "RecursiveStruct" {!cir.int<s, 32>, !cir.ptr<!cir.struct<struct "RecursiveStruct">>} #cir.record.decl.ast>
+struct RecursiveStruct {
+  int value;
+  struct RecursiveStruct *next;
+};
+// CHECK3: testRecursiveStruct(%arg0: !cir.ptr<![[STRUCT]]>
+void testRecursiveStruct(struct RecursiveStruct *arg) {
+  // CHECK3: %[[#NEXT:]] = cir.get_member %{{.+}}[1] {name = "next"} : !cir.ptr<![[STRUCT]]> -> !cir.ptr<!cir.ptr<![[STRUCT]]>>
+  // CHECK3: %[[#DEREF:]] = cir.load %[[#NEXT]] : cir.ptr <!cir.ptr<![[STRUCT]]>>, !cir.ptr<![[STRUCT]]>
+  // CHECK3: cir.get_member %[[#DEREF]][0] {name = "value"} : !cir.ptr<![[STRUCT]]> -> !cir.ptr<!s32i>
+  arg->next->value;
+}
+
+
+
+//--- indirect_recursive_struct
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %t/indirect_recursive_struct -o %t/indirect_recursive_struct.cir
+// RUN: FileCheck --check-prefix=CHECK4 --input-file=%t/indirect_recursive_struct.cir %s
+
+// Node B refers to A, and vice-versa, so a forward declaration is used to
+// ensure the classes can be defined. Since types alias are not yet supported
+// in recursive type, each struct is expanded until there are no more recursive
+// types, or all the recursive types are self references.
+
+// CHECK4: ![[B:.+]] = !cir.struct<struct "StructNodeB" {!cir.int<s, 32>, !cir.ptr<!cir.struct<struct "StructNodeA" {!cir.int<s, 32>, !cir.ptr<!cir.struct<struct "StructNodeB">>}
+// CHECK4: ![[A:.+]] = !cir.struct<struct "StructNodeA" {!cir.int<s, 32>, !cir.ptr<!cir.struct<struct "StructNodeB" {!cir.int<s, 32>, !cir.ptr<!cir.struct<struct "StructNodeA">>}
+struct StructNodeB;
+struct StructNodeA {
+  int value;
+  struct StructNodeB *next;
+};
+struct StructNodeB {
+  int value;
+  struct StructNodeA *next;
+};
+
+void testIndirectSelfReference(struct StructNodeA arg) {
+  // CHECK4: %[[#V1:]] = cir.get_member %{{.+}}[1] {name = "next"} : !cir.ptr<![[A]]> -> !cir.ptr<!cir.ptr<![[B]]>>
+  // CHECK4: %[[#V2:]] = cir.load %[[#V1]] : cir.ptr <!cir.ptr<![[B]]>>, !cir.ptr<![[B]]>
+  // CHECK4: %[[#V3:]] = cir.get_member %[[#V2]][1] {name = "next"} : !cir.ptr<![[B]]> -> !cir.ptr<!cir.ptr<![[A]]>>
+  // CHECK4: %[[#V4:]] = cir.load %[[#V3]] : cir.ptr <!cir.ptr<![[A]]>>, !cir.ptr<![[A]]>
+  // CHECK4: cir.get_member %[[#V4]][0] {name = "value"} : !cir.ptr<![[A]]> -> !cir.ptr<!s32i>
+  arg.next->next->value;
+}

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -6,7 +6,7 @@ void fn() {
   a();
 }
 
-//      CHECK: !ty_22anon2E222 = !cir.struct<class "anon.2" {!u8i}>
+//      CHECK: !ty_22anon2E222 = !cir.struct<class "anon.2" {!cir.int<u, 8>}>
 //  CHECK-DAG: module
 
 //      CHECK: cir.func lambda internal private @_ZZ2fnvENK3$_0clEv

--- a/clang/test/CIR/CodeGen/move.cpp
+++ b/clang/test/CIR/CodeGen/move.cpp
@@ -16,7 +16,7 @@ struct string {
 
 } // std namespace
 
-// CHECK: ![[StdString:ty_.*]] = !cir.struct<struct "std::string" {!u8i}>
+// CHECK: ![[StdString:ty_.*]] = !cir.struct<struct "std::string" {!cir.int<u, 8>}>
 
 std::string getstr();
 void emplace(std::string &&s);

--- a/clang/test/CIR/CodeGen/nrvo.cpp
+++ b/clang/test/CIR/CodeGen/nrvo.cpp
@@ -9,7 +9,7 @@ std::vector<const char*> test_nrvo() {
   return result;
 }
 
-// CHECK: ![[VEC:.*]] = !cir.struct<class "std::vector<const char *>" {!cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>}>
+// CHECK: ![[VEC:.*]] = !cir.struct<class "std::vector<const char *>" {!cir.ptr<!cir.ptr<!cir.int<s, 8>>>, !cir.ptr<!cir.ptr<!cir.int<s, 8>>>, !cir.ptr<!cir.ptr<!cir.int<s, 8>>>}>
 
 // CHECK: cir.func @_Z9test_nrvov() -> ![[VEC]]
 // CHECK:   %0 = cir.alloca ![[VEC]], cir.ptr <![[VEC]]>, ["__retval", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -21,9 +21,9 @@ void init(unsigned numImages) {
   }
 }
 
-// CHECK-DAG: !ty_22triple22 = !cir.struct<struct "triple" {!u32i, !cir.ptr<!void>, !u32i}>
-// CHECK-DAG: ![[VEC:.*]] = !cir.struct<class "std::vector<triple>" {!cir.ptr<!ty_22triple22>, !cir.ptr<!ty_22triple22>, !cir.ptr<!ty_22triple22>}>
-// CHECK-DAG: ![[VEC_IT:.*]] = !cir.struct<struct "__vector_iterator<triple, triple *, triple &>" {!cir.ptr<!ty_22triple22>}>
+// CHECK-DAG: !ty_22triple22 = !cir.struct<struct "triple" {!cir.int<u, 32>, !cir.ptr<!cir.void>, !cir.int<u, 32>}>
+// CHECK-DAG: ![[VEC:.*]] = !cir.struct<class "std::vector<triple>" {!cir.ptr<!cir.struct<struct "triple" {!cir.int<u, 32>, !cir.ptr<!cir.void>, !cir.int<u, 32>}>>, !cir.ptr<!cir.struct<struct "triple" {!cir.int<u, 32>, !cir.ptr<!cir.void>, !cir.int<u, 32>}>>, !cir.ptr<!cir.struct<struct "triple" {!cir.int<u, 32>, !cir.ptr<!cir.void>, !cir.int<u, 32>}>>}>
+// CHECK-DAG: ![[VEC_IT:.*]] = !cir.struct<struct "__vector_iterator<triple, triple *, triple &>" {!cir.ptr<!cir.struct<struct "triple" {!cir.int<u, 32>, !cir.ptr<!cir.void>, !cir.int<u, 32>}>
 
 // CHECK: cir.func @_Z4initj(%arg0: !u32i
 // CHECK:   %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["numImages", init] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -22,10 +22,9 @@ void baz(void) {
   struct Foo f;
 }
 
-// CHECK-DAG: !ty_22Node22 = !cir.struct<struct "Node" incomplete>
-// CHECK-DAG: !ty_22Node221 = !cir.struct<struct "Node" {!cir.ptr<!ty_22Node22>} #cir.record.decl.ast>
-// CHECK-DAG: !ty_22Bar22 = !cir.struct<struct "Bar" {!s32i, !s8i}>
-// CHECK-DAG: !ty_22Foo22 = !cir.struct<struct "Foo" {!s32i, !s8i, !ty_22Bar22}>
+// CHECK-DAG: !ty_22Node22 = !cir.struct<struct "Node" {!cir.ptr<!cir.struct<struct "Node">>} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22Bar22 = !cir.struct<struct "Bar" {!cir.int<s, 32>, !cir.int<s, 8>}>
+// CHECK-DAG: !ty_22Foo22 = !cir.struct<struct "Foo" {!cir.int<s, 32>, !cir.int<s, 8>, !cir.struct<struct "Bar" {!cir.int<s, 32>, !cir.int<s, 8>}>}>
 //  CHECK-DAG: module {{.*}} {
      // CHECK:   cir.func @baz()
 // CHECK-NEXT:     %0 = cir.alloca !ty_22Bar22, cir.ptr <!ty_22Bar22>, ["b"] {alignment = 4 : i64}
@@ -96,7 +95,7 @@ void local_decl(void) {
 }
 
 // CHECK-DAG: cir.func @useRecursiveType
-// CHECK-DAG: cir.get_member {{%.}}[0] {name = "next"} : !cir.ptr<!ty_22Node221> -> !cir.ptr<!cir.ptr<!ty_22Node221>>
+// CHECK-DAG: cir.get_member {{%.}}[0] {name = "next"} : !cir.ptr<!ty_22Node22> -> !cir.ptr<!cir.ptr<!ty_22Node22>>
 void useRecursiveType(NodeStru* a) {
   a->next = 0;
 }

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -26,13 +26,13 @@ void baz() {
 struct incomplete;
 void yoyo(incomplete *i) {}
 
-//  CHECK-DAG-DAG: !ty_22incomplete22 = !cir.struct<struct "incomplete" incomplete
-//  CHECK-DAG: !ty_22Bar22 = !cir.struct<struct "Bar" {!s32i, !s8i}>
+//  CHECK-DAG: !ty_22incomplete22 = !cir.struct<struct "incomplete" incomplete
+//  CHECK-DAG: !ty_22Bar22 = !cir.struct<struct "Bar" {!cir.int<s, 32>, !cir.int<s, 8>}>
 
-//  CHECK-DAG: !ty_22Foo22 = !cir.struct<struct "Foo" {!s32i, !s8i, !ty_22Bar22}>
-//  CHECK-DAG: !ty_22Mandalore22 = !cir.struct<struct "Mandalore" {!u32i, !cir.ptr<!void>, !s32i} #cir.record.decl.ast>
-//  CHECK-DAG: !ty_22Adv22 = !cir.struct<class "Adv" {!ty_22Mandalore22}>
-//  CHECK-DAG: !ty_22Entry22 = !cir.struct<struct "Entry" {!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>}>
+//  CHECK-DAG: !ty_22Foo22 = !cir.struct<struct "Foo" {!cir.int<s, 32>, !cir.int<s, 8>, !cir.struct<struct "Bar" {!cir.int<s, 32>, !cir.int<s, 8>}>}>
+//  CHECK-DAG: !ty_22Mandalore22 = !cir.struct<struct "Mandalore" {!cir.int<u, 32>, !cir.ptr<!cir.void>, !cir.int<s, 32>} #cir.record.decl.ast>
+//  CHECK-DAG: !ty_22Adv22 = !cir.struct<class "Adv" {!cir.struct<struct "Mandalore" {!cir.int<u, 32>, !cir.ptr<!cir.void>, !cir.int<s, 32>} #cir.record.decl.ast>}>
+//  CHECK-DAG: !ty_22Entry22 = !cir.struct<struct "Entry" {!cir.ptr<!cir.func<!cir.int<u, 32> (!cir.int<s, 32>, !cir.ptr<!cir.int<s, 8>>, !cir.ptr<!cir.void>)>>}>
 
 //      CHECK: cir.func linkonce_odr @_ZN3Bar6methodEv(%arg0: !cir.ptr<!ty_22Bar22>
 // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_22Bar22>, cir.ptr <!cir.ptr<!ty_22Bar22>>, ["this", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/union.cpp
+++ b/clang/test/CIR/CodeGen/union.cpp
@@ -6,14 +6,15 @@ typedef union { yolo y; struct { int lifecnt; }; } yolm;
 typedef union { yolo y; struct { int *lifecnt; int genpad; }; } yolm2;
 typedef union { yolo y; struct { bool life; int genpad; }; } yolm3;
 
-// CHECK-DAG: !ty_22U23A3ADummy22 = !cir.struct<struct "U2::Dummy" {!s16i, f32} #cir.record.decl.ast>
-// CHECK-DAG: !ty_22anon2E522 = !cir.struct<struct "anon.5" {!cir.bool, !s32i} #cir.record.decl.ast>
-// CHECK-DAG: !ty_22yolo22 = !cir.struct<struct "yolo" {!s32i} #cir.record.decl.ast>
-// CHECK-DAG: !ty_22anon2E322 = !cir.struct<struct "anon.3" {!cir.ptr<!s32i>, !s32i} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22U23A3ADummy22 = !cir.struct<struct "U2::Dummy" {!cir.int<s, 16>, f32} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22anon2E522 = !cir.struct<struct "anon.5" {!cir.bool, !cir.int<s, 32>} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22anon2E122 = !cir.struct<struct "anon.1" {!cir.int<s, 32>} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22yolo22 = !cir.struct<struct "yolo" {!cir.int<s, 32>} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22anon2E322 = !cir.struct<struct "anon.3" {!cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>} #cir.record.decl.ast>
 
-// CHECK-DAG: !ty_22yolm22 = !cir.struct<union "yolm" {!ty_22yolo22, !ty_22anon2E122}>
-// CHECK-DAG: !ty_22yolm322 = !cir.struct<union "yolm3" {!ty_22yolo22, !ty_22anon2E522}>
-// CHECK-DAG: !ty_22yolm222 = !cir.struct<union "yolm2" {!ty_22yolo22, !ty_22anon2E322}>
+// CHECK-DAG: !ty_22yolm22 = !cir.struct<union "yolm" {!cir.struct<struct "yolo" {!cir.int<s, 32>} #cir.record.decl.ast>, !cir.struct<struct "anon.1" {!cir.int<s, 32>} #cir.record.decl.ast>}>
+// CHECK-DAG: !ty_22yolm322 = !cir.struct<union "yolm3" {!cir.struct<struct "yolo" {!cir.int<s, 32>} #cir.record.decl.ast>, !cir.struct<struct "anon.5" {!cir.bool, !cir.int<s, 32>} #cir.record.decl.ast>}>
+// CHECK-DAG: !ty_22yolm222 = !cir.struct<union "yolm2" {!cir.struct<struct "yolo" {!cir.int<s, 32>} #cir.record.decl.ast>, !cir.struct<struct "anon.3" {!cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>} #cir.record.decl.ast>}>
 
 // Should generate a union type with all members preserved.
 union U {
@@ -23,7 +24,7 @@ union U {
   float f;
   double d;
 };
-// CHECK-DAG: !ty_22U22 = !cir.struct<union "U" {!cir.bool, !s16i, !s32i, f32, f64}>
+// CHECK-DAG: !ty_22U22 = !cir.struct<union "U" {!cir.bool, !cir.int<s, 16>, !cir.int<s, 32>, f32, f64}>
 
 // Should generate unions with complex members.
 union U2 {
@@ -33,14 +34,14 @@ union U2 {
     float f;
   } s;
 } u2;
-// CHECK-DAG: !cir.struct<union "U2" {!cir.bool, !ty_22U23A3ADummy22} #cir.record.decl.ast>
+// CHECK-DAG: !cir.struct<union "U2" {!cir.bool, !cir.struct<struct "U2::Dummy" {!cir.int<s, 16>, f32} #cir.record.decl.ast>} #cir.record.decl.ast>
 
 // Should genereate unions without padding.
 union U3 {
   short b;
   U u;
 } u3;
-// CHECK-DAG: !ty_22U322 = !cir.struct<union "U3" {!s16i, !ty_22U22} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22U322 = !cir.struct<union "U3" {!cir.int<s, 16>, !cir.struct<union "U" {!cir.bool, !cir.int<s, 16>, !cir.int<s, 32>, f32, f64}>} #cir.record.decl.ast>
 
 void m() {
   yolm q;

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -18,16 +18,16 @@ public:
 };
 
 // Type info B.
-// CHECK: ![[TypeInfoB:ty_.*]] = !cir.struct<struct {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+// CHECK: ![[TypeInfoB:ty_.*]] = !cir.struct<struct {!cir.ptr<!cir.int<u, 8>>, !cir.ptr<!cir.int<u, 8>>, !cir.ptr<!cir.int<u, 8>>}>
 
 // vtable for A type
-// CHECK: ![[VTableTypeA:ty_.*]] = !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
+// CHECK: ![[VTableTypeA:ty_.*]] = !cir.struct<struct {!cir.array<!cir.ptr<!cir.int<u, 8>> x 5>}>
 
 // Class A
-// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.record.decl.ast>
+// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>
 
 // Class B
-// CHECK: ![[ClassB:ty_.*]] = !cir.struct<class "B" {![[ClassA]]}>
+// CHECK: ![[ClassB:ty_.*]] = !cir.struct<class "B" {!cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>}>
 
 // B ctor => @B::B()
 // Calls @A::A() and initialize __vptr with address of B's vtable.

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -560,3 +560,13 @@ module {
 !u16i = !cir.int<u, 16>
 // expected-error@+1 {{identified structs cannot have an empty name}}
 !struct = !cir.struct<struct "" incomplete>
+
+// -----
+
+// expected-error@+1 {{invalid self-reference within record}}
+!struct = !cir.struct<struct {!cir.struct<struct "SelfReference">}>
+
+// -----
+
+// expected-error@+1 {{record already defined}}
+!struct = !cir.struct<struct "SelfReference" {!cir.struct<struct "SelfReference" {}>}>

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -13,7 +13,16 @@
 !ty_22S22 = !cir.struct<struct "S" {!u8i, !u16i, !u32i}>
 !ty_22S122 = !cir.struct<struct "S1" {!s32i, !s32i}>
 
+// Test recursive struct parsing/printing.
+!ty_22Node22 = !cir.struct<struct "Node" {!cir.ptr<!cir.struct<struct "Node">>} #cir.record.decl.ast>
+// CHECK-DAG: !cir.struct<struct "Node" {!cir.ptr<!cir.struct<struct "Node">>} #cir.record.decl.ast>
+
 module  {
+  // Dummy function to use types and force them to be printed.
+  cir.func @useTypes(%arg0: !ty_22Node22) {
+    cir.return
+  }
+
   cir.func @structs() {
     %0 = cir.alloca !cir.ptr<!cir.struct<struct "S" {!u8i, !u16i, !u32i}>>, cir.ptr <!cir.ptr<!cir.struct<struct "S" {!u8i, !u16i, !u32i}>>>, ["s", init]
     %1 = cir.alloca !cir.ptr<!cir.struct<union "i" incomplete>>, cir.ptr <!cir.ptr<!cir.struct<union "i" incomplete>>>, ["i", init]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #303
* #302

This allows a named StructType to be mutated after it has been created,
if it is identified and incomplete.

The motivation for this is to improve the codegen of CIR in certain
scenarios where an incomplete type is used and later completed. These
usually leave the IR in an inconsistent state, where there are two
records types with the same identifier but different definitions (one
complete the other incomplete).

For example:

```c++
struct Node {
  Node *next;
};
void test(struct Node n) {}
```

Generates:

```mlir
!temp_struct = !cir.struct<struct "Node" incomplete>
!full_struct = !cir.struct<struct "Node" {!cir.ptr<!temp_struct>}>
```

To generate the `Node` struct type, its members must be created first.
However, the `next` member is a recursive reference, so it can only be
completed after its parent. This generates a temporary incomplete
definition of the `Node` type that remains in the code even after the
type to which it refers is completed. As a consequence, accessing the
`next` member of a `Node` value fetches the old incomplete version of
the type which affects CIR's type-checking capabilities.

This patch ensures that, once the parent is fully visited, the `next`
member can be completed in place, automatically updating any references
to it at a low cost. To represent recursive types, the StructType now
is equipped with self-references. These are represented by a
`cir.struct` type with just the name of the parent struct that it
refers to. The same snippet of code will not generate the following
CIR IR:

```mlir
!full_struct = !cir.struct<struct "Node" {!cir.ptr<!cir.struct<struct "Node">>}>
```

Summary of the changes made:
 - Named records are now uniquely identified by their name. An attempt
   to create a new record with the same will fail.
 - Anonymous records are uniquely identified by members and other
   relevant attributes.
 - StructType has a new `mutate` method that allows it to be mutated
   after it has been created. Each type can only be mutated if it is
   identified and incomplete, rendering further changes impossible.
 - When building a new name StructType, the builder will try to first
   create, then complete the type, ensuring that:

    - Inexistent types are created
    - Existing incomplete types are completed
    - Existing complete types with matching attributes are reused
    - Existing complete types with different attributes raise errors

 - StructType now uses the CyclicParser/Printer guard to avoid infinite
   recursion and identify when it should print/parse a self-reference.