### PR TITLE
[CIR][CodeGen] Enchance alloca helpers

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2470,15 +2470,11 @@ Address CIRGenFunction::CreateMemTemp(QualType Ty, CharUnits Align,
 
 /// This creates a alloca and inserts it into the entry block of the
 /// current region.
-Address CIRGenFunction::CreateTempAllocaWithoutCast(mlir::Type Ty,
-                                                    CharUnits Align,
-                                                    mlir::Location Loc,
-                                                    const Twine &Name,
-                                                    mlir::Value ArraySize,
-                                                    mlir::OpBuilder::InsertPoint ip) {
-  auto Alloca = ip.isSet()
-                ? CreateTempAlloca(Ty, Loc, Name, ip, ArraySize)
-                : CreateTempAlloca(Ty, Loc, Name, ArraySize);
+Address CIRGenFunction::CreateTempAllocaWithoutCast(
+    mlir::Type Ty, CharUnits Align, mlir::Location Loc, const Twine &Name,
+    mlir::Value ArraySize, mlir::OpBuilder::InsertPoint ip) {
+  auto Alloca = ip.isSet() ? CreateTempAlloca(Ty, Loc, Name, ip, ArraySize)
+                           : CreateTempAlloca(Ty, Loc, Name, ArraySize);
   Alloca.setAlignmentAttr(CGM.getSize(Align));
   return Address(Alloca, Ty, Align);
 }
@@ -2490,7 +2486,8 @@ Address CIRGenFunction::CreateTempAlloca(mlir::Type Ty, CharUnits Align,
                                          mlir::Value ArraySize,
                                          Address *AllocaAddr,
                                          mlir::OpBuilder::InsertPoint ip) {
-  auto Alloca = CreateTempAllocaWithoutCast(Ty, Align, Loc, Name, ArraySize, ip);
+  auto Alloca =
+      CreateTempAllocaWithoutCast(Ty, Align, Loc, Name, ArraySize, ip);
   if (AllocaAddr)
     *AllocaAddr = Alloca;
   mlir::Value V = Alloca.getPointer();
@@ -2509,22 +2506,21 @@ mlir::cir::AllocaOp
 CIRGenFunction::CreateTempAlloca(mlir::Type Ty, mlir::Location Loc,
                                  const Twine &Name, mlir::Value ArraySize,
                                  bool insertIntoFnEntryBlock) {
-   return cast<mlir::cir::AllocaOp>(
-      buildAlloca(Name.str(), Ty, Loc, CharUnits(), insertIntoFnEntryBlock, ArraySize)
-          .getDefiningOp());
+  return cast<mlir::cir::AllocaOp>(buildAlloca(Name.str(), Ty, Loc, CharUnits(),
+                                               insertIntoFnEntryBlock,
+                                               ArraySize)
+                                       .getDefiningOp());
 }
 
 /// This creates an alloca and inserts it into the provided insertion point
-mlir::cir::AllocaOp
-CIRGenFunction::CreateTempAlloca(mlir::Type Ty, mlir::Location Loc,
-                                 const Twine &Name, 
-                                 mlir::OpBuilder::InsertPoint ip,
-                                 mlir::Value ArraySize) {
+mlir::cir::AllocaOp CIRGenFunction::CreateTempAlloca(
+    mlir::Type Ty, mlir::Location Loc, const Twine &Name,
+    mlir::OpBuilder::InsertPoint ip, mlir::Value ArraySize) {
   assert(ip.isSet() && "Insertion point is not set");
   return cast<mlir::cir::AllocaOp>(
       buildAlloca(Name.str(), Ty, Loc, CharUnits(), ip, ArraySize)
-           .getDefiningOp());
- }
+          .getDefiningOp());
+}
 
 /// Just like CreateTempAlloca above, but place the alloca into the function
 /// entry basic block instead.

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2286,17 +2286,19 @@ mlir::Value CIRGenFunction::buildOpOnBoolExpr(const Expr *cond,
 
 mlir::Value CIRGenFunction::buildAlloca(StringRef name, mlir::Type ty,
                                         mlir::Location loc, CharUnits alignment,
-                                        bool insertIntoFnEntryBlock) {
+                                        bool insertIntoFnEntryBlock,
+                                        mlir::Value arraySize) {
   mlir::Block *entryBlock = insertIntoFnEntryBlock
                                 ? getCurFunctionEntryBlock()
                                 : currLexScope->getEntryBlock();
   return buildAlloca(name, ty, loc, alignment,
-                     builder.getBestAllocaInsertPoint(entryBlock));
+                     builder.getBestAllocaInsertPoint(entryBlock), arraySize);
 }
 
 mlir::Value CIRGenFunction::buildAlloca(StringRef name, mlir::Type ty,
                                         mlir::Location loc, CharUnits alignment,
-                                        mlir::OpBuilder::InsertPoint ip) {
+                                        mlir::OpBuilder::InsertPoint ip,
+                                        mlir::Value arraySize) {
   auto localVarPtrTy = mlir::cir::PointerType::get(builder.getContext(), ty);
   auto alignIntAttr = CGM.getSize(alignment);
 
@@ -2306,7 +2308,7 @@ mlir::Value CIRGenFunction::buildAlloca(StringRef name, mlir::Type ty,
     builder.restoreInsertionPoint(ip);
     addr = builder.create<mlir::cir::AllocaOp>(loc, /*addr type*/ localVarPtrTy,
                                                /*var type*/ ty, name,
-                                               alignIntAttr);
+                                               alignIntAttr, arraySize);
     if (currVarDecl) {
       auto alloca = cast<mlir::cir::AllocaOp>(addr.getDefiningOp());
       alloca.setAstAttr(ASTVarDeclAttr::get(builder.getContext(), currVarDecl));
@@ -2317,9 +2319,10 @@ mlir::Value CIRGenFunction::buildAlloca(StringRef name, mlir::Type ty,
 
 mlir::Value CIRGenFunction::buildAlloca(StringRef name, QualType ty,
                                         mlir::Location loc, CharUnits alignment,
-                                        bool insertIntoFnEntryBlock) {
+                                        bool insertIntoFnEntryBlock,
+                                        mlir::Value arraySize) {
   return buildAlloca(name, getCIRType(ty), loc, alignment,
-                     insertIntoFnEntryBlock);
+                     insertIntoFnEntryBlock, arraySize);
 }
 
 mlir::Value CIRGenFunction::buildLoadOfScalar(LValue lvalue,
@@ -2471,8 +2474,11 @@ Address CIRGenFunction::CreateTempAllocaWithoutCast(mlir::Type Ty,
                                                     CharUnits Align,
                                                     mlir::Location Loc,
                                                     const Twine &Name,
-                                                    mlir::Value ArraySize) {
-  auto Alloca = CreateTempAlloca(Ty, Loc, Name, ArraySize);
+                                                    mlir::Value ArraySize,
+                                                    mlir::OpBuilder::InsertPoint ip) {
+  auto Alloca = ip.isSet()
+                ? CreateTempAlloca(Ty, Loc, Name, ip, ArraySize)
+                : CreateTempAlloca(Ty, Loc, Name, ArraySize);
   Alloca.setAlignmentAttr(CGM.getSize(Align));
   return Address(Alloca, Ty, Align);
 }
@@ -2482,8 +2488,9 @@ Address CIRGenFunction::CreateTempAllocaWithoutCast(mlir::Type Ty,
 Address CIRGenFunction::CreateTempAlloca(mlir::Type Ty, CharUnits Align,
                                          mlir::Location Loc, const Twine &Name,
                                          mlir::Value ArraySize,
-                                         Address *AllocaAddr) {
-  auto Alloca = CreateTempAllocaWithoutCast(Ty, Align, Loc, Name, ArraySize);
+                                         Address *AllocaAddr,
+                                         mlir::OpBuilder::InsertPoint ip) {
+  auto Alloca = CreateTempAllocaWithoutCast(Ty, Align, Loc, Name, ArraySize, ip);
   if (AllocaAddr)
     *AllocaAddr = Alloca;
   mlir::Value V = Alloca.getPointer();
@@ -2502,12 +2509,22 @@ mlir::cir::AllocaOp
 CIRGenFunction::CreateTempAlloca(mlir::Type Ty, mlir::Location Loc,
                                  const Twine &Name, mlir::Value ArraySize,
                                  bool insertIntoFnEntryBlock) {
-  if (ArraySize)
-    assert(0 && "NYI");
-  return cast<mlir::cir::AllocaOp>(
-      buildAlloca(Name.str(), Ty, Loc, CharUnits(), insertIntoFnEntryBlock)
+   return cast<mlir::cir::AllocaOp>(
+      buildAlloca(Name.str(), Ty, Loc, CharUnits(), insertIntoFnEntryBlock, ArraySize)
           .getDefiningOp());
 }
+
+/// This creates an alloca and inserts it into the provided insertion point
+mlir::cir::AllocaOp
+CIRGenFunction::CreateTempAlloca(mlir::Type Ty, mlir::Location Loc,
+                                 const Twine &Name, 
+                                 mlir::OpBuilder::InsertPoint ip,
+                                 mlir::Value ArraySize) {
+  assert(ip.isSet() && "Insertion point is not set");
+  return cast<mlir::cir::AllocaOp>(
+      buildAlloca(Name.str(), Ty, Loc, CharUnits(), ip, ArraySize)
+           .getDefiningOp());
+ }
 
 /// Just like CreateTempAlloca above, but place the alloca into the function
 /// entry basic block instead.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -239,13 +239,16 @@ public:
   // FIXME(cir): move this to CIRGenBuider.h
   mlir::Value buildAlloca(llvm::StringRef name, clang::QualType ty,
                           mlir::Location loc, clang::CharUnits alignment,
-                          bool insertIntoFnEntryBlock = false);
+                          bool insertIntoFnEntryBlock = false,
+                          mlir::Value arraySize = nullptr);
   mlir::Value buildAlloca(llvm::StringRef name, mlir::Type ty,
                           mlir::Location loc, clang::CharUnits alignment,
-                          bool insertIntoFnEntryBlock = false);
+                          bool insertIntoFnEntryBlock = false,
+                          mlir::Value arraySize = nullptr);
   mlir::Value buildAlloca(llvm::StringRef name, mlir::Type ty,
                           mlir::Location loc, clang::CharUnits alignment,
-                          mlir::OpBuilder::InsertPoint ip);
+                          mlir::OpBuilder::InsertPoint ip,
+                          mlir::Value arraySize = nullptr);
 
 private:
   void buildAndUpdateRetAlloca(clang::QualType ty, mlir::Location loc,
@@ -1877,14 +1880,20 @@ public:
   CreateTempAllocaInFnEntryBlock(mlir::Type Ty, mlir::Location Loc,
                                  const Twine &Name = "tmp",
                                  mlir::Value ArraySize = nullptr);
+  mlir::cir::AllocaOp CreateTempAlloca(mlir::Type Ty, mlir::Location Loc,
+                                       const Twine &Name = "tmp",
+                                       mlir::OpBuilder::InsertPoint ip = {},
+                                       mlir::Value ArraySize = nullptr);
   Address CreateTempAlloca(mlir::Type Ty, CharUnits align, mlir::Location Loc,
                            const Twine &Name = "tmp",
                            mlir::Value ArraySize = nullptr,
-                           Address *Alloca = nullptr);
+                           Address *Alloca = nullptr,
+                           mlir::OpBuilder::InsertPoint ip = {});
   Address CreateTempAllocaWithoutCast(mlir::Type Ty, CharUnits align,
                                       mlir::Location Loc,
                                       const Twine &Name = "tmp",
-                                      mlir::Value ArraySize = nullptr);
+                                      mlir::Value ArraySize = nullptr,
+                                      mlir::OpBuilder::InsertPoint ip = {});
 
   /// Create a temporary memory object of the given type, with
   /// appropriate alignmen and cast it to the default address space. Returns


### PR DESCRIPTION
One more step towards variable length array support. 
This PR adds one more helper for the `alloca` instruction  and re-use the existing ones.

The reason is the following: right now  there are two possible ways to insert alloca: either to a function entry block or to the given block after all the existing alloca instructions. But for VLA support we need to insert alloca anywhere, right after an array's size  becomes known.  Thus, we add  one more parameter with the default value - insertion point. 

Also, we don't want copy-paste the code, and reuse the existing helpers, but it may be a little bit confusing to read. 