### PR TITLE
[CIR][CodeGen] codegen of lvalue comma expression

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -868,7 +868,8 @@ LValue CIRGenFunction::buildDeclRefLValue(const DeclRefExpr *E) {
 LValue CIRGenFunction::buildBinaryOperatorLValue(const BinaryOperator *E) {
   // Comma expressions just emit their LHS then their RHS as an l-value.
   if (E->getOpcode() == BO_Comma) {
-    assert(0 && "not implemented");
+    buildIgnoredExpr(E->getLHS());
+    return buildLValue(E->getRHS());
   }
 
   if (E->getOpcode() == BO_PtrMemD || E->getOpcode() == BO_PtrMemI)

--- a/clang/test/CIR/CodeGen/comma.cpp
+++ b/clang/test/CIR/CodeGen/comma.cpp
@@ -15,3 +15,16 @@ int c0() {
 // CHECK: %[[#]] = cir.binop(add, %[[#LOADED_B]], %[[#]]) : !s32i
 // CHECK: %[[#LOADED_A:]] = cir.load %[[#A]] : cir.ptr <!s32i>, !s32i
 // CHECK: cir.store %[[#LOADED_A]], %[[#RET]] : !s32i, cir.ptr <!s32i>
+
+int &foo1();
+int &foo2();
+
+void c1() {
+    int &x = (foo1(), foo2());
+}
+
+// CHECK: cir.func @_Z2c1v()
+// CHECK: %0 = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
+// CHECK: %1 = cir.call @_Z4foo1v() : () -> !cir.ptr<!s32i>
+// CHECK: %2 = cir.call @_Z4foo2v() : () -> !cir.ptr<!s32i>
+// CHECK: cir.store %2, %0 : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>


### PR DESCRIPTION
Currently, codegen of lvalue comma expression would crash:

```cpp
int &foo1();
int &foo2();

void c1() {
    int &x = (foo1(), foo2());  // CRASH
}
```

This simple patch fixes this issue.