### PR TITLE
Fix lowering of the callOp to llvm IR dialect

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -908,9 +908,8 @@ void CallOp::build(OpBuilder &builder, OperationState &state, TypeRange results,
 
 void CallOp::build(OpBuilder &builder, OperationState &state, TypeRange results,
                    FlatSymbolRefAttr callee, ValueRange args) {
-  auto fargs = callee ? args : args.drop_front();
   build(builder, state, results,
-        TypeAttr::get(getLLVMFuncType(builder.getContext(), results, fargs)),
+        TypeAttr::get(getLLVMFuncType(builder.getContext(), results, args)),
         callee, args, /*fastmathFlags=*/nullptr, /*branch_weights=*/nullptr,
         /*CConv=*/nullptr,
         /*access_groups=*/nullptr, /*alias_scopes=*/nullptr,


### PR DESCRIPTION

#### Short story
This PR fixes `CallOp` lowering and now we use different builders from `llvm IR` dialect  for direct and indirect calls

#### Long story
After variadic  calls were added in the `llvm IR` dialect, the  lowering of the dialect to the true LLVM IR  was slightly changed, hence we got several fails in tests recently after rebasing.  Actually, the bug was always there, and these changes just made it visible.

It turned out that one of the `mlir::LLVM::CallOp` builders  in the dialect is not supposed for using with indirect calls. My initial approach was to fix this builder  and infer the fact if the call is direct or indirect right there in order to simplify life of the dialect users (i.e. ours life in this case :) ). LLVM guys have some other thoughts though, and the only change they want to see is an assert that checks the given call is a direct one (i.e. that the callee attribute passed is not null). They advice us to use proper builder for each kind of calls, hence this PR is introduced. The full discussion is [here](https://github.com/llvm/llvm-project/pull/76240l). 

No matter if my PR to llvm will be merged or not, we have to use different builders for direct and indirect calls. This is why we need to revert the previous fix that was cherry-picked.
