### PR TITLE
[CIR][IR] Deprecate `cir.yield fallthrough`

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -606,30 +606,21 @@ def ConditionOp : CIR_Op<"condition", [
 // YieldOp
 //===----------------------------------------------------------------------===//
 
-def YieldOpKind_FT : I32EnumAttrCase<"Fallthrough", 2, "fallthrough">;
-
-def YieldOpKind : I32EnumAttr<
-    "YieldOpKind",
-    "yield kind",
-    [YieldOpKind_FT]> {
-  let cppNamespace = "::mlir::cir";
-}
-
 def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     ParentOneOf<["IfOp", "ScopeOp", "SwitchOp", "LoopOp", "AwaitOp",
                  "TernaryOp", "GlobalOp"]>]> {
-  let summary = "Terminate CIR regions";
+  let summary = "Represents the default branching behaviour of a region";
   let description = [{
-    The `cir.yield` operation terminates regions on different CIR operations:
-    `cir.if`, `cir.scope`, `cir.switch`, `cir.loop`, `cir.await`, `cir.ternary`
-    and `cir.global`.
+    The `cir.yield` operation terminates regions on different CIR operations,
+    and it is used to represent the default branching behaviour of a region.
+    Said branching behaviour is determinted by the parent operation. For
+    example, a yield in a `switch-case` region implies a fallthrough, while
+    a yield in a `cir.if` region implies a branch to the exit block, and so
+    on.
 
-    Might yield an SSA value and the semantics of how the values are yielded is
-    defined by the parent operation.
-
-    Optionally, `cir.yield` can be annotated with extra kind specifiers:
-    - `fallthrough`: execution falls to the next region in `cir.switch` case list.
-    Only available inside `cir.switch` regions.
+    In some cases, it might yield an SSA value and the semantics of how the
+    values are yielded is defined by the parent operation. For example, a
+    `cir.ternary` operation yields a value from one of its regions.
 
     As a general rule, `cir.yield` must be explicitly used whenever a region has
     more than one block and no terminator, or within `cir.switch` regions not
@@ -645,7 +636,7 @@ def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     cir.switch (%5) [
       case (equal, 3) {
         ...
-        cir.yield fallthrough
+        cir.yield
       }, ...
     ]
 
@@ -666,35 +657,11 @@ def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     ```
   }];
 
-  let arguments = (ins OptionalAttr<YieldOpKind>:$kind,
-                       Variadic<CIR_AnyType>:$args);
+  let arguments = (ins Variadic<CIR_AnyType>:$args);
+  let assemblyFormat = "($args^ `:` type($args))? attr-dict";
   let builders = [
     OpBuilder<(ins), [{ /* nothing to do */ }]>,
-    OpBuilder<(ins "YieldOpKind":$kind), [{
-      mlir::cir::YieldOpKindAttr kattr = mlir::cir::YieldOpKindAttr::get(
-        $_builder.getContext(), kind);
-      $_state.addAttribute(getKindAttrName($_state.name), kattr);
-    }]>,
-    OpBuilder<(ins "ValueRange":$results), [{
-      $_state.addOperands(results);
-    }]>
   ];
-
-  let assemblyFormat = [{
-    ($kind^)? ($args^ `:` type($args))? attr-dict
-  }];
-
-  let extraClassDeclaration = [{
-    // None of the below
-    bool isPlain() {
-      return !getKind();
-    }
-    bool isFallthrough() {
-      return !isPlain() && *getKind() == YieldOpKind::Fallthrough;
-    }
-  }];
-
-  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -588,6 +588,11 @@ public:
     return create<mlir::cir::BreakOp>(loc);
   }
 
+  /// Create a yield operation.
+  mlir::cir::YieldOp createYield(mlir::Location loc, mlir::ValueRange value = {}) {
+    return create<mlir::cir::YieldOp>(loc, value);
+  }
+
   /// Create a continue operation.
   mlir::cir::ContinueOp createContinue(mlir::Location loc) {
     return create<mlir::cir::ContinueOp>(loc);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -992,8 +992,6 @@ public:
   const CaseStmt *foldCaseStmt(const clang::CaseStmt &S, mlir::Type condType,
                                SmallVector<mlir::Attribute, 4> &caseAttrs);
 
-  void insertFallthrough(const clang::Stmt &S);
-
   template <typename T>
   mlir::LogicalResult
   buildCaseDefaultCascade(const T *stmt, mlir::Type condType,

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Address.h"
+#include "CIRGenBuilder.h"
 #include "CIRGenFunction.h"
 #include "mlir/IR/Value.h"
 #include "clang/AST/CharUnits.h"
@@ -337,7 +338,7 @@ mlir::LogicalResult CIRGenFunction::buildLabelStmt(const clang::LabelStmt &S) {
 // Add terminating yield on body regions (loops, ...) in case there are
 // not other terminators used.
 // FIXME: make terminateCaseRegion use this too.
-static void terminateBody(mlir::OpBuilder &builder, mlir::Region &r,
+static void terminateBody(CIRGenBuilderTy &builder, mlir::Region &r,
                           mlir::Location loc) {
   if (r.empty())
     return;
@@ -355,7 +356,7 @@ static void terminateBody(mlir::OpBuilder &builder, mlir::Region &r,
         !block.back().hasTrait<mlir::OpTrait::IsTerminator>()) {
       mlir::OpBuilder::InsertionGuard guardCase(builder);
       builder.setInsertionPointToEnd(&block);
-      builder.create<YieldOp>(loc);
+      builder.createYield(loc);
     }
   }
 
@@ -606,14 +607,6 @@ CIRGenFunction::foldCaseStmt(const clang::CaseStmt &S, mlir::Type condType,
   return lastCase;
 }
 
-void CIRGenFunction::insertFallthrough(const clang::Stmt &S) {
-  builder.create<YieldOp>(
-      getLoc(S.getBeginLoc()),
-      mlir::cir::YieldOpKindAttr::get(builder.getContext(),
-                                      mlir::cir::YieldOpKind::Fallthrough),
-      mlir::ValueRange({}));
-}
-
 template <typename T>
 mlir::LogicalResult CIRGenFunction::buildCaseDefaultCascade(
     const T *stmt, mlir::Type condType,
@@ -635,11 +628,11 @@ mlir::LogicalResult CIRGenFunction::buildCaseDefaultCascade(
   auto *sub = stmt->getSubStmt();
 
   if (isa<DefaultStmt>(sub) && isa<CaseStmt>(stmt)) {
-    insertFallthrough(*stmt);
+    builder.createYield(getLoc(stmt->getBeginLoc()));
     res =
         buildDefaultStmt(*dyn_cast<DefaultStmt>(sub), condType, caseAttrs, os);
   } else if (isa<CaseStmt>(sub) && isa<DefaultStmt>(stmt)) {
-    insertFallthrough(*stmt);
+    builder.createYield(getLoc(stmt->getBeginLoc()));
     res = buildCaseStmt(*dyn_cast<CaseStmt>(sub), condType, caseAttrs, os);
   } else {
     res = buildStmt(sub, /*useCurrentScope=*/!isa<CompoundStmt>(sub));
@@ -725,7 +718,7 @@ CIRGenFunction::buildCXXForRangeStmt(const CXXForRangeStmt &S,
           if (S.getInc())
             if (buildStmt(S.getInc(), /*useCurrentScope=*/true).failed())
               loopRes = mlir::failure();
-          builder.create<YieldOp>(loc);
+          builder.createYield(loc);
         });
     return loopRes;
   };
@@ -807,7 +800,7 @@ mlir::LogicalResult CIRGenFunction::buildForStmt(const ForStmt &S) {
           if (S.getInc())
             if (buildStmt(S.getInc(), /*useCurrentScope=*/true).failed())
               loopRes = mlir::failure();
-          builder.create<YieldOp>(loc);
+          builder.createYield(loc);
         });
     return loopRes;
   };
@@ -861,7 +854,7 @@ mlir::LogicalResult CIRGenFunction::buildDoStmt(const DoStmt &S) {
         },
         /*stepBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          builder.create<YieldOp>(loc);
+          builder.createYield(loc);
         });
     return loopRes;
   };
@@ -920,7 +913,7 @@ mlir::LogicalResult CIRGenFunction::buildWhileStmt(const WhileStmt &S) {
         },
         /*stepBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          builder.create<YieldOp>(loc);
+          builder.createYield(loc);
         });
     return loopRes;
   };
@@ -1047,11 +1040,7 @@ mlir::LogicalResult CIRGenFunction::buildSwitchStmt(const SwitchStmt &S) {
           !block.back().hasTrait<mlir::OpTrait::IsTerminator>()) {
         mlir::OpBuilder::InsertionGuard guardCase(builder);
         builder.setInsertionPointToEnd(&block);
-        builder.create<YieldOp>(
-            loc,
-            mlir::cir::YieldOpKindAttr::get(
-                builder.getContext(), mlir::cir::YieldOpKind::Fallthrough),
-            mlir::ValueRange({}));
+        builder.createYield(loc);
       }
     }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -181,7 +181,7 @@ bool omitRegionTerm(mlir::Region &r) {
   const auto singleNonEmptyBlock = r.hasOneBlock() && !r.back().empty();
   const auto yieldsNothing = [&r]() {
     YieldOp y = dyn_cast<YieldOp>(r.back().getTerminator());
-    return y && y.isPlain() && y.getArgs().empty();
+    return y && y.getArgs().empty();
   };
   return singleNonEmptyBlock && yieldsNothing();
 }
@@ -791,20 +791,6 @@ void TernaryOp::build(OpBuilder &builder, OperationState &result, Value cond,
          "expected zero or one result type");
   if (yield.getNumOperands() == 1)
     result.addTypes(TypeRange{yield.getOperandTypes().front()});
-}
-
-//===----------------------------------------------------------------------===//
-// YieldOp
-//===----------------------------------------------------------------------===//
-
-mlir::LogicalResult YieldOp::verify() {
-  if (isFallthrough()) {
-    if (!llvm::isa<SwitchOp>(getOperation()->getParentOp()))
-      return emitOpError() << "fallthrough only expected within 'cir.switch'";
-    return mlir::success();
-  }
-
-  return mlir::success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -820,9 +820,7 @@ void LifetimeCheckPass::checkSwitch(SwitchOp switchOp) {
     YieldOp y = dyn_cast<YieldOp>(block.back());
     if (!y)
       return false;
-    if (y.isFallthrough())
-      return true;
-    return false;
+    return true;
   };
 
   auto regions = switchOp.getRegions();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1370,18 +1370,8 @@ public:
           continue;
 
         // Handle switch-case yields.
-        auto *terminator = blk.getTerminator();
-        if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(terminator)) {
-          // TODO(cir): Ensure every yield instead of dealing with optional
-          // values.
-          assert(yieldOp.getKind().has_value() && "switch yield has no kind");
-          switch (yieldOp.getKind().value()) {
-          // Fallthrough to next case: track it for the next case to handle.
-          case mlir::cir::YieldOpKind::Fallthrough:
-            fallthroughYieldOp = yieldOp;
-            break;
-          }
-        }
+        if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(blk.getTerminator()))
+          fallthroughYieldOp = yieldOp;
       }
 
       // Handle break statements.

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -38,7 +38,7 @@ void sw1(int a) {
 // CHECK-NEXT:       cir.store %8, %4 : !s32i, cir.ptr <!s32i>
 // CHECK-NEXT:       cir.break
 // CHECK-NEXT:     }
-// CHECK-NEXT:     cir.yield fallthrough
+// CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   }
 
 void sw2(int a) {
@@ -96,7 +96,7 @@ int sw4(int a) {
 // CHECK-NEXT:           %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:           cir.return %6 : !s32i
 // CHECK-NEXT:         }
-// CHECK-NEXT:         cir.yield fallthrough
+// CHECK-NEXT:         cir.yield
 // CHECK-NEXT:       },
 // CHECK-NEXT:       case (default)  {
 // CHECK-NEXT:         %5 = cir.const(#cir.int<2> : !s32i) : !s32i
@@ -115,7 +115,7 @@ void sw5(int a) {
 // CHECK: cir.func @_Z3sw5i
 // CHECK: cir.switch (%1 : !s32i) [
 // CHECK-NEXT:   case (equal, 1)  {
-// CHECK-NEXT:     cir.yield fallthrough
+// CHECK-NEXT:     cir.yield
 
 void sw6(int a) {
   switch (a) {
@@ -154,7 +154,7 @@ void sw7(int a) {
 
 // CHECK: cir.func @_Z3sw7i
 // CHECK: case (anyof, [0, 1, 2] : !s32i)  {
-// CHECK-NEXT:   cir.yield fallthrough
+// CHECK-NEXT:   cir.yield
 // CHECK-NEXT: },
 // CHECK-NEXT: case (anyof, [3, 4, 5] : !s32i)  {
 // CHECK-NEXT:   cir.break
@@ -176,7 +176,7 @@ void sw8(int a) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: },
 //CHECK-NEXT: case (equal, 4) {
-//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
 //CHECK-NEXT:   cir.break
@@ -198,7 +198,7 @@ void sw9(int a) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
-//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
 //CHECK:      case (equal, 4)
 //CHECK-NEXT:   cir.break
@@ -221,10 +221,10 @@ void sw10(int a) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: },
 //CHECK-NEXT: case (equal, 4) {
-//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
-//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
 //CHECK-NEXT: case (equal, 5) {
 //CHECK-NEXT:   cir.break
@@ -249,10 +249,10 @@ void sw11(int a) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: },
 //CHECK-NEXT: case (anyof, [4, 5] : !s32i) {
-//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
 //CHECK-NEXT: case (default) {
-//CHECK-NEXT:   cir.yield fallthrough
+//CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
 //CHECK-NEXT: case (anyof, [6, 7] : !s32i)  {
 //CHECK-NEXT:   cir.break

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -52,18 +52,6 @@ cir.func @yield0() {
 
 #false = #cir.bool<false> : !cir.bool
 #true = #cir.bool<true> : !cir.bool
-cir.func @yieldfallthrough() {
-  %0 = cir.const(#true) : !cir.bool
-  cir.if %0 {
-    cir.yield fallthrough // expected-error {{'cir.yield' op fallthrough only expected within 'cir.switch'}}
-  }
-  cir.return
-}
-
-// -----
-
-#false = #cir.bool<false> : !cir.bool
-#true = #cir.bool<true> : !cir.bool
 cir.func @yieldbreak() {
   %0 = cir.const(#true) : !cir.bool
   cir.if %0 {

--- a/clang/test/CIR/IR/switch.cir
+++ b/clang/test/CIR/IR/switch.cir
@@ -8,7 +8,7 @@ cir.func @s0() {
       cir.return
     },
     case (equal, 3) {
-      cir.yield fallthrough
+      cir.yield
     },
     case (anyof, [6, 7, 8] : !s32i) {
       cir.break
@@ -25,7 +25,7 @@ cir.func @s0() {
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: },
 // CHECK-NEXT: case (equal, 3)  {
-// CHECK-NEXT:   cir.yield fallthrough
+// CHECK-NEXT:   cir.yield
 // CHECK-NEXT: },
 // CHECK-NEXT: case (anyof, [6, 7, 8] : !s32i) {
 // CHECK-NEXT:   cir.break

--- a/clang/test/CIR/Lowering/switch.cir
+++ b/clang/test/CIR/Lowering/switch.cir
@@ -68,7 +68,7 @@ module {
       // CHECK:   2: ^bb[[#CASE2:]]
       // CHECK: ]
       case (equal, 1 : !s64i) { // case 1 has its own region
-        cir.yield fallthrough // fallthrough to case 2
+        cir.yield // fallthrough to case 2
       },
       // CHECK: ^bb[[#CASE1]]:
       // CHECK:   llvm.br ^bb[[#CASE2]]
@@ -89,7 +89,7 @@ module {
       // CHECK:   1: ^bb[[#CASE1:]]
       // CHECK: ]
       case (equal, 1 : !s64i) {
-        cir.yield fallthrough // fallthrough to exit
+        cir.yield // fallthrough to exit
       }
       // CHECK: ^bb[[#CASE1]]:
       // CHECK:   llvm.br ^bb[[#EXIT]]

--- a/clang/test/CIR/Transforms/merge-cleanups.cir
+++ b/clang/test/CIR/Transforms/merge-cleanups.cir
@@ -39,7 +39,7 @@ module  {
           }
           cir.break
         }
-        cir.yield fallthrough
+        cir.yield
       },
       case (equal, 2 : !s32i)  {
         cir.scope {
@@ -54,7 +54,7 @@ module  {
         ^bb1:  // pred: ^bb0
           cir.return
         }
-        cir.yield fallthrough
+        cir.yield
       }
       ]
     }
@@ -97,7 +97,7 @@ module  {
 // CHECK-NEXT:       }
 // CHECK-NEXT:       cir.break
 // CHECK-NEXT:     }
-// CHECK-NEXT:     cir.yield fallthrough
+// CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   },
 // CHECK-NEXT:   case (equal, 2)  {
 // CHECK-NEXT:     cir.scope {
@@ -110,7 +110,7 @@ module  {
 // CHECK-NEXT:       cir.store %9, %5 : !s32i, cir.ptr <!s32i>
 // CHECK-NEXT:       cir.return
 // CHECK-NEXT:     }
-// CHECK-NEXT:     cir.yield fallthrough
+// CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   }
 // CHECK-NEXT: ]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #397
* #396
* #395
* #394

Instead of having a `cir.yield fallthrough` operation, the default
branching behavior of the parent operation is denoted by `cir.yield`.
In other words, a `cir.yield` operation in a switch case region
represents the default branching behavior of the switch operation, which
is a fallthrough.

The `cir.yield` operation now represents the default branching behavior
of the parent operation's region. For example, in a if-else region, a
`cir.yield` operation represents a branch to the exit block.