### PR TITLE
[CIR][CodeGen][Bugfix] fixes explicit cast in initialization

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -9,7 +9,6 @@
 // This contains code to emit Constant Expr nodes as LLVM code.
 //
 //===----------------------------------------------------------------------===//
-
 #include "Address.h"
 #include "CIRDataLayout.h"
 #include "CIRGenCstEmitter.h"
@@ -704,7 +703,7 @@ public:
 
   mlir::Attribute VisitCastExpr(CastExpr *E, QualType destType) {
     if (const auto *ECE = dyn_cast<ExplicitCastExpr>(E))
-      llvm_unreachable("NYI");
+      CGM.buildExplicitCastExprType(ECE, Emitter.CGF);
     Expr *subExpr = E->getSubExpr();
 
     switch (E->getCastKind()) {

--- a/clang/test/CIR/CodeGen/constptr.c
+++ b/clang/test/CIR/CodeGen/constptr.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o - | FileCheck %s -check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
-// XFAIL: *
 
 int *p = (int*)0x1234;
 


### PR DESCRIPTION
The PR fixes a var initialization with explicit cast. 
