### PR TITLE
[CIR] initial support for pointer-to-data-member type

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -296,11 +296,6 @@ def DataMemberAttr : CIR_Attr<"DataMember", "data_member",
     bool isNullValue() const {
       return !getMemberIndex().has_value();
     }
-
-    /// Get the type of the class that contains the target member.
-    mlir::Type getClsTy() const {
-      return getType().getClsTy();
-    }
   }];
 
   let genVerifyDecl = 1;

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -291,13 +291,6 @@ def DataMemberAttr : CIR_Attr<"DataMember", "data_member",
     ```
   }];
 
-  let extraClassDeclaration = [{
-    /// Determine whether the data member pointer is a null pointer value.
-    bool isNullValue() const {
-      return !getMemberIndex().has_value();
-    }
-  }];
-
   let genVerifyDecl = 1;
 
   let assemblyFormat = [{

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -265,6 +265,52 @@ def ConstPtrAttr : CIR_Attr<"ConstPtr", "ptr", [TypedAttrInterface]> {
 }
 
 //===----------------------------------------------------------------------===//
+// DataMemberAttr
+//===----------------------------------------------------------------------===//
+
+def DataMemberAttr : CIR_Attr<"DataMember", "data_member",
+                              [TypedAttrInterface]> {
+  let summary = "Holds a constant data member pointer value";
+  let parameters = (ins AttributeSelfTypeParameter<
+                            "", "mlir::cir::DataMemberType">:$type,
+                        OptionalParameter<
+                            "std::optional<size_t>">:$memberIndex);
+  let description = [{
+    A data member attribute is a literal attribute that represents a constant
+    pointer-to-data-member value.
+
+    The `memberIndex` parameter represents the index of the pointed-to member
+    within its containing struct. It is an optional parameter; lack of this
+    parameter indicates a null pointer-to-data-member value.
+
+    Example:
+    ```
+    #ptr = #cir.data_member<1> : !cir.data_member<!s32i in !ty_22Point22>
+
+    #null = #cir.data_member<null> : !cir.data_member<!s32i in !ty_22Point22>
+    ```
+  }];
+
+  let extraClassDeclaration = [{
+    /// Determine whether the data member pointer is a null pointer value.
+    bool isNullValue() const {
+      return !getMemberIndex().has_value();
+    }
+
+    /// Get the type of the class that contains the target member.
+    mlir::Type getClsTy() const {
+      return getType().getClsTy();
+    }
+  }];
+
+  let genVerifyDecl = 1;
+
+  let assemblyFormat = [{
+    `<` ($memberIndex^):(`null`)? `>`
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // SignedOverflowBehaviorAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1785,12 +1785,40 @@ def GetRuntimeMemberOp : CIR_Op<"get_runtime_member"> {
     the input record. The target member is given by a value of type
     `!cir.data_member` (i.e. a pointer-to-data-member value).
 
-    It expects a pointer to the base record as well as the pointer to the target
-    member.
+    This operation differs from `cir.get_member` in when the target member can
+    be determined. For the `cir.get_member` operation, the target member is
+    specified as a constant index so the member it returns access to is known
+    when the operation is constructed. For the `cir.get_runtime_member`
+    operation, the target member is given through a pointer-to-data-member
+    value which is unknown until the program being compiled is executed. In
+    other words, `cir.get_member` represents a normal member access through the
+    `.` operator in C/C++:
+
+    ```cpp
+    struct Foo { int x; };
+    Foo f;
+    (void)f.x;  // cir.get_member
+    ```
+
+    And `cir.get_runtime_member` represents a member access through the `.*` or
+    the `->*` operator in C++:
+
+    ```cpp
+    struct Foo { int x; }
+    Foo f;
+    Foo *p;
+    int Foo::*member;
+
+    (void)f.*member;   // cir.get_runtime_member
+    (void)f->*member;  // cir.get_runtime_member
+    ```
+
+    This operation expects a pointer to the base record as well as the pointer
+    to the target member.
   }];
 
   let arguments = (ins
-    Arg<CIR_PointerType, "address of the struct object", [MemRead]>:$addr,
+    Arg<StructPtr, "address of the struct object", [MemRead]>:$addr,
     Arg<CIR_DataMemberType, "pointer to the target member">:$member);
 
   let results = (outs Res<CIR_PointerType, "">:$result);

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1775,6 +1775,35 @@ def GetMemberOp : CIR_Op<"get_member"> {
 }
 
 //===----------------------------------------------------------------------===//
+// GetRuntimeMemberOp
+//===----------------------------------------------------------------------===//
+
+def GetRuntimeMemberOp : CIR_Op<"get_runtime_member"> {
+  let summary = "Get the address of a member of a struct";
+  let description = [{
+    The `cir.get_runtime_member` operation gets the address of a member from
+    the input record. The target member is given by a value of type
+    `!cir.data_member` (i.e. a pointer-to-data-member value).
+
+    It expects a pointer to the base record as well as the pointer to the target
+    member.
+  }];
+
+  let arguments = (ins
+    Arg<CIR_PointerType, "address of the struct object", [MemRead]>:$addr,
+    Arg<CIR_DataMemberType, "pointer to the target member">:$member);
+
+  let results = (outs Res<CIR_PointerType, "">:$result);
+
+  let assemblyFormat = [{
+    $addr `[` $member `:` qualified(type($member)) `]` attr-dict
+    `:` qualified(type($addr)) `->` qualified(type($result))
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // VecInsertOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -21,13 +21,6 @@
 #include "clang/CIR/Interfaces/ASTAttrInterfaces.h"
 
 //===----------------------------------------------------------------------===//
-// CIR Dialect Tablegen'd Types
-//===----------------------------------------------------------------------===//
-
-#define GET_TYPEDEF_CLASSES
-#include "clang/CIR/Dialect/IR/CIROpsTypes.h.inc"
-
-//===----------------------------------------------------------------------===//
 // CIR StructType
 //
 // The base type for all RecordDecls.
@@ -183,5 +176,12 @@ private:
 
 } // namespace cir
 } // namespace mlir
+
+//===----------------------------------------------------------------------===//
+// CIR Dialect Tablegen'd Types
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "clang/CIR/Dialect/IR/CIROpsTypes.h.inc"
 
 #endif // MLIR_DIALECT_CIR_IR_CIRTYPES_H_

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -331,6 +331,15 @@ def VoidPtr : Type<
       "mlir::cir::VoidType::get($_builder.getContext()))"> {
 }
 
+// Pointer to struct
+def StructPtr : Type<
+    And<[
+      CPred<"$_self.isa<::mlir::cir::PointerType>()">,
+      CPred<"$_self.cast<::mlir::cir::PointerType>()"
+            ".getPointee().isa<::mlir::cir::StructType>()">,
+    ]>, "!cir.struct*"> {
+}
+
 // Pointers to exception info
 def ExceptionInfoPtr : Type<
     And<[

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -146,6 +146,28 @@ def CIR_PointerType : CIR_Type<"Pointer", "ptr",
 }
 
 //===----------------------------------------------------------------------===//
+// DataMemberType
+//===----------------------------------------------------------------------===//
+
+def CIR_DataMemberType : CIR_Type<"DataMember", "data_member",
+    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
+
+  let summary = "CIR type that represents pointer-to-data-member type in C++";
+  let description = [{
+    `cir.member_ptr` models the pointer-to-data-member type in C++. Values of
+    this type are essentially offsets of the pointed-to member within one of
+    its containing struct.
+  }];
+
+  let parameters = (ins "mlir::Type":$memberTy,
+                        "mlir::cir::StructType":$clsTy);
+
+  let assemblyFormat = [{
+    `<` $memberTy `in` $clsTy `>`
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // BoolType
 //
 // An alternative here is to represent bool as mlir::i1, but let's be more
@@ -351,8 +373,9 @@ def CIR_StructType : Type<CPred<"$_self.isa<::mlir::cir::StructType>()">,
 //===----------------------------------------------------------------------===//
 
 def CIR_AnyType : AnyTypeOf<[
-  CIR_IntType, CIR_PointerType, CIR_BoolType, CIR_ArrayType, CIR_VectorType,
-  CIR_FuncType, CIR_VoidType, CIR_StructType, CIR_ExceptionInfo, CIR_AnyFloat,
+  CIR_IntType, CIR_PointerType, CIR_DataMemberType, CIR_BoolType, CIR_ArrayType,
+  CIR_VectorType, CIR_FuncType, CIR_VoidType, CIR_StructType, CIR_ExceptionInfo,
+  CIR_AnyFloat,
 ]>;
 
 #endif // MLIR_CIR_DIALECT_CIR_TYPES

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1760,6 +1760,21 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
     return buildArrayConstant(CGM, Desired, CommonElementType, NumElements,
                               Elts, typedFiller);
   }
+  case APValue::MemberPointer: {
+    assert(!UnimplementedFeature::cxxABI());
+
+    const ValueDecl *memberDecl = Value.getMemberPointerDecl();
+    assert(!Value.isMemberPointerToDerivedMember() && "NYI");
+
+    if (const auto *memberFuncDecl = dyn_cast<CXXMethodDecl>(memberDecl))
+      assert(0 && "not implemented");
+
+    auto cirTy =
+        CGM.getTypes().ConvertType(DestType).cast<mlir::cir::DataMemberType>();
+
+    const auto *fieldDecl = cast<FieldDecl>(memberDecl);
+    return builder.getDataMemberAttr(cirTy, fieldDecl->getFieldIndex());
+  }
   case APValue::LValue:
     return ConstantLValueEmitter(*this, Value, DestType).tryEmit();
   case APValue::Struct:
@@ -1770,7 +1785,6 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
   case APValue::ComplexFloat:
   case APValue::Vector:
   case APValue::AddrLabelDiff:
-  case APValue::MemberPointer:
     assert(0 && "not implemented");
   }
   llvm_unreachable("Unknown APValue kind");
@@ -1797,6 +1811,26 @@ mlir::Value CIRGenModule::buildNullConstant(QualType T, mlir::Location loc) {
 
   llvm_unreachable("NYI");
   return {};
+}
+
+mlir::Value CIRGenModule::buildMemberPointerConstant(const UnaryOperator *E) {
+  assert(!UnimplementedFeature::cxxABI());
+
+  auto loc = getLoc(E->getSourceRange());
+
+  const auto *decl = cast<DeclRefExpr>(E->getSubExpr())->getDecl();
+
+  // A member function pointer.
+  // Member function pointer is not supported yet.
+  if (const auto *methodDecl = dyn_cast<CXXMethodDecl>(decl))
+    assert(0 && "not implemented");
+
+  auto ty = getCIRType(E->getType()).cast<mlir::cir::DataMemberType>();
+
+  // Otherwise, a member data pointer.
+  const auto *fieldDecl = cast<FieldDecl>(decl);
+  return builder.create<mlir::cir::ConstantOp>(
+      loc, ty, builder.getDataMemberAttr(ty, fieldDecl->getFieldIndex()));
 }
 
 mlir::Attribute ConstantEmitter::emitAbstract(const Expr *E,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -787,6 +787,13 @@ public:
 
   LValue buildStmtExprLValue(const StmtExpr *E);
 
+  LValue buildPointerToDataMemberBinaryExpr(const BinaryOperator *E);
+
+  /// TODO: Add TBAAAccessInfo
+  Address buildCXXMemberDataPointerAddress(
+      const Expr *E, Address base, mlir::Value memberPtr,
+      const MemberPointerType *memberPtrType, LValueBaseInfo *baseInfo);
+
   /// Generate a call of the given function, expecting the given
   /// result type, and using the given argument list which specifies both the
   /// LLVM arguments and the types they were derived from.

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -384,6 +384,12 @@ public:
                                            LValueBaseInfo *BaseInfo = nullptr,
                                            bool forPointeeType = false);
 
+  /// TODO: Add TBAAAccessInfo
+  clang::CharUnits
+  getDynamicOffsetAlignment(clang::CharUnits actualBaseAlign,
+                            const clang::CXXRecordDecl *baseDecl,
+                            clang::CharUnits expectedTargetAlign);
+
   mlir::cir::FuncOp getAddrOfCXXStructor(
       clang::GlobalDecl GD, const CIRGenFunctionInfo *FnInfo = nullptr,
       mlir::cir::FuncType FnType = nullptr, bool DontDefer = false,
@@ -510,6 +516,8 @@ public:
   /// expression of the given type.  This is usually, but not always, an LLVM
   /// null constant.
   mlir::Value buildNullConstant(QualType T, mlir::Location loc);
+
+  mlir::Value buildMemberPointerConstant(const UnaryOperator *E);
 
   llvm::StringRef getMangledName(clang::GlobalDecl GD);
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -697,7 +697,14 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
   }
 
   case Type::MemberPointer: {
-    assert(0 && "not implemented");
+    const auto *MPT = cast<MemberPointerType>(Ty);
+    assert(MPT->isMemberDataPointer() && "ptr-to-member-function is NYI");
+
+    auto memberTy = ConvertType(MPT->getPointeeType());
+    auto clsTy =
+        ConvertType(QualType(MPT->getClass(), 0)).cast<mlir::cir::StructType>();
+    ResultType =
+        mlir::cir::DataMemberType::get(Builder.getContext(), memberTy, clsTy);
     break;
   }
 

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -365,33 +365,29 @@ LogicalResult
 DataMemberAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                        mlir::cir::DataMemberType ty,
                        std::optional<size_t> memberIndex) {
-  auto clsStructTy = ty.getClsTy();
-  if (!clsStructTy) {
-    emitError() << "class type of a DataMemberAttr must be a struct type";
-    return failure();
-  }
-
   if (!memberIndex.has_value()) {
     // DataMemberAttr without a given index represents a null value.
     return success();
   }
 
+  auto clsStructTy = ty.getClsTy();
   if (clsStructTy.isIncomplete()) {
-    emitError() << "trying to build a non-null ptr to data member of an "
-                   "incomplete class";
+    emitError() << "incomplete 'cir.struct' cannot be used to build a non-null "
+                   "data member pointer";
     return failure();
   }
 
   auto memberIndexValue = memberIndex.value();
   if (memberIndexValue >= clsStructTy.getNumElements()) {
-    emitError() << "member index of a DataMemberAttr is out of range";
+    emitError()
+        << "member index of a #cir.data_member attribute is out of range";
     return failure();
   }
 
   auto memberTy = clsStructTy.getMembers()[memberIndexValue];
   if (memberTy != ty.getMemberTy()) {
-    emitError()
-        << "member type of a DataMemberAttr must match the attribute type";
+    emitError() << "member type of a #cir.data_member attribute must match the "
+                   "attribute type";
     return failure();
   }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2581,12 +2581,8 @@ LogicalResult GetMemberOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult GetRuntimeMemberOp::verify() {
-  auto recordTy = getAddr().getType().getPointee().dyn_cast<StructType>();
-  if (!recordTy) {
-    emitError() << "expected pointer to a record type";
-    return mlir::failure();
-  }
-
+  auto recordTy =
+      getAddr().getType().cast<PointerType>().getPointee().cast<StructType>();
   auto memberPtrTy = getMember().getType();
 
   if (recordTy != memberPtrTy.getClsTy()) {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -292,6 +292,12 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
     return op->emitOpError("nullptr expects pointer type");
   }
 
+  if (attrType.isa<DataMemberAttr>()) {
+    // More detailed type verifications are already done in
+    // DataMemberAttr::verify. Don't need to repeat here.
+    return success();
+  }
+
   if (attrType.isa<ZeroAttr>()) {
     if (opType.isa<::mlir::cir::StructType, ::mlir::cir::ArrayType>())
       return success();
@@ -2566,6 +2572,32 @@ LogicalResult GetMemberOp::verify() {
   if (!recordTy.isClass() &&
       recordTy.getMembers()[getIndex()] != getResultTy().getPointee())
     return emitError() << "member type mismatch";
+
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
+// GetRuntimeMemberOp Definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult GetRuntimeMemberOp::verify() {
+  auto recordTy = getAddr().getType().getPointee().dyn_cast<StructType>();
+  if (!recordTy) {
+    emitError() << "expected pointer to a record type";
+    return mlir::failure();
+  }
+
+  auto memberPtrTy = getMember().getType();
+
+  if (recordTy != memberPtrTy.getClsTy()) {
+    emitError() << "record type does not match the member pointer type";
+    return mlir::failure();
+  }
+
+  if (getType().getPointee() != memberPtrTy.getMemberTy()) {
+    emitError() << "result type does not match the member pointer type";
+    return mlir::failure();
+  }
 
   return mlir::success();
 }

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -408,7 +408,6 @@ llvm::TypeSize
 DataMemberType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
                                   ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider size differences under different ABIs
-  // FIXME: consider pointer-to-member-function
   return llvm::TypeSize::getFixed(64);
 }
 
@@ -416,7 +415,6 @@ uint64_t
 DataMemberType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
                                 ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider alignment differences under different ABIs
-  // FIXME: consider pointer-to-member-function
   return 8;
 }
 
@@ -424,7 +422,6 @@ uint64_t DataMemberType::getPreferredAlignment(
     const ::mlir::DataLayout &dataLayout,
     ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider alignment differences under different ABIs
-  // FIXME: consider pointer-to-member-function
   return 8;
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -405,6 +405,30 @@ uint64_t PointerType::getPreferredAlignment(
 }
 
 llvm::TypeSize
+DataMemberType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
+                                  ::mlir::DataLayoutEntryListRef params) const {
+  // FIXME: consider size differences under different ABIs
+  // FIXME: consider pointer-to-member-function
+  return llvm::TypeSize::getFixed(64);
+}
+
+uint64_t
+DataMemberType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
+                                ::mlir::DataLayoutEntryListRef params) const {
+  // FIXME: consider alignment differences under different ABIs
+  // FIXME: consider pointer-to-member-function
+  return 8;
+}
+
+uint64_t DataMemberType::getPreferredAlignment(
+    const ::mlir::DataLayout &dataLayout,
+    ::mlir::DataLayoutEntryListRef params) const {
+  // FIXME: consider alignment differences under different ABIs
+  // FIXME: consider pointer-to-member-function
+  return 8;
+}
+
+llvm::TypeSize
 ArrayType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
                              ::mlir::DataLayoutEntryListRef params) const {
   return getSize() * dataLayout.getTypeSizeInBits(getEltType());

--- a/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir-enable -Wno-unused-value -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+struct Point {
+  int x;
+  int y;
+  int z;
+};
+// CHECK-DAG: !ty_22Point22 = !cir.struct<struct "Point" {!cir.int<s, 32>, !cir.int<s, 32>, !cir.int<s, 32>}
+
+struct Incomplete;
+// CHECK-DAG: !ty_22Incomplete22 = !cir.struct<struct "Incomplete" incomplete>
+
+int Point::*pt_member = &Point::x;
+// CHECK: cir.global external @pt_member = #cir.data_member<0> : !cir.data_member<!s32i in !ty_22Point22>
+
+auto test1() -> int Point::* {
+  return &Point::y;
+}
+// CHECK: cir.func @_Z5test1v() -> !cir.data_member<!s32i in !ty_22Point22>
+// CHECK:   %{{.+}} = cir.const(#cir.data_member<1> : !cir.data_member<!s32i in !ty_22Point22>) : !cir.data_member<!s32i in !ty_22Point22>
+// CHECK: }
+
+int test2(const Point &pt, int Point::*member) {
+  return pt.*member;
+}
+// CHECK: cir.func @_Z5test2RK5PointMS_i
+// CHECK:   %{{.+}} = cir.get_runtime_member %{{.+}}[%{{.+}} : !cir.data_member<!s32i in !ty_22Point22>] : !cir.ptr<!ty_22Point22> -> !cir.ptr<!s32i>
+// CHECK: }
+
+int test3(const Point *pt, int Point::*member) {
+  return pt->*member;
+}
+// CHECK: cir.func @_Z5test3PK5PointMS_i
+// CHECK:   %{{.+}} = cir.get_runtime_member %{{.+}}[%{{.+}} : !cir.data_member<!s32i in !ty_22Point22>] : !cir.ptr<!ty_22Point22> -> !cir.ptr<!s32i>
+// CHECK: }
+
+auto test4(int Incomplete::*member) -> int Incomplete::* {
+  return member;
+}
+// CHECK: cir.func @_Z5test4M10Incompletei(%arg0: !cir.data_member<!s32i in !ty_22Incomplete22> loc({{.+}})) -> !cir.data_member<!s32i in !ty_22Incomplete22>
+
+int test5(Incomplete *ic, int Incomplete::*member) {
+  return ic->*member;
+}
+// CHECK: cir.func @_Z5test5P10IncompleteMS_i
+// CHECK: %{{.+}} = cir.get_runtime_member %{{.+}}[%{{.+}} : !cir.data_member<!s32i in !ty_22Incomplete22>] : !cir.ptr<!ty_22Incomplete22> -> !cir.ptr<!s32i>
+// CHECK: }
+
+auto test_null() -> int Point::* {
+  return nullptr;
+}
+// CHECK: cir.func @_Z9test_nullv
+// CHECK:   %{{.+}} = cir.const(#cir.data_member<null> : !cir.data_member<!s32i in !ty_22Point22>) : !cir.data_member<!s32i in !ty_22Point22>
+// CHECK: }
+
+auto test_null_incomplete() -> int Incomplete::* {
+  return nullptr;
+}
+// CHECK: cir.func @_Z20test_null_incompletev
+// CHECK:   %{{.+}} = cir.const(#cir.data_member<null> : !cir.data_member<!s32i in !ty_22Incomplete22>) : !cir.data_member<!s32i in !ty_22Incomplete22>
+// CHECK: }

--- a/clang/test/CIR/IR/data-member-ptr.cir
+++ b/clang/test/CIR/IR/data-member-ptr.cir
@@ -1,8 +1,9 @@
 // RUN: cir-opt %s | cir-opt | FileCheck %s
 
 !s32i = !cir.int<s, 32>
-!void = !cir.void
-!ty_22Foo22 = !cir.struct<struct "Foo" {!cir.int<s, 32>}>
+!ty_22Foo22 = !cir.struct<struct "Foo" {!s32i}>
+
+#global_ptr = #cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>
 
 module {
   cir.func @null_member() {
@@ -12,6 +13,12 @@ module {
 
   cir.func @get_runtime_member(%arg0: !cir.ptr<!ty_22Foo22>) {
     %0 = cir.const(#cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>) : !cir.data_member<!s32i in !ty_22Foo22>
+    %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
+    cir.return
+  }
+
+  cir.func @get_global_member(%arg0: !cir.ptr<!ty_22Foo22>) {
+    %0 = cir.const(#global_ptr) : !cir.data_member<!s32i in !ty_22Foo22>
     %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
     cir.return
   }
@@ -28,6 +35,12 @@ module {
 // CHECK-NEXT:      %0 = cir.const(#cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>) : !cir.data_member<!s32i in !ty_22Foo22>
 // CHECK-NEXT:      %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
 // CHECK-NEXT:      cir.return
+// CHECK-NEXT:   }
+
+// CHECK-NEXT:   cir.func @get_global_member(%arg0: !cir.ptr<!ty_22Foo22>) {
+// CHECK-NEXT:     %0 = cir.const(#cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>) : !cir.data_member<!s32i in !ty_22Foo22>
+// CHECK-NEXT:     %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
+// CHECK-NEXT:     cir.return
 // CHECK-NEXT:   }
 
 //      CHECK: }

--- a/clang/test/CIR/IR/data-member-ptr.cir
+++ b/clang/test/CIR/IR/data-member-ptr.cir
@@ -1,0 +1,33 @@
+// RUN: cir-opt %s | cir-opt | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!void = !cir.void
+!ty_22Foo22 = !cir.struct<struct "Foo" {!cir.int<s, 32>}>
+
+module {
+  cir.func @null_member() {
+    %0 = cir.const(#cir.data_member<null> : !cir.data_member<!s32i in !ty_22Foo22>) : !cir.data_member<!s32i in !ty_22Foo22>
+    cir.return
+  }
+
+  cir.func @get_runtime_member(%arg0: !cir.ptr<!ty_22Foo22>) {
+    %0 = cir.const(#cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>) : !cir.data_member<!s32i in !ty_22Foo22>
+    %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
+    cir.return
+  }
+}
+
+//      CHECK: module {
+
+// CHECK-NEXT:   cir.func @null_member() {
+// CHECK-NEXT:     %0 = cir.const(#cir.data_member<null> : !cir.data_member<!s32i in !ty_22Foo22>) : !cir.data_member<!s32i in !ty_22Foo22>
+// CHECK-NEXT:     cir.return
+// CHECK-NEXT:   }
+
+// CHECK-NEXT:   cir.func @get_runtime_member(%arg0: !cir.ptr<!ty_22Foo22>) {
+// CHECK-NEXT:      %0 = cir.const(#cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>) : !cir.data_member<!s32i in !ty_22Foo22>
+// CHECK-NEXT:      %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
+// CHECK-NEXT:      cir.return
+// CHECK-NEXT:   }
+
+//      CHECK: }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -789,3 +789,73 @@ cir.func @const_type_mismatch() -> () {
     %2 = cir.const(#cir.int<0> : !s8i) : !u8i
     cir.return
 }
+
+// -----
+
+!u16i = !cir.int<u, 16>
+
+// expected-error@+1 {{invalid kind of type specified}}
+#invalid_type = #cir.data_member<0> : !u16i
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
+
+// expected-error@+1 {{member type of a DataMemberAttr must match the attribute type}}
+#invalid_member_ty = #cir.data_member<0> : !cir.data_member<!u32i in !struct1>
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
+
+module {
+  cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {
+    %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["tmp"] {alignment = 4 : i64}
+    // expected-error@+1 {{expected pointer to a record type}}
+    %1 = cir.get_runtime_member %0[%arg0 : !cir.data_member<!u32i in !struct1>] : !cir.ptr<!u32i> -> !cir.ptr<!u32i>
+    cir.return
+  }
+}
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
+!struct2 = !cir.struct<struct "Struct2" {!u16i, !u32i}>
+
+module {
+  cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {
+    %0 = cir.alloca !struct2, cir.ptr <!struct2>, ["tmp"] {alignment = 4 : i64}
+    // expected-error@+1 {{record type does not match the member pointer type}}
+    %1 = cir.get_runtime_member %0[%arg0 : !cir.data_member<!u32i in !struct1>] : !cir.ptr<!struct2> -> !cir.ptr<!u32i>
+    cir.return
+  }
+}
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
+
+module {
+  cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {
+    %0 = cir.alloca !struct1, cir.ptr <!struct1>, ["tmp"] {alignment = 4 : i64}
+    // expected-error@+1 {{result type does not match the member pointer type}}
+    %1 = cir.get_runtime_member %0[%arg0 : !cir.data_member<!u32i in !struct1>] : !cir.ptr<!struct1> -> !cir.ptr<!u16i>
+    cir.return
+  }
+}
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!incomplete_struct = !cir.struct<struct "Incomplete" incomplete>
+
+// expected-error@+1 {{trying to build a non-null ptr to data member of an incomplete class}}
+#incomplete_cls_member = #cir.data_member<0> : !cir.data_member<!u16i in !incomplete_struct>

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -803,7 +803,7 @@ cir.func @const_type_mismatch() -> () {
 !u32i = !cir.int<u, 32>
 !struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
 
-// expected-error@+1 {{member type of a DataMemberAttr must match the attribute type}}
+// expected-error@+1 {{member type of a #cir.data_member attribute must match the attribute type}}
 #invalid_member_ty = #cir.data_member<0> : !cir.data_member<!u32i in !struct1>
 
 // -----
@@ -815,7 +815,7 @@ cir.func @const_type_mismatch() -> () {
 module {
   cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {
     %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["tmp"] {alignment = 4 : i64}
-    // expected-error@+1 {{expected pointer to a record type}}
+    // expected-error@+1 {{'cir.get_runtime_member' op operand #0 must be !cir.struct*}}
     %1 = cir.get_runtime_member %0[%arg0 : !cir.data_member<!u32i in !struct1>] : !cir.ptr<!u32i> -> !cir.ptr<!u32i>
     cir.return
   }
@@ -857,5 +857,5 @@ module {
 !u16i = !cir.int<u, 16>
 !incomplete_struct = !cir.struct<struct "Incomplete" incomplete>
 
-// expected-error@+1 {{trying to build a non-null ptr to data member of an incomplete class}}
+// expected-error@+1 {{incomplete 'cir.struct' cannot be used to build a non-null data member pointer}}
 #incomplete_cls_member = #cir.data_member<0> : !cir.data_member<!u16i in !incomplete_struct>


### PR DESCRIPTION
This patch adds initial support for the pointer-to-data-member type. Specifically, this commit includes:

- New ops, types, and attributes:
  - Add a new type `!cir.member_ptr`
  - Add a new attribute `#cir.data_member_ptr`
  - Add a new operation `cir.get_indirect_member`
- CodeGen for pointer-to-data-member types and values
  - Lower C++ pointer-to-member type to `!cir.member_ptr`
  - Lower C++ expression `&C::D` to `cir.const(#cir.data_member_ptr)`
  - Lower C++ expression `c.*p` and `c->*p` to `cir.get_indirect_member`

This patch only includes an initial support. The following stuff related to pointer-to-member types are not supported yet:

- Pointer to member function;
- Conversion from `T Base::*` to `T Derived::*`;
- LLVMIR lowering.

Hopefully they will eventually be supported in later PRs :)