### PR TITLE
[CIR][CodeGen] supports struct copy from function call result

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -351,7 +351,7 @@ void AggExprEmitter::buildFinalDestCopy(QualType type, const LValue &src,
   if (Dest.isIgnored())
     return;
 
-  // Copy non-trivial C structs here. 
+  // Copy non-trivial C structs here.
   if (Dest.isVolatile())
     assert(!UnimplementedFeature::volatileTypes());
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -138,6 +138,9 @@ public:
 
   enum ExprValueKind { EVK_RValue, EVK_NonRValue };
 
+  /// Perform the final copy to DestPtr, if desired.
+  void buildFinalDestCopy(QualType type, RValue src);
+
   /// Perform the final copy to DestPtr, if desired. SrcIsRValue is true if
   /// source comes from an RValue.
   void buildFinalDestCopy(QualType type, const LValue &src,
@@ -332,6 +335,13 @@ void AggExprEmitter::buildAggLoadOfLValue(const Expr *E) {
 }
 
 /// Perform the final copy to DestPtr, if desired.
+void AggExprEmitter::buildFinalDestCopy(QualType type, RValue src) {
+  assert(src.isAggregate() && "value must be aggregate value!");
+  LValue srcLV = CGF.makeAddrLValue(src.getAggregateAddress(), type);
+  buildFinalDestCopy(type, srcLV, EVK_RValue);
+}
+
+/// Perform the final copy to DestPtr, if desired.
 void AggExprEmitter::buildFinalDestCopy(QualType type, const LValue &src,
                                         ExprValueKind SrcValueKind) {
   // If Dest is ignored, then we're evaluating an aggregate expression
@@ -341,12 +351,14 @@ void AggExprEmitter::buildFinalDestCopy(QualType type, const LValue &src,
   if (Dest.isIgnored())
     return;
 
-  // Copy non-trivial C structs here.
-  if (Dest.isVolatile() || UnimplementedFeature::volatileTypes())
-    llvm_unreachable("volatile is NYI");
+  // Copy non-trivial C structs here. 
+  if (Dest.isVolatile())
+    assert(!UnimplementedFeature::volatileTypes());
 
   if (SrcValueKind == EVK_RValue) {
-    llvm_unreachable("rvalue is NYI");
+     if (type.isNonTrivialToPrimitiveDestructiveMove() == QualType::PCK_Struct) {
+        llvm_unreachable("move assignment/move ctor for rvalue is NYI");
+    }
   } else {
     if (type.isNonTrivialToPrimitiveCopy() == QualType::PCK_Struct)
       llvm_unreachable("non-trivial primitive copy is NYI");
@@ -808,7 +820,9 @@ void AggExprEmitter::withReturnValueSlot(
   if (!UseTemp) {
     RetAddr = Dest.getAddress();
   } else {
-    llvm_unreachable("NYI");
+    RetAddr = CGF.CreateMemTemp(RetTy, CGF.getLoc(E->getSourceRange()),
+                                "tmp", &RetAddr);
+    assert(!UnimplementedFeature::shouldEmitLifetimeMarkers() && "NYI");
   }
 
   RValue Src =
@@ -819,14 +833,13 @@ void AggExprEmitter::withReturnValueSlot(
     return;
 
   assert(Dest.isIgnored() || Dest.getPointer() != Src.getAggregatePointer());
-  llvm_unreachable("NYI");
-  // TODO(cir): EmitFinalDestCopy(E->getType(), Src);
+  buildFinalDestCopy(E->getType(), Src);
 
   if (!RequiresDestruction) {
     // If there's no dtor to run, the copy was the last use of our temporary.
     // Since we're not guaranteed to be in an ExprWithCleanups, clean up
     // eagerly.
-    llvm_unreachable("NYI");
+    assert(!UnimplementedFeature::shouldEmitLifetimeMarkers() && "NYI");
   }
 }
 

--- a/clang/test/CIR/CodeGen/agg-copy.c
+++ b/clang/test/CIR/CodeGen/agg-copy.c
@@ -60,3 +60,16 @@ A foo3(void) {
 void foo4(A* a1) {
     A a2 = *a1;
 }
+
+A create() { A a; return a; }
+
+// CHECK: cir.func {{.*@foo5}}
+// CHECK:   [[TMP0]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>,
+// CHECK:   [[TMP1]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>, ["tmp"] {alignment = 4 : i64}
+// CHECK:   [[TMP2]] = cir.call @create() : () -> !ty_22A22
+// CHECK:   cir.store [[TMP2]], [[TMP1]] : !ty_22A22, cir.ptr <!ty_22A22>
+// CHECK:   cir.copy [[TMP1]] to [[TMP0]] : !cir.ptr<!ty_22A22> 
+void foo5() {
+    A a;
+    a = create();
+}


### PR DESCRIPTION
This PR fixes the next case 
```
typedef struct { } A;

A create() { A a; return a; }

void foo() {
    A a;
    a = create();
}
```
i.e. when a struct  is assigned to a function call result