### PR TITLE
[CIR][IR] Implement `cir.break` operation

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -605,14 +605,13 @@ def ConditionOp : CIR_Op<"condition", [
 // YieldOp
 //===----------------------------------------------------------------------===//
 
-def YieldOpKind_BK : I32EnumAttrCase<"Break", 1, "break">;
 def YieldOpKind_FT : I32EnumAttrCase<"Fallthrough", 2, "fallthrough">;
 def YieldOpKind_NS : I32EnumAttrCase<"NoSuspend", 4, "nosuspend">;
 
 def YieldOpKind : I32EnumAttr<
     "YieldOpKind",
     "yield kind",
-    [YieldOpKind_BK, YieldOpKind_FT, YieldOpKind_NS]> {
+    [YieldOpKind_FT, YieldOpKind_NS]> {
   let cppNamespace = "::mlir::cir";
 }
 
@@ -629,8 +628,6 @@ def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     defined by the parent operation.
 
     Optionally, `cir.yield` can be annotated with extra kind specifiers:
-    - `break`: breaking out of the innermost `cir.switch` / `cir.loop` semantics,
-    cannot be used if not dominated by these parent operations.
     - `fallthrough`: execution falls to the next region in `cir.switch` case list.
     Only available inside `cir.switch` regions.
     - `nosuspend`: specific to the `ready` region inside `cir.await` op, it makes
@@ -707,14 +704,26 @@ def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     bool isFallthrough() {
       return !isPlain() && *getKind() == YieldOpKind::Fallthrough;
     }
-    bool isBreak() {
-      return !isPlain() && *getKind() == YieldOpKind::Break;
-    }
     bool isNoSuspend() {
       return !isPlain() && *getKind() == YieldOpKind::NoSuspend;
     }
   }];
 
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// BreakOp
+//===----------------------------------------------------------------------===//
+
+def BreakOp : CIR_Op<"break", [Terminator]> {
+  let summary = "C/C++ `break` statement equivalent";
+  let description = [{
+    The `cir.break` operation is used to cease the control flow to the parent
+    operation, exiting its region's control flow. It is only allowed if it is
+    within a breakable operation (loops and `switch`).
+  }];
+  let assemblyFormat = "attr-dict";
   let hasVerifier = 1;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -583,6 +583,11 @@ public:
     return create<mlir::cir::ConditionOp>(condition.getLoc(), condition);
   }
 
