### PR TITLE
Setup github test CIR workflow.

### DIFF
--- a/.github/workflows/clang-cir-tests.yml
+++ b/.github/workflows/clang-cir-tests.yml
@@ -1,0 +1,37 @@
+name: Clang CIR Tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'clang/**'
+      - '.github/workflows/clang-cir-tests.yml'
+      - '.github/workflows/llvm-project-tests.yml'
+      - '!llvm/**'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'clang/**'
+      - '.github/workflows/clang-cir-tests.yml'
+      - '.github/workflows/llvm-project-tests.yml'
+      - '!llvm/**'
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  check_clang_cir:
+    name: Test clang-cir
+    uses: ./.github/workflows/llvm-project-tests.yml
+    with:
+      build_target: check-clang-cir
+      projects: clang;mlir;cir


### PR DESCRIPTION
Closes #288 

The action mirrors https://github.com/llvm/llvm-project/blob/main/.github/workflows/clang-tests.yml with a few minor differences:
 - it is not restricted to: `github.repository_owner == 'llvm'`
 - it triggers on pull requests and pushes to `main` instead of  `release` branches

I suggest adding branch protection rule to require tests to pass for each pull request:
`Settings -> Branches -> Add branch protection rule -> Require status checks to pass before merging`