### PR TITLE
[CIR] Move CI to CLANG_ENABLE_CIR

### DIFF
--- a/.github/workflows/clang-cir-tests.yml
+++ b/.github/workflows/clang-cir-tests.yml
@@ -34,4 +34,5 @@ jobs:
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-clang-cir
-      projects: clang;mlir;cir
+      projects: clang;mlir
+      extra_cmake_args: -DCLANG_ENABLE_CIR=ON


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #427

