### PR TITLE
[CIR] support -std=gnu89

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2658,7 +2658,8 @@ mlir::cir::SourceLanguage CIRGenModule::getCIRSourceLanguage() {
       opts.CPlusPlus26)
     return CIRLang::CXX;
   if (opts.C99 || opts.C11 || opts.C17 || opts.C23 ||
-      opts.LangStd == ClangStd::lang_c89)
+      opts.LangStd == ClangStd::lang_c89 ||
+      opts.LangStd == ClangStd::lang_gnu89)
     return CIRLang::C;
 
   // TODO(cir): support remaining source languages.

--- a/clang/test/CIR/CodeGen/gnu89.c
+++ b/clang/test/CIR/CodeGen/gnu89.c
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -std=gnu89 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void foo() {}
+//CHECK: cir.func {{.*@foo}}


### PR DESCRIPTION
Tiny PR, support `-std=gnu89` option
This is quite frequent bug in `llvm-test-suite`