### PR TITLE
[CIR][Lowering][Bugfix] Lower nested breaks in switch statements

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -818,9 +818,9 @@ public:
     // Replace the scopeop return with a branch that jumps out of the body.
     // Stack restore before leaving the body region.
     rewriter.setInsertionPointToEnd(afterBody);
+    auto yieldOp = cast<mlir::cir::YieldOp>(afterBody->getTerminator());
 
-    auto yieldOp = dyn_cast<mlir::cir::YieldOp>(afterBody->getTerminator());
-    if (yieldOp && !isBreakOrContinue(yieldOp)) {
+    if (!isBreakOrContinue(yieldOp)) {
       auto branchOp = rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
           yieldOp, yieldOp.getArgs(), continueBlock);
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -325,9 +325,9 @@ mlir::LLVM::Linkage convertLinkage(mlir::cir::GlobalLinkageKind linkage) {
 }
 
 static void lowerNestedYield(mlir::cir::YieldOpKind targetKind,
-                            mlir::ConversionPatternRewriter &rewriter,
-                            mlir::Region &body,
-                            mlir::Block *dst) {
+                             mlir::ConversionPatternRewriter &rewriter,
+                             mlir::Region &body,
+                             mlir::Block *dst) {
   // top-level yields are lowered in matchAndRewrite of the parent operations
   auto isNested = [&](mlir::Operation *op) {
     return op->getParentRegion() != &body;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -324,6 +324,35 @@ mlir::LLVM::Linkage convertLinkage(mlir::cir::GlobalLinkageKind linkage) {
   };
 }
 
+static void lowerNestedYield(mlir::cir::YieldOpKind targetKind,
+                            mlir::ConversionPatternRewriter &rewriter,
+                            mlir::Region &body,
+                            mlir::Block *dst) {
+  // top-level yields are lowered in matchAndRewrite of the parent operations
+  auto isNested = [&](mlir::Operation *op) {
+    return op->getParentRegion() != &body;
+  };
+
+  body.walk<mlir::WalkOrder::PreOrder>(
+    [&](mlir::Operation *op) {
+      if (!isNested(op))
+        return mlir::WalkResult::advance();
+      
+      // don't process breaks/continues in nested loops and switches
+      if (isa<mlir::cir::LoopOp, mlir::cir::SwitchOp>(*op))
+        return mlir::WalkResult::skip();
+
+      auto yield = dyn_cast<mlir::cir::YieldOp>(*op);
+      if (yield && yield.getKind() == targetKind) {
+        rewriter.setInsertionPoint(op);
+        rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(op, yield.getArgs(), dst); 
+      }
+
+      return mlir::WalkResult::advance();
+    });
+}
+
+
 class CIRCopyOpLowering : public mlir::OpConversionPattern<mlir::cir::CopyOp> {
 public:
   using mlir::OpConversionPattern<mlir::cir::CopyOp>::OpConversionPattern;
@@ -398,57 +427,6 @@ public:
     return mlir::success();
   }
 
-  void makeYieldIf(mlir::cir::YieldOpKind kind, mlir::cir::YieldOp &op,
-                   mlir::Block *to,
-                   mlir::ConversionPatternRewriter &rewriter) const {
-    if (op.getKind() == kind) {
-      rewriter.setInsertionPoint(op);
-      rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(op, op.getArgs(), to);
-    }
-  }
-
-  void
-  lowerNestedBreakContinue(mlir::Region &loopBody, mlir::Block *exitBlock,
-                           mlir::Block *continueBlock,
-                           mlir::ConversionPatternRewriter &rewriter) const {
-    // top-level yields are lowered in matchAndRewrite
-    auto isNested = [&](mlir::Operation *op) {
-      return op->getParentRegion() != &loopBody;
-    };
-
-    auto processBreak = [&](mlir::Operation *op) {
-      if (!isNested(op))
-        return mlir::WalkResult::advance();
-
-      if (isa<mlir::cir::LoopOp, mlir::cir::SwitchOp>(
-              *op)) // don't process breaks in nested loops and switches
-        return mlir::WalkResult::skip();
-
-      if (auto yield = dyn_cast<mlir::cir::YieldOp>(*op))
-        makeYieldIf(mlir::cir::YieldOpKind::Break, yield, exitBlock, rewriter);
-
-      return mlir::WalkResult::advance();
-    };
-
-    auto processContinue = [&](mlir::Operation *op) {
-      if (!isNested(op))
-        return mlir::WalkResult::advance();
-
-      if (isa<mlir::cir::LoopOp>(
-              *op)) // don't process continues in nested loops
-        return mlir::WalkResult::skip();
-
-      if (auto yield = dyn_cast<mlir::cir::YieldOp>(*op))
-        makeYieldIf(mlir::cir::YieldOpKind::Continue, yield, continueBlock,
-                    rewriter);
-
-      return mlir::WalkResult::advance();
-    };
-
-    loopBody.walk<mlir::WalkOrder::PreOrder>(processBreak);
-    loopBody.walk<mlir::WalkOrder::PreOrder>(processContinue);
-  }
-
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::LoopOp loopOp, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
@@ -478,7 +456,10 @@ public:
         dyn_cast<mlir::cir::YieldOp>(stepRegion.back().getTerminator());
     auto &stepBlock = (kind == LoopKind::For ? stepFrontBlock : condFrontBlock);
 
-    lowerNestedBreakContinue(bodyRegion, continueBlock, &stepBlock, rewriter);
+    lowerNestedYield(mlir::cir::YieldOpKind::Break,
+                     rewriter, bodyRegion, continueBlock);
+    lowerNestedYield(mlir::cir::YieldOpKind::Continue,
+                     rewriter, bodyRegion, &stepBlock);
 
     // Move loop op region contents to current CFG.
     rewriter.inlineRegionBefore(condRegion, continueBlock);
@@ -713,7 +694,7 @@ public:
   }
 };
 
