### PR TITLE
[CIR][CodeGen] Support global variable offsets in initializers (gh-299).

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1004,10 +1004,10 @@ struct ConstantLValue {
   /*implicit*/ ConstantLValue(mlir::Value value, bool hasOffsetApplied = false)
       : Value(value), HasOffsetApplied(hasOffsetApplied) {}
 
-  /*implicit*/ ConstantLValue(mlir::cir::GlobalViewAttr address) : Value(address) {}
+  /*implicit*/ ConstantLValue(mlir::cir::GlobalViewAttr address)
+      : Value(address), HasOffsetApplied(false) {}
 
   ConstantLValue(std::nullptr_t) : ConstantLValue({}, false) {}
-  ConstantLValue(mlir::Attribute value) : Value(value) {}
 };
 
 /// A helper class for emitting constant l-values.
@@ -1049,8 +1049,22 @@ private:
 
   bool hasNonZeroOffset() const { return !Value.getLValueOffset().isZero(); }
 
-  /// Return the value offset.
-  mlir::Attribute getOffset() { llvm_unreachable("NYI"); }
+  /// Return GEP-like value offset
+  mlir::ArrayAttr getOffset(mlir::Type Ty) {
+    auto Offset = Value.getLValueOffset().getQuantity();
+    CIRDataLayout Layout(CGM.getModule());
+    SmallVector<int64_t, 3> Idx;
+    CGM.getBuilder().computeGlobalViewIndicesFromFlatOffset(Offset, Ty, Layout,
+                                                            Idx);
+
+    llvm::SmallVector<mlir::Attribute, 3> Indices;
+    for (auto I : Idx) {
+      auto Attr = mlir::cir::IntAttr::get(CGM.getBuilder().getSInt64Ty(), I);
+      Indices.push_back(Attr);
+    }
+
+    return CGM.getBuilder().getArrayAttr(Indices);
+  }
 
   // TODO(cir): create a proper interface to absctract CIR constant values.
 
@@ -1058,6 +1072,14 @@ private:
   ConstantLValue applyOffset(ConstantLValue &C) {
     if (!hasNonZeroOffset())
       return C;
+
+    if (auto Attr = C.Value.dyn_cast<mlir::Attribute>()) {
+      auto GV = cast<mlir::cir::GlobalViewAttr>(Attr);
+      assert(!GV.getIndices());
+
+      return mlir::cir::GlobalViewAttr::get(
+          GV.getType(), GV.getSymbol(), getOffset(GV.getType()));
+    }
 
     // TODO(cir): use ptr_stride, or something...
     llvm_unreachable("NYI");
@@ -1094,7 +1116,7 @@ mlir::Attribute ConstantLValueEmitter::tryEmit() {
     return {};
 
   // Apply the offset if necessary and not already done.
-  if (!result.HasOffsetApplied && !value.is<mlir::Attribute>()) {
+  if (!result.HasOffsetApplied) {
     value = applyOffset(result).Value;
   }
 

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -47,6 +47,9 @@ struct {
 } nestedStringPtr = {"1"};
 // CHECK: cir.global external @nestedStringPtr = #cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>}>
 
+int *globalPtr = &nestedString.y[1];
+// CHECK: cir.global external @globalPtr = #cir.global_view<@nestedString, [#cir.int<0> : !s64i, #cir.int<1> : !s64i, #cir.int<1> : !s64i]>
+
 // TODO: test tentatives with internal linkage.
 
 // Tentative definition is THE definition. Should be zero-initialized.


### PR DESCRIPTION
This PR adds proper handling for address offsets in global initializers as e.g. in
```
int val[10];                                                                     
int *addr = &val[1];                                                               
```
(such offsets are ignored on current trunk).

I'm not proud of this patch because it performs an ugly conversion from byte offset, produced by `APValue::getLValueOffset`, to a sequence of CIR indices. Alternative suggestions are welcomed.