### PR TITLE
[CIR][Codegen][Bugfix] ensure proper tmp location for agg exprs

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1208,7 +1208,7 @@ RValue CIRGenFunction::buildCall(clang::QualType CalleeType,
 /// Emit code to compute the specified expression, ignoring the result.
 void CIRGenFunction::buildIgnoredExpr(const Expr *E) {
   if (E->isPRValue())
-    return (void)buildAnyExpr(E);
+    return (void)buildAnyExpr(E, AggValueSlot::ignored(), true);
 
   // Just emit it as an l-value and drop the result.
   buildLValue(E);

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -43,9 +43,11 @@ class AggExprEmitter : public StmtVisitor<AggExprEmitter> {
   void withReturnValueSlot(const Expr *E,
                            llvm::function_ref<RValue(ReturnValueSlot)> Fn);
 
-  AggValueSlot EnsureSlot(QualType T) {
-    assert(!Dest.isIgnored() && "ignored slots NYI");
-    return Dest;
+  AggValueSlot EnsureSlot(mlir::Location loc, QualType T) {
+    // assert(!Dest.isIgnored() && "ignored slots NYI");
+    // return Dest;
+    if (!Dest.isIgnored()) return Dest;
+    return CGF.CreateAggTemp(T, loc, "agg.tmp.ensured");    
   }
 
   void EnsureDest(mlir::Location loc, QualType T) {
@@ -501,7 +503,7 @@ void AggExprEmitter::VisitMaterializeTemporaryExpr(
 }
 
 void AggExprEmitter::VisitCXXConstructExpr(const CXXConstructExpr *E) {
-  AggValueSlot Slot = EnsureSlot(E->getType());
+  AggValueSlot Slot = EnsureSlot(CGF.getLoc(E->getSourceRange()), E->getType());
   CGF.buildCXXConstructExpr(E, Slot);
 }
 
@@ -523,7 +525,7 @@ void AggExprEmitter::VisitExprWithCleanups(ExprWithCleanups *E) {
 
 void AggExprEmitter::VisitLambdaExpr(LambdaExpr *E) {
   CIRGenFunction::SourceLocRAIIObject loc{CGF, CGF.getLoc(E->getSourceRange())};
-  AggValueSlot Slot = EnsureSlot(E->getType());
+  AggValueSlot Slot = EnsureSlot(CGF.getLoc(E->getSourceRange()), E->getType());
   LLVM_ATTRIBUTE_UNUSED LValue SlotLV =
       CGF.makeAddrLValue(Slot.getAddress(), E->getType());
 
@@ -751,7 +753,8 @@ void AggExprEmitter::VisitCXXParenListOrInitListExpr(
   }
 #endif
 
-  AggValueSlot Dest = EnsureSlot(ExprToVisit->getType());
+  AggValueSlot Dest = EnsureSlot(CGF.getLoc(ExprToVisit->getSourceRange()),
+                                 ExprToVisit->getType());
 
   LValue DestLV = CGF.makeAddrLValue(Dest.getAddress(), ExprToVisit->getType());
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -44,10 +44,8 @@ class AggExprEmitter : public StmtVisitor<AggExprEmitter> {
                            llvm::function_ref<RValue(ReturnValueSlot)> Fn);
 
   AggValueSlot EnsureSlot(mlir::Location loc, QualType T) {
-    // assert(!Dest.isIgnored() && "ignored slots NYI");
-    // return Dest;
     if (!Dest.isIgnored()) return Dest;
-    return CGF.CreateAggTemp(T, loc, "agg.tmp.ensured");    
+    return CGF.CreateAggTemp(T, loc, "agg.tmp.ensured");
   }
 
   void EnsureDest(mlir::Location loc, QualType T) {

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -17,7 +17,7 @@ typedef struct yep_ {
 void use() { yop{}; }
 
 // CHECK: cir.func @_Z3usev()
-// CHECK:   %0 = cir.alloca !ty_22yep_22, cir.ptr <!ty_22yep_22>, ["agg.tmp0"] {alignment = 4 : i64}
+// CHECK:   %0 = cir.alloca !ty_22yep_22, cir.ptr <!ty_22yep_22>, ["agg.tmp.ensured"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.get_member %0[0] {name = "Status"} : !cir.ptr<!ty_22yep_22> -> !cir.ptr<!u32i>
 // CHECK:   %2 = cir.const(#cir.int<0> : !u32i) : !u32i
 // CHECK:   cir.store %2, %1 : !u32i, cir.ptr <!u32i>

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -47,14 +47,14 @@ public:
 // foo - zero initialize object B and call ctor (@B::B())
 //
 // CHECK: cir.func @_Z3foov()
-// CHECK:     %0 = cir.alloca ![[ClassB]], cir.ptr <![[ClassB]]>, ["agg.tmp0"] {alignment = 8 : i64}
-// CHECK:     cir.scope {
-// CHECK:       %1 = cir.const(#cir.zero : ![[ClassB]]) : ![[ClassB]]
-// CHECK:       cir.store %1, %0 : ![[ClassB]], cir.ptr <![[ClassB]]>
-// CHECK:       cir.call @_ZN1BC2Ev(%0) : (!cir.ptr<![[ClassB]]>) -> ()
-// CHECK:     }
-// CHECK:     cir.return
+// CHECK:   cir.scope {
+// CHECK:     %0 = cir.alloca !ty_22B22, cir.ptr <!ty_22B22>, ["agg.tmp.ensured"] {alignment = 8 : i64}
+// CHECK:     %1 = cir.const(#cir.zero : ![[ClassB]]) : ![[ClassB]]
+// CHECK:     cir.store %1, %0 : ![[ClassB]], cir.ptr <![[ClassB]]>
+// CHECK:     cir.call @_ZN1BC2Ev(%0) : (!cir.ptr<![[ClassB]]>) -> ()
 // CHECK:   }
+// CHECK:   cir.return
+// CHECK: }
 
 // Vtable definition for A
 // CHECK: cir.global "private" external @_ZTV1A : ![[VTableTypeA]] {alignment = 8 : i64}


### PR DESCRIPTION
This PR fixes a bug with wrong arguments passed into the call to `buildAnyExpr`. This function has args with default  values, hence the bug occurred. 
All the changes are even with the clang's original codegen.

For the reference, the LLVM IR code for `agg-init.cpp::usev()` function looks like the following:
```
define dso_local void @_Z3usev() #0 {
entry:
  %agg.tmp.ensured = alloca %struct.yep_, align 4
  %Status = getelementptr inbounds %struct.yep_, ptr %agg.tmp.ensured, i32 0, i32 0
  store i32 0, ptr %Status, align 4
  %HC = getelementptr inbounds %struct.yep_, ptr %agg.tmp.ensured, i32 0, i32 1
  store i32 0, ptr %HC, align 4
  ret void
}
```
