### PR TITLE
[CIR][CodeGen][Lowering] Supports arrays with trailing zeros

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -117,15 +117,21 @@ def ConstArrayAttr : CIR_Attr<"ConstArray", "const_array", [TypedAttrInterface]>
 
   let parameters = (ins AttributeSelfTypeParameter<"">:$type,
                         "Attribute":$elts,
-                        "bool":$hasTrailingZeros);
+                        "int":$trailingZerosNum);
 
   // Define a custom builder for the type; that removes the need to pass
   // in an MLIRContext instance, as it can be infered from the `type`.
   let builders = [
     AttrBuilderWithInferredContext<(ins "mlir::cir::ArrayType":$type,
-                                        "Attribute":$elts,
-                                        CArg<"bool", "false">:$hasTrailingZeros), [{
-      return $_get(type.getContext(), type, elts, hasTrailingZeros);
+                                        "Attribute":$elts), [{
+      int zeros = 0;
+      auto typeSize = type.cast<mlir::cir::ArrayType>().getSize();
+      if (auto str = elts.dyn_cast<mlir::StringAttr>())
+        zeros = typeSize - str.size();
+      else
+        zeros = typeSize - elts.cast<mlir::ArrayAttr>().size();
+
+      return $_get(type.getContext(), type, elts, zeros);
     }]>
   ];
 
@@ -137,15 +143,6 @@ def ConstArrayAttr : CIR_Attr<"ConstArray", "const_array", [TypedAttrInterface]>
 
   let extraClassDeclaration = [{
     bool hasTrailingZeros() const { return getTrailingZerosNum() != 0; };
-
-    int getTrailingZerosNum() const {
-      auto typeSize = getType().cast<mlir::cir::ArrayType>().getSize();
-      auto elts = getElts();
-      if (auto str = elts.dyn_cast<mlir::StringAttr>())
-        return typeSize - str.size();
-      else
-        return typeSize - getElts().cast<mlir::ArrayAttr>().size();
-    }
   }];
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -116,14 +116,16 @@ def ConstArrayAttr : CIR_Attr<"ConstArray", "const_array", [TypedAttrInterface]>
   }];
 
   let parameters = (ins AttributeSelfTypeParameter<"">:$type,
-                        "Attribute":$elts);
+                        "Attribute":$elts,
+                        "bool":$hasTrailingZeros);
 
   // Define a custom builder for the type; that removes the need to pass
   // in an MLIRContext instance, as it can be infered from the `type`.
   let builders = [
     AttrBuilderWithInferredContext<(ins "mlir::cir::ArrayType":$type,
-                                        "Attribute":$elts), [{
-      return $_get(type.getContext(), type, elts);
+                                        "Attribute":$elts,
+                                        CArg<"bool", "false">:$hasTrailingZeros), [{
+      return $_get(type.getContext(), type, elts, hasTrailingZeros);
     }]>
   ];
 
@@ -132,6 +134,19 @@ def ConstArrayAttr : CIR_Attr<"ConstArray", "const_array", [TypedAttrInterface]>
 
   // Enable verifier.
   let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    bool hasTrailingZeros() const { return getTrailingZerosNum() != 0; };
+
+    int getTrailingZerosNum() const {
+      auto typeSize = getType().cast<mlir::cir::ArrayType>().getSize();
+      auto elts = getElts();
+      if (auto str = elts.dyn_cast<mlir::StringAttr>())
+        return typeSize - str.size();
+      else
+        return typeSize - getElts().cast<mlir::ArrayAttr>().size();
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -165,8 +165,9 @@ public:
   }
 
   mlir::cir::ConstArrayAttr getConstArray(mlir::Attribute attrs,
-                                          mlir::cir::ArrayType arrayTy) {
-    return mlir::cir::ConstArrayAttr::get(arrayTy, attrs);
+                                          mlir::cir::ArrayType arrayTy,
+                                          bool hasTrailingZeros = false) {
+    return mlir::cir::ConstArrayAttr::get(arrayTy, attrs, hasTrailingZeros);
   }
 
   mlir::Attribute getConstStructOrZeroAttr(mlir::ArrayAttr arrayAttr,

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -165,9 +165,8 @@ public:
   }
 
   mlir::cir::ConstArrayAttr getConstArray(mlir::Attribute attrs,
-                                          mlir::cir::ArrayType arrayTy,
-                                          bool hasTrailingZeros = false) {
-    return mlir::cir::ConstArrayAttr::get(arrayTy, attrs, hasTrailingZeros);
+                                          mlir::cir::ArrayType arrayTy) {
+    return mlir::cir::ConstArrayAttr::get(arrayTy, attrs);
   }
 
   mlir::Attribute getConstStructOrZeroAttr(mlir::ArrayAttr arrayAttr,

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -956,10 +956,19 @@ buildArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
   // Add a zeroinitializer array filler if we have lots of trailing zeroes.
   unsigned TrailingZeroes = ArrayBound - NonzeroLength;
   if (TrailingZeroes >= 8) {
-    assert(0 && "NYE");
     assert(Elements.size() >= NonzeroLength &&
            "missing initializer for non-zero element");
 
+    SmallVector<mlir::Attribute, 4> Eles;
+    Eles.reserve(Elements.size());
+    for (auto const &Element : Elements)
+      Eles.push_back(Element);
+
+    return builder.getConstArray(
+        mlir::ArrayAttr::get(builder.getContext(), Eles),
+        mlir::cir::ArrayType::get(builder.getContext(), CommonElementType,
+                                  ArrayBound),
+        TrailingZeroes);
     // TODO(cir): If all the elements had the same type up to the trailing
     // zeroes, emit a struct of two arrays (the nonzero data and the
     // zeroinitializer). Use DesiredType to get the element type.

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -967,8 +967,7 @@ buildArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
     return builder.getConstArray(
         mlir::ArrayAttr::get(builder.getContext(), Eles),
         mlir::cir::ArrayType::get(builder.getContext(), CommonElementType,
-                                  ArrayBound),
-        TrailingZeroes);
+                                  ArrayBound));
     // TODO(cir): If all the elements had the same type up to the trailing
     // zeroes, emit a struct of two arrays (the nonzero data and the
     // zeroinitializer). Use DesiredType to get the element type.

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2305,13 +2305,9 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
   auto at = type.cast<ArrayType>();
 
   // Make sure both number of elements and subelement types match type.
-<<<<<<< HEAD
-  if (at.getSize() != arrayAttr.size())
-=======
   auto trailingZeros = at.getSize() - arrayAttr.size();
   if ((!hasTrailingZeros && trailingZeros) ||
       (hasTrailingZeros && !trailingZeros))
->>>>>>> 23611f0f5608 (simplified a little)
     return emitError() << "constant array size should match type size";
   LogicalResult eltTypeCheck = success();
   arrayAttr.walkImmediateSubElements(
@@ -2376,13 +2372,6 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
     }
   }
 
