### PR TITLE
[CIR][CodeGen][Lowering] Support multi-block case/default clauses

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -619,7 +619,6 @@ mlir::LogicalResult CIRGenFunction::buildCaseDefaultCascade(
     insertFallthrough(*stmt);
     res = buildCaseStmt(*dyn_cast<CaseStmt>(sub), condType, caseAttrs, os);
   } else {
-    mlir::OpBuilder::InsertionGuard guardCase(builder);
     res = buildStmt(sub, /*useCurrentScope=*/!isa<CompoundStmt>(sub));
   }
 
@@ -985,6 +984,7 @@ mlir::LogicalResult CIRGenFunction::buildSwitchStmt(const SwitchStmt &S) {
               mlir::OpBuilder::InsertionGuard guardCase(builder);
               builder.setInsertionPointToEnd(lastCaseBlock);
               res = buildStmt(c, /*useCurrentScope=*/!isa<CompoundStmt>(c));
+              lastCaseBlock = builder.getBlock();
               if (res.failed())
                 break;
               continue;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1275,38 +1275,6 @@ public:
 class CIRSwitchOpLowering
     : public mlir::OpConversionPattern<mlir::cir::SwitchOp> {
 
-  void lowerRegion(mlir::Region& region, mlir::Block* exitBlock, 
-                   mlir::cir::YieldOp* fallthroughYieldOp,
-                   mlir::ConversionPatternRewriter &rewriter) const {
-    for (auto& blk : region.getBlocks()) {
-      if (blk.hasNoSuccessors()) {
-        auto *terminator = blk.getTerminator();
-        if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(terminator)) {
-        // TODO(cir): Ensure every yield instead of dealing with optional
-        // values.
-        assert(yieldOp.getKind().has_value() && "switch yield has no kind");
-
-        switch (yieldOp.getKind().value()) {
-        // Fallthrough to next case: track it for the next case to handle.
-        case mlir::cir::YieldOpKind::Fallthrough:
-          *fallthroughYieldOp = yieldOp;
-          break;
-        // Break out of switch: branch to exit block.
-        case mlir::cir::YieldOpKind::Break:
-          rewriteYieldOp(rewriter, yieldOp, exitBlock);
-          break;
-        case mlir::cir::YieldOpKind::Continue: // Continue is handled only in
-                                               // loop lowering
-          break;
-        default:
-          //return op->emitError("invalid yield kind in case statement");
-          break;
-        }
-      }
-      }
-    }
-  }
-
 public:
   using OpConversionPattern<mlir::cir::SwitchOp>::OpConversionPattern;
 
@@ -1368,36 +1336,34 @@ public:
         fallthroughYieldOp = nullptr;
       }
 
-      lowerRegion(region, exitBlock, &fallthroughYieldOp, rewriter);
-/*
-      // TODO(cir): Handle multi-block case statements.
-      if (region.getBlocks().size() != 1)
-        return op->emitError("multi-block case statement is NYI");
+      for (auto& blk : region.getBlocks()) {
+        if (blk.getNumSuccessors()) 
+          continue;
 
-      // Handle switch-case yields.
-      auto *terminator = region.front().getTerminator();
-      if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(terminator)) {
-        // TODO(cir): Ensure every yield instead of dealing with optional
-        // values.
-        assert(yieldOp.getKind().has_value() && "switch yield has no kind");
+        // Handle switch-case yields.
+        auto *terminator = blk.getTerminator();        
+        if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(terminator)) {
+          // TODO(cir): Ensure every yield instead of dealing with optional
+          // values.
+          assert(yieldOp.getKind().has_value() && "switch yield has no kind");
 
-        switch (yieldOp.getKind().value()) {
-        // Fallthrough to next case: track it for the next case to handle.
-        case mlir::cir::YieldOpKind::Fallthrough:
-          fallthroughYieldOp = yieldOp;
-          break;
-        // Break out of switch: branch to exit block.
-        case mlir::cir::YieldOpKind::Break:
-          rewriteYieldOp(rewriter, yieldOp, exitBlock);
-          break;
-        case mlir::cir::YieldOpKind::Continue: // Continue is handled only in
-                                               // loop lowering
-          break;
-        default:
-          return op->emitError("invalid yield kind in case statement");
+          switch (yieldOp.getKind().value()) {
+          // Fallthrough to next case: track it for the next case to handle.
+          case mlir::cir::YieldOpKind::Fallthrough:
+            fallthroughYieldOp = yieldOp;
+            break;
+          // Break out of switch: branch to exit block.
+          case mlir::cir::YieldOpKind::Break:
+            rewriteYieldOp(rewriter, yieldOp, exitBlock);
+            break;
+          case mlir::cir::YieldOpKind::Continue: // Continue is handled only in
+                                                // loop lowering
+            break;
+          default:
+            return op->emitError("invalid yield kind in case statement");
+          }
         }
-      }
-      */
+      }  
 
       // Extract region contents before erasing the switch op.
       rewriter.inlineRegionBefore(region, exitBlock);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1274,7 +1274,6 @@ public:
 
 class CIRSwitchOpLowering
     : public mlir::OpConversionPattern<mlir::cir::SwitchOp> {
-
 public:
   using OpConversionPattern<mlir::cir::SwitchOp>::OpConversionPattern;
 
@@ -1363,7 +1362,7 @@ public:
             return op->emitError("invalid yield kind in case statement");
           }
         }
