### PR TITLE
[CIR][IR] Refactor while loops

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -442,7 +442,7 @@ def StoreOp : CIR_Op<"store", [
 
 def ReturnOp : CIR_Op<"return", [ParentOneOf<["FuncOp", "ScopeOp", "IfOp",
                                               "SwitchOp", "DoWhileOp",
-                                              "LoopOp"]>,
+                                              "WhileOp", "LoopOp"]>,
                                  Terminator]> {
   let summary = "Return from function";
   let description = [{
@@ -635,7 +635,7 @@ def ConditionOp : CIR_Op<"condition", [
 //===----------------------------------------------------------------------===//
 
 def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
-    ParentOneOf<["IfOp", "ScopeOp", "SwitchOp", "LoopOp", "AwaitOp",
+    ParentOneOf<["IfOp", "ScopeOp", "SwitchOp", "WhileOp", "LoopOp", "AwaitOp",
                  "TernaryOp", "GlobalOp", "DoWhileOp"]>]> {
   let summary = "Represents the default branching behaviour of a region";
   let description = [{
@@ -1139,12 +1139,11 @@ def BrCondOp : CIR_Op<"brcond",
 //===----------------------------------------------------------------------===//
 
 def LoopOpKind_For : I32EnumAttrCase<"For", 1, "for">;
-def LoopOpKind_While : I32EnumAttrCase<"While", 2, "while">;
 
 def LoopOpKind : I32EnumAttr<
     "LoopOpKind",
     "Loop kind",
-    [LoopOpKind_For, LoopOpKind_While]> {
+    [LoopOpKind_For]> {
   let cppNamespace = "::mlir::cir";
 }
 
@@ -1231,7 +1230,7 @@ def LoopOp : CIR_Op<"loop",
 }
 
 //===----------------------------------------------------------------------===//
-// DoWhileOp
+// While & DoWhileOp
 //===----------------------------------------------------------------------===//
 
 class WhileOpBase<string mnemonic> : CIR_Op<mnemonic, [
@@ -1255,6 +1254,31 @@ class WhileOpBase<string mnemonic> : CIR_Op<mnemonic, [
         condBuilder($_builder, $_state.location);
       }])>
   ];
+}
+
+def WhileOp : WhileOpBase<"while"> {
+  let regions = (region SizedRegion<1>:$cond, MinSizedRegion<1>:$body);
+  let assemblyFormat = "$cond `do` $body attr-dict";
+
+  let description = [{
+    Represents a C/C++ while loop. It consists of two regions:
+
+     - `cond`: single block region with the loop's condition. Should be
+     terminated with a `cir.condition` operation.
+     - `body`: contains the loop body and an arbitrary number of blocks.
+
+    Example:
+
+    ```mlir
+    cir.while {
+      cir.break
+    ^bb2:
+      cir.yield
+    } do {
+      cir.condition %cond : cir.bool
+    }
+    ```
+  }];
 }
 
 def DoWhileOp : WhileOpBase<"do"> {
@@ -2630,7 +2654,7 @@ def AllocException : CIR_Op<"alloc_exception", [
 
 def ThrowOp : CIR_Op<"throw", [
                      ParentOneOf<["FuncOp", "ScopeOp", "IfOp", "SwitchOp",
-                                  "DoWhileOp", "LoopOp"]>,
+                                  "DoWhileOp", "WhileOp", "LoopOp"]>,
                      Terminator]> {
   let summary = "(Re)Throws an exception";
   let description = [{

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -607,6 +607,14 @@ public:
     return create<mlir::cir::DoWhileOp>(loc, condBuilder, bodyBuilder);
   }
 
+  /// Create a while operation.
+  mlir::cir::WhileOp createWhile(
+      mlir::Location loc,
+      llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)> condBuilder,
+      llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)> bodyBuilder) {
+    return create<mlir::cir::WhileOp>(loc, condBuilder, bodyBuilder);
+  }
+
   mlir::cir::MemCpyOp createMemCpy(mlir::Location loc, mlir::Value dst,
                                    mlir::Value src, mlir::Value len) {
     return create<mlir::cir::MemCpyOp>(loc, dst, src, len);

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1290,6 +1290,14 @@ void DoWhileOp::getSuccessorRegions(
   return {&getBody()};
 }
 
+void WhileOp::getSuccessorRegions(
+    ::mlir::RegionBranchPoint point,
+    ::llvm::SmallVectorImpl<::mlir::RegionSuccessor> &regions) {
+  LoopOpInterface::getLoopOpSuccessorRegions(*this, point, regions);
+}
+
+::llvm::SmallVector<Region *> WhileOp::getLoopRegions() { return {&getBody()}; }
+
 //===----------------------------------------------------------------------===//
 // GlobalOp
 //===----------------------------------------------------------------------===//

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -53,12 +53,10 @@ void l2(bool cond) {
 
 // CHECK: cir.func @_Z2l2b
 // CHECK:         cir.scope {
-// CHECK-NEXT:     cir.loop while(cond :  {
+// CHECK-NEXT:     cir.while {
 // CHECK-NEXT:       %3 = cir.load %0 : cir.ptr <!cir.bool>, !cir.bool
 // CHECK-NEXT:       cir.condition(%3)
-// CHECK-NEXT:     }, step :  {
-// CHECK-NEXT:       cir.yield
-// CHECK-NEXT:     })  {
+// CHECK-NEXT:     } do {
 // CHECK-NEXT:       %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:       %4 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK-NEXT:       %5 = cir.binop(add, %3, %4) : !s32i
@@ -67,12 +65,10 @@ void l2(bool cond) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:     cir.loop while(cond :  {
+// CHECK-NEXT:     cir.while {
 // CHECK-NEXT:       %[[#TRUE:]] = cir.const(#true) : !cir.bool
 // CHECK-NEXT:       cir.condition(%[[#TRUE]])
-// CHECK-NEXT:     }, step :  {
-// CHECK-NEXT:       cir.yield
-// CHECK-NEXT:     })  {
+// CHECK-NEXT:     } do {
 // CHECK-NEXT:       %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:       %4 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK-NEXT:       %5 = cir.binop(add, %3, %4) : !s32i
@@ -81,13 +77,11 @@ void l2(bool cond) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:     cir.loop while(cond :  {
+// CHECK-NEXT:     cir.while {
 // CHECK-NEXT:       %3 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK-NEXT:       %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
 // CHECK-NEXT:       cir.condition(%4)
-// CHECK-NEXT:     }, step :  {
-// CHECK-NEXT:       cir.yield
-// CHECK-NEXT:     })  {
+// CHECK-NEXT:     } do {
 // CHECK-NEXT:       %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:       %4 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK-NEXT:       %5 = cir.binop(add, %3, %4) : !s32i
@@ -159,12 +153,10 @@ void l4() {
 }
 
 // CHECK: cir.func @_Z2l4v
-// CHECK: cir.loop while(cond :  {
+// CHECK: cir.while {
 // CHECK-NEXT:   %[[#TRUE:]] = cir.const(#true) : !cir.bool
 // CHECK-NEXT:   cir.condition(%[[#TRUE]])
-// CHECK-NEXT: }, step :  {
-// CHECK-NEXT:   cir.yield
-// CHECK-NEXT: })  {
+// CHECK-NEXT: } do {
 // CHECK-NEXT:   %4 = cir.load %0 : cir.ptr <!s32i>, !s32i
 // CHECK-NEXT:   %5 = cir.const(#cir.int<1> : !s32i) : !s32i
 // CHECK-NEXT:   %6 = cir.binop(add, %4, %5) : !s32i
@@ -204,12 +196,10 @@ void l6() {
 
 // CHECK: cir.func @_Z2l6v()
 // CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:     cir.loop while(cond :  {
+// CHECK-NEXT:     cir.while {
 // CHECK-NEXT:       %[[#TRUE:]] = cir.const(#true) : !cir.bool
 // CHECK-NEXT:       cir.condition(%[[#TRUE]])
-// CHECK-NEXT:     }, step :  {
-// CHECK-NEXT:       cir.yield
-// CHECK-NEXT:     })  {
+// CHECK-NEXT:     } do {
 // CHECK-NEXT:       cir.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -306,11 +306,9 @@ cir.func @cast24(%p : !u32i) {
 #true = #cir.bool<true> : !cir.bool
 cir.func @b0() {
   cir.scope {
-    cir.loop while(cond :  {  // expected-error {{expected condition region to terminate with 'cir.condition'}}
+    cir.while {  // expected-error {{expected condition region to terminate with 'cir.condition'}}
       cir.yield
-    }, step :  {
-      cir.yield
-    })  {
+    } do {
       cir.br ^bb1
     ^bb1:
       cir.return

--- a/clang/test/CIR/IR/loop.cir
+++ b/clang/test/CIR/IR/loop.cir
@@ -34,29 +34,6 @@ cir.func @l0() {
       cir.yield
     }
   }
-  cir.scope {
-    %2 = cir.alloca !u32i, cir.ptr <!u32i>, ["i", init] {alignment = 4 : i64}
-    %3 = cir.const(#cir.int<0> : !u32i) : !u32i
-    cir.store %3, %2 : !u32i, cir.ptr <!u32i>
-    cir.loop while(cond :  {
-      %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
-      %5 = cir.const(#cir.int<10> : !u32i) : !u32i
-      %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-      cir.condition(%6)
-    }, step :  {
-      cir.yield
-    })  {
-      %4 = cir.load %0 : cir.ptr <!u32i>, !u32i
-      %5 = cir.const(#cir.int<1> : !u32i) : !u32i
-      %6 = cir.binop(add, %4, %5) : !u32i
-      cir.store %6, %0 : !u32i, cir.ptr <!u32i>
-      %7 = cir.const(#true) : !cir.bool
-      cir.if %7 {
-        cir.continue
-      }
-      cir.yield
-    }
-  }
 
   cir.return
 }
@@ -83,75 +60,4 @@ cir.func @l0() {
 // CHECK-NEXT:       cir.break
 // CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield
-// CHECK-NEXT: }
-
-// CHECK:        cir.loop while(cond :  {
-// CHECK-NEXT:     %4 = cir.load %2 : cir.ptr <!u32i>, !u32i
-// CHECK-NEXT:     %5 = cir.const(#cir.int<10> : !u32i) : !u32i
-// CHECK-NEXT:     %6 = cir.cmp(lt, %4, %5) : !u32i, !cir.bool
-// CHECK-NEXT:     cir.condition(%6)
-// CHECK-NEXT:   }, step :  {
-// CHECK-NEXT:     cir.yield
-// CHECK-NEXT:   })  {
-// CHECK-NEXT:     %4 = cir.load %0 : cir.ptr <!u32i>, !u32i
-// CHECK-NEXT:     %5 = cir.const(#cir.int<1> : !u32i) : !u32i
-// CHECK-NEXT:     %6 = cir.binop(add, %4, %5) : !u32i
-// CHECK-NEXT:     cir.store %6, %0 : !u32i, cir.ptr <!u32i>
-// CHECK-NEXT:     %7 = cir.const(#true) : !cir.bool
-// CHECK-NEXT:     cir.if %7 {
-// CHECK-NEXT:       cir.continue
-// CHECK-NEXT:     }
-// CHECK-NEXT:     cir.yield
-// CHECK-NEXT:   }
-
-cir.func @l1(%arg0 : !cir.bool) {
-  cir.scope {
-    cir.loop while(cond :  {
-      cir.condition(%arg0)
-    }, step :  {
-      cir.yield
-    })  {
-      cir.yield
-    }
-  }
-  cir.return
-}
-
-// CHECK: cir.func @l1
-// CHECK-NEXT:  cir.scope {
-// CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      cir.condition(%arg0)
-// CHECK-NEXT:    }, step :  {
-// CHECK-NEXT:      cir.yield
-// CHECK-NEXT:    })  {
-// CHECK-NEXT:      cir.yield
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-// CHECK-NEXT:  cir.return
-// CHECK-NEXT: }
-
-cir.func @l2(%arg0 : !cir.bool) {
-  cir.scope {
-    cir.loop while(cond :  {
-      cir.condition(%arg0)
-    }, step :  {
-      cir.yield
-    })  {
-      cir.yield
-    }
-  }
-  cir.return
-}
-
-// CHECK: cir.func @l2
-// CHECK-NEXT:  cir.scope {
-// CHECK-NEXT:    cir.loop while(cond :  {
-// CHECK-NEXT:      cir.condition(%arg0)
-// CHECK-NEXT:    }, step :  {
-// CHECK-NEXT:      cir.yield
-// CHECK-NEXT:    })  {
-// CHECK-NEXT:      cir.yield
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-// CHECK-NEXT:  cir.return
 // CHECK-NEXT: }

--- a/clang/test/CIR/IR/while.cir
+++ b/clang/test/CIR/IR/while.cir
@@ -1,0 +1,18 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+cir.func @testPrintingParsing(%arg0 : !cir.bool) {
+  cir.while {
+    cir.condition(%arg0)
+  } do {
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK: @testPrintingParsing
+// CHECK: cir.while {
+// CHECK:   cir.condition(%arg0)
+// CHECK: } do {
+// CHECK:   cir.yield
+// CHECK: }

--- a/clang/test/CIR/Lowering/loop.cir
+++ b/clang/test/CIR/Lowering/loop.cir
@@ -31,11 +31,9 @@ module {
 
   // Test while cir.loop operation lowering.
   cir.func @testWhile(%arg0 : !cir.bool) {
-    cir.loop while(cond : {
+    cir.while {
       cir.condition(%arg0)
-    }, step : { // Droped when lowering while statements.
-      cir.yield
-    }) {
+    } do {
       cir.yield
     }
     cir.return
@@ -76,11 +74,9 @@ module {
   //     break;
   // }
   cir.func @testWhileWithBreakTerminatedBody(%arg0 : !cir.bool) {
-    cir.loop while(cond : {
+    cir.while {
       cir.condition(%arg0)
-    }, step : { // Droped when lowering while statements.
-      cir.yield
-    }) {
+    } do {
       cir.break
     }
     cir.return

--- a/clang/test/CIR/Lowering/loops-with-break.cir
+++ b/clang/test/CIR/Lowering/loops-with-break.cir
@@ -171,15 +171,13 @@ module {
     %1 = cir.const(#cir.int<0> : !s32i) : !s32i
     cir.store %1, %0 : !s32i, cir.ptr <!s32i>
     cir.scope {
-      cir.loop while(cond : {
+      cir.while {
         %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
         %3 = cir.const(#cir.int<10> : !s32i) : !s32i
         %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
         %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
         cir.condition(%5)
-      }, step : {
-        cir.yield
-      }) {
+      } do {
         %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
         %3 = cir.unary(inc, %2) : !s32i, !s32i
         cir.store %3, %0 : !s32i, cir.ptr <!s32i>

--- a/clang/test/CIR/Lowering/loops-with-continue.cir
+++ b/clang/test/CIR/Lowering/loops-with-continue.cir
@@ -171,15 +171,13 @@ cir.func @testWhile() {
     %1 = cir.const(#cir.int<0> : !s32i) : !s32i
     cir.store %1, %0 : !s32i, cir.ptr <!s32i>
     cir.scope {
-      cir.loop while(cond : {
+      cir.while {
         %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
         %3 = cir.const(#cir.int<10> : !s32i) : !s32i
         %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
         %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
         cir.condition(%5)
-      }, step : {
-        cir.yield
-      }) {
+      } do {
         %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
         %3 = cir.unary(inc, %2) : !s32i, !s32i
         cir.store %3, %0 : !s32i, cir.ptr <!s32i>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #409
* __->__ #408
* #407
* #406
* #405

Creates a separate C/C++ operation for while loops, while keeping the
LoopOpInterface to generically handle loops. This simplifies the IR
generation and printing/parsing of while loops.