### PR TITLE
[CIR][CIRGen] add missing case to VisitMemberExpr

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1593,8 +1593,11 @@ mlir::Value ScalarExprEmitter::VisitMemberExpr(MemberExpr *E) {
   // keep assertion for now.
   assert(!UnimplementedFeature::tryEmitAsConstant());
   Expr::EvalResult Result;
-  if (E->EvaluateAsInt(Result, CGF.getContext(), Expr::SE_AllowSideEffects))
-    assert(0 && "NYI");
+  if (E->EvaluateAsInt(Result, CGF.getContext(), Expr::SE_AllowSideEffects)) {
+    llvm::APSInt Value = Result.Val.getInt();
+    CGF.buildIgnoredExpr(E->getBase());
+    return Builder.getConstInt(CGF.getLoc(E->getExprLoc()), Value);
+  }
   return buildLoadOfLValue(E);
 }
 

--- a/clang/test/CIR/CodeGen/evaluate-expr.c
+++ b/clang/test/CIR/CodeGen/evaluate-expr.c
@@ -18,3 +18,15 @@ void foo() {
 // CHECK:    }
 // CHECK:    cir.return
 
+typedef struct { int x; } S;
+static const S s = {0};
+void bar() {
+  int a =  s.x;
+}
+// CHECK:  cir.func no_proto @bar()
+// CHECK:    [[ALLOC:%.*]] = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64}
+// CHECK:    {{%.*}} = cir.get_global @s : cir.ptr <!ty_22S22>
+// CHECK:    [[CONST:%.*]] = cir.const(#cir.int<0> : !s32i) : !s32i
+// CHECK:    cir.store [[CONST]], [[ALLOC]] : !s32i, cir.ptr <!s32i>
+// CHECK:    cir.return
+


### PR DESCRIPTION
This PR adds support for evaluating constants in member exprs.
The change is taken from original codegen.