### PR TITLE
[CIR][CIRGen] Fix agg-init2.cpp test

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -912,7 +912,7 @@ public:
       return nullptr;
     }
 
-    llvm_unreachable("NYI");
+    return CGM.getBuilder().getZeroInitAttr(CGM.getCIRType(Ty));
   }
 
   mlir::Attribute VisitStringLiteral(StringLiteral *E, QualType T) {

--- a/clang/test/CIR/CodeGen/agg-init2.cpp
+++ b/clang/test/CIR/CodeGen/agg-init2.cpp
@@ -1,8 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir-enable -Wno-unused-value -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
-// CHECK: !ty_22Zero22 = !cir.struct<struct "Zero" {!u8i}>
+// CHECK: !ty_22Zero22 = !cir.struct<struct "Zero" {!cir.int<u, 8>}>
 
 struct Zero {
   void yolo();


### PR DESCRIPTION
This patch fixes the agg-init2.cpp test by doing two things:

 - Updating the `VisitCXXConstructExpr` to return a zero attribute initializer for trivial zero-initialized objects.
 - Forcing the `buildAutoVarInit` method to use ctor calls on temporary object expressions even if the object can be constant-initialized.