### PR TITLE
[CIR][CodeGen] emit cir.zero for constant string literals

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -1397,7 +1397,12 @@ mlir::cir::GlobalOp CIRGenItaniumRTTIBuilder::GetAddrOfTypeName(
   auto Align =
       CGM.getASTContext().getTypeAlignInChars(CGM.getASTContext().CharTy);
 
-  auto GV = CGM.createOrReplaceCXXRuntimeVariable(loc, Name, Init.getType(),
+  // builder.getString can return a #cir.zero if the string given to it only
+  // contains null bytes. However, type names cannot be full of null bytes.
+  // So cast Init to a ConstArrayAttr should be safe.
+  auto InitStr = cast<mlir::cir::ConstArrayAttr>(Init);
+
+  auto GV = CGM.createOrReplaceCXXRuntimeVariable(loc, Name, InitStr.getType(),
                                                   Linkage, Align);
   CIRGenModule::setInitializer(GV, Init);
   return GV;

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1063,15 +1063,6 @@ CIRGenModule::getConstantArrayFromStringLiteral(const StringLiteral *E) {
     Str.resize(finalSize);
 
     auto eltTy = getTypes().ConvertType(CAT->getElementType());
-
-    // If the string is full of null bytes, emit a #cir.zero rather than
-    // a #cir.const_array.
-    if (Str.count('\0') == Str.size()) {
-      auto arrayTy =
-          mlir::cir::ArrayType::get(builder.getContext(), eltTy, finalSize);
-      return builder.getZeroAttr(arrayTy);
-    }
-
     return builder.getString(Str, eltTy, finalSize);
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1063,6 +1063,15 @@ CIRGenModule::getConstantArrayFromStringLiteral(const StringLiteral *E) {
     Str.resize(finalSize);
 
     auto eltTy = getTypes().ConvertType(CAT->getElementType());
+
+    // If the string is full of null bytes, emit a #cir.zero rather than
+    // a #cir.const_array.
+    if (Str.count('\0') == Str.size()) {
+      auto arrayTy =
+          mlir::cir::ArrayType::get(builder.getContext(), eltTy, finalSize);
+      return builder.getZeroAttr(arrayTy);
+    }
+
     return builder.getString(Str, eltTy, finalSize);
   }
 

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -41,7 +41,7 @@ struct {
   char y[3];
   char z[3];
 } nestedString = {"1", "", "\0"};
-// CHECK: cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>}>
+// CHECK: cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>}>
 
 struct {
   char *name;


### PR DESCRIPTION
This PR addresses #248 .

Currently string literals are always lowered to a `cir.const_array` attribute even if the string literal only contains null bytes. This patch make the CodeGen emits `cir.zero` for these string literals.