### PR TITLE
[CIR][IR] Deprecate `cir.yield nosuspend`

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -599,6 +599,7 @@ def ConditionOp : CIR_Op<"condition", [
   }];
   let arguments = (ins CIR_BoolType:$condition);
   let assemblyFormat = " `(` $condition `)` attr-dict ";
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -606,12 +607,11 @@ def ConditionOp : CIR_Op<"condition", [
 //===----------------------------------------------------------------------===//
 
 def YieldOpKind_FT : I32EnumAttrCase<"Fallthrough", 2, "fallthrough">;
-def YieldOpKind_NS : I32EnumAttrCase<"NoSuspend", 4, "nosuspend">;
 
 def YieldOpKind : I32EnumAttr<
     "YieldOpKind",
     "yield kind",
-    [YieldOpKind_FT, YieldOpKind_NS]> {
+    [YieldOpKind_FT]> {
   let cppNamespace = "::mlir::cir";
 }
 
@@ -630,8 +630,6 @@ def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     Optionally, `cir.yield` can be annotated with extra kind specifiers:
     - `fallthrough`: execution falls to the next region in `cir.switch` case list.
     Only available inside `cir.switch` regions.
-    - `nosuspend`: specific to the `ready` region inside `cir.await` op, it makes
-    control-flow to be transfered back to the parent, preventing suspension.
 
     As a general rule, `cir.yield` must be explicitly used whenever a region has
     more than one block and no terminator, or within `cir.switch` regions not
@@ -650,16 +648,6 @@ def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
         cir.yield fallthrough
       }, ...
     ]