+  /// Create a break operation.
+  mlir::cir::BreakOp createBreak(mlir::Location loc) {
+    return create<mlir::cir::BreakOp>(loc);
+  }
+
   /// Create a continue operation.
   mlir::cir::ContinueOp createContinue(mlir::Location loc) {
     return create<mlir::cir::ContinueOp>(loc);

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -574,11 +574,7 @@ CIRGenFunction::buildContinueStmt(const clang::ContinueStmt &S) {
 }
 
 mlir::LogicalResult CIRGenFunction::buildBreakStmt(const clang::BreakStmt &S) {
-  builder.create<YieldOp>(
-      getLoc(S.getBreakLoc()),
-      mlir::cir::YieldOpKindAttr::get(builder.getContext(),
-                                      mlir::cir::YieldOpKind::Break),
-      mlir::ValueRange({}));
+  builder.createBreak(getLoc(S.getBreakLoc()));
   return mlir::success();
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -226,6 +226,17 @@ void AllocaOp::build(::mlir::OpBuilder &odsBuilder,
 }
 
 //===----------------------------------------------------------------------===//
+// BreakOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult BreakOp::verify() {
+  if (!getOperation()->getParentOfType<LoopOp>() &&
+      !getOperation()->getParentOfType<SwitchOp>())
+    return emitOpError("must be within a loop or switch");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConditionOp
 //===-----------------------------------------------------------------------===//
 
@@ -774,17 +785,6 @@ void TernaryOp::build(OpBuilder &builder, OperationState &result, Value cond,
 //===----------------------------------------------------------------------===//
 
 mlir::LogicalResult YieldOp::verify() {
-  auto isDominatedByLoopOrSwitch = [&](Operation *parentOp) {
-    while (!llvm::isa<cir::FuncOp>(parentOp)) {
-      if (llvm::isa<cir::SwitchOp, cir::LoopOp>(parentOp))
-        return true;
-      parentOp = parentOp->getParentOp();
-    }
-
-    emitOpError() << "shall be dominated by 'cir.loop' or 'cir.switch'";
-    return false;
-  };
-
   auto isDominatedByProperAwaitRegion = [&](Operation *parentOp,
                                             mlir::Region *currRegion) {
     while (!llvm::isa<cir::FuncOp>(parentOp)) {
@@ -809,12 +809,6 @@ mlir::LogicalResult YieldOp::verify() {
   if (isNoSuspend()) {
     if (!isDominatedByProperAwaitRegion(getOperation()->getParentOp(),
                                         getOperation()->getParentRegion()))
-      return mlir::failure();
-    return mlir::success();
-  }
-
-  if (isBreak()) {
-    if (!isDominatedByLoopOrSwitch(getOperation()->getParentOp()))
       return mlir::failure();
     return mlir::success();
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -356,32 +356,6 @@ mlir::LLVM::Linkage convertLinkage(mlir::cir::GlobalLinkageKind linkage) {
   };
 }
 
-static void lowerNestedYield(mlir::cir::YieldOpKind targetKind,
-                             mlir::ConversionPatternRewriter &rewriter,
-                             mlir::Region &body, mlir::Block *dst) {
-  // top-level yields are lowered in matchAndRewrite of the parent operations
-  auto isNested = [&](mlir::Operation *op) {
-    return op->getParentRegion() != &body;
-  };
-
-  body.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
-    if (!isNested(op))
-      return mlir::WalkResult::advance();
-
-    // don't process breaks/continues in nested loops and switches
-    if (isa<mlir::cir::LoopOp, mlir::cir::SwitchOp>(*op))
-      return mlir::WalkResult::skip();
-
-    auto yield = dyn_cast<mlir::cir::YieldOp>(*op);
-    if (yield && yield.getKind() == targetKind) {
-      rewriter.setInsertionPoint(op);
-      rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(op, yield.getArgs(), dst);
-    }
-
-    return mlir::WalkResult::advance();
-  });
-}
-
 class CIRCopyOpLowering : public mlir::OpConversionPattern<mlir::cir::CopyOp> {
 public:
   using mlir::OpConversionPattern<mlir::cir::CopyOp>::OpConversionPattern;
@@ -462,7 +436,6 @@ public:
     auto &bodyFrontBlock = bodyRegion.front();
     auto bodyYield =
         dyn_cast<mlir::cir::YieldOp>(bodyRegion.back().getTerminator());
-    assert(bodyYield && "unstructured while loops are NYI");
 
     // Fetch required info from the step region.
     auto &stepRegion = loopOp.getStep();
@@ -471,9 +444,6 @@ public:
         dyn_cast<mlir::cir::YieldOp>(stepRegion.back().getTerminator());
     auto &stepBlock = (kind == LoopKind::For ? stepFrontBlock : condFrontBlock);
 
-    lowerNestedYield(mlir::cir::YieldOpKind::Break, rewriter, bodyRegion,
-                     continueBlock);
-
     // Lower continue statements.
     mlir::Block &dest =
         (kind != LoopKind::For ? condFrontBlock : stepFrontBlock);
@@ -481,6 +451,13 @@ public:
         loopOp.getBody(), [&](mlir::Operation *op) {
           if (isa<mlir::cir::ContinueOp>(op))
             lowerTerminator(op, &dest, rewriter);
+        });
+
+    // Lower break statements.
+    walkRegionSkipping<mlir::cir::LoopOp, mlir::cir::SwitchOp>(
+        loopOp.getBody(), [&](mlir::Operation *op) {
+          if (isa<mlir::cir::BreakOp>(op))
+            lowerTerminator(op, continueBlock, rewriter);
         });
 
     // Move loop op region contents to current CFG.
@@ -500,11 +477,10 @@ public:
     lowerConditionOp(conditionOp, &bodyFrontBlock, continueBlock, rewriter);
 
     // Branch from body to condition or to step on for-loop cases.
-    rewriter.setInsertionPoint(bodyYield);
-    auto bodyYieldDest = bodyYield.getKind() == mlir::cir::YieldOpKind::Break
-                             ? continueBlock
-                             : &stepBlock;
-    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(bodyYield, bodyYieldDest);
+    if (bodyYield) {
+      rewriter.setInsertionPoint(bodyYield);
+      rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(bodyYield, &stepBlock);
+    }
 
     // Is a for loop: branch from step to condition.
     if (kind == LoopKind::For) {
@@ -711,10 +687,6 @@ public:
   }
 };
 
-static bool isBreak(mlir::cir::YieldOp &op) {
-  return op.getKind() == mlir::cir::YieldOpKind::Break;
-}
-
 class CIRIfLowering : public mlir::OpConversionPattern<mlir::cir::IfOp> {
 public:
   using mlir::OpConversionPattern<mlir::cir::IfOp>::OpConversionPattern;
@@ -743,10 +715,8 @@ public:
     rewriter.setInsertionPointToEnd(thenAfterBody);
     if (auto thenYieldOp =
             dyn_cast<mlir::cir::YieldOp>(thenAfterBody->getTerminator())) {
-      if (!isBreak(thenYieldOp)) // lowering of parent loop yields is
-                                 // deferred to loop lowering
-        rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
-            thenYieldOp, thenYieldOp.getArgs(), continueBlock);
+      rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
+          thenYieldOp, thenYieldOp.getArgs(), continueBlock);
     }
 
     rewriter.setInsertionPointToEnd(continueBlock);
@@ -772,10 +742,8 @@ public:
       rewriter.setInsertionPointToEnd(elseAfterBody);
       if (auto elseYieldOp =
               dyn_cast<mlir::cir::YieldOp>(elseAfterBody->getTerminator())) {
-        if (!isBreak(elseYieldOp)) // lowering of parent loop yields
-                                   // is deferred to loop lowering
-          rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
-              elseYieldOp, elseYieldOp.getArgs(), continueBlock);
+        rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
+            elseYieldOp, elseYieldOp.getArgs(), continueBlock);
       }
     }
 
