### PR TITLE
[CIR][CodeGen] support extern var in function

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -330,7 +330,6 @@ void CIRGenFunction::buildAutoVarDecl(const VarDecl &D) {
 
 void CIRGenFunction::buildVarDecl(const VarDecl &D) {
   if (D.hasExternalStorage()) {
-    assert(0 && "should we just returns is there something to track?");
     // Don't emit it now, allow it to be emitted lazily on its first use.
     return;
   }

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -75,6 +75,23 @@ struct { int *x; } q2 = {q};
 // CHECK: cir.global external @q1 = #cir.global_view<@q> : !cir.ptr<!s32i>
 // CHECK: cir.global external @q2 = #cir.const_struct<{#cir.global_view<@q> : !cir.ptr<!s32i>}> : !ty_22anon2E1322
 
+struct Glob {
+  double a[42];
+  int pad1[3];
+  double b[42];
+} glob;
+
+double *const glob_ptr = &glob.b[1];
+// CHECK: cir.global external @glob_ptr = #cir.global_view<@glob, [2 : i32, 1 : i32]> : !cir.ptr<f64>
+
+int foo() {
+    extern int optind;
+    return optind;
+}
+// CHECK: cir.global "private" external @optind : !s32i
+// CHECK: cir.func {{.*@foo}}
+// CHECK:   {{.*}} = cir.get_global @optind : cir.ptr <!s32i>
+
 // TODO: test tentatives with internal linkage.
 
 // Tentative definition is THE definition. Should be zero-initialized.

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -75,15 +75,6 @@ struct { int *x; } q2 = {q};
 // CHECK: cir.global external @q1 = #cir.global_view<@q> : !cir.ptr<!s32i>
 // CHECK: cir.global external @q2 = #cir.const_struct<{#cir.global_view<@q> : !cir.ptr<!s32i>}> : !ty_22anon2E1322
 
-struct Glob {
-  double a[42];
-  int pad1[3];
-  double b[42];
-} glob;
-
-double *const glob_ptr = &glob.b[1];
-// CHECK: cir.global external @glob_ptr = #cir.global_view<@glob, [2 : i32, 1 : i32]> : !cir.ptr<f64>
-
 int foo() {
     extern int optind;
     return optind;


### PR DESCRIPTION
This PR "adds" the support of extern vars in function body. Actually, I just erased an assert. Any reason it was there?
```
int foo() {
    extern int optind;
    return optind;
}
```

This is quite frequent bug in `llvm-test-suite`