-
-    cir.await(init, ready : {
-      // Call std::suspend_always::await_ready
-      %18 = cir.call @_ZNSt14suspend_always11await_readyEv(...)
-      cir.if %18 {
-        // yields back to the parent.
-        cir.yield nosuspend
-      }
-      cir.yield // control-flow to the next region for suspension.
-    }, ...)
 
     cir.scope {
       ...
@@ -703,9 +691,6 @@ def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     }
     bool isFallthrough() {
       return !isPlain() && *getKind() == YieldOpKind::Fallthrough;
-    }
-    bool isNoSuspend() {
-      return !isPlain() && *getKind() == YieldOpKind::NoSuspend;
     }
   }];
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -14,6 +14,7 @@
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <optional>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -245,19 +246,31 @@ LogicalResult BreakOp::verify() {
 
 void ConditionOp::getSuccessorRegions(
     ArrayRef<Attribute> operands, SmallVectorImpl<RegionSuccessor> &regions) {
-  auto loopOp = cast<LoopOp>(getOperation()->getParentOp());
-
   // TODO(cir): The condition value may be folded to a constant, narrowing
   // down its list of possible successors.
-  // Condition may branch to the body or to the parent op.
-  regions.emplace_back(&loopOp.getBody(), loopOp.getBody().getArguments());
-  regions.emplace_back(loopOp->getResults());
+
+  // Parent is a loop: condition may branch to the body or to the parent op.
+  if (auto loopOp = dyn_cast<LoopOp>(getOperation()->getParentOp())) {
+    regions.emplace_back(&loopOp.getBody(), loopOp.getBody().getArguments());
+    regions.emplace_back(loopOp->getResults());
+  }
+
+  // Parent is an await: condition may branch to resume or suspend regions.
+  auto await = cast<AwaitOp>(getOperation()->getParentOp());
+  regions.emplace_back(&await.getResume(), await.getResume().getArguments());
+  regions.emplace_back(&await.getSuspend(), await.getSuspend().getArguments());
 }
 
 MutableOperandRange
 ConditionOp::getMutableSuccessorOperands(RegionBranchPoint point) {
   // No values are yielded to the successor region.
   return MutableOperandRange(getOperation(), 0, 0);
+}
+
+LogicalResult ConditionOp::verify() {
+  if (!isa<LoopOp, AwaitOp>(getOperation()->getParentOp()))
+    return emitOpError("condition must be within a conditional region");
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -785,34 +798,6 @@ void TernaryOp::build(OpBuilder &builder, OperationState &result, Value cond,
 //===----------------------------------------------------------------------===//
 
 mlir::LogicalResult YieldOp::verify() {
-  auto isDominatedByProperAwaitRegion = [&](Operation *parentOp,
-                                            mlir::Region *currRegion) {
-    while (!llvm::isa<cir::FuncOp>(parentOp)) {
-      auto awaitOp = dyn_cast<cir::AwaitOp>(parentOp);
-      if (awaitOp) {
-        if (currRegion && currRegion == &awaitOp.getResume()) {
-          emitOpError() << "kind 'nosuspend' can only be used in 'ready' and "
-                           "'suspend' regions";
-          return false;
-        }
-        return true;
-      }
-
-      currRegion = parentOp->getParentRegion();
-      parentOp = parentOp->getParentOp();
-    }
-
-    emitOpError() << "shall be dominated by 'cir.await'";
-    return false;
-  };
-
-  if (isNoSuspend()) {
-    if (!isDominatedByProperAwaitRegion(getOperation()->getParentOp(),
-                                        getOperation()->getParentRegion()))
-      return mlir::failure();
-    return mlir::success();
-  }
-
   if (isFallthrough()) {
     if (!llvm::isa<SwitchOp>(getOperation()->getParentOp()))
       return emitOpError() << "fallthrough only expected within 'cir.switch'";
@@ -2165,7 +2150,11 @@ void AwaitOp::getSuccessorRegions(mlir::RegionBranchPoint point,
   regions.push_back(RegionSuccessor(&this->getResume()));
 }
 
-LogicalResult AwaitOp::verify() { return success(); }
+LogicalResult AwaitOp::verify() {
+  if (!isa<ConditionOp>(this->getReady().back().getTerminator()))
+    return emitOpError("ready region must end with cir.condition");
+  return success();
+}
 
 //===----------------------------------------------------------------------===//
 // CIR defined traits

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1380,8 +1380,6 @@ public:
           case mlir::cir::YieldOpKind::Fallthrough:
             fallthroughYieldOp = yieldOp;
             break;
-          default:
-            return op->emitError("invalid yield kind in case statement");
           }
         }
       }

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -206,10 +206,7 @@ VoidTask silly_task() {
 // CHECK:       %[[#TmpCallRes:]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[#SuspendAlwaysAddr]])
 // CHECK:       cir.yield %[[#TmpCallRes]] : !cir.bool
 // CHECK:     }
-// CHECK:     cir.if %[[#ReadyVeto]] {
-// CHECK:       cir.yield nosuspend
-// CHECK:     }
-// CHECK:     cir.yield
+// CHECK:     cir.condition(%[[#ReadyVeto]])
 
 // Second region `suspend` contains the actual suspend logic.
 //

--- a/clang/test/CIR/IR/await.cir
+++ b/clang/test/CIR/IR/await.cir
@@ -1,0 +1,22 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+cir.func coroutine @checkPrintParse(%arg0 : !cir.bool) {
+  cir.await(user, ready : {
+    cir.condition(%arg0)
+  }, suspend : {
+    cir.yield
+  }, resume : {
+    cir.yield
+  },)
+  cir.return
+}
+
+// CHECK:  cir.func coroutine @checkPrintParse
+// CHECK:  cir.await(user, ready : {
+// CHECK:    cir.condition(%arg0)
+// CHECK:  }, suspend : {
+// CHECK:    cir.yield
+// CHECK:  }, resume : {
+// CHECK:    cir.yield
+// CHECK:  },)

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -449,27 +449,12 @@ cir.func coroutine @bad_task() { // expected-error {{coroutine body must use at 
 
 // -----
 
-cir.func coroutine @bad_yield() {
+cir.func coroutine @missing_condition() {
   cir.scope {
-    cir.await(user, ready : {
+    cir.await(user, ready : { // expected-error {{ready region must end with cir.condition}}
       cir.yield
     }, suspend : {
       cir.yield
-    }, resume : {
-      cir.yield nosuspend // expected-error {{kind 'nosuspend' can only be used in 'ready' and 'suspend' regions}}
-    },)
-  }
-  cir.return
-}
-
-// -----
-
-cir.func coroutine @good_yield() {
-  cir.scope {
-    cir.await(user, ready : {
-      cir.yield nosuspend
-    }, suspend : {
-      cir.yield nosuspend
     }, resume : {
       cir.yield
     },)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #397
* __->__ #396
* #395
* #394

This changes the `cir.await` operation to expect a `cir.condition` as
the terminator for the ready region. This simplifies the `cir.await`
while also simplifying the `cir.yield`. If `cir.condition` holds a
true value, then the `cir.await` will continue the coroutine, otherwise,
it will suspend its execution.

The `cir.condition` op was also updated to allow `cir.await` as its
parent operation.