### PR TITLE
[CIR] Vector types - part 1

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -73,13 +73,18 @@ def CastOp : CIR_Op<"cast", [Pure]> {
   let description = [{
     Apply C/C++ usual conversions rules between values. Currently supported kinds:
 
-    - `int_to_bool`
-    - `ptr_to_bool`
     - `array_to_ptrdecay`
-    - `integral`
     - `bitcast`
+    - `integral`
+    - `int_to_bool`
+    - `int_to_float`
     - `floating`
     - `float_to_int`
+    - `float_to_bool`
+    - `ptr_to_int`
+    - `ptr_to_bool`
+    - `bool_to_int`
+    - `bool_to_float`
 
     This is effectively a subset of the rules from
     `llvm-project/clang/include/clang/AST/OperationKinds.def`; but note that some
@@ -1625,6 +1630,52 @@ def GetMemberOp : CIR_Op<"get_member"> {
     mlir::cir::PointerType getResultTy() {
       return getResult().getType().cast<mlir::cir::PointerType>();
     }
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// VecElemOp
+//===----------------------------------------------------------------------===//
+
+def VecElemOp : CIR_Op<"vec_elem", [Pure,
+  TypesMatchWith<"type of 'result' matches element type of 'vec'",
+                 "vec", "result",
+                 "$_self.cast<VectorType>().getEltType()">]> {
+
+  let summary = "Extract one element from a vector object";
+  let description = [{
+    The `cir.vec_elem` operation extracts one element from a vector object.
+  }];
+
+  let arguments = (ins CIR_VectorType:$vec, CIR_IntType:$index);
+  let results = (outs AnyType:$result);
+
+  let assemblyFormat = [{
+    $vec `[` $index `:` type($index) `]` type($vec) `->` type($result) attr-dict
+  }];
+
+  let hasVerifier = 0;
+}
+
+//===----------------------------------------------------------------------===//
+// VecValue
+//===----------------------------------------------------------------------===//
+
+def VecValueOp : CIR_Op<"vec", [Pure]> {
+
+  let summary = "Create non-const vector value";
+  let description = [{
+    The `cir.vec` operation creates a vector value with the given element
+    values.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$elements);
+  let results = (outs CIR_VectorType:$result);
+
+  let assemblyFormat = [{
+    `(` ($elements^ `:` type($elements))? `)` `:` type($result) attr-dict
   }];
 
   let hasVerifier = 1;

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -110,6 +110,26 @@ def CIR_ArrayType : CIR_Type<"Array", "array",
 }
 
 //===----------------------------------------------------------------------===//
+// VectorType (fixed size)
+//===----------------------------------------------------------------------===//
+
+def CIR_VectorType : CIR_Type<"Vector", "vector",
+    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
+
+  let summary = "CIR vector type";
+  let description = [{
+    `cir.vector' represents fixed-size vector types.  The parameters are the
+    element type and the number of elements.
+  }];
+
+  let parameters = (ins "mlir::Type":$eltType, "uint64_t":$size);
+
+  let assemblyFormat = [{
+    `<` $eltType `x` $size `>`
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // FuncType
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -543,12 +543,6 @@ void CIRGenFunction::buildStoreOfScalar(mlir::Value Value, Address Addr,
                                         bool Volatile, QualType Ty,
                                         LValueBaseInfo BaseInfo, bool isInit,
                                         bool isNontemporal) {
-  if (!CGM.getCodeGenOpts().PreserveVec3Type) {
-    if (Ty->isVectorType()) {
-      llvm_unreachable("NYI");
-    }
-  }
-
   Value = buildToMemory(Value, Ty);
 
   if (Ty->isAtomicType()) {
@@ -2357,12 +2351,6 @@ mlir::Value CIRGenFunction::buildLoadOfScalar(Address Addr, bool Volatile,
                                               QualType Ty, mlir::Location Loc,
                                               LValueBaseInfo BaseInfo,
                                               bool isNontemporal) {
-  if (!CGM.getCodeGenOpts().PreserveVec3Type) {
-    if (Ty->isVectorType()) {
-      llvm_unreachable("NYI");
-    }
-  }
-
   // Atomic operations have to be done on integral types
   LValue AtomicLValue = LValue::makeAddr(Addr, Ty, getContext(), BaseInfo);
   if (Ty->isAtomicType() || LValueIsSuitableForInlineAtomic(AtomicLValue)) {

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -647,7 +647,10 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
   }
   case Type::ExtVector:
   case Type::Vector: {
-    assert(0 && "not implemented");
+    const VectorType *V = cast<VectorType>(Ty);
+    auto ElementType = convertTypeForMem(V->getElementType());
+    ResultType = ::mlir::cir::VectorType::get(Builder.getContext(), ElementType,
+                                              V->getNumElements());
     break;
   }
   case Type::ConstantMatrix: {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -423,6 +423,31 @@ LogicalResult CastOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// VecValueOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult VecValueOp::verify() {
+  // Verify that the number of arguments matches the number of elements in the
+  // vector, and that the type of all the arguments matches the type of the
+  // elements in the vector.
+  auto VecTy = getResult().getType();
+  if (getElements().size() != VecTy.getSize()) {
+    return emitOpError() << "operand count of " << getElements().size()
+                         << " doesn't match vector type " << VecTy
+                         << " element count of " << VecTy.getSize();
+  }
+  auto ElementType = VecTy.getEltType();
+  for (auto Element : getElements()) {
+    if (Element.getType() != ElementType) {
+      return emitOpError() << "operand type " << Element.getType()
+                           << " doesn't match vector element type "
+                           << ElementType;
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ReturnOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -411,6 +411,24 @@ ArrayType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
   return dataLayout.getTypePreferredAlignment(getEltType());
 }
 
+unsigned cir::VectorType::getTypeSizeInBits(
+    const ::mlir::DataLayout &dataLayout,
+    ::mlir::DataLayoutEntryListRef params) const {
+  return getSize() * dataLayout.getTypeSizeInBits(getEltType());
+}
+
+unsigned
+cir::VectorType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
+                                 ::mlir::DataLayoutEntryListRef params) const {
+  return getSize() * dataLayout.getTypeABIAlignment(getEltType());
+}
+
+unsigned cir::VectorType::getPreferredAlignment(
+    const ::mlir::DataLayout &dataLayout,
+    ::mlir::DataLayoutEntryListRef params) const {
+  return getSize() * dataLayout.getTypePreferredAlignment(getEltType());
+}
+
 unsigned
 StructType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
                               ::mlir::DataLayoutEntryListRef params) const {

--- a/clang/test/CIR/CodeGen/vectype.cpp
+++ b/clang/test/CIR/CodeGen/vectype.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o - | FileCheck %s
+
+typedef int int4 __attribute__((vector_size(16)));
+int main() {
+  int4 a = { 1, 2, 3, 4 };
+  int4 b = { 5, 6, 7, 8 };
+  int4 c = a + b;
+  return c[1];
+}
+
+// CHECK:    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK:    %1 = cir.alloca !cir.vector<!s32i x 4>, cir.ptr <!cir.vector<!s32i x 4>>, ["a", init] {alignment = 16 : i64}
+// CHECK:    %2 = cir.alloca !cir.vector<!s32i x 4>, cir.ptr <!cir.vector<!s32i x 4>>, ["b", init] {alignment = 16 : i64}
+// CHECK:    %3 = cir.alloca !cir.vector<!s32i x 4>, cir.ptr <!cir.vector<!s32i x 4>>, ["c", init] {alignment = 16 : i64}
+// CHECK:    %4 = cir.const(#cir.int<1> : !s32i) : !s32i
+// CHECK:    %5 = cir.const(#cir.int<2> : !s32i) : !s32i
+// CHECK:    %6 = cir.const(#cir.int<3> : !s32i) : !s32i
+// CHECK:    %7 = cir.const(#cir.int<4> : !s32i) : !s32i
+// CHECK:    %8 = cir.vec(%4, %5, %6, %7 : !s32i, !s32i, !s32i, !s32i) : <!s32i x 4>
+// CHECK:    cir.store %8, %1 : !cir.vector<!s32i x 4>, cir.ptr <!cir.vector<!s32i x 4>>
+// CHECK:    %9 = cir.const(#cir.int<5> : !s32i) : !s32i
+// CHECK:    %10 = cir.const(#cir.int<6> : !s32i) : !s32i
+// CHECK:    %11 = cir.const(#cir.int<7> : !s32i) : !s32i
+// CHECK:    %12 = cir.const(#cir.int<8> : !s32i) : !s32i
+// CHECK:    %13 = cir.vec(%9, %10, %11, %12 : !s32i, !s32i, !s32i, !s32i) : <!s32i x 4>
+// CHECK:    cir.store %13, %2 : !cir.vector<!s32i x 4>, cir.ptr <!cir.vector<!s32i x 4>>
+// CHECK:    %14 = cir.load %1 : cir.ptr <!cir.vector<!s32i x 4>>, !cir.vector<!s32i x 4>
+// CHECK:    %15 = cir.load %2 : cir.ptr <!cir.vector<!s32i x 4>>, !cir.vector<!s32i x 4>
+// CHECK:    %16 = cir.binop(add, %14, %15) : !cir.vector<!s32i x 4>
+// CHECK:    cir.store %16, %3 : !cir.vector<!s32i x 4>, cir.ptr <!cir.vector<!s32i x 4>>
+// CHECK:    %17 = cir.const(#cir.int<1> : !s32i) : !s32i
+// CHECK:    %18 = cir.load %3 : cir.ptr <!cir.vector<!s32i x 4>>, !cir.vector<!s32i x 4>
+// CHECK:    %19 = cir.vec_elem %18[%17 : !s32i] <!s32i x 4> -> !s32i
+// CHECK:    cir.store %19, %0 : !s32i, cir.ptr <!s32i>
+// CHECK:    %20 = cir.load %0 : cir.ptr <!s32i>, !s32i
+// CHECK:    cir.return %20 : !s32i

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -419,6 +419,35 @@ module {
 
 // -----
 
+!s32i = !cir.int<s, 32>
+cir.func @vec_op_size() {
+  %0 = cir.const(#cir.int<1> : !s32i) : !s32i
+  %1 = cir.vec(%0 : !s32i) : <!s32i x 2> // expected-error {{'cir.vec' op operand count of 1 doesn't match vector type '!cir.vector<!cir.int<s, 32> x 2>' element count of 2}}
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!u32i = !cir.int<u, 32>
+cir.func @vec_op_type() {
+  %0 = cir.const(#cir.int<1> : !s32i) : !s32i
+  %1 = cir.const(#cir.int<2> : !u32i) : !u32i
+  %2 = cir.vec(%0, %1 : !s32i, !u32i) : <!s32i x 2> // expected-error {{'cir.vec' op operand type '!cir.int<u, 32>' doesn't match vector element type '!cir.int<s, 32>'}}
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!u32i = !cir.int<u, 32>
+cir.func @vec_elem_type() {
+  %0 = cir.const(#cir.int<1> : !s32i) : !s32i
+  %1 = cir.const(#cir.int<2> : !s32i) : !s32i
+  %2 = cir.vec(%0, %1 : !s32i, !s32i) : <!s32i x 2>
+  %3 = cir.vec_elem %2[%0 : !s32i] <!s32i x 2> -> !u32i // expected-error {{'cir.vec_elem' op failed to verify that type of 'result' matches element type of 'vec'}}
+}
+
+// -----
+
 cir.func coroutine @bad_task() { // expected-error {{coroutine body must use at least one cir.await op}}
   cir.return
 }


### PR DESCRIPTION
This is the first part of implementing vector types and vector operations in ClangIR, issue #284.  This is enough to compile this test program.  I haven't tried to do anything beyond that yet.
```
typedef int int4 __attribute__((vector_size(16)));
int main(int argc, char** argv) {
  int4 a = { 1, argc, argc + 1, 4 };
  int4 b = { 5, argc + 2, argc + 3, 8 };
  int4 c = a + b;
  return c[1];
}
```

This change includes:

* Fixed-sized vector types which are parameterized on the element type and the number of elements.  For example, `!cir.vector<s32i x 4>`.  (No scalable vector types yet; those will come later.)

* New operation `cir.vec` which creates an object of a vector type with the given operands.

* New operation `cir.vec_elem` which extracts an element from a vector. (The array subscript operation doesn't work here because the result is an rvalue, not an lvalue.)

* Basic binary arithmetic operations on vector types, though only addition has been tested.

There are no unary operators, comparison operators, casts, or shuffle operations yet.  Those will all come later.