### PR TITLE
[CIR] Support bool-to-float conversions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -55,6 +55,7 @@ def CK_PointerToIntegral : I32EnumAttrCase<"ptr_to_int", 9>;
 def CK_FloatToBoolean : I32EnumAttrCase<"float_to_bool", 10>;
 def CK_BooleanToIntegral : I32EnumAttrCase<"bool_to_int", 11>;
 def CK_IntegralToFloat : I32EnumAttrCase<"int_to_float", 12>;
+def CK_BooleanToFloat : I32EnumAttrCase<"bool_to_float", 13>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
@@ -62,7 +63,7 @@ def CastKind : I32EnumAttr<
     [CK_IntegralToBoolean, CK_ArrayToPointerDecay, CK_IntegralCast,
      CK_BitCast, CK_FloatingCast, CK_PtrToBoolean, CK_FloatToIntegral,
      CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean,
-     CK_BooleanToIntegral, CK_IntegralToFloat]> {
+     CK_BooleanToIntegral, CK_IntegralToFloat, CK_BooleanToFloat]> {
   let cppNamespace = "::mlir::cir";
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1636,7 +1636,7 @@ mlir::Value ScalarExprEmitter::buildScalarCast(
     if (CGF.getBuilder().isInt(DstTy)) {
       CastKind = mlir::cir::CastKind::bool_to_int;
     } else if (DstTy.isa<mlir::FloatType>()) {
-      llvm_unreachable("NYI: bool->float cast");
+      CastKind = mlir::cir::CastKind::bool_to_float;
     } else {
       llvm_unreachable("Internal error: Cast to unexpected type");
     }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -344,12 +344,20 @@ LogicalResult CastOp::verify() {
       return emitOpError() << "requires !cir.int for result";
     return success();
   }
-  case cir::CastKind::int_to_float:
+  case cir::CastKind::int_to_float: {
     if (!srcType.isa<mlir::cir::IntType>())
       return emitOpError() << "requires !cir.int for source";
     if (!resType.isa<mlir::FloatType>())
       return emitOpError() << "requires !cir.float for result";
     return success();
+  }
+  case cir::CastKind::bool_to_float: {
+    if (!srcType.isa<mlir::cir::BoolType>())
+      return emitOpError() << "requires !cir.bool for source";
+    if (!resType.isa<mlir::FloatType>())
+      return emitOpError() << " requires !cir.float for result";
+    return success();
+  }
   }
 
   llvm_unreachable("Unknown CastOp kind?");

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -355,7 +355,7 @@ LogicalResult CastOp::verify() {
     if (!srcType.isa<mlir::cir::BoolType>())
       return emitOpError() << "requires !cir.bool for source";
     if (!resType.isa<mlir::FloatType>())
-      return emitOpError() << " requires !cir.float for result";
+      return emitOpError() << "requires !cir.float for result";
     return success();
   }
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -647,6 +647,14 @@ public:
                                                       llvmSrcVal);
       return mlir::success();
     }
+    case mlir::cir::CastKind::bool_to_float: {
+      auto dstTy = castOp.getType();
+      auto llvmSrcVal = adaptor.getOperands().front();
+      auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::UIToFPOp>(castOp, llvmDstTy,
+                                                        llvmSrcVal);
+      return mlir::success();
+    }
     case mlir::cir::CastKind::int_to_float: {
       auto dstTy = castOp.getType();
       auto llvmSrcVal = adaptor.getOperands().front();

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -68,10 +68,13 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
   unsigned fptoui = (unsigned)x3; // Floating point to unsigned integer
   // CHECK: %{{.+}} = cir.cast(float_to_int, %{{[0-9]+}} : f32), !u32i
 
-  bool ib = (bool)x1; // No checking, because this isn't a cast.
+  bool ib = (bool)x1; // No checking, because this isn't a regular cast.
 
   int bi = (int)ib; // bool to int
   // CHECK: %{{[0-9]+}} = cir.cast(bool_to_int, %{{[0-9]+}} : !cir.bool), !s32i
+
+  float bf = (float)ib; // bool to float
+  // CHECK: %{{[0-9]+}} = cir.cast(bool_to_float, %{{[0-9]+}} : !cir.bool), f32
 
   float dptofp = (float)x5;
   // CHECK: %{{.+}} = cir.cast(floating, %{{[0-9]+}} : f64), f32

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -159,6 +159,20 @@ cir.func @cast4(%p: !cir.ptr<!u32i>) {
 
 // -----
 
+cir.func @cast5(%p: f32) {
+  %2 = cir.cast(bool_to_float, %p : f32), f32 // expected-error {{requires !cir.bool for source}}
+  cir.return
+}
+
+// -----
+
+cir.func @cast6(%p: !cir.bool) {
+  %2 = cir.cast(bool_to_float, %p : !cir.bool), !cir.int<u, 32> // expected-error {{requires !cir.float for result}}
+  cir.return
+}
+
+// -----
+
 #false = #cir.bool<false> : !cir.bool
 #true = #cir.bool<true> : !cir.bool
 cir.func @b0() {


### PR DESCRIPTION
Add a new entry to enum `CastKind`, `bool_to_float`, since none of the existing enum values adequately covered that conversion.  Add code to code gen, CIR validation, LLVM lowering, and the cast test to cover this conversion.

Fix ClangIR issue #290