### PR TITLE
[CIR][CodeGen] Use signed type for result of ptrdiff operation.

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -162,6 +162,10 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
   // TODO: ConstGlobalsPtrTy
   // TODO: ASTAllocaAddressSpace
 
+  PtrDiffTy = ::mlir::cir::IntType::get(
+      builder.getContext(), astCtx.getTargetInfo().getMaxPointerWidth(),
+      /*isSigned=*/true);
+
   mlir::cir::sob::SignedOverflowBehavior sob;
   switch (langOpts.getSignedOverflowBehavior()) {
   case clang::LangOptions::SignedOverflowBehaviorTy::SOB_Defined:

--- a/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
@@ -49,8 +49,9 @@ struct CIRGenTypeCache {
   union {
     mlir::Type UIntPtrTy;
     mlir::Type SizeTy;
-    mlir::Type PtrDiffTy;
   };
+
+  mlir::Type PtrDiffTy;
 
   /// void* in address space 0
   mlir::cir::PointerType VoidPtrTy;

--- a/clang/test/CIR/CodeGen/ptr_diff.cpp
+++ b/clang/test/CIR/CodeGen/ptr_diff.cpp
@@ -9,5 +9,16 @@ size_type size(unsigned long *_start, unsigned long *_finish) {
 // CHECK: cir.func @_Z4sizePmS_(%arg0: !cir.ptr<!u64i>
 // CHECK:   %3 = cir.load %1 : cir.ptr <!cir.ptr<!u64i>>, !cir.ptr<!u64i>
 // CHECK:   %4 = cir.load %0 : cir.ptr <!cir.ptr<!u64i>>, !cir.ptr<!u64i>
-// CHECK:   %5 = cir.ptr_diff(%3, %4) : !cir.ptr<!u64i> -> !u64i
-  
+// CHECK:   %5 = cir.ptr_diff(%3, %4) : !cir.ptr<!u64i> -> !s64i
+// CHECK:   %6 = cir.cast(integral, %5 : !s64i), !u64i
+
+long add(char *a, char *b) {
+  return a - b + 1;
+}
+
+// CHECK: cir.func @_Z3addPcS_(%arg0: !cir.ptr<!s8i>
+//          %5 = cir.ptr_diff(%3, %4) : !cir.ptr<!s8i> -> !s64i
+//          %6 = cir.const(#cir.int<1> : !s32i) : !s32i
+//          %7 = cir.cast(integral, %6 : !s32i), !s64i
+//          %8 = cir.binop(add, %5, %7) : !s64i
+


### PR DESCRIPTION
Before this fix attached test case has been failing due to type mismatch (signed vs unsigned).