-static bool isLoopYield(mlir::cir::YieldOp &op) {
+static bool isBreakOrContinue(mlir::cir::YieldOp &op) {
   return op.getKind() == mlir::cir::YieldOpKind::Break ||
          op.getKind() == mlir::cir::YieldOpKind::Continue;
 }
@@ -746,8 +727,8 @@ public:
     rewriter.setInsertionPointToEnd(thenAfterBody);
     if (auto thenYieldOp =
             dyn_cast<mlir::cir::YieldOp>(thenAfterBody->getTerminator())) {
-      if (!isLoopYield(thenYieldOp)) // lowering of parent loop yields is
-                                     // deferred to loop lowering
+      if (!isBreakOrContinue(thenYieldOp)) // lowering of parent loop yields is
+                                           // deferred to loop lowering
         rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
             thenYieldOp, thenYieldOp.getArgs(), continueBlock);
     } else if (!dyn_cast<mlir::cir::ReturnOp>(thenAfterBody->getTerminator())) {
@@ -777,8 +758,8 @@ public:
       rewriter.setInsertionPointToEnd(elseAfterBody);
       if (auto elseYieldOp =
               dyn_cast<mlir::cir::YieldOp>(elseAfterBody->getTerminator())) {
-        if (!isLoopYield(elseYieldOp)) // lowering of parent loop yields is
-                                       // deferred to loop lowering
+        if (!isBreakOrContinue(elseYieldOp)) // lowering of parent loop yields is
+                                             // deferred to loop lowering
           rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
               elseYieldOp, elseYieldOp.getArgs(), continueBlock);
       } else if (!dyn_cast<mlir::cir::ReturnOp>(
@@ -839,7 +820,7 @@ public:
     rewriter.setInsertionPointToEnd(afterBody);
 
     auto yieldOp = dyn_cast<mlir::cir::YieldOp>(afterBody->getTerminator());
-    if (yieldOp && !isLoopYield(yieldOp)) {
+    if (yieldOp && !isBreakOrContinue(yieldOp)) {
       auto branchOp = rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
           yieldOp, yieldOp.getArgs(), continueBlock);
 
@@ -1331,31 +1312,6 @@ public:
                                                  destination);
   }
 
-  void lowerNestedBreak(mlir::Region &body, mlir::Block *exitBlock,                           
-                        mlir::ConversionPatternRewriter &rewriter) const {
-    // top-level yields are lowered in matchAndRewrite
-    auto isNested = [&](mlir::Operation *op) {
-      return op->getParentRegion() != &body;
-    };
-
-    auto processBreak = [&](mlir::Operation *op) {
-      if (!isNested(op))
-        return mlir::WalkResult::advance();
-
-      // don't process breaks in nested loops and switches
-      if (isa<mlir::cir::LoopOp, mlir::cir::SwitchOp>(*op)) 
-        return mlir::WalkResult::skip();
-      
-      auto yield = dyn_cast<mlir::cir::YieldOp>(*op);
-      if (yield && yield.getKind() == mlir::cir::YieldOpKind::Break)
-        rewriteYieldOp(rewriter, yield, exitBlock);
-
-      return mlir::WalkResult::advance();
-    };
-
-    body.walk<mlir::WalkOrder::PreOrder>(processBreak);
-  }
-
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::SwitchOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
@@ -1436,7 +1392,8 @@ public:
         }
       }
 
