### PR TITLE
[CIR] allow mlir::UnknownLoc in function op

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1397,7 +1397,8 @@ public:
       auto FusedLoc = Loc.cast<mlir::FusedLoc>();
       Loc = FusedLoc.getLocations()[0];
     }
-    assert(Loc.isa<mlir::FileLineColLoc>() && "expected single location here");
+    assert((Loc.isa<mlir::FileLineColLoc>() || Loc.isa<mlir::UnknownLoc>()) &&
+           "expected single location or unknown location here");
 
     auto linkage = convertLinkage(op.getLinkage());
     SmallVector<mlir::NamedAttribute, 4> attributes;


### PR DESCRIPTION
Originally, the location associated with a function is checked to be an `mlir::FileLineColLoc` before the function is lowered to an LLVMIR FuncOp. However, runtime function declarations do not have such locations. This patch further allows `mlir::UnknownLoc` to be associated with a function.