### PR TITLE
[CIR] fix constant type verification

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -250,7 +250,7 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
     return success();
   }
 
-  if (attrType.isa<IntegerAttr, FloatAttr>()) {
+  if (attrType.isa<mlir::cir::IntAttr, FloatAttr>()) {
     auto at = attrType.cast<TypedAttr>();
     if (at.getType() != opType) {
       return op->emitOpError("result type (")

--- a/clang/test/CIR/IR/int.cir
+++ b/clang/test/CIR/IR/int.cir
@@ -8,10 +8,10 @@
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
 
-!u8i = !cir.int<s, 8>
-!u16i = !cir.int<s, 16>
-!u32i = !cir.int<s, 32>
-!u64i = !cir.int<s, 64>
+!u8i = !cir.int<u, 8>
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
 
 cir.func @validIntTypesAndAttributes() -> () {
 

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -786,3 +786,12 @@ module {
   }
 }
 
+// -----
+
+!s8i = !cir.int<s, 8>
+!u8i = !cir.int<u, 8>
+cir.func @const_type_mismatch() -> () {
+    // expected-error@+1 {{'cir.const' op result type ('!cir.int<u, 8>') does not match value type ('!cir.int<s, 8>')}}
+    %2 = cir.const(#cir.int<0> : !s8i) : !u8i
+    cir.return
+}


### PR DESCRIPTION
When introducing attribute `#cir.int`, the constant type verification is not updated. If a `cir.const` operation produces an integral constant from a `#cir.int` attribute, the integer's type is not verified:

```mlir
%1 = cir.const(#cir.int<0> : !cir.int<s, 8>) : !cir.int<u, 8>
// Not verified: !cir.int<s, 8> differs from !cir.int<u, 8>
```

The corresponding test is also wrong but fail to be detected.

This patch fixes this issue.