### PR TITLE
[CIR][Lowering] fixes loop lowering for top-level break/continue

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -409,7 +409,7 @@ public:
                            mlir::Block *continueBlock,
                            mlir::ConversionPatternRewriter &rewriter) const {
     // top-level yields are lowered in matchAndRewrite
-    auto isNested = [&](mlir::Operation* op) {
+    auto isNested = [&](mlir::Operation *op) {
       return op->getParentRegion() != &loopBody;
     };
 
@@ -500,8 +500,9 @@ public:
 
     // Branch from body to condition or to step on for-loop cases.
     rewriter.setInsertionPoint(bodyYield);
-    auto bodyYieldDest =
-      bodyYield.getKind() == mlir::cir::YieldOpKind::Break ? continueBlock : &stepBlock;
+    auto bodyYieldDest = bodyYield.getKind() == mlir::cir::YieldOpKind::Break
+                             ? continueBlock
+                             : &stepBlock;
     rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(bodyYield, bodyYieldDest);
 
     // Is a for loop: branch from step to condition.

--- a/clang/test/CIR/Lowering/loop.cir
+++ b/clang/test/CIR/Lowering/loop.cir
@@ -295,5 +295,4 @@ module {
 // MLIR-NEXT:     llvm.br ^bb8
 // MLIR-NEXT:   ^bb8:  // pred: ^bb7
 // MLIR-NEXT:     llvm.return
-
 }


### PR DESCRIPTION
This PR fixes a couple of corner cases connected with the `YieldOp` lowering in loops. 
Previously,  in  #211 we introduced `lowerNestedBreakContinue`   but we didn't check that `YieldOp` may belong to the same region, i.e. it is not nested, e.g.
```
while(1) {
   break;
}
```
Hence the error `op already replaced`. 

Next, we fix `yield` lowering for `ifOp` and `switchOp` but didn't cover `scopeOp`, and the same error occurred. This PR fixes this as well.

I added two tests - with no checks actually, just to make sure no more crashes happen.

fixes #324
