### PR TITLE
[CIR][CIRGen] fix calling a function through a function pointer

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1145,10 +1145,6 @@ RValue CIRGenFunction::buildCall(clang::QualType CalleeType,
   if (isa<FunctionNoProtoType>(FnType) || Chain) {
     assert(!UnimplementedFeature::chainCalls());
     assert(!UnimplementedFeature::addressSpace());
-
-    // Set no-proto function as callee.
-    auto Fn = llvm::dyn_cast<mlir::cir::FuncOp>(Callee.getFunctionPointer());
-    Callee.setFunctionPointer(Fn);
   }
 
   assert(!CGM.getLangOpts().HIP && "HIP NYI");

--- a/clang/test/CIR/CodeGen/agg-copy.c
+++ b/clang/test/CIR/CodeGen/agg-copy.c
@@ -64,9 +64,9 @@ void foo4(A* a1) {
 A create() { A a; return a; }
 
 // CHECK: cir.func {{.*@foo5}}
-// CHECK:   [[TMP0]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>,
-// CHECK:   [[TMP1]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>, ["tmp"] {alignment = 4 : i64}
-// CHECK:   [[TMP2]] = cir.call @create() : () -> !ty_22A22
+// CHECK:   [[TMP0:%.*]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>,
+// CHECK:   [[TMP1:%.*]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>, ["tmp"] {alignment = 4 : i64}
+// CHECK:   [[TMP2:%.*]] = cir.call @create() : () -> !ty_22A22
 // CHECK:   cir.store [[TMP2]], [[TMP1]] : !ty_22A22, cir.ptr <!ty_22A22>
 // CHECK:   cir.copy [[TMP1]] to [[TMP0]] : !cir.ptr<!ty_22A22> 
 void foo5() {
@@ -77,9 +77,9 @@ void foo5() {
 void foo6(A* a1) {
   A a2 = (*a1);
 // CHECK: cir.func {{.*@foo6}}
-// CHECK:   [[TMP0]] = cir.alloca !cir.ptr<!ty_22A22>, cir.ptr <!cir.ptr<!ty_22A22>>, ["a1", init] {alignment = 8 : i64}
-// CHECK:   [[TMP1]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>, ["a2", init] {alignment = 4 : i64}
+// CHECK:   [[TMP0:%.*]] = cir.alloca !cir.ptr<!ty_22A22>, cir.ptr <!cir.ptr<!ty_22A22>>, ["a1", init] {alignment = 8 : i64}
+// CHECK:   [[TMP1:%.*]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>, ["a2", init] {alignment = 4 : i64}
 // CHECK:   cir.store %arg0, [[TMP0]] : !cir.ptr<!ty_22A22>, cir.ptr <!cir.ptr<!ty_22A22>>
-// CHECK:   [[TMP2]] = cir.load deref [[TMP0]] : cir.ptr <!cir.ptr<!ty_22A22>>, !cir.ptr<!ty_22A22>
+// CHECK:   [[TMP2:%.*]] = cir.load deref [[TMP0]] : cir.ptr <!cir.ptr<!ty_22A22>>, !cir.ptr<!ty_22A22>
 // CHECK:   cir.copy [[TMP2]] to [[TMP1]] : !cir.ptr<!ty_22A22>
 }

--- a/clang/test/CIR/CodeGen/no-proto-fun-ptr.c
+++ b/clang/test/CIR/CodeGen/no-proto-fun-ptr.c
@@ -15,3 +15,13 @@ void check_noproto_ptr() {
 
 void empty(void) {}
 
+void buz() {
+  void (*func)();
+  (*func)();
+}
+
+// CHECK:  cir.func no_proto @buz()
+// CHECK:    [[FNPTR_ALLOC:%.*]] = cir.alloca !cir.ptr<!cir.func<!void (...)>>, cir.ptr <!cir.ptr<!cir.func<!void (...)>>>, ["func"] {alignment = 8 : i64}
+// CHECK:    [[FNPTR:%.*]] = cir.load deref [[FNPTR_ALLOC]] : cir.ptr <!cir.ptr<!cir.func<!void (...)>>>, !cir.ptr<!cir.func<!void (...)>>
+// CHECK:    cir.call [[FNPTR]]() : (!cir.ptr<!cir.func<!void (...)>>) -> ()
+// CHECK:    cir.return

--- a/clang/test/CIR/CodeGen/no-proto-fun-ptr.c
+++ b/clang/test/CIR/CodeGen/no-proto-fun-ptr.c
@@ -23,5 +23,6 @@ void buz() {
 // CHECK:  cir.func no_proto @buz()
 // CHECK:    [[FNPTR_ALLOC:%.*]] = cir.alloca !cir.ptr<!cir.func<!void (...)>>, cir.ptr <!cir.ptr<!cir.func<!void (...)>>>, ["func"] {alignment = 8 : i64}
 // CHECK:    [[FNPTR:%.*]] = cir.load deref [[FNPTR_ALLOC]] : cir.ptr <!cir.ptr<!cir.func<!void (...)>>>, !cir.ptr<!cir.func<!void (...)>>
-// CHECK:    cir.call [[FNPTR]]() : (!cir.ptr<!cir.func<!void (...)>>) -> ()
+// CHECK:    [[CAST:%.*]] = cir.cast(bitcast, %1 : !cir.ptr<!cir.func<!void (...)>>), !cir.ptr<!cir.func<!void ()>>
+// CHECK:    cir.call [[CAST]]() : (!cir.ptr<!cir.func<!void ()>>) -> ()
 // CHECK:    cir.return

--- a/clang/test/CIR/CodeGen/no-prototype.c
+++ b/clang/test/CIR/CodeGen/no-prototype.c
@@ -35,7 +35,9 @@ int test1(int x) {
 int noProto2();
 int test2(int x) {
   return noProto2(x);
-  // CHECK: %{{.+}} = cir.call @noProto2(%{{[0-9]+}}) : (!s32i) -> !s32i
+  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto2 : cir.ptr <!cir.func<!s32i (!s32i)>>
+  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, %3 : !cir.ptr<!cir.func<!s32i (!s32i)>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
+  // CHECK:  {{.*}} = cir.call [[CAST]](%{{[0-9]+}}) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
 }
 int noProto2(int x) { return x; }
 // CHECK: cir.func no_proto @noProto2(%arg0: !s32i {{.+}}) -> !s32i
@@ -49,7 +51,9 @@ int noProto3();
 int test3(int x) {
 // CHECK: cir.func @test3
   return noProto3(x);
-  // CHECK: %{{.+}} = cir.call @noProto3(%{{[0-9]+}}) : (!s32i) -> !s32i
+  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto3 : cir.ptr <!cir.func<!s32i (...)>>
+  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<!s32i (...)>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
+  // CHECK:  {{%.*}} = cir.call [[CAST]](%{{[0-9]+}}) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
 }
 
 
@@ -64,14 +68,18 @@ int noProto4() { return 0; }
 // cir.func private no_proto @noProto4() -> !s32i
 int test4(int x) {
   return noProto4(x); // Even if we know the definition, this should compile.
-  // CHECK: %{{.+}} = cir.call @noProto4(%{{.+}}) : (!s32i) -> !s32i
+  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto4 : cir.ptr <!cir.func<!s32i ()>>
+  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<!s32i ()>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
+  // CHECK:  {{%.*}} = cir.call [[CAST]]({{%.*}}) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
 }
 
 // No-proto definition followed by an incorrect call due to lack of args.
 int noProto5();
 int test5(int x) {
   return noProto5();
-  // CHECK: %{{.+}} = cir.call @noProto5() : () -> !s32i
+  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto5 : cir.ptr <!cir.func<!s32i (!s32i)>>
+  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<!s32i (!s32i)>>), !cir.ptr<!cir.func<!s32i ()>>
+  // CHECK:  {{%.*}} = cir.call [[CAST]]() : (!cir.ptr<!cir.func<!s32i ()>>) -> !s32i
 }
 int noProto5(int x) { return x; }
 // CHECK: cir.func no_proto @noProto5(%arg0: !s32i {{.+}}) -> !s32i


### PR DESCRIPTION
CIR codegen always casts the no-proto function pointer to `FuncOp`. But the function pointer may be result of cir operations (f.e. `cir.load`). As a result in such cases the function pointer sets to `nullptr`. That leads to compilation error.
So this PR removes the unecessary cast to 'FuncOp' and resolves the issue.
