### PR TITLE
[CIR] introduce cir.unreachable operation

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2845,6 +2845,22 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
 }
 
 //===----------------------------------------------------------------------===//
+// UnreachableOp
+//===----------------------------------------------------------------------===//
+
+def UnreachableOp : CIR_Op<"unreachable", [Terminator]> {
+  let summary = "invoke immediate undefined behavior";
+  let description = [{
+    If the program control flow reaches a `cir.unreachable` operation, the
+    program exhibits undefined behavior immediately. This operation is useful
+    in cases where the unreachability of a program point needs to be explicitly
+    marked.
+  }];
+
+  let assemblyFormat = "attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // Operations Lowered Directly to LLVM IR
 //
 // These operations are hacks to get around missing features in LLVM's dialect.

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -451,6 +451,14 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     return RValue::get(emitBuiltinObjectSize(E->getArg(0), Type, ResType,
                                              /*EmittedE=*/nullptr, IsDynamic));
   }
+  case Builtin::BI__builtin_unreachable: {
+    buildUnreachable(E->getExprLoc());
+
+    // We do need to preserve an insertion point.
+    builder.createBlock(builder.getBlock()->getParent());
+
+    return RValue::get(nullptr);
+  }
   case Builtin::BImemcpy:
   case Builtin::BI__builtin_memcpy:
   case Builtin::BImempcpy:

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2536,6 +2536,12 @@ LValue CIRGenFunction::buildLoadOfReferenceLValue(LValue RefLVal,
                         PointeeBaseInfo);
 }
 
+void CIRGenFunction::buildUnreachable(SourceLocation Loc) {
+  if (SanOpts.has(SanitizerKind::Unreachable))
+    llvm_unreachable("NYI");
+  builder.create<mlir::cir::UnreachableOp>(getLoc(Loc));
+}
+
 //===----------------------------------------------------------------------===//
 // CIR builder helpers
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -757,7 +757,9 @@ mlir::Value CIRGenFunction::buildCXXNewExpr(const CXXNewExpr *E) {
     EnterNewDeleteCleanup(*this, E, allocation, allocSize, allocAlign,
                           allocatorArgs);
     operatorDeleteCleanup = EHStack.stable_begin();
-    // FIXME: cleanupDominator = Builder.CreateUnreachable();
+    cleanupDominator =
+        builder.create<mlir::cir::UnreachableOp>(getLoc(E->getSourceRange()))
+            .getOperation();
   }
 
   assert((allocSize == allocSizeWithoutCookie) ==

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -677,6 +677,7 @@ CIRGenFunction::generateCode(clang::GlobalDecl GD, mlir::cir::FuncOp Fn,
     }
     if (SanOpts.has(SanitizerKind::Return) || shouldEmitUnreachable) {
       // TODO: builder.createUnreachable();
+      assert(!UnimplementedFeature::unreachableOp());
       builder.clearInsertionPoint();
     }
   }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1516,6 +1516,10 @@ public:
                           AggValueSlot::Overlap_t MayOverlap,
                           bool isVolatile = false);
 
+  /// Emit a reached-unreachable diagnostic if \p Loc is valid and runtime
+  /// checking is enabled. Otherwise, just emit an unreachable instruction.
+  void buildUnreachable(SourceLocation Loc);
+
   ///
   /// Cleanups
   /// --------

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -2208,8 +2208,8 @@ void CIRGenItaniumCXXABI::buildBadCastCall(CIRGenFunction &CGF,
   assert(!UnimplementedFeature::setCallingConv());
 
   CGF.buildRuntimeCall(loc, getBadCastFn(CGF));
-  // TODO(cir): mark the current insertion point as unreachable.
-  assert(!UnimplementedFeature::unreachableOp());
+  CGF.getBuilder().create<mlir::cir::UnreachableOp>(loc);
+  CGF.getBuilder().clearInsertionPoint();
 }
 
 static CharUnits computeOffsetHint(ASTContext &Context,

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -132,21 +132,6 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
       mlir::Block *outgoing = builder.getInsertionBlock();
       assert(outgoing && "expression emission cleared block!");
 
-      // FIXME: Should we mimic LLVM emission here?
-      // The expression emitters assume (reasonably!) that the insertion
-      // point is always set.  To maintain that, the call-emission code
-      // for noreturn functions has to enter a new block with no
-      // predecessors.  We want to kill that block and mark the current
-      // insertion point unreachable in the common case of a call like
-      // "exit();".  Since expression emission doesn't otherwise create
-      // blocks with no predecessors, we can just test for that.
-      // However, we must be careful not to do this to our incoming
-      // block, because *statement* emission does sometimes create
-      // reachable blocks which will have no predecessors until later in
-      // the function.  This occurs with, e.g., labels that are not
-      // reachable by fallthrough.
-      if (incoming != outgoing && outgoing->use_empty())
-        assert(0 && "not implemented");
       break;
     }
 

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -159,6 +159,7 @@ struct UnimplementedFeature {
   static bool emitScalarRangeCheck() { return false; }
   static bool stmtExprEvaluation() { return false; }
   static bool setCallingConv() { return false; }
+  static bool unreachableOp() { return false; }
   static bool tryMarkNoThrow() { return false; }
   static bool indirectBranch() { return false; }
   static bool escapedLocals() { return false; }

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -159,7 +159,6 @@ struct UnimplementedFeature {
   static bool emitScalarRangeCheck() { return false; }
   static bool stmtExprEvaluation() { return false; }
   static bool setCallingConv() { return false; }
-  static bool unreachableOp() { return false; }
   static bool tryMarkNoThrow() { return false; }
   static bool indirectBranch() { return false; }
   static bool escapedLocals() { return false; }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2206,6 +2206,19 @@ public:
   }
 };
 