@@ -829,18 +797,13 @@ public:
     // Replace the scopeop return with a branch that jumps out of the body.
     // Stack restore before leaving the body region.
     rewriter.setInsertionPointToEnd(afterBody);
-    auto yieldOp = dyn_cast<mlir::cir::YieldOp>(afterBody->getTerminator());
-
-    if (yieldOp && !isBreak(yieldOp)) {
-      auto branchOp = rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(
-          yieldOp, yieldOp.getArgs(), continueBlock);
-
-      // // Insert stack restore before jumping out of the body of the region.
-      rewriter.setInsertionPoint(branchOp);
+    if (auto yieldOp =
+            dyn_cast<mlir::cir::YieldOp>(afterBody->getTerminator())) {
+      rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldOp, yieldOp.getArgs(),
+                                                   continueBlock);
     }
 
-    // TODO(CIR): stackrestore?
-    // rewriter.create<mlir::LLVM::StackRestoreOp>(loc, stackSaveOp);
+    // TODO(cir): stackrestore?
 
     // Replace the op with values return from the body region.
     rewriter.replaceOp(scopeOp, continueBlock->getArguments());
@@ -1412,15 +1375,10 @@ public:
           // TODO(cir): Ensure every yield instead of dealing with optional
           // values.
           assert(yieldOp.getKind().has_value() && "switch yield has no kind");
-
           switch (yieldOp.getKind().value()) {
           // Fallthrough to next case: track it for the next case to handle.
           case mlir::cir::YieldOpKind::Fallthrough:
             fallthroughYieldOp = yieldOp;
-            break;
-          // Break out of switch: branch to exit block.
-          case mlir::cir::YieldOpKind::Break:
-            rewriteYieldOp(rewriter, yieldOp, exitBlock);
             break;
           default:
             return op->emitError("invalid yield kind in case statement");
@@ -1428,8 +1386,12 @@ public:
         }
       }
 
