### PR TITLE
[CIR][DOC] Rename cir-tool to cir-opt

### DIFF
--- a/GettingStarted/build-install.md
+++ b/GettingStarted/build-install.md
@@ -35,8 +35,8 @@ $ /Applications/CMake.app/Contents/bin/cmake -GNinja \
 $ ninja install
 ```
 
-Check for `cir-tool` to confirm all is fine:
+Check for `cir-opt` to confirm all is fine:
 
 ```
-$ /tmp/install-llvm/bin/cir-tool --help
+$ /tmp/install-llvm/bin/cir-opt --help
 ```


### PR DESCRIPTION
This renaming was forgotten in "Build and install" section after
https://github.com/llvm/clangir/commit/3bdb4f282f928843605d041726ab20f47332e93b