### PR TITLE
[CIR] Fix bool-to-pointer conversions

### DIFF
--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -76,6 +76,10 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
   float bf = (float)ib; // bool to float
   // CHECK: %{{[0-9]+}} = cir.cast(bool_to_float, %{{[0-9]+}} : !cir.bool), f32
 
+  void* bpv = (void*)ib; // bool to pointer, which is done in two steps
+  // CHECK: %[[TMP:[0-9]+]] = cir.cast(bool_to_int,  %{{[0-9]+}} : !cir.bool), !u64i
+  // CHECK: %{{[0-9]+}} = cir.cast(int_to_ptr, %[[TMP]] : !u64i), !cir.ptr<!void>
+
   float dptofp = (float)x5;
   // CHECK: %{{.+}} = cir.cast(floating, %{{[0-9]+}} : f64), f32
 


### PR DESCRIPTION
Conversions from an integer to a pointer are implemented in CIR code gen as an integral conversion to uintptr_t followed by the integral-to-pointer conversion.  Conversions from bool to pointer were following the same code path.  But bool-to-int is a different CastKind than int-to-int in CIR, and CIR was failing validation.  Fix the integer to pointer conversion code to correctly handle a source type of bool.

(A conversion from bool to pointer makes no sense and should never happen in the real world.  But it is legal due to bool being sort of an integral type.  So we need to support it.)

Also, in `ScalarExprEmitter::buildScalarConversion` change a couple not-yet-implemented messages about pointer types into assertion failures.  Conversions involving pointer types should never go through `ScalarExprEmitter::buildScalarConversion`.