### PR TITLE
[CIR][CIRGen] Fix in replacing of no_proto func

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1641,22 +1641,28 @@ void CIRGenModule::ReplaceUsesOfNonProtoTypeWithRealFunction(
   NewFn.setNoProtoAttr(OldFn.getNoProtoAttr());
 
   // Iterate through all calls of the no-proto function.
-  auto Calls = OldFn.getSymbolUses(OldFn->getParentOp());
-  for (auto Call : Calls.value()) {
+  auto SymUses = OldFn.getSymbolUses(OldFn->getParentOp());
+  for (auto Use : SymUses.value()) {
     mlir::OpBuilder::InsertionGuard guard(builder);
 
-    // Fetch no-proto call to be replaced.
-    auto noProtoCallOp = dyn_cast<mlir::cir::CallOp>(Call.getUser());
-    assert(noProtoCallOp && "unexpected use of no-proto function");
-    builder.setInsertionPoint(noProtoCallOp);
+    if (auto noProtoCallOp = dyn_cast<mlir::cir::CallOp>(Use.getUser())) {
+      builder.setInsertionPoint(noProtoCallOp);
 
-    // Patch call type with the real function type.
-    auto realCallOp = builder.create<mlir::cir::CallOp>(
-        noProtoCallOp.getLoc(), NewFn, noProtoCallOp.getOperands());
+      // Patch call type with the real function type.
+      auto realCallOp = builder.create<mlir::cir::CallOp>(
+          noProtoCallOp.getLoc(), NewFn, noProtoCallOp.getOperands());
 
-    // Replace old no proto call with fixed call.
-    noProtoCallOp.replaceAllUsesWith(realCallOp);
-    noProtoCallOp.erase();
+      // Replace old no proto call with fixed call.
+      noProtoCallOp.replaceAllUsesWith(realCallOp);
+      noProtoCallOp.erase();
+    } else if (auto getGlobalOp =
+                   dyn_cast<mlir::cir::GetGlobalOp>(Use.getUser())) {
+      // Replace type
+      getGlobalOp.getAddr().setType(mlir::cir::PointerType::get(
+          builder.getContext(), NewFn.getFunctionType()));
+    } else {
+      llvm_unreachable("NIY");
+    }
   }
 }
 

--- a/clang/test/CIR/CodeGen/no-proto-fun-ptr.c
+++ b/clang/test/CIR/CodeGen/no-proto-fun-ptr.c
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o -  | FileCheck %s
+
+void empty();
+
+void check_noproto_ptr() {
+  void (*fun)(void) = empty;
+}
+
+// CHECK:  cir.func no_proto @check_noproto_ptr()
+// CHECK:    [[ALLOC:%.*]] = cir.alloca !cir.ptr<!cir.func<!void ()>>, cir.ptr <!cir.ptr<!cir.func<!void ()>>>, ["fun", init] {alignment = 8 : i64}
+// CHECK:    [[GGO:%.*]] = cir.get_global @empty : cir.ptr <!cir.func<!void ()>>
+// CHECK:    [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<!void ()>>), !cir.ptr<!cir.func<!void ()>>
+// CHECK:    cir.store [[CAST]], [[ALLOC]] : !cir.ptr<!cir.func<!void ()>>, cir.ptr <!cir.ptr<!cir.func<!void ()>>>
+// CHECK:    cir.return
+
+void empty(void) {}
+


### PR DESCRIPTION
When replacing the no-proto functions with it's real definition, codegen assumes that only `cir.call` operation may use the replaced function. 
Such behaviour leads to compilation error because of the `cir.get_global` op can also use the function to get pointer to function.
This PR adds handle the case with `cir.get_global` operation and fixes the issue.