-      lowerNestedYield(mlir::cir::YieldOpKind::Break, rewriter, region,
-                       exitBlock);
+      // Handle break statements.
+      walkRegionSkipping<mlir::cir::LoopOp, mlir::cir::SwitchOp>(
+          region, [&](mlir::Operation *op) {
+            if (isa<mlir::cir::BreakOp>(op))
+              lowerTerminator(op, exitBlock, rewriter);
+          });
 
       // Extract region contents before erasing the switch op.
       rewriter.inlineRegionBefore(region, exitBlock);

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -22,10 +22,10 @@ void sw1(int a) {
 // CHECK-NEXT:   %5 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK-NEXT:   %6 = cir.binop(add, %4, %5) : !s32i
 // CHECK-NEXT:   cir.store %6, %1 : !s32i, cir.ptr <!s32i>
-// CHECK-NEXT:   cir.yield break
+// CHECK-NEXT:   cir.break
 // CHECK-NEXT: },
 // CHECK-NEXT: case (equal, 1)  {
-// CHECK-NEXT:   cir.yield break
+// CHECK-NEXT:   cir.break
 // CHECK-NEXT: },
 // CHECK-NEXT: case (equal, 2)  {
 // CHECK-NEXT:   cir.scope {
@@ -36,7 +36,7 @@ void sw1(int a) {
 // CHECK-NEXT:       cir.store %7, %1 : !s32i, cir.ptr <!s32i>
 // CHECK-NEXT:       %8 = cir.const(#cir.int<100> : !s32i) : !s32i
 // CHECK-NEXT:       cir.store %8, %4 : !s32i, cir.ptr <!s32i>
-// CHECK-NEXT:       cir.yield break
+// CHECK-NEXT:       cir.break
 // CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield fallthrough
 // CHECK-NEXT:   }
@@ -72,7 +72,7 @@ void sw3(int a) {
 // CHECK-NEXT:   %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:   cir.switch (%1 : !s32i) [
 // CHECK-NEXT:   case (default)  {
-// CHECK-NEXT:     cir.yield break
+// CHECK-NEXT:     cir.break
 // CHECK-NEXT:   }
 // CHECK-NEXT:   ]
 
@@ -133,10 +133,10 @@ void sw6(int a) {
 // CHECK: cir.func @_Z3sw6i
 // CHECK: cir.switch (%1 : !s32i) [
 // CHECK-NEXT: case (anyof, [0, 1, 2] : !s32i)  {
-// CHECK-NEXT:   cir.yield break
+// CHECK-NEXT:   cir.break
 // CHECK-NEXT: },
 // CHECK-NEXT: case (anyof, [3, 4, 5] : !s32i)  {
-// CHECK-NEXT:   cir.yield break
+// CHECK-NEXT:   cir.break
 // CHECK-NEXT: }
 
 void sw7(int a) {
@@ -157,7 +157,7 @@ void sw7(int a) {
 // CHECK-NEXT:   cir.yield fallthrough
 // CHECK-NEXT: },
 // CHECK-NEXT: case (anyof, [3, 4, 5] : !s32i)  {
-// CHECK-NEXT:   cir.yield break
+// CHECK-NEXT:   cir.break
 // CHECK-NEXT: }
 
 void sw8(int a) {
@@ -173,13 +173,13 @@ void sw8(int a) {
 
 //CHECK:    cir.func @_Z3sw8i
 //CHECK:      case (equal, 3)
-//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   cir.break
 //CHECK-NEXT: },
 //CHECK-NEXT: case (equal, 4) {
 //CHECK-NEXT:   cir.yield fallthrough
 //CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
-//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   cir.break
 //CHECK-NEXT: }  
 
 void sw9(int a) {
@@ -195,13 +195,13 @@ void sw9(int a) {
 
 //CHECK:    cir.func @_Z3sw9i
 //CHECK:      case (equal, 3) {
-//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
 //CHECK-NEXT:   cir.yield fallthrough
 //CHECK-NEXT: }
 //CHECK:      case (equal, 4)
-//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 
 void sw10(int a) {
@@ -218,7 +218,7 @@ void sw10(int a) {
 
 //CHECK:    cir.func @_Z4sw10i
 //CHECK:      case (equal, 3)
-//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   cir.break
 //CHECK-NEXT: },
 //CHECK-NEXT: case (equal, 4) {
 //CHECK-NEXT:   cir.yield fallthrough
@@ -227,7 +227,7 @@ void sw10(int a) {
 //CHECK-NEXT:   cir.yield fallthrough
 //CHECK-NEXT: }
 //CHECK-NEXT: case (equal, 5) {
-//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 
 void sw11(int a) {
@@ -246,7 +246,7 @@ void sw11(int a) {
 
 //CHECK:    cir.func @_Z4sw11i
 //CHECK:      case (equal, 3)
-//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   cir.break
 //CHECK-NEXT: },
 //CHECK-NEXT: case (anyof, [4, 5] : !s32i) {
 //CHECK-NEXT:   cir.yield fallthrough
@@ -255,7 +255,7 @@ void sw11(int a) {
 //CHECK-NEXT:   cir.yield fallthrough
 //CHECK-NEXT: }
 //CHECK-NEXT: case (anyof, [6, 7] : !s32i)  {
-//CHECK-NEXT:   cir.yield break
+//CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 
 void sw12(int a) {
@@ -272,5 +272,5 @@ void sw12(int a) {
 // CHECK-NEXT:     case (equal, 3) {
 // CHECK-NEXT:       cir.return
 // CHECK-NEXT:     ^bb1:  // no predecessors
-// CHECK-NEXT:       cir.yield break
+// CHECK-NEXT:       cir.break
 // CHECK-NEXT:     }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -67,7 +67,7 @@ cir.func @yieldfallthrough() {
 cir.func @yieldbreak() {
   %0 = cir.const(#true) : !cir.bool
   cir.if %0 {
-    cir.yield break // expected-error {{shall be dominated by 'cir.loop' or 'cir.switch'}}
+    cir.break // expected-error {{op must be within a loop or switch}}
   }
   cir.return
 }

--- a/clang/test/CIR/IR/loop.cir
+++ b/clang/test/CIR/IR/loop.cir
@@ -29,7 +29,7 @@ cir.func @l0() {
       cir.store %6, %0 : !u32i, cir.ptr <!u32i>
       %7 = cir.const(#true) : !cir.bool
       cir.if %7 {
-        cir.yield break
+        cir.break
       }
       cir.yield
     }
@@ -99,7 +99,7 @@ cir.func @l0() {
 // CHECK-NEXT:     cir.store %6, %0 : !u32i, cir.ptr <!u32i>
 // CHECK-NEXT:     %7 = cir.const(#true) : !cir.bool
 // CHECK-NEXT:     cir.if %7 {
-// CHECK-NEXT:       cir.yield break
+// CHECK-NEXT:       cir.break
 // CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT: }

--- a/clang/test/CIR/IR/switch.cir
+++ b/clang/test/CIR/IR/switch.cir
@@ -11,7 +11,7 @@ cir.func @s0() {
       cir.yield fallthrough
     },
     case (anyof, [6, 7, 8] : !s32i) {
-      cir.yield break
+      cir.break
     },
     case (equal, 5 : !s32i) {
       cir.yield
@@ -28,7 +28,7 @@ cir.func @s0() {
 // CHECK-NEXT:   cir.yield fallthrough
 // CHECK-NEXT: },
 // CHECK-NEXT: case (anyof, [6, 7, 8] : !s32i) {
-// CHECK-NEXT:   cir.yield break
+// CHECK-NEXT:   cir.break
 // CHECK-NEXT: },
 // CHECK-NEXT: case (equal, 5)  {
 // CHECK-NEXT:   cir.yield

--- a/clang/test/CIR/Lowering/loop.cir
+++ b/clang/test/CIR/Lowering/loop.cir
@@ -83,7 +83,7 @@ module {
     }, step : { // Droped when lowering while statements.
       cir.yield
     }) {
-      cir.yield break
+      cir.break
     }
     cir.return
   }
@@ -109,7 +109,7 @@ module {
         cir.yield
       }) {
         cir.scope { // FIXME(cir): Redundant scope emitted during C codegen.
-          cir.yield break
+          cir.break
         }
         cir.yield
       }

--- a/clang/test/CIR/Lowering/loops-with-break.cir
+++ b/clang/test/CIR/Lowering/loops-with-break.cir
@@ -27,7 +27,7 @@ module {
             %4 = cir.cmp(eq, %2, %3) : !s32i, !s32i
             %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
             cir.if %5 {
-              cir.yield break
+              cir.break
             }
           }
         }
@@ -106,7 +106,7 @@ module {
                   %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
                   %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
                   cir.if %7 {
-                    cir.yield break
+                    cir.break
                   }
                 }
               }
@@ -189,7 +189,7 @@ module {
           %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
           %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
           cir.if %7 {
-            cir.yield break
+            cir.break
           }
         }
         cir.yield
@@ -246,7 +246,7 @@ cir.func @testDoWhile() {
           %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
           %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
           cir.if %7 {
-            cir.yield break
+            cir.break
           }
         }
         cir.yield

--- a/clang/test/CIR/Lowering/switch.cir
+++ b/clang/test/CIR/Lowering/switch.cir
@@ -12,12 +12,12 @@ module {
     // CHECK:   1: ^bb[[#CASE1:]]
     // CHECK: ]
     case (equal, 1) {
-      cir.yield break
+      cir.break
     },
     // CHECK: ^bb[[#CASE1]]:
     // CHECK:   llvm.br ^bb[[#EXIT:]]
     case (default) {
-      cir.yield break
+      cir.break
     }
     // CHECK: ^bb[[#DEFAULT]]:
     // CHECK:   llvm.br ^bb[[#EXIT]]
@@ -34,7 +34,7 @@ module {
     // CHECK:   1: ^bb[[#CASE1:]]
     // CHECK: ]
     case (equal, 1) {
-      cir.yield break
+      cir.break
     }
     // CHECK: ^bb[[#CASE1]]:
     // CHECK:   llvm.br ^bb[[#EXIT]]
@@ -51,7 +51,7 @@ module {
     // CHECK:   2: ^bb[[#CASE1N2]]
     // CHECK: ]
     case (anyof, [1, 2] : !s64i) { // case 1 and 2 use same region
-      cir.yield break
+      cir.break
     }
     // CHECK: ^bb[[#CASE1N2]]:
     // CHECK:   llvm.br ^bb[[#EXIT]]
@@ -73,7 +73,7 @@ module {
       // CHECK: ^bb[[#CASE1]]:
       // CHECK:   llvm.br ^bb[[#CASE2]]
       case (equal, 2 : !s64i) {
-        cir.yield break
+        cir.break
       }
       // CHECK: ^bb[[#CASE2]]:
       // CHECK:   llvm.br ^bb[[#EXIT]]
@@ -115,7 +115,7 @@ module {
       case (equal, 3) {
         cir.return
       ^bb1:  // no predecessors
-        cir.yield break
+        cir.break
       }
       ] 
     }
@@ -152,10 +152,10 @@ module {
           %8 = cir.cmp(ge, %6, %7) : !s32i, !s32i
           %9 = cir.cast(int_to_bool, %8 : !s32i), !cir.bool
           cir.if %9 {
-            cir.yield break
+            cir.break
           }
         }
-        cir.yield break
+        cir.break
       }
       ] 
     } 

--- a/clang/test/CIR/Transforms/merge-cleanups.cir
+++ b/clang/test/CIR/Transforms/merge-cleanups.cir
@@ -37,7 +37,7 @@ module  {
               cir.return
             }
           }
-          cir.yield break
+          cir.break
         }
         cir.yield fallthrough
       },
@@ -95,7 +95,7 @@ module  {
 // CHECK-NEXT:           cir.return
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:       cir.yield break
+// CHECK-NEXT:       cir.break
 // CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield fallthrough
 // CHECK-NEXT:   },


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #397
* #396
* __->__ #395
* #394

Same rationale as `cir.continue`, it detaches the representation of the
C/C++ `break` statement into a separate operation. This simplifies
lowering and verifications related to `break` statements, as well as the
definition and lowering of the `cir.yield` operation.