### PR TITLE
[CIR][CIRGen][Bugfix] Emit valid type for evaluated const

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -552,16 +552,7 @@ public:
 
   // Creates constant null value for integral type ty.
   mlir::cir::ConstantOp getNullValue(mlir::Type ty, mlir::Location loc) {
-    if (ty.isa<mlir::cir::PointerType>())
-      return getNullPtr(ty, loc);
-
-    mlir::TypedAttr attr;
-    if (ty.isa<mlir::cir::IntType>())
-      attr = mlir::cir::IntAttr::get(ty, 0);
-    else
-      llvm_unreachable("NYI");
-
-    return create<mlir::cir::ConstantOp>(loc, ty, attr);
+    return create<mlir::cir::ConstantOp>(loc, ty, getZeroInitAttr(ty));
   }
 
   mlir::cir::ConstantOp getZero(mlir::Location loc, mlir::Type ty) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2200,8 +2200,12 @@ mlir::Value ScalarExprEmitter::VisitBinLOr(const clang::BinaryOperator *E) {
       return Builder.createZExtOrBitCast(RHSCond.getLoc(), RHSCond, ResTy);
     }
     // 1 || RHS: If it is safe, just elide the RHS, and return 1/true.
-    if (!CGF.ContainsLabel(E->getRHS()))
-      return Builder.getBool(true, Loc);
+    if (!CGF.ContainsLabel(E->getRHS())) {
+      if (auto intTy = ResTy.dyn_cast<mlir::cir::IntType>())
+        return Builder.getConstInt(Loc, intTy, 1);
+      else
+        return Builder.getBool(true, Loc);
+    }
   }
 
   CIRGenFunction::ConditionalEvaluation eval(CGF);

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2127,7 +2127,7 @@ mlir::Value ScalarExprEmitter::VisitBinLAnd(const clang::BinaryOperator *E) {
     }
     // 0 && RHS: If it is safe, just elide the RHS, and return 0/false.
     if (!CGF.ContainsLabel(E->getRHS()))
-      return Builder.getBool(false, Loc);
+      return Builder.getNullValue(ResTy, Loc);
   }
 
   CIRGenFunction::ConditionalEvaluation eval(CGF);

--- a/clang/test/CIR/CodeGen/evaluate-expr.c
+++ b/clang/test/CIR/CodeGen/evaluate-expr.c
@@ -3,7 +3,9 @@
 
 static const int g = 1;
 void foo() {
-  if((g != 1) && (g != 1))
+  if ((g != 1) && (g != 1))
+    return;
+  if ((g == 1) || (g == 1))
     return;
 }
 // CHECK:  cir.func no_proto @foo()

--- a/clang/test/CIR/CodeGen/evaluate-expr.c
+++ b/clang/test/CIR/CodeGen/evaluate-expr.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+static const int g = 1;
+void foo() {
+  if((g != 1) && (g != 1))
+    return;
+}
+// CHECK:  cir.func no_proto @foo()
+// CHECK:    cir.scope {
+// CHECK:      [[ZERO:%.*]] = cir.const(#cir.int<0> : !s32i) : !s32i
+// CHECK:      [[FALSE:%.*]] = cir.cast(int_to_bool, [[ZERO:%.*]] : !s32i), !cir.bool
+// CHECK:      cir.if [[FALSE]] {
+// CHECK:        cir.return
+// CHECK:      }
+// CHECK:    }
+// CHECK:    cir.return
+


### PR DESCRIPTION
This PR fixes the issue connected with folding a simple boolean expresion pattern (f.e. `0 && RHS = 0`). 
The problem is that the scalar expression emitter always creates a `cir.bool` attribute as a result of expression. But in some cases the result expression should be a `cir.int` attr.