### PR TITLE
[CIR][IR] harden the get_member verifier

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2423,14 +2423,6 @@ LogicalResult MemCpyOp::verify() {
   return mlir::success();
 }
 
-static bool isIncompleteType(mlir::Type typ) {
-  if (auto ptr = typ.dyn_cast<PointerType>())
-    return isIncompleteType(ptr.getPointee());
-  else if (auto rec = typ.dyn_cast<StructType>())
-    return rec.isIncomplete();
-  return false;
-}
-
 //===----------------------------------------------------------------------===//
 // GetMemberOp Definitions
 //===----------------------------------------------------------------------===//
@@ -2441,21 +2433,12 @@ LogicalResult GetMemberOp::verify() {
   if (!recordTy)
     return emitError() << "expected pointer to a record type";
 
-  // FIXME: currently we bypass typechecking of incomplete types due to errors
-  // in the codegen process. This should be removed once the codegen is fixed.
-  if (isIncompleteType(recordTy))
-    return mlir::success();
-
   if (recordTy.getMembers().size() <= getIndex())
     return emitError() << "member index out of bounds";
 
   // FIXME(cir): member type check is disabled for classes as the codegen for
   // these still need to be patched.
-  // Also we bypass the typechecking for the fields of incomplete types.
-  bool shouldSkipMemberTypeMismatch =
-    recordTy.isClass() || isIncompleteType(recordTy.getMembers()[getIndex()]);
-
-  if (!shouldSkipMemberTypeMismatch
+  if (!recordTy.isClass()
       && recordTy.getMembers()[getIndex()] != getResultTy().getPointee())
     return emitError() << "member type mismatch";
 

--- a/clang/test/CIR/IR/getmember.cir
+++ b/clang/test/CIR/IR/getmember.cir
@@ -15,13 +15,6 @@ module  {
     cir.return
   }
 
-  // FIXME: remove bypass once codegen for CIR records is patched.
-  cir.func @shouldBypassMemberIndexCheckForIncompleteRecords(%arg0 : !cir.ptr<!ty_22Incomplete22>) {
-    // CHECK: cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Incomplete22> -> !cir.ptr<!u32i>
-    %0 = cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Incomplete22> -> !cir.ptr<!u32i>
-    cir.return
-  }
-
   // FIXME: remove bypass once codegen for CIR class records is patched.
   cir.func @shouldBypassMemberTypeCheckForClassRecords(%arg0 : !cir.ptr<!ty_22Class22>) {
     // CHECK: cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_22Class22> -> !cir.ptr<!cir.ptr<!u32i>> 


### PR DESCRIPTION
I think it's time to claim that CIR supports recursive types (many thanks to #303 and to @sitio-couto :) )
And we can bring back the `get_member` verification back, with no checks for incomplete types. What do you think?