### PR TITLE
[CIR][CodeGen][Bugfix] fixes storage size for bitfields

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -501,10 +501,10 @@ void CIRRecordLowering::accumulateBitFields(
   // with lower cost.
   auto IsBetterAsSingleFieldRun = [&](uint64_t OffsetInRecord,
                                       uint64_t StartBitOffset,
-                                      uint64_t nextTail=0) {
+                                      uint64_t nextTail = 0) {
     if (OffsetInRecord >= 64 ||
         (nextTail > StartBitOffset &&
-          nextTail - StartBitOffset >= 64)) { // See IntType::verify
+         nextTail - StartBitOffset >= 64)) { // See IntType::verify
       return true;
     }
 
@@ -555,7 +555,8 @@ void CIRRecordLowering::accumulateBitFields(
       nextTail += Field->getBitWidthValue(astContext);
 
     if (!StartFieldAsSingleRun && Field != FieldEnd &&
-        !IsBetterAsSingleFieldRun(Tail - StartBitOffset, StartBitOffset, nextTail) &&
+        !IsBetterAsSingleFieldRun(Tail - StartBitOffset, StartBitOffset,
+                                  nextTail) &&
         (!Field->isZeroLengthBitField(astContext) ||
          (!astContext.getTargetInfo().useZeroLengthBitfieldAlignment() &&
           !astContext.getTargetInfo().useBitFieldTypeAlignment())) &&

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -500,9 +500,14 @@ void CIRRecordLowering::accumulateBitFields(
   // bitfield a separate storage component so as it can be accessed directly
   // with lower cost.
   auto IsBetterAsSingleFieldRun = [&](uint64_t OffsetInRecord,
-                                      uint64_t StartBitOffset) {
-    if (OffsetInRecord >= 64) // See IntType::verify
+                                      uint64_t StartBitOffset,
+                                      uint64_t nextTail=0) {
+    if (OffsetInRecord >= 64 ||
+        (nextTail > StartBitOffset &&
+          nextTail - StartBitOffset >= 64)) { // See IntType::verify
       return true;
+    }
+
     if (!cirGenTypes.getModule().getCodeGenOpts().FineGrainedBitfieldAccesses)
       return false;
     llvm_unreachable("NYI");
@@ -545,13 +550,17 @@ void CIRRecordLowering::accumulateBitFields(
     // field is inconsistent with the offset of previous field plus its offset,
     // skip the block below and go ahead to emit the storage. Otherwise, try to
     // add bitfields to the run.
+    uint64_t nextTail = Tail;
+    if (Field != FieldEnd)
+      nextTail += Field->getBitWidthValue(astContext);
+
     if (!StartFieldAsSingleRun && Field != FieldEnd &&
-        !IsBetterAsSingleFieldRun(Tail - StartBitOffset, StartBitOffset) &&
+        !IsBetterAsSingleFieldRun(Tail - StartBitOffset, StartBitOffset, nextTail) &&
         (!Field->isZeroLengthBitField(astContext) ||
          (!astContext.getTargetInfo().useZeroLengthBitfieldAlignment() &&
           !astContext.getTargetInfo().useBitFieldTypeAlignment())) &&
         Tail == getFieldBitOffset(*Field)) {
-      Tail += Field->getBitWidthValue(astContext);
+      Tail = nextTail;
       ++Field;
       continue;
     }

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -27,8 +27,29 @@ typedef struct {
   int a : 3;  // one bitfield with size < 8
   unsigned b;
 } T; 
+
+typedef struct {
+    char a;
+    char b;
+    char c;
+  
+    // startOffset 24 bits, new storage from here
+    int d: 2;  
+    int e: 2;
+    int f: 4;
+    int g: 25;
+    int h: 3;
+    int i: 4;  
+    int j: 3;
+    int k: 8;
+
+    int l: 14; // need to be a part of the new storage
+               // because (tail - startOffset) is 65 after 'l' field   
+} U;
+
 // CHECK: !ty_22S22 = !cir.struct<struct "S" {!cir.int<u, 32>, !cir.int<u, 32>, !cir.int<u, 16>, !cir.int<u, 32>}>
 // CHECK: !ty_22T22 = !cir.struct<struct "T" {!cir.int<u, 8>, !cir.int<u, 32>} #cir.record.decl.ast>
+// CHECK: !ty_22U22 = !cir.struct<struct "U" {!cir.int<s, 8>, !cir.int<s, 8>, !cir.int<s, 8>, !cir.int<u, 64>, !cir.int<u, 16>}>
 // CHECK: !ty_22anon2E122 = !cir.struct<struct "anon.1" {!cir.int<u, 32>} #cir.record.decl.ast>
 // CHECK: !ty_22__long22 = !cir.struct<struct "__long" {!cir.struct<struct "anon.1" {!cir.int<u, 32>} #cir.record.decl.ast>, !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>}>
 
@@ -96,4 +117,9 @@ unsigned load_non_bitfield(S *s) {
 // CHECK: cir.func {{.*@load_one_bitfield}}
 int load_one_bitfield(T* t) {
   return t->a;
+}
+
+// CHECK: cir.func {{.*@createU}}
+void createU() {
+  U u;
 }


### PR DESCRIPTION
This PR fixes a bug caused by `IntType` size limitations in CIR (and by some magic of numbers as well). 

As you know, we need to create a storage for bit fields that usually contain several of them. There next code fails with `IntType` size check which exceeds 64 bits.
```
typedef struct {
    uint8_t a;
    uint8_t b;
    uint8_t c;
  
    int d: 2;
    int e: 2;
    int f: 4;
    int g: 25;  
    int h: 3;
    int i: 4;  
    int j: 3;
    int k: 8;
    int l: 14;
} D;

void foo() {
    D d;	
} 
```
Note, if we remove first three fields (or even one) everything will be fine even without this fix, because [this](https://github.com/llvm/clangir/blob/main/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp#L553) check won't pass. The bug is kind of hard to reproduce and I would say it's a rare case. I mean the problem is not only in the number of bit fields that form together something bigger than 64 bits.

### Several details

Well, while iterating over the bit fields in some struct type, we need to stop accumulating bit fields in one storage and start to do the same in another one. Basically, we operate with `Tail` and `StartBitOffset` where the former is an offset of the next field. And once `Tail - StartBitOffset >= 64` we say that it's not possible to create a storage of such size due to `IntType` size limitation. Sounds reasonable. 

But it can be a case when we can not afford to take the next field because its `Tail` in turn leads to a storage of the size bigger then 64. Thus, we want to check it as well. From the implementation point of view I added one more check to the `IsBetterAsSingleFieldRun` in order to have all these checks for size in a single place.  And the check I mentioned before were saving us from hitting this issue.