-      }  
+      }
 
       // Extract region contents before erasing the switch op.
       rewriter.inlineRegionBefore(region, exitBlock);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1274,6 +1274,39 @@ public:
 
 class CIRSwitchOpLowering
     : public mlir::OpConversionPattern<mlir::cir::SwitchOp> {
+
+  void lowerRegion(mlir::Region& region, mlir::Block* exitBlock, 
+                   mlir::cir::YieldOp* fallthroughYieldOp,
+                   mlir::ConversionPatternRewriter &rewriter) const {
+    for (auto& blk : region.getBlocks()) {
+      if (blk.hasNoSuccessors()) {
+        auto *terminator = blk.getTerminator();
+        if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(terminator)) {
+        // TODO(cir): Ensure every yield instead of dealing with optional
+        // values.
+        assert(yieldOp.getKind().has_value() && "switch yield has no kind");
+
+        switch (yieldOp.getKind().value()) {
+        // Fallthrough to next case: track it for the next case to handle.
+        case mlir::cir::YieldOpKind::Fallthrough:
+          *fallthroughYieldOp = yieldOp;
+          break;
+        // Break out of switch: branch to exit block.
+        case mlir::cir::YieldOpKind::Break:
+          rewriteYieldOp(rewriter, yieldOp, exitBlock);
+          break;
+        case mlir::cir::YieldOpKind::Continue: // Continue is handled only in
+                                               // loop lowering
+          break;
+        default:
+          //return op->emitError("invalid yield kind in case statement");
+          break;
+        }
+      }
+      }
+    }
+  }
+
 public:
   using OpConversionPattern<mlir::cir::SwitchOp>::OpConversionPattern;
 
@@ -1335,6 +1368,8 @@ public:
         fallthroughYieldOp = nullptr;
       }
 
+      lowerRegion(region, exitBlock, &fallthroughYieldOp, rewriter);
+/*
       // TODO(cir): Handle multi-block case statements.
       if (region.getBlocks().size() != 1)
         return op->emitError("multi-block case statement is NYI");
@@ -1362,6 +1397,7 @@ public:
           return op->emitError("invalid yield kind in case statement");
         }
       }
+      */
 
       // Extract region contents before erasing the switch op.
       rewriter.inlineRegionBefore(region, exitBlock);

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -258,3 +258,19 @@ void sw11(int a) {
 //CHECK-NEXT:   cir.yield break
 //CHECK-NEXT: }
 
+void sw12(int a) {
+  switch (a)
+  {
+  case 3:
+    return;
+    break;
+  }
+}
+//      CHECK: cir.func @_Z4sw12i
+//      CHECK:   cir.scope {
+//      CHECK:     cir.switch
+// CHECK-NEXT:     case (equal, 3) {
+// CHECK-NEXT:       cir.return
+// CHECK-NEXT:     ^bb1:  // no predecessors
+// CHECK-NEXT:       cir.yield break
+// CHECK-NEXT:     }

--- a/clang/test/CIR/Lowering/switch.cir
+++ b/clang/test/CIR/Lowering/switch.cir
@@ -105,4 +105,35 @@ module {
     // CHECK-NOT: llvm.switch
     cir.return
   }
+
+  cir.func @shouldLowerMultiBlockCase(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+      cir.switch (%1 : !s32i) [
+      case (equal, 3) {
+        cir.return
+      ^bb1:  // no predecessors
+        cir.yield break
+      }
+      ] 
+    }
+    cir.return
+  }
+  // CHECK: llvm.func @shouldLowerMultiBlockCase
+  // CHECK: ^bb1:  // pred: ^bb0
+  // CHECK:   llvm.switch {{.*}} : i32, ^bb4 [
+  // CHECK:     3: ^bb2
+  // CHECK:   ]
+  // CHECK: ^bb2:  // pred: ^bb1
+  // CHECK:   llvm.return
+  // CHECK: ^bb3:  // no predecessors
+  // CHECK:   llvm.br ^bb4
+  // CHECK: ^bb4:  // 2 preds: ^bb1, ^bb3
+  // CHECK:   llvm.br ^bb5
+  // CHECK: ^bb5:  // pred: ^bb4
+  // CHECK:   llvm.return
+  // CHECK: }
+
 }


### PR DESCRIPTION
This PR adds a support for the multi-block case statements.
Previously, the code example below caused crash in cir verification 

Lowering to the `llvm` dialect is pretty straightforward: the same logic as before is applied to all the region's blocks with no successors, i.e. we no longer think a case/default region contains only one block.

The `CodeGen` part is a little bit tricky. Previously, any sub-statement  of `case` or`default`, that was not any of them (i.e. neither `case` nor `default`) was processed with an insertion guard, meaning that the next sub-statement in the same clause was inserted again in the same block as the first one. It would be fine, once sub-statement didn't generate any blocks as well. 

For instance, 
```
void foo(int a) {
  switch (a)
  {
  case 3:
    return;
    break;
  }
}
```
The `return` statement actually emit a new block after, where the unreachable code with `break` should be inserted in. That's why we also need to update `lastCaseBlock` while generating `cir.switch`

This is quite frequent bug in `llvm-test-suite`