### PR TITLE
[CIR][CodeGen] Fix flat offset lowering code to consider field alignments

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -761,14 +761,18 @@ public:
       Offset %= EltSize;
     } else if (auto StructTy = Ty.dyn_cast<mlir::cir::StructType>()) {
       auto Elts = StructTy.getMembers();
+      unsigned Pos = 0;
       for (size_t I = 0; I < Elts.size(); ++I) {
         auto EltSize = Layout.getTypeAllocSize(Elts[I]);
-        if (Offset < EltSize) {
+        unsigned AlignMask = Layout.getABITypeAlign(Elts[I]) - 1;
+        Pos = (Pos + AlignMask) & ~AlignMask;
+        if (Offset < Pos + EltSize) {
           Indices.push_back(I);
           SubType = Elts[I];
+          Offset -= Pos;
           break;
         }
-        Offset -= EltSize;
+        Pos += EltSize;
       }
     } else {
       llvm_unreachable("unexpected type");

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -75,6 +75,15 @@ struct { int *x; } q2 = {q};
 // CHECK: cir.global external @q1 = #cir.global_view<@q> : !cir.ptr<!s32i>
 // CHECK: cir.global external @q2 = #cir.const_struct<{#cir.global_view<@q> : !cir.ptr<!s32i>}> : !ty_22anon2E1322
 
+struct Glob {
+  double a[42];
+  int pad1[3];
+  double b[42];
+} glob;
+
+double *const glob_ptr = &glob.b[1];
+// CHECK: cir.global external @glob_ptr = #cir.global_view<@glob, [2 : i32, 1 : i32]> : !cir.ptr<f64>
+
 // TODO: test tentatives with internal linkage.
 
 // Tentative definition is THE definition. Should be zero-initialized.


### PR DESCRIPTION
Before this fix conversion of flat offset to GlobalView indices could crash or compute invalid result.