### PR TITLE
[CIR] Fix build error

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_library(MLIRCIR
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRCIRInterfaces
   MLIRDataLayoutInterfaces
   MLIRFuncDialect
   MLIRLoopLikeInterface


### PR DESCRIPTION
Currently build on main branch fails with the the error:

[602/787] Linking CXX shared library lib/libMLIRCIR.so.18git
FAILED: lib/libMLIRCIR.so.18git
...
ld.lld: error: undefined symbol: mlir::cir::CIRCallOpInterface::getNumArgOperands()

This PR fixes this issue