-<<<<<<< HEAD
-  // Parse literal '>'
-  if (parser.parseGreater())
-    return {};
-  return parser.getChecked<ConstArrayAttr>(loc, parser.getContext(),
-                                           resultTy.value(), resultVal.value());
-=======
   bool hasZeros = false;
   if (parser.parseOptionalComma().succeeded()) {
     if (parser.parseOptionalKeyword("trailingZeros").succeeded())
@@ -2397,17 +2386,13 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
 
   return parser.getChecked<ConstArrayAttr>(
       loc, parser.getContext(), resultTy.value(), resultVal.value(), hasZeros);
->>>>>>> 23611f0f5608 (simplified a little)
 }
 
 void ConstArrayAttr::print(::mlir::AsmPrinter &printer) const {
   printer << "<";
   printer.printStrippedAttrOrType(getElts());
-<<<<<<< HEAD
-=======
   if (auto zeros = getTrailingZerosNum())
     printer << ", trailingZeros";
->>>>>>> 23611f0f5608 (simplified a little)
   printer << ">";
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2282,7 +2282,7 @@ mlir::OpTrait::impl::verifySameFirstSecondOperandAndResultType(Operation *op) {
 
 LogicalResult mlir::cir::ConstArrayAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
-    ::mlir::Type type, Attribute attr) {
+    ::mlir::Type type, Attribute attr, bool hasTrailingZeros) {
 
   if (!(attr.isa<mlir::ArrayAttr>() || attr.isa<mlir::StringAttr>()))
     return emitError() << "constant array expects ArrayAttr or StringAttr";
@@ -2305,7 +2305,13 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
   auto at = type.cast<ArrayType>();
 
   // Make sure both number of elements and subelement types match type.
+<<<<<<< HEAD
   if (at.getSize() != arrayAttr.size())
+=======
+  auto trailingZeros = at.getSize() - arrayAttr.size();
+  if ((!hasTrailingZeros && trailingZeros) ||
+      (hasTrailingZeros && !trailingZeros))
+>>>>>>> 23611f0f5608 (simplified a little)
     return emitError() << "constant array size should match type size";
   LogicalResult eltTypeCheck = success();
   arrayAttr.walkImmediateSubElements(
@@ -2370,16 +2376,38 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
     }
   }
 
+<<<<<<< HEAD
   // Parse literal '>'
   if (parser.parseGreater())
     return {};
   return parser.getChecked<ConstArrayAttr>(loc, parser.getContext(),
                                            resultTy.value(), resultVal.value());
+=======
+  bool hasZeros = false;
+  if (parser.parseOptionalComma().succeeded()) {
+    if (parser.parseOptionalKeyword("trailingZeros").succeeded())
+      hasZeros = true;
+    else
+      return {};
+  }
+
+  // Parse literal '>'
+  if (parser.parseGreater())
+    return {};
+
+  return parser.getChecked<ConstArrayAttr>(
+      loc, parser.getContext(), resultTy.value(), resultVal.value(), hasZeros);
+>>>>>>> 23611f0f5608 (simplified a little)
 }
 
 void ConstArrayAttr::print(::mlir::AsmPrinter &printer) const {
   printer << "<";
   printer.printStrippedAttrOrType(getElts());
+<<<<<<< HEAD
+=======
+  if (auto zeros = getTrailingZerosNum())
+    printer << ", trailingZeros";
+>>>>>>> 23611f0f5608 (simplified a little)
   printer << ">";
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1034,8 +1034,13 @@ public:
         return op.emitError() << "array does not have a constant initializer";
 
       std::optional<mlir::Attribute> denseAttr;
-      if (constArr &&
-          (denseAttr = lowerConstArrayAttr(constArr, typeConverter))) {
+      if (constArr && hasTrailingZeros(constArr)) {
+        auto newOp =
+            lowerCirAttrAsValue(op, constArr, rewriter, getTypeConverter());
+        rewriter.replaceOp(op, newOp);
+        return mlir::success();
+      } else if (constArr &&
+                 (denseAttr = lowerConstArrayAttr(constArr, typeConverter))) {
         attr = denseAttr.value();
       } else {
         auto initVal =

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -983,6 +983,15 @@ lowerConstArrayAttr(mlir::cir::ConstArrayAttr constArr,
   return std::nullopt;
 }
 
+bool hasTrailingZeros(mlir::cir::ConstArrayAttr attr) {
+  auto array = attr.getElts().dyn_cast<mlir::ArrayAttr>();
+  return attr.hasTrailingZeros() ||
+         (array && std::count_if(array.begin(), array.end(), [](auto elt) {
+            auto ar = dyn_cast<mlir::cir::ConstArrayAttr>(elt);
+            return ar && hasTrailingZeros(ar);
+          }));
+}
+
 class CIRConstantLowering
     : public mlir::OpConversionPattern<mlir::cir::ConstantOp> {
 public:

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -213,7 +213,15 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
                                 const mlir::TypeConverter *converter) {
   auto llvmTy = converter->convertType(constArr.getType());
   auto loc = parentOp->getLoc();
-  mlir::Value result = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
+  mlir::Value result;
+
+  if (auto zeros = constArr.getTrailingZerosNum()) {
+    auto arrayTy = constArr.getType();
+    result = rewriter.create<mlir::cir::ZeroInitConstOp>(
+        loc, converter->convertType(arrayTy));
+  } else {
+    result = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
+  }
 
   // Iteratively lower each constant element of the array.
   if (auto arrayAttr = constArr.getElts().dyn_cast<mlir::ArrayAttr>()) {

--- a/clang/test/CIR/CodeGen/const-array.c
+++ b/clang/test/CIR/CodeGen/const-array.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s
+
+void foo() {
+  int a[10] = {1};
+}
+
+// CHECK: cir.func {{.*@foo}}
+// CHECK:   %0 = cir.alloca !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>, ["a"] {alignment = 16 : i64}
+// CHECK:   %1 = cir.const(#cir.const_array<[#cir.int<1> : !s32i], trailingZeros> : !cir.array<!s32i x 10>) : !cir.array<!s32i x 10>
+// CHECK:   cir.store %1, %0 : !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>

--- a/clang/test/CIR/CodeGen/const-array.c
+++ b/clang/test/CIR/CodeGen/const-array.c
@@ -6,5 +6,5 @@ void foo() {
 
 // CHECK: cir.func {{.*@foo}}
 // CHECK:   %0 = cir.alloca !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>, ["a"] {alignment = 16 : i64}
-// CHECK:   %1 = cir.const(#cir.const_array<[#cir.int<1> : !s32i], trailingZeros> : !cir.array<!s32i x 10>) : !cir.array<!s32i x 10>
+// CHECK:   %1 = cir.const(#cir.const_array<[#cir.int<1> : !s32i], trailing_zeros> : !cir.array<!s32i x 10>) : !cir.array<!s32i x 10>
 // CHECK:   cir.store %1, %0 : !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>

--- a/clang/test/CIR/Lowering/const.cir
+++ b/clang/test/CIR/Lowering/const.cir
@@ -39,7 +39,7 @@ module {
 
   cir.func @testArrWithTrailingZeros() {
     %0 = cir.alloca !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>, ["a"] {alignment = 16 : i64}
-    %1 = cir.const(#cir.const_array<[#cir.int<1> : !s32i], trailingZeros> : !cir.array<!s32i x 10>) : !cir.array<!s32i x 10>
+    %1 = cir.const(#cir.const_array<[#cir.int<1> : !s32i], trailing_zeros> : !cir.array<!s32i x 10>) : !cir.array<!s32i x 10>
     cir.store %1, %0 : !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>
     cir.return
   }

--- a/clang/test/CIR/Lowering/const.cir
+++ b/clang/test/CIR/Lowering/const.cir
@@ -18,10 +18,10 @@ module {
     cir.return
   }
 
-  cir.func @testConstArrayOfStructs() {
-    %0 = cir.alloca !cir.array<!ty_22anon2E122 x 1>, cir.ptr <!cir.array<!ty_22anon2E122 x 1>>, ["a"] {alignment = 4 : i64}
-    %1 = cir.const(#cir.const_array<[#cir.const_struct<{#cir.int<0> : !s32i, #cir.int<1> : !s32i}> : !ty_22anon2E122]> : !cir.array<!ty_22anon2E122 x 1>) : !cir.array<!ty_22anon2E122 x 1>
-    cir.store %1, %0 : !cir.array<!ty_22anon2E122 x 1>, cir.ptr <!cir.array<!ty_22anon2E122 x 1>>
+  cir.func @testArrWithTrailingZeros() {
+    %0 = cir.alloca !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>, ["a"] {alignment = 16 : i64}
+    %1 = cir.const(#cir.const_array<[#cir.int<1> : !s32i], trailingZeros> : !cir.array<!s32i x 10>) : !cir.array<!s32i x 10>
+    cir.store %1, %0 : !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>
     cir.return
   }
   // CHECK:  llvm.func @testConstArrayOfStructs()

--- a/clang/test/CIR/Lowering/const.cir
+++ b/clang/test/CIR/Lowering/const.cir
@@ -18,10 +18,10 @@ module {
     cir.return
   }
 
-  cir.func @testArrWithTrailingZeros() {
-    %0 = cir.alloca !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>, ["a"] {alignment = 16 : i64}
-    %1 = cir.const(#cir.const_array<[#cir.int<1> : !s32i], trailingZeros> : !cir.array<!s32i x 10>) : !cir.array<!s32i x 10>
-    cir.store %1, %0 : !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>
+  cir.func @testConstArrayOfStructs() {
+    %0 = cir.alloca !cir.array<!ty_22anon2E122 x 1>, cir.ptr <!cir.array<!ty_22anon2E122 x 1>>, ["a"] {alignment = 4 : i64}
+    %1 = cir.const(#cir.const_array<[#cir.const_struct<{#cir.int<0> : !s32i, #cir.int<1> : !s32i}> : !ty_22anon2E122]> : !cir.array<!ty_22anon2E122 x 1>) : !cir.array<!ty_22anon2E122 x 1>
+    cir.store %1, %0 : !cir.array<!ty_22anon2E122 x 1>, cir.ptr <!cir.array<!ty_22anon2E122 x 1>>
     cir.return
   }
   // CHECK:  llvm.func @testConstArrayOfStructs()
@@ -36,5 +36,18 @@ module {
   // CHECK:    %8 = llvm.insertvalue %7, %2[0] : !llvm.array<1 x struct<"struct.anon.1", (i32, i32)>>
   // CHECK:    llvm.store %8, %1 : !llvm.array<1 x struct<"struct.anon.1", (i32, i32)>>, !llvm.ptr
   // CHECK:    llvm.return
+
+  cir.func @testArrWithTrailingZeros() {
+    %0 = cir.alloca !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>, ["a"] {alignment = 16 : i64}
+    %1 = cir.const(#cir.const_array<[#cir.int<1> : !s32i], trailingZeros> : !cir.array<!s32i x 10>) : !cir.array<!s32i x 10>
+    cir.store %1, %0 : !cir.array<!s32i x 10>, cir.ptr <!cir.array<!s32i x 10>>
+    cir.return
+  }
+  // CHECK: llvm.func @testArrWithTrailingZeros()
+  // CHECK:   %0 = llvm.mlir.constant(1 : index) : i64
+  // CHECK:   %1 = llvm.alloca %0 x !llvm.array<10 x i32> {alignment = 16 : i64} : (i64) -> !llvm.ptr
+  // CHECK:   %2 = cir.llvmir.zeroinit : !llvm.array<10 x i32>
+  // CHECK:   %3 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK:   %4 = llvm.insertvalue %3, %2[0] : !llvm.array<10 x i32>
 
 }


### PR DESCRIPTION
This PR adds support for constant arrays with trailing zeros.

The original `CodeGen` does the following: once a constant array contain trailing zeros,  a struct with two members is generated: initialized elements and `zeroinitializer` for the remaining part. And depending on some conditions,  `memset` or `memcpy` are emitted.  In the latter case a global const array is created. 
Well, we may go this way, but it requires us to implement [features](https://github.com/llvm/clangir/blob/main/clang/lib/CIR/CodeGen/CIRGenDecl.cpp#L182) that are not implemented yet. 

Another option is to add one more parameter to the `constArrayAttr` and utilize it during the lowering.  So far I chose this way, but if you have any doubts, we can discuss here. So we just emit constant array as usually and once there are trailing zeros, lower this arrray (i.e. an attribute) as a value.

I added a couple of tests and will add more, once we agree on the approach. So far I marked the PR as a draft one. 
