### PR TITLE
[CIR][CodeGen][BugFix] use proper base type for derived class

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -601,15 +601,15 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *D,
   builder.lower(/*nonVirtualBaseType=*/false);
 
   // If we're in C++, compute the base subobject type.
-  mlir::cir::StructType *BaseTy = nullptr;
+  mlir::cir::StructType BaseTy;
   if (llvm::isa<CXXRecordDecl>(D) && !D->isUnion() &&
       !D->hasAttr<FinalAttr>()) {
-    BaseTy = Ty;
+    BaseTy = *Ty;
     if (builder.astRecordLayout.getNonVirtualSize() !=
         builder.astRecordLayout.getSize()) {
       CIRRecordLowering baseBuilder(*this, D, /*Packed=*/builder.isPacked);
       auto baseIdentifier = getRecordTypeName(D, ".base");
-      *BaseTy =
+      BaseTy =
           Builder.getCompleteStructTy(baseBuilder.fieldTypes, baseIdentifier,
                                       /*packed=*/false, D);
       // TODO(cir): add something like addRecordTypeName
@@ -630,7 +630,7 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *D,
 
   auto RL = std::make_unique<CIRGenRecordLayout>(
       Ty ? *Ty : mlir::cir::StructType{},
-      BaseTy ? *BaseTy : mlir::cir::StructType{},
+      BaseTy ? BaseTy : mlir::cir::StructType{},
       (bool)builder.IsZeroInitializable,
       (bool)builder.IsZeroInitializableAsBase);
 

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -608,6 +608,7 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *D,
     if (builder.astRecordLayout.getNonVirtualSize() !=
         builder.astRecordLayout.getSize()) {
       CIRRecordLowering baseBuilder(*this, D, /*Packed=*/builder.isPacked);
+      baseBuilder.lower(/*NonVirtualBaseType=*/true);
       auto baseIdentifier = getRecordTypeName(D, ".base");
       BaseTy =
           Builder.getCompleteStructTy(baseBuilder.fieldTypes, baseIdentifier,

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -77,6 +77,9 @@ void C3::Layer::Initialize() {
 
 // CHECK-DAG: !ty_22C23A3ALayer22 = !cir.struct<class "C2::Layer"
 // CHECK-DAG: !ty_22C33A3ALayer22 = !cir.struct<struct "C3::Layer"
+// CHECK-DAG: !ty_22A22 = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>, !cir.int<s, 32>}>
+// CHECK-DAG: !ty_22A2Ebase22 = !cir.struct<class "A.base" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>, !cir.int<s, 32>} #cir.record.decl.ast>
+// CHECK-DAG: !ty_22B22 = !cir.struct<class "B" {!cir.struct<class "A.base" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>, !cir.int<s, 32>} #cir.record.decl.ast>, !cir.int<s, 32>}>
 
 // CHECK: cir.func @_ZN2C35Layer10InitializeEv
 

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -77,9 +77,9 @@ void C3::Layer::Initialize() {
 
 // CHECK-DAG: !ty_22C23A3ALayer22 = !cir.struct<class "C2::Layer"
 // CHECK-DAG: !ty_22C33A3ALayer22 = !cir.struct<struct "C3::Layer"
-// CHECK-DAG: !ty_22A22 = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>, !cir.int<s, 32>}>
-// CHECK-DAG: !ty_22A2Ebase22 = !cir.struct<class "A.base" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>, !cir.int<s, 32>} #cir.record.decl.ast>
-// CHECK-DAG: !ty_22B22 = !cir.struct<class "B" {!cir.struct<class "A.base" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>, !cir.int<s, 32>} #cir.record.decl.ast>, !cir.int<s, 32>}>
+// CHECK-DAG: !ty_22A22 = !cir.struct<class "A"
+// CHECK-DAG: !ty_22A2Ebase22 = !cir.struct<class "A.base"
+// CHECK-DAG: !ty_22B22 = !cir.struct<class "B" {!cir.struct<class "A.base"
 
 // CHECK: cir.func @_ZN2C35Layer10InitializeEv
 


### PR DESCRIPTION
In the original codegen a new type is created for the base class, while in CIR we were rewriting the type being processed (due tp misused pointers). This  PR fix this, and also makes CIR codegen even with the original one. 