### PR TITLE
[CIR][CIRGen] Support for local const arrays

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1099,6 +1099,9 @@ public:
         : Variable(&variable), Addr(Address::invalid()) {}
 
     static AutoVarEmission invalid() { return AutoVarEmission(Invalid()); }
+
+    bool wasEmittedAsGlobal() const { return !Addr.isValid(); }
+
     /// Returns the raw, allocated address, which is not necessarily
     /// the address of the object itself. It is casted to default
     /// address space for address space agnostic languages.

--- a/clang/test/CIR/CodeGen/const-array.c
+++ b/clang/test/CIR/CodeGen/const-array.c
@@ -1,5 +1,13 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s
 
+void bar() {
+  const int arr[1] = {1};
+}
+
+// CHECK: cir.global "private" constant internal @bar.arr = #cir.const_array<[#cir.int<1> : !s32i]> : !cir.array<!s32i x 1> {alignment = 4 : i64}
+// CHECK: cir.func no_proto @bar()
+// CHECK:   {{.*}} = cir.get_global @bar.arr : cir.ptr <!cir.array<!s32i x 1>>
+
 void foo() {
   int a[10] = {1};
 }


### PR DESCRIPTION
The change is taken from the original llvm codegen.