### PR TITLE
[CIR][Lowering] supports lowering of const arrays of structs

### DIFF
--- a/clang/test/CIR/Lowering/const.cir
+++ b/clang/test/CIR/Lowering/const.cir
@@ -3,6 +3,8 @@
 
 !s32i = !cir.int<s, 32>
 !s8i = !cir.int<s, 8>
+!ty_22anon2E122 = !cir.struct<struct "anon.1" {!cir.int<s, 32>, !cir.int<s, 32>} #cir.record.decl.ast>
+
 module {
   cir.func @testConstArrInit() {
     %0 = cir.const(#cir.const_array<"string\00" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7>) : !cir.array<!s8i x 7>
@@ -13,4 +15,24 @@ module {
     // CHECK: llvm.mlir.constant(dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>) : !llvm.array<2 x f32>
     cir.return
   }
+
+  cir.func @testConstArrayOfStructs() {
+    %0 = cir.alloca !cir.array<!ty_22anon2E122 x 1>, cir.ptr <!cir.array<!ty_22anon2E122 x 1>>, ["a"] {alignment = 4 : i64}
+    %1 = cir.const(#cir.const_array<[#cir.const_struct<{#cir.int<0> : !s32i, #cir.int<1> : !s32i}> : !ty_22anon2E122]> : !cir.array<!ty_22anon2E122 x 1>) : !cir.array<!ty_22anon2E122 x 1>
+    cir.store %1, %0 : !cir.array<!ty_22anon2E122 x 1>, cir.ptr <!cir.array<!ty_22anon2E122 x 1>>
+    cir.return
+  }
+  // CHECK:  llvm.func @testConstArrayOfStructs()
+  // CHECK:    %0 = llvm.mlir.constant(1 : index) : i64
+  // CHECK:    %1 = llvm.alloca %0 x !llvm.array<1 x struct<"struct.anon.1", (i32, i32)>> {alignment = 4 : i64} : (i64) -> !llvm.ptr
+  // CHECK:    %2 = llvm.mlir.undef : !llvm.array<1 x struct<"struct.anon.1", (i32, i32)>>
+  // CHECK:    %3 = llvm.mlir.undef : !llvm.struct<"struct.anon.1", (i32, i32)>
+  // CHECK:    %4 = llvm.mlir.constant(0 : i32) : i32
+  // CHECK:    %5 = llvm.insertvalue %4, %3[0] : !llvm.struct<"struct.anon.1", (i32, i32)>
+  // CHECK:    %6 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK:    %7 = llvm.insertvalue %6, %5[1] : !llvm.struct<"struct.anon.1", (i32, i32)>
+  // CHECK:    %8 = llvm.insertvalue %7, %2[0] : !llvm.array<1 x struct<"struct.anon.1", (i32, i32)>>
+  // CHECK:    llvm.store %8, %1 : !llvm.array<1 x struct<"struct.anon.1", (i32, i32)>>, !llvm.ptr
+  // CHECK:    llvm.return
+
 }


### PR DESCRIPTION
This PR fixes CIR lowering for the next case.

```
void foo() {
    struct {
        int a;
        int b;
    } a[1] = {{0,1}}; 
}
```
Note, we don't create attribute here and lower such const arrays as values.