### PR TITLE
[CIR][CIRGen] Add missing visitor for ParenExpr

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -172,7 +172,7 @@ public:
                  << S->getStmtClassName() << "\n";
     llvm_unreachable("NYI");
   }
-  void VisitParenExpr(ParenExpr *PE) { llvm_unreachable("NYI"); }
+  void VisitParenExpr(ParenExpr *PE) { Visit(PE->getSubExpr()); }
   void VisitGenericSelectionExpr(GenericSelectionExpr *GE) {
     llvm_unreachable("NYI");
   }

--- a/clang/test/CIR/CodeGen/agg-copy.c
+++ b/clang/test/CIR/CodeGen/agg-copy.c
@@ -73,3 +73,13 @@ void foo5() {
     A a;
     a = create();
 }
+
+void foo6(A* a1) {
+  A a2 = (*a1);
+// CHECK: cir.func {{.*@foo6}}
+// CHECK:   [[TMP0]] = cir.alloca !cir.ptr<!ty_22A22>, cir.ptr <!cir.ptr<!ty_22A22>>, ["a1", init] {alignment = 8 : i64}
+// CHECK:   [[TMP1]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>, ["a2", init] {alignment = 4 : i64}
+// CHECK:   cir.store %arg0, [[TMP0]] : !cir.ptr<!ty_22A22>, cir.ptr <!cir.ptr<!ty_22A22>>
+// CHECK:   [[TMP2]] = cir.load deref [[TMP0]] : cir.ptr <!cir.ptr<!ty_22A22>>, !cir.ptr<!ty_22A22>
+// CHECK:   cir.copy [[TMP2]] to [[TMP1]] : !cir.ptr<!ty_22A22>
+}


### PR DESCRIPTION
Compilation of the following test
```
void foo6(A* a1) {
  A a2 = (*a1);
}
```
fails with.
```
NYI
UNREACHABLE executed at /home/huawei/cir/repo/llvm-project/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp:175!
```
Commit adds required visitor and fixes the issue.