### PR TITLE
[CIR][Lowering] add cir.ternary to scf.if lowering

### DIFF
--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -39,6 +39,7 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Passes.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace cir;
 using namespace llvm;
@@ -65,7 +66,8 @@ struct ConvertCIRToMLIRPass
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::BuiltinDialect, mlir::func::FuncDialect,
                     mlir::affine::AffineDialect, mlir::memref::MemRefDialect,
-                    mlir::arith::ArithDialect, mlir::cf::ControlFlowDialect>();
+                    mlir::arith::ArithDialect, mlir::cf::ControlFlowDialect,
+                    mlir::scf::SCFDialect>();
   }
   void runOnOperation() final;
 
@@ -547,6 +549,55 @@ struct CIRBrCondOpLowering
   }
 };
 
+class CIRTernaryOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::TernaryOp> {
+public:
+  using OpConversionPattern<mlir::cir::TernaryOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::TernaryOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.setInsertionPoint(op);
+    auto condition = adaptor.getCond();
+    auto i1Condition = rewriter.create<mlir::arith::TruncIOp>(
+        op.getLoc(), rewriter.getI1Type(), condition);
+    SmallVector<mlir::Type> resultTypes;
+    if (mlir::failed(getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                      resultTypes)))
+      return mlir::failure();
+
+    auto ifOp = rewriter.create<mlir::scf::IfOp>(op.getLoc(), resultTypes,
+                                                 i1Condition.getResult(), true);
+    auto *thenBlock = &ifOp.getThenRegion().front();
+    auto *elseBlock = &ifOp.getElseRegion().front();
+    rewriter.inlineBlockBefore(&op.getTrueRegion().front(), thenBlock,
+                               thenBlock->end());
+    rewriter.inlineBlockBefore(&op.getFalseRegion().front(), elseBlock,
+                               elseBlock->end());
+
+    rewriter.replaceOp(op, ifOp);
+    return mlir::success();
+  }
+};
+
+class CIRYieldOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::YieldOp> {
+public:
+  using OpConversionPattern<mlir::cir::YieldOp>::OpConversionPattern;
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::YieldOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto *parentOp = op->getParentOp();
+    return llvm::TypeSwitch<mlir::Operation *, mlir::LogicalResult>(parentOp)
+        .Case<mlir::scf::IfOp>([&](auto) {
+          rewriter.replaceOpWithNewOp<mlir::scf::YieldOp>(
+              op, adaptor.getOperands());
+          return mlir::success();
+        })
+        .Default([](auto) { return mlir::failure(); });
+  }
+};
+
 void populateCIRToMLIRConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter) {
   patterns.add<CIRReturnLowering, CIRBrOpLowering>(patterns.getContext());
@@ -554,8 +605,8 @@ void populateCIRToMLIRConversionPatterns(mlir::RewritePatternSet &patterns,
   patterns.add<CIRCmpOpLowering, CIRCallLowering, CIRUnaryOpLowering,
                CIRBinOpLowering, CIRLoadLowering, CIRConstantLowering,
                CIRStoreLowering, CIRAllocaLowering, CIRFuncLowering,
-               CIRScopeOpLowering, CIRBrCondOpLowering>(converter,
-                                                        patterns.getContext());
+               CIRScopeOpLowering, CIRBrCondOpLowering, CIRTernaryOpLowering,
+               CIRYieldOpLowering>(converter, patterns.getContext());
 }
 
 static mlir::TypeConverter prepareTypeConverter() {

--- a/clang/test/CIR/Lowering/ThroughMLIR/tenary.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/tenary.cir
@@ -1,0 +1,44 @@
+// RUN: cir-opt %s -cir-to-mlir | FileCheck %s -check-prefix=MLIR
+// RUN: cir-opt %s -cir-to-mlir --canonicalize | FileCheck %s --check-prefix=MLIR-CANONICALIZE
+// RUN: cir-opt %s -cir-to-mlir --canonicalize -cir-mlir-to-llvm | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
+
+!s32i = !cir.int<s, 32>
+
+module {
+cir.func @_Z1xi(%arg0: !s32i) -> !s32i {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["y", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    %3 = cir.const(#cir.int<0> : !s32i) : !s32i
+    %4 = cir.cmp(gt, %2, %3) : !s32i, !cir.bool
+    %5 = cir.ternary(%4, true {
+      %7 = cir.const(#cir.int<3> : !s32i) : !s32i
+      cir.yield %7 : !s32i
+    }, false {
+      %7 = cir.const(#cir.int<5> : !s32i) : !s32i
+      cir.yield %7 : !s32i
+    }) : (!cir.bool) -> !s32i
+    cir.store %5, %1 : !s32i, cir.ptr <!s32i>
+    %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
+    cir.return %6 : !s32i
+  }
+}
+
+// MLIR:      %1 = arith.cmpi ugt, %0, %c0_i32 : i32
+// MLIR-NEXT: %2 = arith.extui %1 : i1 to i8
+// MLIR-NEXT: %3 = arith.trunci %2 : i8 to i1
+// MLIR-NEXT: %4 = scf.if %3 -> (i32) {
+// MLIR-NEXT:   %c3_i32 = arith.constant 3 : i32
+// MLIR-NEXT:   scf.yield %c3_i32 : i32
+// MLIR-NEXT: } else {
+// MLIR-NEXT:   %c5_i32 = arith.constant 5 : i32
+// MLIR-NEXT:   scf.yield %c5_i32 : i32
+// MLIR-NEXT: }
+// MLIR-NEXT: memref.store %4, %alloca_0[] : memref<i32>
+
+// MLIR-CANONICALIZE: %[[CMP:.*]] = arith.cmpi ugt
+// MLIR-CANONICALIZE: arith.select %[[CMP]]
+
+// LLVM: %[[CMP:.*]] = icmp ugt
+// LLVM: select i1 %[[CMP]]


### PR DESCRIPTION
This PR adds `cir.ternary` lowering. There are two approaches to lower `cir.ternary` imo:
1. Use `scf.if` op.
2. Use `cf.cond_br` op. 

I choose `scf.if`  because `scf.if` + canonicalization produces `arith.select` whereas `cf.cond_br` requires scf lifting. In many ways `scf.if` is more high-level and closer to `cir.ternary`.

A separate `cir.yield` lowering is required since we cannot directly replace `cir.yield` in the ternary op lowering -- the yield operands may still be illegal and doing so produces `builtin.unrealized_cast` ops. I couldn't figured out a way to solve this issue without adding a separate lowering pattern. Please let me know if you know a way to solve this issue.