-      lowerNestedBreak(region, exitBlock, rewriter);
+      lowerNestedYield(mlir::cir::YieldOpKind::Break, 
+                       rewriter, region, exitBlock);
 
       // Extract region contents before erasing the switch op.
       rewriter.inlineRegionBefore(region, exitBlock);

--- a/clang/test/CIR/Lowering/switch.cir
+++ b/clang/test/CIR/Lowering/switch.cir
@@ -136,4 +136,50 @@ module {
   // CHECK:   llvm.return
   // CHECK: }
 
+  cir.func @bar(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["y", init] {alignment = 4 : i64}
+    %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    cir.store %arg1, %1 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      %5 = cir.load %0 : cir.ptr <!s32i>, !s32i
+      cir.switch (%5 : !s32i) [
+      case (equal, 0) {
+        cir.scope {
+          %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
+          %7 = cir.const(#cir.int<0> : !s32i) : !s32i
+          %8 = cir.cmp(ge, %6, %7) : !s32i, !s32i
+          %9 = cir.cast(int_to_bool, %8 : !s32i), !cir.bool
+          cir.if %9 {
+            cir.yield break
+          }
+        }
+        cir.yield break
+      }
+      ] 
+    } 
+    %3 = cir.const(#cir.int<3> : !s32i) : !s32i
+    cir.store %3, %2 : !s32i, cir.ptr <!s32i>
+    %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+    cir.return %4 : !s32i 
+  }
+  // CHECK:  llvm.func @bar
+  // CHECK:    llvm.switch %6 : i32, ^bb7 [
+  // CHECK:      0: ^bb2
+  // CHECK:    ]
+  // CHECK:  ^bb2:  // pred: ^bb1
+  // CHECK:    llvm.br ^bb3
+  // CHECK:  ^bb3:  // pred: ^bb2
+  // CHECK:    llvm.cond_br %14, ^bb4, ^bb5
+  // CHECK:  ^bb4:  // pred: ^bb3
+  // CHECK:    llvm.br ^bb7
+  // CHECK:  ^bb5:  // pred: ^bb3
+  // CHECK:    llvm.br ^bb6
+  // CHECK:  ^bb6:  // pred: ^bb5
+  // CHECK:    llvm.br ^bb7
+  // CHECK:  ^bb7:  // 3 preds: ^bb1, ^bb4, ^bb6
+  // CHECK:    llvm.br ^bb8
+  // CHECK:  ^bb8:  // pred: ^bb7
+  // CHECK:    llvm.return
 }

--- a/clang/test/CIR/Lowering/switch.cir
+++ b/clang/test/CIR/Lowering/switch.cir
@@ -106,7 +106,6 @@ module {
     cir.return
   }
 
-<<<<<<< HEAD
   cir.func @shouldLowerMultiBlockCase(%arg0: !s32i) {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
@@ -137,10 +136,7 @@ module {
   // CHECK:   llvm.return
   // CHECK: }
 
-  cir.func @bar(%arg0: !s32i, %arg1: !s32i) -> !s32i {
-=======
   cir.func @shouldLowerNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
->>>>>>> e94ae0c18fb3 (minor stylish changes)
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["y", init] {alignment = 4 : i64}
     %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}

--- a/clang/test/CIR/Lowering/switch.cir
+++ b/clang/test/CIR/Lowering/switch.cir
@@ -106,6 +106,7 @@ module {
     cir.return
   }
 
+<<<<<<< HEAD
   cir.func @shouldLowerMultiBlockCase(%arg0: !s32i) {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
@@ -137,6 +138,9 @@ module {
   // CHECK: }
 
   cir.func @bar(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+=======
+  cir.func @shouldLowerNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+>>>>>>> e94ae0c18fb3 (minor stylish changes)
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["y", init] {alignment = 4 : i64}
     %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
@@ -164,7 +168,7 @@ module {
     %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
     cir.return %4 : !s32i 
   }
-  // CHECK:  llvm.func @bar
+  // CHECK:  llvm.func @shouldLowerNestedBreak
   // CHECK:    llvm.switch %6 : i32, ^bb7 [
   // CHECK:      0: ^bb2
   // CHECK:    ]


### PR DESCRIPTION
This PR fixes lowering of the next code: 
```
void foo(int x, int y) {
    switch (x) {
        case 0: 
            if (y) 
                break;
            break;
    }
}
```
i.e. when some sub statement contains `break` as well. Previously, we did this trick for `loop`: process nested `break`/`continue` statements while `LoopOp` lowering if they don't belong to another  `LoopOp` or `SwitchOp`. This is why there is some refactoring here as well, but the idea is stiil the same: we need to process nested operations and emit branches to the proper blocks. 

This is quite frequent bug in `llvm-test-suite`