+class CIRUnreachableLowering
+    : public mlir::OpConversionPattern<mlir::cir::UnreachableOp> {
+public:
+  using OpConversionPattern<mlir::cir::UnreachableOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::UnreachableOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::UnreachableOp>(op);
+    return mlir::success();
+  }
+};
+
 void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter) {
   patterns.add<CIRReturnLowering>(patterns.getContext());
@@ -2221,8 +2234,8 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRPtrDiffOpLowering, CIRCopyOpLowering, CIRMemCpyOpLowering,
       CIRFAbsOpLowering, CIRVTableAddrPointOpLowering, CIRVectorCreateLowering,
       CIRVectorInsertLowering, CIRVectorExtractLowering, CIRVectorCmpOpLowering,
-      CIRStackSaveLowering, CIRStackRestoreLowering>(converter,
-                                                     patterns.getContext());
+      CIRStackSaveLowering, CIRStackRestoreLowering, CIRUnreachableLowering>(
+      converter, patterns.getContext());
 }
 
 namespace {

--- a/clang/test/CIR/CodeGen/dynamic-cast.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast.cpp
@@ -48,6 +48,7 @@ Derived &ref_cast(Base &b) {
 // CHECK-NEXT:   %[[#V18:]] = cir.unary(not, %[[#V17]]) : !cir.bool, !cir.bool
 // CHECK-NEXT:   cir.if %[[#V18]] {
 // CHECK-NEXT:     cir.call @__cxa_bad_cast() : () -> ()
+// CHECK-NEXT:     cir.unreachable
 // CHECK-NEXT:   }
 // CHECK-NEXT:   %{{.+}} = cir.cast(bitcast, %[[#V16]] : !cir.ptr<!void>), !cir.ptr<!ty_22Derived22>
 

--- a/clang/test/CIR/CodeGen/unreachable.cpp
+++ b/clang/test/CIR/CodeGen/unreachable.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void foo();
+
+void basic() {
+  foo();
+  __builtin_unreachable();
+}
+
+//      CHECK: cir.func @_Z5basicv()
+// CHECK-NEXT:   cir.call @_Z3foov() : () -> ()
+// CHECK-NEXT:   cir.unreachable
+// CHECK-NEXT: }
+
+void code_after_unreachable() {
+  foo();
+  __builtin_unreachable();
+  foo();
+}
+
+// CHECK: cir.func @_Z22code_after_unreachablev()
+// CHECK:   cir.call @_Z3foov() : () -> ()
+// CHECK:   cir.unreachable
+// CHECK: ^{{.+}}:
+// CHECK:   cir.call @_Z3foov() : () -> ()
+// CHECK:   cir.return
+// CHECK: }

--- a/clang/test/CIR/IR/unreachable.cir
+++ b/clang/test/CIR/IR/unreachable.cir
@@ -1,0 +1,9 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+cir.func @test() {
+  cir.unreachable
+}
+
+//      CHECK: cir.func @test
+// CHECK-NEXT:   cir.unreachable

--- a/clang/test/CIR/Lowering/intrinsics.cir
+++ b/clang/test/CIR/Lowering/intrinsics.cir
@@ -1,0 +1,10 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+
+module {
+  cir.func @test_unreachable() {
+    cir.unreachable
+  }
+
+  //      MLIR: llvm.func @test_unreachable()
+  // MLIR-NEXT:   llvm.unreachable
+}


### PR DESCRIPTION
In #426 we confirmed that CIR needs a `cir.unreachable` operation to mark unreachable program points [(discussion)](https://github.com/llvm/clangir/pull/426#discussion_r1472287368). This PR adds it.