### PR TITLE
[CIR][OpenMP] Initial commit for OpenMP support in CIR

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -14,6 +14,7 @@
 #include "CIRGenBuilder.h"
 #include "CIRGenCstEmitter.h"
 #include "CIRGenFunction.h"
+#include "CIRGenOpenMPRuntime.h"
 #include "EHScopeStack.h"
 #include "UnimplementedFeatureGuarding.h"
 #include "mlir/IR/Attributes.h"
@@ -54,9 +55,10 @@ CIRGenFunction::buildAutoVarAlloca(const VarDecl &D) {
 
   Address address = Address::invalid();
   Address allocaAddr = Address::invalid();
-  // TODO[OpenMP]: Set openMPLocalAddr with the equivalent of
-  // getOpenMPRuntime().getAddressOfLocalVariable().
-  Address openMPLocalAddr = Address::invalid();
+  Address openMPLocalAddr =
+      getCIRGenModule().getOpenMPRuntime().getAddressOfLocalVariable(*this, &D);
+  if (getLangOpts().OpenMPIsTargetDevice)
+    assert(UnimplementedFeature::openMPTarget());
   if (getLangOpts().OpenMP && openMPLocalAddr.isValid()) {
     llvm_unreachable("NYI");
   } else if (Ty->isConstantSizeType()) {

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -57,8 +57,7 @@ CIRGenFunction::buildAutoVarAlloca(const VarDecl &D) {
   Address allocaAddr = Address::invalid();
   Address openMPLocalAddr =
       getCIRGenModule().getOpenMPRuntime().getAddressOfLocalVariable(*this, &D);
-  if (getLangOpts().OpenMPIsTargetDevice)
-    assert(UnimplementedFeature::openMPTarget());
+  assert(!getLangOpts().OpenMPIsTargetDevice && "NYI");
   if (getLangOpts().OpenMP && openMPLocalAddr.isValid()) {
     llvm_unreachable("NYI");
   } else if (Ty->isConstantSizeType()) {

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -37,13 +37,8 @@ CIRGenFunction::buildAutoVarAlloca(const VarDecl &D) {
   // TODO: (|| Ty.getAddressSpace() == LangAS::opencl_private &&
   //        getLangOpts().OpenCL))
   assert(!UnimplementedFeature::openCL());
-  assert(!UnimplementedFeature::openMP());
   assert(Ty.getAddressSpace() == LangAS::Default);
   assert(!Ty->isVariablyModifiedType() && "not implemented");
-  assert(!getContext()
-              .getLangOpts()
-              .OpenMP && // !CGF.getLangOpts().OpenMPIRBuilder
-         "not implemented");
   assert(!D.hasAttr<AnnotateAttr>() && "not implemented");
 
   auto loc = getLoc(D.getSourceRange());
@@ -59,6 +54,8 @@ CIRGenFunction::buildAutoVarAlloca(const VarDecl &D) {
 
   Address address = Address::invalid();
   Address allocaAddr = Address::invalid();
+  // TODO[OpenMP]: Set openMPLocalAddr with the equivalent of
+  // getOpenMPRuntime().getAddressOfLocalVariable().
   Address openMPLocalAddr = Address::invalid();
   if (getLangOpts().OpenMP && openMPLocalAddr.isValid()) {
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -764,6 +764,7 @@ LValue CIRGenFunction::buildDeclRefLValue(const DeclRefExpr *E) {
       // it.
       // TODO[OpenMP]: Set non-temporal information in the captured LVal.
       // LLVM codegen:
+      assert(!UnimplementedFeature::openMP());
       // Address addr = GetAddrOfBlockDecl(VD);
       // return MakeAddrLValue(addr, T, AlignmentSource::Decl);
     }

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -15,6 +15,7 @@
 #include "CIRGenCstEmitter.h"
 #include "CIRGenFunction.h"
 #include "CIRGenModule.h"
+#include "CIRGenOpenMPRuntime.h"
 #include "CIRGenValue.h"
 #include "UnimplementedFeatureGuarding.h"
 
@@ -912,9 +913,9 @@ LValue CIRGenFunction::buildBinaryOperatorLValue(const BinaryOperator *E) {
     } else {
       buildStoreThroughLValue(RV, LV);
     }
-
-    // TODO[OpenMP]: Check and handle assignment to a variable declared as
-    // last-private.
+    if (getLangOpts().OpenMP)
+      CGM.getOpenMPRuntime().checkAndEmitLastprivateConditional(*this,
+                                                                E->getLHS());
     return LV;
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -759,7 +759,9 @@ LValue CIRGenFunction::buildDeclRefLValue(const DeclRefExpr *E) {
       if (auto *FD = LambdaCaptureFields.lookup(VD))
         return buildCapturedFieldLValue(*this, FD, CXXABIThisValue);
       assert(!UnimplementedFeature::CGCapturedStmtInfo() && "NYI");
-      llvm_unreachable("NYI");
+      // TODO[OpenMP]: Find the appropiate captured variable value and return
+      // it.
+      // TODO[OpenMP]: Set non-temporal information in the captured LVal.
       // LLVM codegen:
       // Address addr = GetAddrOfBlockDecl(VD);
       // return MakeAddrLValue(addr, T, AlignmentSource::Decl);
@@ -911,8 +913,8 @@ LValue CIRGenFunction::buildBinaryOperatorLValue(const BinaryOperator *E) {
       buildStoreThroughLValue(RV, LV);
     }
 
-    assert(!getContext().getLangOpts().OpenMP &&
-           "last priv cond not implemented");
+    // TODO[OpenMP]: Check and handle assignment to a variable declared as
+    // last-private.
     return LV;
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1805,7 +1805,8 @@ LValue ScalarExprEmitter::buildCompoundAssignLValue(
   else
     CGF.buildStoreThroughLValue(RValue::get(Result), LHSLV);
 
-  assert(!CGF.getLangOpts().OpenMP && "Not implemented");
+  // TODO[OpenMP]: Check and handle assignment to a variable declared as
+  // last-private.
   return LHSLV;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -14,6 +14,7 @@
 #include "CIRDataLayout.h"
 #include "CIRGenFunction.h"
 #include "CIRGenModule.h"
+#include "CIRGenOpenMPRuntime.h"
 #include "UnimplementedFeatureGuarding.h"
 
 #include "clang/AST/StmtVisitor.h"
@@ -1805,8 +1806,9 @@ LValue ScalarExprEmitter::buildCompoundAssignLValue(
   else
     CGF.buildStoreThroughLValue(RValue::get(Result), LHSLV);
 
-  // TODO[OpenMP]: Check and handle assignment to a variable declared as
-  // last-private.
+  if (CGF.getLangOpts().OpenMP)
+    CGF.CGM.getOpenMPRuntime().checkAndEmitLastprivateConditional(CGF,
+                                                                  E->getLHS());
   return LHSLV;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -973,8 +973,7 @@ void CIRGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
 
   // TODO: prologuecleanupdepth
 
-  if (getLangOpts().OpenMP && CurCodeDecl)
-    llvm_unreachable("NYI");
+  // TODO[OpenMP]: Emit OpenMP specific initialization of the device functions.
 
   // TODO: buildFunctionProlog
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -13,6 +13,7 @@
 #include "CIRGenFunction.h"
 #include "CIRGenCXXABI.h"
 #include "CIRGenModule.h"
+#include "CIRGenOpenMPRuntime.h"
 #include "UnimplementedFeatureGuarding.h"
 
 #include "clang/AST/ASTLambda.h"
@@ -973,7 +974,8 @@ void CIRGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
 
   // TODO: prologuecleanupdepth
 
-  // TODO[OpenMP]: Emit OpenMP specific initialization of the device functions.
+  if (getLangOpts().OpenMP && CurCodeDecl)
+    CGM.getOpenMPRuntime().emitFunctionProlog(*this, CurCodeDecl);
 
   // TODO: buildFunctionProlog
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -928,6 +928,9 @@ public:
   mlir::LogicalResult buildBreakStmt(const clang::BreakStmt &S);
   mlir::LogicalResult buildContinueStmt(const clang::ContinueStmt &S);
 
+  // OpenMP gen functions:
+  mlir::LogicalResult buildOMPParallelDirective(const OMPParallelDirective &S);
+
   LValue buildOpaqueValueLValue(const OpaqueValueExpr *e);
 
   /// Emit code to compute a designator that specifies the location

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -372,15 +372,15 @@ void CIRGenModule::buildGlobal(GlobalDecl GD) {
   if (langOpts.OpenMP) {
     // If this is OpenMP, check if it is legal to emit this global normally.
     if (openMPRuntime && openMPRuntime->emitTargetGlobal(GD)) {
-      assert(UnimplementedFeature::openMPRuntime());
+      assert(!UnimplementedFeature::openMPRuntime());
       return;
     }
     if (auto *DRD = dyn_cast<OMPDeclareReductionDecl>(Global)) {
-      assert(UnimplementedFeature::openMP());
+      assert(!UnimplementedFeature::openMP());
       return;
     }
     if (auto *DMD = dyn_cast<OMPDeclareMapperDecl>(Global)) {
-      assert(UnimplementedFeature::openMP());
+      assert(!UnimplementedFeature::openMP());
       return;
     }
   }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -371,12 +371,16 @@ void CIRGenModule::buildGlobal(GlobalDecl GD) {
 
   if (langOpts.OpenMP) {
     // If this is OpenMP, check if it is legal to emit this global normally.
+    if (openMPRuntime && openMPRuntime->emitTargetGlobal(GD)) {
+      assert(UnimplementedFeature::openMPRuntime());
+      return;
+    }
     if (auto *DRD = dyn_cast<OMPDeclareReductionDecl>(Global)) {
-      assert(0 && "OMPDeclareReductionDecl NYI");
+      assert(UnimplementedFeature::openMP());
       return;
     }
     if (auto *DMD = dyn_cast<OMPDeclareMapperDecl>(Global)) {
-      assert(0 && "OMPDeclareMapperDecl NYI");
+      assert(UnimplementedFeature::openMP());
       return;
     }
   }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -46,6 +46,7 @@ namespace cir {
 class CIRGenFunction;
 class CIRGenCXXABI;
 class TargetCIRGenInfo;
+class CIRGenOpenMPRuntime;
 
 enum ForDefinition_t : bool { NotForDefinition = false, ForDefinition = true };
 
@@ -99,6 +100,9 @@ private:
 
   /// Holds information about C++ vtables.
   CIRGenVTables VTables;
+
+  /// Holds the OpenMP runtime
+  std::unique_ptr<CIRGenOpenMPRuntime> openMPRuntime;
 
   /// Per-function codegen information. Updated everytime buildCIR is called
   /// for FunctionDecls's.
@@ -625,6 +629,12 @@ public:
 
   /// Print out an error that codegen doesn't support the specified decl yet.
   void ErrorUnsupported(const Decl *D, const char *Type);
+
+  /// Return a reference to the configured OpenMP runtime.
+  CIRGenOpenMPRuntime &getOpenMPRuntime() {
+    assert(openMPRuntime != nullptr);
+    return *openMPRuntime;
+  }
 
 private:
   // An ordered map of canonical GlobalDecls to their mangled names.

--- a/clang/lib/CIR/CodeGen/CIRGenOpenMPRuntime.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenMPRuntime.cpp
@@ -1,0 +1,54 @@
+//===--- CIRGenStmtOpenMP.cpp - Interface to OpenMP Runtimes --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This provides a class for OpenMP runtime MLIR code generation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenOpenMPRuntime.h"
+#include "CIRGenFunction.h"
+#include "CIRGenModule.h"
+
+using namespace cir;
+using namespace clang;
+
+CIRGenOpenMPRuntime::CIRGenOpenMPRuntime(CIRGenModule &CGM) : CGM(CGM) {}
+
+Address CIRGenOpenMPRuntime::getAddressOfLocalVariable(CIRGenFunction &CGF,
+                                                       const VarDecl *VD) {
+  // TODO[OpenMP]: Implement this method.
+  return Address::invalid();
+}
+
+void CIRGenOpenMPRuntime::checkAndEmitLastprivateConditional(
+    CIRGenFunction &CGF, const Expr *LHS) {
+  // TODO[OpenMP]: Implement this method.
+  return;
+}
+
+void CIRGenOpenMPRuntime::registerTargetGlobalVariable(
+    const clang::VarDecl *VD, mlir::cir::GlobalOp globalOp) {
+  // TODO[OpenMP]: Implement this method.
+  return;
+}
+
+void CIRGenOpenMPRuntime::emitDeferredTargetDecls() const {
+  // TODO[OpenMP]: Implement this method.
+  return;
+}
+
+void CIRGenOpenMPRuntime::emitFunctionProlog(CIRGenFunction &CGF,
+                                             const clang::Decl *D) {
+  // TODO[OpenMP]: Implement this method.
+  return;
+}
+
+bool CIRGenOpenMPRuntime::emitTargetGlobal(clang::GlobalDecl &GD) {
+  // TODO[OpenMP]: Implement this method.
+  return false;
+}

--- a/clang/lib/CIR/CodeGen/CIRGenOpenMPRuntime.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenMPRuntime.cpp
@@ -21,34 +21,34 @@ CIRGenOpenMPRuntime::CIRGenOpenMPRuntime(CIRGenModule &CGM) : CGM(CGM) {}
 
 Address CIRGenOpenMPRuntime::getAddressOfLocalVariable(CIRGenFunction &CGF,
                                                        const VarDecl *VD) {
-  // TODO[OpenMP]: Implement this method.
+  assert(!UnimplementedFeature::openMPRuntime());
   return Address::invalid();
 }
 
 void CIRGenOpenMPRuntime::checkAndEmitLastprivateConditional(
     CIRGenFunction &CGF, const Expr *LHS) {
-  // TODO[OpenMP]: Implement this method.
+  assert(!UnimplementedFeature::openMPRuntime());
   return;
 }
 
 void CIRGenOpenMPRuntime::registerTargetGlobalVariable(
     const clang::VarDecl *VD, mlir::cir::GlobalOp globalOp) {
-  // TODO[OpenMP]: Implement this method.
+  assert(!UnimplementedFeature::openMPRuntime());
   return;
 }
 
 void CIRGenOpenMPRuntime::emitDeferredTargetDecls() const {
-  // TODO[OpenMP]: Implement this method.
+  assert(!UnimplementedFeature::openMPRuntime());
   return;
 }
 
 void CIRGenOpenMPRuntime::emitFunctionProlog(CIRGenFunction &CGF,
                                              const clang::Decl *D) {
-  // TODO[OpenMP]: Implement this method.
+  assert(!UnimplementedFeature::openMPRuntime());
   return;
 }
 
 bool CIRGenOpenMPRuntime::emitTargetGlobal(clang::GlobalDecl &GD) {
-  // TODO[OpenMP]: Implement this method.
+  assert(!UnimplementedFeature::openMPRuntime());
   return false;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenOpenMPRuntime.h
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenMPRuntime.h
@@ -1,0 +1,77 @@
+//===--- CIRGenOpenMPRuntime.h - Interface to OpenMP Runtimes -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This provides a class for OpenMP runtime MLIR code generation.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_CIR_CODEGEN_CIRGENOPENMPRUNTIME_H
+#define LLVM_CLANG_LIB_CIR_CODEGEN_CIRGENOPENMPRUNTIME_H
+
+#include "CIRGenValue.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+
+namespace clang {
+class Decl;
+class Expr;
+class GlobalDecl;
+class VarDecl;
+} // namespace clang
+
+namespace cir {
+class CIRGenModule;
+class CIRGenFunction;
+
+class CIRGenOpenMPRuntime {
+public:
+  explicit CIRGenOpenMPRuntime(CIRGenModule &CGM);
+  virtual ~CIRGenOpenMPRuntime() {}
+
+  /// Gets the OpenMP-specific address of the local variable.
+  virtual Address getAddressOfLocalVariable(CIRGenFunction &CGF,
+                                            const clang::VarDecl *VD);
+
+  /// Checks if the provided \p LVal is lastprivate conditional and emits the
+  /// code to update the value of the original variable.
+  /// \code
+  /// lastprivate(conditional: a)
+  /// ...
+  /// <type> a;
+  /// lp_a = ...;
+  /// #pragma omp critical(a)
+  /// if (last_iv_a <= iv) {
+  ///   last_iv_a = iv;
+  ///   global_a = lp_a;
+  /// }
+  /// \endcode
+  virtual void checkAndEmitLastprivateConditional(CIRGenFunction &CGF,
+                                                  const clang::Expr *LHS);
+
+  /// Checks if the provided global decl \a GD is a declare target variable and
+  /// registers it when emitting code for the host.
+  virtual void registerTargetGlobalVariable(const clang::VarDecl *VD,
+                                            mlir::cir::GlobalOp globalOp);
+
+  /// Emit deferred declare target variables marked for deferred emission.
+  void emitDeferredTargetDecls() const;
+
+  /// Emits OpenMP-specific function prolog.
+  /// Required for device constructs.
+  virtual void emitFunctionProlog(CIRGenFunction &CGF, const clang::Decl *D);
+
+  /// Emit the global \a GD if it is meaningful for the target. Returns
+  /// if it was emitted successfully.
+  /// \param GD Global to scan.
+  virtual bool emitTargetGlobal(clang::GlobalDecl &D);
+
+protected:
+  CIRGenModule &CGM;
+};
+} // namespace cir
+
+#endif // LLVM_CLANG_LIB_CIR_CODEGEN_CIRGENOPENMPRUNTIME_H

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -187,6 +187,10 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
   case Stmt::GCCAsmStmtClass:
   case Stmt::MSAsmStmtClass:
     return buildAsmStmt(cast<AsmStmt>(*S));
+  // OMP directives:
+  case Stmt::OMPParallelDirectiveClass:
+    return buildOMPParallelDirective(cast<OMPParallelDirective>(*S));
+  // Unsupported AST nodes:
   case Stmt::CapturedStmtClass:
   case Stmt::ObjCAtTryStmtClass:
   case Stmt::ObjCAtThrowStmtClass:
@@ -197,7 +201,6 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
   case Stmt::OMPMetaDirectiveClass:
   case Stmt::OMPCanonicalLoopClass:
   case Stmt::OMPErrorDirectiveClass:
-  case Stmt::OMPParallelDirectiveClass:
   case Stmt::OMPSimdDirectiveClass:
   case Stmt::OMPScopeDirectiveClass:
   case Stmt::OMPTileDirectiveClass:

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -1,0 +1,45 @@
+//===--- CIRGenStmtOpenMP.cpp - Emit MLIR Code from OpenMP Statements -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains code to emit OpenMP Stmt nodes as MLIR code.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenFunction.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+
+using namespace cir;
+using namespace clang;
+using namespace mlir::cir;
+using namespace mlir::omp;
+
+mlir::LogicalResult
+CIRGenFunction::buildOMPParallelDirective(const OMPParallelDirective &S) {
+  mlir::LogicalResult res = mlir::success();
+  auto scopeLoc = getLoc(S.getSourceRange());
+  // Create a `omp.parallel` op.
+  auto parallelOp = builder.create<ParallelOp>(scopeLoc);
+  mlir::Block &block = parallelOp.getRegion().emplaceBlock();
+  mlir::OpBuilder::InsertionGuard guardCase(builder);
+  builder.setInsertionPointToEnd(&block);
+  // Create a scope for the OpenMP region.
+  builder.create<ScopeOp>(
+      scopeLoc, /*scopeBuilder=*/
+      [&](mlir::OpBuilder &b, mlir::Location loc) {
+        LexicalScope lexScope{*this, scopeLoc, builder.getInsertionBlock()};
+        // Emit the body of the region.
+        if (buildStmt(S.getCapturedStmt(OpenMPDirectiveKind::OMPD_parallel)
+                          ->getCapturedStmt(),
+                      /*useCurrentScope=*/true)
+                .failed())
+          res = mlir::failure();
+      });
+  // Add the terminator for `omp.parallel`.
+  builder.create<TerminatorOp>(getLoc(S.getSourceRange().getEnd()));
+  return res;
+}

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -11,11 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "CIRGenFunction.h"
+#include "CIRGenOpenMPRuntime.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 
 using namespace cir;
 using namespace clang;
-using namespace mlir::cir;
 using namespace mlir::omp;
 
 mlir::LogicalResult
@@ -28,7 +28,7 @@ CIRGenFunction::buildOMPParallelDirective(const OMPParallelDirective &S) {
   mlir::OpBuilder::InsertionGuard guardCase(builder);
   builder.setInsertionPointToEnd(&block);
   // Create a scope for the OpenMP region.
-  builder.create<ScopeOp>(
+  builder.create<mlir::cir::ScopeOp>(
       scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
         LexicalScope lexScope{*this, scopeLoc, builder.getInsertionBlock()};

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Target/LLVMIR/Import.h"
 
@@ -58,6 +59,7 @@ void CIRGenerator::Initialize(ASTContext &astCtx) {
   mlirCtx->getOrLoadDialect<mlir::cir::CIRDialect>();
   mlirCtx->getOrLoadDialect<mlir::LLVM::LLVMDialect>();
   mlirCtx->getOrLoadDialect<mlir::memref::MemRefDialect>();
+  mlirCtx->getOrLoadDialect<mlir::omp::OpenMPDialect>();
   CGM = std::make_unique<CIRGenModule>(*mlirCtx.get(), astCtx, codeGenOpts,
                                        Diags);
   auto mod = CGM->getModule();

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -26,6 +26,7 @@ add_clang_library(clangCIR
   CIRGenFunction.cpp
   CIRGenItaniumCXXABI.cpp
   CIRGenModule.cpp
+  CIRGenOpenMPRuntime.cpp
   CIRGenStmt.cpp
   CIRGenStmtOpenMP.cpp
   CIRGenTBAA.cpp

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -27,6 +27,7 @@ add_clang_library(clangCIR
   CIRGenItaniumCXXABI.cpp
   CIRGenModule.cpp
   CIRGenStmt.cpp
+  CIRGenStmtOpenMP.cpp
   CIRGenTBAA.cpp
   CIRGenTypes.cpp
   CIRGenVTables.cpp
@@ -58,6 +59,7 @@ add_clang_library(clangCIR
   MLIRIR
   MLIRLLVMCommonConversion
   MLIRLLVMDialect
+  MLIROpenMPDialect
   MLIRLLVMToLLVMIRTranslation
   MLIRMemRefDialect
   MLIRMemRefToLLVM

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -121,6 +121,8 @@ struct UnimplementedFeature {
   static bool cxxABI() { return false; }
   static bool openCL() { return false; }
   static bool openMP() { return false; }
+  static bool openMPRuntime() { return false; }
+  static bool openMPTarget() { return false; }
   static bool ehStack() { return false; }
   static bool isVarArg() { return false; }
   static bool setNonGC() { return false; }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -34,4 +34,6 @@ add_clang_library(clangCIRLoweringDirectToLLVM
   MLIRTransforms
   MLIRSupport
   MLIRMemRefDialect
+  MLIROpenMPDialect
+  MLIROpenMPToLLVMIRTranslation
   )

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -42,6 +42,7 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
@@ -2341,6 +2342,7 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx,
 
   mlir::registerBuiltinDialectTranslation(*mlirCtx);
   mlir::registerLLVMDialectTranslation(*mlirCtx);
+  mlir::registerOpenMPDialectTranslation(*mlirCtx);
   registerCIRDialectTranslation(*mlirCtx);
 
   auto ModuleName = theModule.getName();

--- a/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
@@ -34,4 +34,6 @@ add_clang_library(clangCIRLoweringThroughMLIR
   MLIRTransforms
   MLIRSupport
   MLIRMemRefDialect
+  MLIROpenMPDialect
+  MLIROpenMPToLLVMIRTranslation
   )

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -33,6 +33,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
@@ -679,6 +680,7 @@ lowerFromCIRToMLIRToLLVMIR(mlir::ModuleOp theModule,
 
   mlir::registerBuiltinDialectTranslation(*mlirCtx);
   mlir::registerLLVMDialectTranslation(*mlirCtx);
+  mlir::registerOpenMPDialectTranslation(*mlirCtx);
 
   auto llvmModule = mlir::translateModuleToLLVMIR(theModule, llvmCtx);
 

--- a/clang/test/CIR/CodeGen/openmp.cpp
+++ b/clang/test/CIR/CodeGen/openmp.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -clangir-disable-emit-cxx-default -fopenmp -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fopenmp -fclangir-enable -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 // CHECK: cir.func

--- a/clang/test/CIR/CodeGen/openmp.cpp
+++ b/clang/test/CIR/CodeGen/openmp.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -clangir-disable-emit-cxx-default -fopenmp -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// CHECK: cir.func
+void omp_parallel_1() {
+// CHECK: omp.parallel {
+// CHECK-NEXT: cir.scope {
+// CHECK-NEXT: }
+// CHECK-NEXT: omp.terminator
+// CHECK-NEXT: }
+#pragma omp parallel
+{
+}
+}
+// CHECK: cir.func
+void omp_parallel_2() {
+// CHECK: %[[YVarDecl:.+]] = {{.*}} ["y", init]
+// CHECK: omp.parallel {
+// CHECK-NEXT: cir.scope {
+// CHECK-NEXT: %[[XVarDecl:.+]] = {{.*}} ["x", init]
+// CHECK-NEXT: %[[C1:.+]] = cir.const(#cir.int<1> : !s32i)
+// CHECK-NEXT: cir.store %[[C1]], %[[XVarDecl]]
+// CHECK-NEXT: %[[XVal:.+]] = cir.load %[[XVarDecl]]
+// CHECK-NEXT: %[[COne:.+]] = cir.const(#cir.int<1> : !s32i)
+// CHECK-NEXT: %[[BinOpVal:.+]] = cir.binop(add, %[[XVal]], %[[COne]])
+// CHECK-NEXT: cir.store %[[BinOpVal]], %[[YVarDecl]]
+// CHECK-NEXT: }
+// CHECK-NEXT: omp.terminator
+// CHECK-NEXT: }
+  int y = 0;
+#pragma omp parallel
+{
+  int x = 1;
+  y = x + 1;
+}
+}

--- a/clang/test/CIR/Lowering/openmp.cir
+++ b/clang/test/CIR/Lowering/openmp.cir
@@ -1,0 +1,35 @@
+// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+module {
+    cir.func @omp_parallel() {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["y", init] {alignment = 4 : i64}
+    %1 = cir.const(#cir.int<0> : !s32i) : !s32i
+    cir.store %1, %0 : !s32i, cir.ptr <!s32i>
+    omp.parallel {
+      cir.scope {
+        %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
+        %3 = cir.const(#cir.int<1> : !s32i) : !s32i
+        cir.store %3, %2 : !s32i, cir.ptr <!s32i>
+        %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+        %5 = cir.const(#cir.int<1> : !s32i) : !s32i
+        %6 = cir.binop(add, %4, %5) : !s32i
+        cir.store %6, %0 : !s32i, cir.ptr <!s32i>
+      }
+      omp.terminator
+    }
+    cir.return
+  }
+}
+// CHECK-LABEL: omp_parallel
+// CHECK: call void (ptr, i32, ptr, ...) @__kmpc_fork_call({{.*}}, ptr @omp_parallel..omp_par,
+// CHECK: ret void
+// CHECK-NEXT: }
+// CHECK: define{{.*}} void @omp_parallel..omp_par(ptr
+// CHECK: %[[YVar:.*]] = load ptr, ptr %{{.*}}, align 8
+// CHECK: %[[XVar:.*]] = alloca i32, i64 1, align 4
+// CHECK: store i32 1, ptr %[[XVar]], align 4
+// CHECK: %[[XVal:.*]] = load i32, ptr %[[XVar]], align 4
+// CHECK: %[[BinOp:.*]] = add i32 %[[XVal]], 1
+// CHECK: store i32 %[[BinOp]], ptr %[[YVar]], align 4
+// CHECK: ret

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
@@ -30,7 +31,8 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   registry.insert<mlir::BuiltinDialect, mlir::arith::ArithDialect,
                   mlir::cir::CIRDialect, mlir::memref::MemRefDialect,
-                  mlir::LLVM::LLVMDialect, mlir::DLTIDialect>();
+                  mlir::LLVM::LLVMDialect, mlir::DLTIDialect,
+                  mlir::omp::OpenMPDialect>();
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return cir::createConvertMLIRToLLVMPass();


### PR DESCRIPTION
This patch introduces initial support for:
```
pragma omp parallel
```

This patch doesn't add support for any of the `parallel` clauses, including variable privatization; thus, all variables are handled as shared.

This PR fixes issue #285.