### PR TITLE
[CIR][IR] Fix ConstPtrAttr parsing

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -203,7 +203,7 @@ Attribute ConstPtrAttr::parse(AsmParser &parser, Type odsType) {
   if (parser.parseLess())
     return {};
 
-  if (parser.parseKeyword("null").succeeded()) {
+  if (parser.parseOptionalKeyword("null").succeeded()) {
     value = 0;
   } else {
     if (parser.parseInteger(value))

--- a/clang/test/CIR/IR/constptrattr.cir
+++ b/clang/test/CIR/IR/constptrattr.cir
@@ -1,0 +1,8 @@
+// RUN: cir-opt %s | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+
+cir.global external @const_ptr = #cir.ptr<4660> : !cir.ptr<!s32i>
+// CHECK: cir.global external @const_ptr = #cir.ptr<4660> : !cir.ptr<!s32i>
+cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>
+// CHECK: cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>


### PR DESCRIPTION
ConstPtrAttrs with numbers instead of the `null` keyword were not parsed correctly.