### PR TITLE
[CIR][NFC] Remove XFAIL from ThroughMLIR tests

### DIFF
--- a/clang/test/CIR/Lowering/ThroughMLIR/array.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/array.cir
@@ -1,25 +1,17 @@
-// RUN: cir-opt %s -cir-to-mlir -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-opt %s -cir-to-mlir -cir-to-mlir -cir-mlir-to-llvm -o - | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
-// XFAIL: *
+// RUN: cir-opt %s -cir-to-mlir -o %t.mlir
+// RUN: FileCheck %s --input-file %t.mlir
 
+!s32i = !cir.int<s, 32>
 module {
   cir.func @foo() {
-    %0 = cir.alloca !cir.array<i32 x 10>, cir.ptr <!cir.array<i32 x 10>>, ["a"] {alignment = 16 : i64}
+    %0 = cir.alloca !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>, ["a"] {alignment = 16 : i64}
     cir.return
   }
 }
 
-//      MLIR: module {
-// MLIR-NEXT: func @foo() {
-// MLIR-NEXT:    = memref.alloca() {alignment = 16 : i64} : memref<10xi32>
-// MLIR-NEXT:    return
-// MLIR-NEXT:  }
-// MLIR-NEXT: }
-
-//      LLVM: = alloca i32, i64 ptrtoint (ptr getelementptr (i32, ptr null, i64 10) to i64)
-// LLVM-NEXT: = insertvalue { ptr, ptr, i64, [1 x i64], [1 x i64] } undef, ptr %1, 0
-// LLVM-NEXT: = insertvalue { ptr, ptr, i64, [1 x i64], [1 x i64] } %2, ptr %1, 1
-// LLVM-NEXT: = insertvalue { ptr, ptr, i64, [1 x i64], [1 x i64] } %3, i64 0, 2
-// LLVM-NEXT: = insertvalue { ptr, ptr, i64, [1 x i64], [1 x i64] } %4, i64 10, 3, 0
-// LLVM-NEXT: = insertvalue { ptr, ptr, i64, [1 x i64], [1 x i64] } %5, i64 1, 4, 0
-// LLVM-NEXT: ret void
+// CHECK: module {
+// CHECK: func @foo() {
+// CHECK:    = memref.alloca() {alignment = 16 : i64} : memref<memref<10xi32>>
+// CHECK:    return
+// CHECK:  }
+// CHECK: }

--- a/clang/test/CIR/Lowering/ThroughMLIR/dot.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/dot.cir
@@ -1,29 +1,29 @@
 // RUN: cir-opt %s -cir-to-mlir -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
-// XFAIL: *
 
+!s32i = !cir.int<s, 32>
 module {
-  cir.func @dot(%arg0: !cir.ptr<f64>) -> i32 {
+  cir.func @dot(%arg0: !cir.ptr<f64>) -> !s32i {
     %0 = cir.alloca !cir.ptr<f64>, cir.ptr <!cir.ptr<f64>>, ["x", init] {alignment = 8 : i64}
-    %1 = cir.alloca i32, cir.ptr <i32>, ["__retval"] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
     %2 = cir.alloca !cir.ptr<f64>, cir.ptr <!cir.ptr<f64>>, ["y", init] {alignment = 8 : i64}
     cir.store %arg0, %0 : !cir.ptr<f64>, cir.ptr <!cir.ptr<f64>>
     %3 = cir.load %0 : cir.ptr <!cir.ptr<f64>>, !cir.ptr<f64>
     cir.store %3, %2 : !cir.ptr<f64>, cir.ptr <!cir.ptr<f64>>
-    %4 = cir.const(0 : i32) : i32
-    %5 = cir.load %1 : cir.ptr <i32>, i32
-    cir.return %5 : i32
+    %4 = cir.const(#cir.int<0> : !s32i) : !s32i
+    %5 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    cir.return %5 : !s32i
   }
 }
 
 //      CHECK: module {
-// CHECK-NEXT:   func.func @dot(%arg0: memref<?xf64>) -> i32 {
-// CHECK-NEXT:     %alloca = memref.alloca() {alignment = 8 : i64} : memref<memref<?xf64>>
+// CHECK-NEXT:   func.func @dot(%arg0: memref<f64>) -> i32 {
+// CHECK-NEXT:     %alloca = memref.alloca() {alignment = 8 : i64} : memref<memref<f64>>
 // CHECK-NEXT:     %alloca_0 = memref.alloca() {alignment = 4 : i64} : memref<i32>
-// CHECK-NEXT:     %alloca_1 = memref.alloca() {alignment = 8 : i64} : memref<memref<?xf64>>
-// CHECK-NEXT:     memref.store %arg0, %alloca[] : memref<memref<?xf64>>
-// CHECK-NEXT:     %0 = memref.load %alloca[] : memref<memref<?xf64>>
-// CHECK-NEXT:     memref.store %0, %alloca_1[] : memref<memref<?xf64>>
+// CHECK-NEXT:     %alloca_1 = memref.alloca() {alignment = 8 : i64} : memref<memref<f64>>
+// CHECK-NEXT:     memref.store %arg0, %alloca[] : memref<memref<f64>>
+// CHECK-NEXT:     %0 = memref.load %alloca[] : memref<memref<f64>>
+// CHECK-NEXT:     memref.store %0, %alloca_1[] : memref<memref<f64>>
 // CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT:     %1 = memref.load %alloca_0[] : memref<i32>
 // CHECK-NEXT:     return %1 : i32


### PR DESCRIPTION
Replaces the usage of builtin integers in the CIR code and removes the dynamic dimension from `memref`s lowered from `!cir.ptr` types.