### PR TITLE
[CIR][CodeGen] inline assembler: build CIR operation

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2196,4 +2196,52 @@ def ZeroInitConstOp : CIR_Op<"llvmir.zeroinit", [Pure]>,
   let hasVerifier = 0;
 }
 
+def AsmATT : I32EnumAttrCase<"AD_ATT", 0>;
+def AsmIntel : I32EnumAttrCase<"AD_Intel", 1>;
+
+def AsmATTOrIntel : I32EnumAttr<
+  "AsmDialect",
+  "ATT or Intel",
+  [AsmATT, AsmIntel]> {
+  let cppNamespace = "::mlir::cir";
+}
+
+def CIR_InlineAsmOp : CIR_Op<"inline_asm"> {
+  let description = [{
+    The InlineAsmOp mirrors the underlying LLVM semantics with a notable
+    exception: the embedded `asm_string` is not allowed to define or reference
+    any symbol or any global variable: only the operands of the op may be read,
+    written, or referenced.
+    Attempting to define or reference any symbol or any global behavior is
+    considered undefined behavior at this time.
+  }];
+  let arguments = (
+    ins Variadic<AnyType>:$operands,
+        StrAttr:$asm_string,
+        StrAttr:$constraints,
+        UnitAttr:$has_side_effects,
+        UnitAttr:$is_align_stack,
+        OptionalAttr<
+          DefaultValuedAttr<AsmATTOrIntel, "AsmDialect::AD_ATT">>:$asm_dialect,
+        OptionalAttr<ArrayAttr>:$operand_attrs);
+
+  let results = (outs Optional<AnyType>:$res);
+
+  let assemblyFormat = [{
+    (`has_side_effects` $has_side_effects^)?
+    (`is_align_stack` $is_align_stack^)?
+    (`asm_dialect` `=` $asm_dialect^)?
+    (`operand_attrs` `=` $operand_attrs^)?
+    attr-dict
+    $asm_string `,` $constraints
+    operands `:` functional-type(operands, results)
+   }];
+
+  let extraClassDeclaration = [{
+    static StringRef getElementTypeAttrName() {
+      return "elementtype";
+    }
+  }];
+}
+
 #endif // MLIR_CIR_DIALECT_CIR_OPS

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -1,0 +1,54 @@
+#include "clang/Basic/DiagnosticSema.h"
+#include "llvm/ADT/StringExtras.h"
+
+#include "CIRGenFunction.h"
+#include "TargetInfo.h"
+
+using namespace cir;
+using namespace clang;
+using namespace mlir::cir;
+
+static AsmDialect inferDialect(const CIRGenModule &cgm, const AsmStmt &S) {
+  AsmDialect GnuAsmDialect =
+      cgm.getCodeGenOpts().getInlineAsmDialect() == CodeGenOptions::IAD_ATT
+          ? AsmDialect::AD_ATT
+          : AsmDialect::AD_Intel;
+
+  return isa<MSAsmStmt>(&S) ? AsmDialect::AD_Intel : GnuAsmDialect;
+}
+
+mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
+  // Assemble the final asm string.
+  std::string AsmString = S.generateAsmString(getContext());
+
+  std::string Constraints;
+  std::vector<mlir::Type> ResultRegTypes;
+  std::vector<mlir::Value> Args;
+
+  assert(!S.getNumOutputs() && "NYI");
+  assert(!S.getNumInputs() && "NYI");
+  assert(!S.getNumClobbers() && "NYI");
+
+  mlir::Type ResultType;
+
+  if (ResultRegTypes.empty())
+    ResultType = builder.getVoidTy();
+  else if (ResultRegTypes.size() == 1)
+    ResultType = ResultRegTypes[0];
+  else {
+    auto sname = builder.getUniqueAnonRecordName();
+    ResultType =
+        builder.getCompleteStructTy(ResultRegTypes, sname, false, nullptr);
+  }
+
+  bool HasSideEffect = S.isVolatile() || S.getNumOutputs() == 0;
+  AsmDialect AsmDialect = inferDialect(CGM, S);
+
+  builder.create<mlir::cir::InlineAsmOp>(
+      getLoc(S.getAsmLoc()), ResultType, Args, AsmString, Constraints,
+      HasSideEffect,
+      /* IsAlignStack */ false,
+      AsmDialectAttr::get(builder.getContext(), AsmDialect), mlir::ArrayAttr());
+
+  return mlir::success();
+}

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1055,6 +1055,8 @@ public:
 
   mlir::Type convertType(clang::QualType T);
 
+  mlir::LogicalResult buildAsmStmt(const clang::AsmStmt &S);
+
   mlir::LogicalResult buildIfStmt(const clang::IfStmt &S);
 
   mlir::LogicalResult buildReturnStmt(const clang::ReturnStmt &S);

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -154,6 +154,7 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
   // When implemented, GCCAsmStmtClass should fall-through to MSAsmStmtClass.
   case Stmt::GCCAsmStmtClass:
   case Stmt::MSAsmStmtClass:
+    return buildAsmStmt(cast<AsmStmt>(*S));
   case Stmt::CapturedStmtClass:
   case Stmt::ObjCAtTryStmtClass:
   case Stmt::ObjCAtThrowStmtClass:

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -7,6 +7,7 @@ set(
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_clang_library(clangCIR
+  CIRAsm.cpp
   CIRGenBuiltin.cpp
   CIRGenCXX.cpp
   CIRGenCXXABI.cpp

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+//CHECK: cir.inline_asm has_side_effects asm_dialect = AD_ATT "", ""  : () -> !void
+void empty1() {
+  __asm__ volatile("" : : : );
+}
+
+//CHECK: cir.inline_asm has_side_effects asm_dialect = AD_ATT "xyz", ""  : () -> !void
+void empty2() {
+  __asm__ volatile("xyz" : : : );
+}


### PR DESCRIPTION
I will break the PR #308 into pieces and submit them one-by-one.

The first PR introduce CIR operation and the  `buildAsmStmt`  function, the main place for the future changes. 
There is nothing else interesting happen here, but now we can at least emit cir for an empty inline assembler. 