### PR TITLE
[CIR][Lowering] Support lowering of cir.const with GlobalViewAttr (gh-352)

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1040,6 +1040,12 @@ public:
           return mlir::success();
         }
       }
+      // Lower GlobalViewAttr to llvm.mlir.addressof
+      if (auto gv = op.getValue().dyn_cast<mlir::cir::GlobalViewAttr>()) {
+        auto newOp = lowerCirAttrAsValue(op, gv, rewriter, getTypeConverter());
+        rewriter.replaceOp(op, newOp);
+        return mlir::success();
+      }
       attr = op.getValue();
     }
     // TODO(cir): constant arrays are currently just pushed into the stack using

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -178,4 +178,14 @@ module {
   //MLIR:  %[[RES8:.*]] = llvm.getelementptr %[[RES7]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"struct.anon.1", (ptr)>
   //MLIR:  %[[RES9:.*]] = llvm.load %[[RES8]] : !llvm.ptr -> !llvm.ptr
   //MLIR:  llvm.call %[[RES9]]({{.*}}) : !llvm.ptr, (i32) -> ()
+
+  cir.global external @zero_array = #cir.zero : !cir.array<!s32i x 16>
+  cir.func @use_zero_array() {
+    %0 = cir.const(#cir.global_view<@zero_array> : !cir.ptr<!s32i>) : !cir.ptr<!s32i>
+    %1 = cir.const(#cir.int<0> : !s32i) : !s32i
+    %2 = cir.ptr_stride(%0 : !cir.ptr<!s32i>, %1 : !s32i), !cir.ptr<!s32i>
+    %3 = cir.load %2 : cir.ptr <!s32i>, !s32i
+    cir.return
+  }
+  // MLIR:  %0 = llvm.mlir.addressof @zero_array
 }


### PR DESCRIPTION
The error manifested in code like
```
int a[16];
int *const p = a;

void foo() {
  p[0];
}
```
It's one the most frequent errors in current llvm-test-suite.

I've added the test to globals.cir which is currently XFAILed, I think @gitoleg will fix it soon.