### PR TITLE
[CIR][CodeGen] adds array size into AllocaOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -299,7 +299,7 @@ def AllocaOp : CIR_Op<"alloca", [
   }];
 
   let arguments = (ins
-    Optional<CIR_IntType>:$arraySize,
+    Optional<CIR_IntType>:$dynAllocSize,
     TypeAttr:$allocaType,
     StrAttr:$name,
     UnitAttr:$init,
@@ -331,13 +331,15 @@ def AllocaOp : CIR_Op<"alloca", [
   let extraClassDeclaration = [{
     // Whether the alloca input type is a pointer.
     bool isPointerType() { return getAllocaType().isa<::mlir::cir::PointerType>(); }
+
+    bool isDynamic() { return (bool)getDynAllocSize(); }
   }];
 
   // FIXME: we should not be printing `cir.ptr` below, that should come
   // from the pointer type directly.
   let assemblyFormat = [{
     $allocaType `,` `cir.ptr` type($addr) `,`
-    ($arraySize^ `:` type($arraySize) `,`)?
+    ($dynAllocSize^ `:` type($dynAllocSize) `,`)?
     `[` $name
        (`,` `init` $init^)?
     `]`

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -284,6 +284,9 @@ def AllocaOp : CIR_Op<"alloca", [
     cases, the first use contains the initialization (a cir.store, a cir.call
     to a ctor, etc).
 
+    The `dynAllocSize` is a number of elements to be allocated on the stack.
+    Once not specified, the number of elements allocated is one.
+
     The result type is a pointer to the input's type.
 
     Example:

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -315,6 +315,7 @@ def AllocaOp : CIR_Op<"alloca", [
     OpBuilder<(ins "Type":$addr, "Type":$allocaType,
                    "StringRef":$name,
                    "IntegerAttr":$alignment)>,
+
     OpBuilder<(ins "Type":$addr,
                    "Type":$allocaType,
                    "StringRef":$name,

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -284,8 +284,9 @@ def AllocaOp : CIR_Op<"alloca", [
     cases, the first use contains the initialization (a cir.store, a cir.call
     to a ctor, etc).
 
-    The `dynAllocSize` is a number of elements to be allocated on the stack.
-    Once not specified, the number of elements allocated is one.
+    The `dynAllocSize` specifies the size to dynamically allocate on the stack
+    and ignores the allocation size based on the original type. This is useful
+    when handling VLAs and is omitted when declaring regular local variables.
 
     The result type is a pointer to the input's type.
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -324,10 +324,10 @@ def AllocaOp : CIR_Op<"alloca", [
                    "Type":$allocaType,
                    "StringRef":$name,
                    "IntegerAttr":$alignment,
-                   "Value":$arraySize),
+                   "Value":$dynAllocSize),
     [{
-      if (arraySize)
-        $_state.addOperands(arraySize);
+      if (dynAllocSize)
+        $_state.addOperands(dynAllocSize);
       build($_builder, $_state, addr, allocaType, name, alignment);
     }]>
   ];

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -299,6 +299,7 @@ def AllocaOp : CIR_Op<"alloca", [
   }];
 
   let arguments = (ins
+    Optional<CIR_IntType>:$arraySize,
     TypeAttr:$allocaType,
     StrAttr:$name,
     UnitAttr:$init,
@@ -313,7 +314,17 @@ def AllocaOp : CIR_Op<"alloca", [
   let builders = [
     OpBuilder<(ins "Type":$addr, "Type":$allocaType,
                    "StringRef":$name,
-                   "IntegerAttr":$alignment)>
+                   "IntegerAttr":$alignment)>,
+    OpBuilder<(ins "Type":$addr,
+                   "Type":$allocaType,
+                   "StringRef":$name,
+                   "IntegerAttr":$alignment,
+                   "Value":$arraySize),
+    [{
+      if (arraySize)
+        $_state.addOperands(arraySize);
+      build($_builder, $_state, addr, allocaType, name, alignment);
+    }]>
   ];
 
   let extraClassDeclaration = [{
@@ -325,6 +336,7 @@ def AllocaOp : CIR_Op<"alloca", [
   // from the pointer type directly.
   let assemblyFormat = [{
     $allocaType `,` `cir.ptr` type($addr) `,`
+    ($arraySize^ `:` type($arraySize) `,`)?
     `[` $name
        (`,` `init` $init^)?
     `]`

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -897,13 +897,15 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::AllocaOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    mlir::Value one = rewriter.create<mlir::LLVM::ConstantOp>(
-        op.getLoc(), typeConverter->convertType(rewriter.getIndexType()),
-        rewriter.getIntegerAttr(rewriter.getIndexType(), 1));
+    mlir::Value size = adaptor.getArraySize();
+    if (!size)
+      size = rewriter.create<mlir::LLVM::ConstantOp>(
+          op.getLoc(), typeConverter->convertType(rewriter.getIndexType()),
+          rewriter.getIntegerAttr(rewriter.getIndexType(), 1));
     auto elementTy = getTypeConverter()->convertType(op.getAllocaType());
     auto resultTy = mlir::LLVM::LLVMPointerType::get(getContext());
     rewriter.replaceOpWithNewOp<mlir::LLVM::AllocaOp>(
-        op, resultTy, elementTy, one, op.getAlignmentAttr().getInt());
+        op, resultTy, elementTy, size, op.getAlignmentAttr().getInt());
     return mlir::success();
   }
 };

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -897,11 +897,13 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::AllocaOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    mlir::Value size = adaptor.getArraySize();
-    if (!size)
-      size = rewriter.create<mlir::LLVM::ConstantOp>(
-          op.getLoc(), typeConverter->convertType(rewriter.getIndexType()),
-          rewriter.getIntegerAttr(rewriter.getIndexType(), 1));
+    mlir::Value size =
+        op.isDynamic()
+            ? adaptor.getDynAllocSize()
+            : rewriter.create<mlir::LLVM::ConstantOp>(
+                  op.getLoc(),
+                  typeConverter->convertType(rewriter.getIndexType()),
+                  rewriter.getIntegerAttr(rewriter.getIndexType(), 1));
     auto elementTy = getTypeConverter()->convertType(op.getAllocaType());
     auto resultTy = mlir::LLVM::LLVMPointerType::get(getContext());
     rewriter.replaceOpWithNewOp<mlir::LLVM::AllocaOp>(

--- a/clang/test/CIR/IR/alloca.cir
+++ b/clang/test/CIR/IR/alloca.cir
@@ -9,9 +9,9 @@ module  {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    %2 = cir.cast(integral, %1 : !s32i), !u64i 
+    %2 = cir.cast(integral, %1 : !s32i), !u64i
     %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
-    cir.return 
+    cir.return
   }
 }
 
@@ -21,9 +21,9 @@ module  {
 //CHECK-NEXT:    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
 //CHECK-NEXT:    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
 //CHECK-NEXT:    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-//CHECK-NEXT:    %2 = cir.cast(integral, %1 : !s32i), !u64i 
+//CHECK-NEXT:    %2 = cir.cast(integral, %1 : !s32i), !u64i
 //CHECK-NEXT:    %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
-//CHECK-NEXT:    cir.return 
+//CHECK-NEXT:    cir.return
 //CHECK-NEXT:  }
 
 //CHECK: }

--- a/clang/test/CIR/IR/alloca.cir
+++ b/clang/test/CIR/IR/alloca.cir
@@ -6,11 +6,7 @@
 
 module  {
   cir.func @foo(%arg0: !s32i) {
-    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
-    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
-    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    %2 = cir.cast(integral, %1 : !s32i), !u64i
-    %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, %arg0 : !s32i, ["tmp"] {alignment = 16 : i64}
     cir.return
   }
 }
@@ -18,11 +14,7 @@ module  {
 //CHECK: module  {
 
 //CHECK-NEXT:  cir.func @foo(%arg0: !s32i) {
-//CHECK-NEXT:    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
-//CHECK-NEXT:    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
-//CHECK-NEXT:    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-//CHECK-NEXT:    %2 = cir.cast(integral, %1 : !s32i), !u64i
-//CHECK-NEXT:    %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
+//CHECK-NEXT:    %0 = cir.alloca !s32i, cir.ptr <!s32i>, %arg0 : !s32i, ["tmp"] {alignment = 16 : i64}
 //CHECK-NEXT:    cir.return
 //CHECK-NEXT:  }
 

--- a/clang/test/CIR/IR/alloca.cir
+++ b/clang/test/CIR/IR/alloca.cir
@@ -1,0 +1,29 @@
+// Test the CIR operations can parse and print correctly (roundtrip)
+
+// RUN: cir-opt %s | cir-opt | FileCheck %s
+!s32i = !cir.int<s, 32>
+!u64i = !cir.int<u, 64>
+
+module  {
+  cir.func @foo(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %2 = cir.cast(integral, %1 : !s32i), !u64i 
+    %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
+    cir.return 
+  }
+}
+
+//CHECK: module  {
+
+//CHECK-NEXT:  cir.func @foo(%arg0: !s32i) {
+//CHECK-NEXT:    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
+//CHECK-NEXT:    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+//CHECK-NEXT:    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+//CHECK-NEXT:    %2 = cir.cast(integral, %1 : !s32i), !u64i 
+//CHECK-NEXT:    %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
+//CHECK-NEXT:    cir.return 
+//CHECK-NEXT:  }
+
+//CHECK: }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -730,11 +730,8 @@ module {
 !s32i = !cir.int<s, 32>
 module {
   cir.func @tmp(%arg0: f32) {
-    %0 = cir.alloca f32, cir.ptr <f32>, ["a", init] {alignment = 4 : i64} 
-    cir.store %arg0, %0 : f32, cir.ptr <f32>
-    %1 = cir.load %0 : cir.ptr <f32>, f32
     // expected-error@+1 {{operand #0 must be Integer type}}
-    %2 = cir.alloca !s32i, cir.ptr <!s32i>, %1 : f32, ["tmp"] 
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, %arg0 : f32, ["tmp"]
     cir.return
   }
 }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -725,3 +725,16 @@ module {
 
 // expected-error@+1 {{record already defined}}
 !struct = !cir.struct<struct "SelfReference" {!cir.struct<struct "SelfReference" {}>}>
+
+// -----
+!s32i = !cir.int<s, 32>
+module {
+  cir.func @tmp(%arg0: f32) {
+    %0 = cir.alloca f32, cir.ptr <f32>, ["a", init] {alignment = 4 : i64} 
+    cir.store %arg0, %0 : f32, cir.ptr <f32>
+    %1 = cir.load %0 : cir.ptr <f32>, f32
+    // expected-error@+1 {{operand #0 must be Integer type}}
+    %2 = cir.alloca !s32i, cir.ptr <!s32i>, %1 : f32, ["tmp"] 
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/alloca.cir
+++ b/clang/test/CIR/Lowering/alloca.cir
@@ -1,5 +1,4 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir -o -  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 !u64i = !cir.int<u, 64>
@@ -9,7 +8,7 @@ module  {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    %2 = cir.cast(integral, %1 : !s32i), !u64i 
+    %2 = cir.cast(integral, %1 : !s32i), !u64i
     %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
     cir.return 
   }
@@ -26,13 +25,3 @@ module  {
 // MLIR-NEXT:    llvm.return
 // MLIR-NEXT:  }
 // MLIR-NEXT: }
-
-
-//      LLVM: define void @foo(i32 %0) 
-// LLVM-NEXT:  %2 = alloca i32, i64 1, align 4
-// LLVM-NEXT:  store i32 %0, ptr %2, align 4
-// LLVM-NEXT:  %3 = load i32, ptr %2, align 4
-// LLVM-NEXT:  %4 = sext i32 %3 to i64
-// LLVM-NEXT:  %5 = alloca i32, i64 %4, align 16
-// LLVM-NEXT:  ret void
-// LLVM-NEXT: }

--- a/clang/test/CIR/Lowering/alloca.cir
+++ b/clang/test/CIR/Lowering/alloca.cir
@@ -1,0 +1,38 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-translate %s -cir-to-llvmir -o -  | FileCheck %s -check-prefix=LLVM
+
+!s32i = !cir.int<s, 32>
+!u64i = !cir.int<u, 64>
+
+module  {
+  cir.func @foo(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %2 = cir.cast(integral, %1 : !s32i), !u64i 
+    %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
+    cir.return 
+  }
+}
+
+//      MLIR: module {
+// MLIR-NEXT:  llvm.func @foo(%arg0: i32) attributes {cir.extra_attrs = #cir<extra({})>} {
+// MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
+// MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
+// MLIR-NEXT:    llvm.store %arg0, %1 : i32, !llvm.ptr
+// MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr -> i32
+// MLIR-NEXT:    %3 = llvm.sext %2 : i32 to i64
+// MLIR-NEXT:    %4 = llvm.alloca %3 x i32 {alignment = 16 : i64} : (i64) -> !llvm.ptr
+// MLIR-NEXT:    llvm.return
+// MLIR-NEXT:  }
+// MLIR-NEXT: }
+
+
+//      LLVM: define void @foo(i32 %0) 
+// LLVM-NEXT:  %2 = alloca i32, i64 1, align 4
+// LLVM-NEXT:  store i32 %0, ptr %2, align 4
+// LLVM-NEXT:  %3 = load i32, ptr %2, align 4
+// LLVM-NEXT:  %4 = sext i32 %3 to i64
+// LLVM-NEXT:  %5 = alloca i32, i64 %4, align 16
+// LLVM-NEXT:  ret void
+// LLVM-NEXT: }

--- a/clang/test/CIR/Lowering/alloca.cir
+++ b/clang/test/CIR/Lowering/alloca.cir
@@ -1,27 +1,17 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
 
 !s32i = !cir.int<s, 32>
-!u64i = !cir.int<u, 64>
 
 module  {
   cir.func @foo(%arg0: !s32i) {
-    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["len", init] {alignment = 4 : i64}
-    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
-    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    %2 = cir.cast(integral, %1 : !s32i), !u64i
-    %3 = cir.alloca !s32i, cir.ptr <!s32i>, %2 : !u64i, ["tmp"] {alignment = 16 : i64}
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, %arg0 : !s32i, ["tmp"] {alignment = 16 : i64}
     cir.return 
   }
 }
 
 //      MLIR: module {
 // MLIR-NEXT:  llvm.func @foo(%arg0: i32) attributes {cir.extra_attrs = #cir<extra({})>} {
-// MLIR-NEXT:    %0 = llvm.mlir.constant(1 : index) : i64
-// MLIR-NEXT:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr
-// MLIR-NEXT:    llvm.store %arg0, %1 : i32, !llvm.ptr
-// MLIR-NEXT:    %2 = llvm.load %1 : !llvm.ptr -> i32
-// MLIR-NEXT:    %3 = llvm.sext %2 : i32 to i64
-// MLIR-NEXT:    %4 = llvm.alloca %3 x i32 {alignment = 16 : i64} : (i64) -> !llvm.ptr
+// MLIR-NEXT:    %0 = llvm.alloca %arg0 x i32 {alignment = 16 : i64} : (i32) -> !llvm.ptr
 // MLIR-NEXT:    llvm.return
 // MLIR-NEXT:  }
 // MLIR-NEXT: }


### PR DESCRIPTION
This PR adds array size into `AllocaOp` that will be useful in future  - currently I work on variable length array support. So I start to make tiny PRs in advance)
No changes in tests needed, I tried  to make the changes as smooth as possible, so no existing `AllocaOp` usages need to be changed.