### PR TITLE
[CIR][Lowering]  cir.asm lowering

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2857,7 +2857,7 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     $asm_flavor`,`
     `{` $asm_string $constraints `}`
     `)`
-    (`side_effects` $side_effects^ `,`)?
+    (`side_effects` $side_effects^)?
     attr-dict
     operands `:` functional-type(operands, results)
    }];  

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2837,7 +2837,7 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     ... 
     %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
     %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
-    cir.asm(has_side_effects, x86_att, {"foo" "~{dirflag},~{fpsr},~{flags}"}) : () -> ()
+    cir.asm(x86_att, {"foo" "~{dirflag},~{fpsr},~{flags}"}) side_effects : () -> ()
     cir.asm(x86_att, {"bar $$42 $0" "=r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %2 : (!s32i) -> ()
     cir.asm(x86_att, {"baz $$42 $0" "=r,=&r,0,1,~{dirflag},~{fpsr},~{flags}"}) %3, %2 : (!s32i, !s32i) -> ()
     ```
@@ -2849,17 +2849,15 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     ins Variadic<AnyType>:$operands,
         StrAttr:$asm_string,
         StrAttr:$constraints,
-        UnitAttr:$has_side_effects,
-        UnitAttr:$is_align_stack,
+        UnitAttr:$side_effects,
         AsmFlavor:$asm_flavor);
 
   let assemblyFormat = [{
     `(`
-    (`has_side_effects` $has_side_effects^ `,`)?
-    (`is_align_stack` $is_align_stack^ `,`)?
     $asm_flavor`,`
     `{` $asm_string $constraints `}`
     `)`
+    (`side_effects` $side_effects^ `,`)?
     attr-dict
     operands `:` functional-type(operands, results)
    }];  

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2837,7 +2837,7 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     ... 
     %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
     %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
-    cir.asm(x86_att, {"foo" "~{dirflag},~{fpsr},~{flags}"}) : () -> ()
+    cir.asm(has_side_effects, x86_att, {"foo" "~{dirflag},~{fpsr},~{flags}"}) : () -> ()
     cir.asm(x86_att, {"bar $$42 $0" "=r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %2 : (!s32i) -> ()
     cir.asm(x86_att, {"baz $$42 $0" "=r,=&r,0,1,~{dirflag},~{fpsr},~{flags}"}) %3, %2 : (!s32i, !s32i) -> ()
     ```

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2837,9 +2837,9 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     ... 
     %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
     %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
-    cir.asm(x86_att, {"foo" "~{dirflag},~{fpsr},~{flags}"} : () -> ()
-    cir.asm(x86_att, {"bar $$42 $0" "=r,=&r,1,~{dirflag},~{fpsr},~{flags}"} %2 : (!s32i) -> ()
-    cir.asm(x86_att, {"baz $$42 $0" "=r,=&r,0,1,~{dirflag},~{fpsr},~{flags}"} %3, %2 : (!s32i, !s32i) -> ()
+    cir.asm(x86_att, {"foo" "~{dirflag},~{fpsr},~{flags}"}) : () -> ()
+    cir.asm(x86_att, {"bar $$42 $0" "=r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %2 : (!s32i) -> ()
+    cir.asm(x86_att, {"baz $$42 $0" "=r,=&r,0,1,~{dirflag},~{fpsr},~{flags}"}) %3, %2 : (!s32i, !s32i) -> ()
     ```
   }];
 
@@ -2849,10 +2849,14 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     ins Variadic<AnyType>:$operands,
         StrAttr:$asm_string,
         StrAttr:$constraints,
-        AsmFlavor:$asm_flavor);  
+        UnitAttr:$has_side_effects,
+        UnitAttr:$is_align_stack,
+        AsmFlavor:$asm_flavor);
 
   let assemblyFormat = [{
-    `(`$asm_flavor`,` `{` $asm_string $constraints `}` `)` attr-dict 
+    (`has_side_effects` $has_side_effects^)?
+    (`is_align_stack` $is_align_stack^)?    
+    `(`$asm_flavor`,` `{` $asm_string $constraints `}` `)` attr-dict
      operands `:` functional-type(operands, results)
    }];  
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2854,10 +2854,14 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
         AsmFlavor:$asm_flavor);
 
   let assemblyFormat = [{
-    (`has_side_effects` $has_side_effects^)?
-    (`is_align_stack` $is_align_stack^)?    
-    `(`$asm_flavor`,` `{` $asm_string $constraints `}` `)` attr-dict
-     operands `:` functional-type(operands, results)
+    `(`
+    (`has_side_effects` $has_side_effects^ `,`)?
+    (`is_align_stack` $is_align_stack^ `,`)?
+    $asm_flavor`,`
+    `{` $asm_string $constraints `}`
+    `)`
+    attr-dict
+    operands `:` functional-type(operands, results)
    }];  
 }
 

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -432,8 +432,7 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
 
   builder.create<mlir::cir::InlineAsmOp>(
       getLoc(S.getAsmLoc()), ResultType, Args, AsmString, Constraints,
-      HasSideEffect,
-      /* IsAlignStack */ false, inferFlavor(CGM, S));
+      HasSideEffect, inferFlavor(CGM, S));
 
   return mlir::success();
 }

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -430,9 +430,9 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
 
   bool HasSideEffect = S.isVolatile() || S.getNumOutputs() == 0;
 
-  builder.create<mlir::cir::InlineAsmOp>(
-      getLoc(S.getAsmLoc()), ResultType, Args, AsmString, Constraints,
-      HasSideEffect, inferFlavor(CGM, S));
+  builder.create<mlir::cir::InlineAsmOp>(getLoc(S.getAsmLoc()), ResultType,
+                                         Args, AsmString, Constraints,
+                                         HasSideEffect, inferFlavor(CGM, S));
 
   return mlir::success();
 }

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -430,11 +430,10 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
 
   bool HasSideEffect = S.isVolatile() || S.getNumOutputs() == 0;
 
-  builder.create<mlir::cir::InlineAsmOp>(getLoc(S.getAsmLoc()), ResultType,
-                                         Args, AsmString, Constraints,
-                                         HasSideEffect,
-                                         /* IsAlignStack */ false,
-                                         inferFlavor(CGM, S));
+  builder.create<mlir::cir::InlineAsmOp>(
+      getLoc(S.getAsmLoc()), ResultType, Args, AsmString, Constraints,
+      HasSideEffect,
+      /* IsAlignStack */ false, inferFlavor(CGM, S));
 
   return mlir::success();
 }

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -428,11 +428,13 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
         builder.getCompleteStructTy(ResultRegTypes, sname, false, nullptr);
   }
 
-  AsmFlavor AsmFlavor = inferFlavor(CGM, S);
+  bool HasSideEffect = S.isVolatile() || S.getNumOutputs() == 0;
 
   builder.create<mlir::cir::InlineAsmOp>(getLoc(S.getAsmLoc()), ResultType,
                                          Args, AsmString, Constraints,
-                                         AsmFlavor);
+                                         HasSideEffect,
+                                         /* IsAlignStack */ false,
+                                         inferFlavor(CGM, S));
 
   return mlir::success();
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -61,7 +61,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <cstdint>
 #include <optional>
-
+#include <iostream>
 using namespace cir;
 using namespace llvm;
 
@@ -2241,8 +2241,8 @@ class CIRInlineAsmOpLowering
 
     rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
         op, llResTy, adaptor.getOperands(), op.getAsmStringAttr(),
-        op.getConstraintsAttr(), op.getHasSideEffectsAttr(),
-        op.getIsAlignStackAttr(),
+        op.getConstraintsAttr(), op.getSideEffectsAttr(),        
+        /*is_align_stack*/ mlir::UnitAttr(),         
         mlir::LLVM::AsmDialectAttr::get(getContext(), llDialect),
         rewriter.getArrayAttr(opAttrs));
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2241,8 +2241,8 @@ class CIRInlineAsmOpLowering
 
     rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
         op, llResTy, adaptor.getOperands(), op.getAsmStringAttr(),
-        op.getConstraintsAttr(), op.getSideEffectsAttr(),        
-        /*is_align_stack*/ mlir::UnitAttr(),         
+        op.getConstraintsAttr(), op.getSideEffectsAttr(),
+        /*is_align_stack*/ mlir::UnitAttr(),
         mlir::LLVM::AsmDialectAttr::get(getContext(), llDialect),
         rewriter.getArrayAttr(opAttrs));
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -61,7 +61,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <cstdint>
 #include <optional>
-#include <iostream>
+
 using namespace cir;
 using namespace llvm;
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2238,28 +2238,7 @@ using mlir::OpConversionPattern<mlir::cir::InlineAsmOp>::OpConversionPattern;
         ? mlir::LLVM::AsmDialect::AD_ATT
         : mlir::LLVM::AsmDialect::AD_Intel;
 
-    // auto oldAttrName = mlir::cir::InlineAsmOp::getElementTypeAttrName();
-    // auto newAttrName = mlir::LLVM::InlineAsmOp::getElementTypeAttrName();
-
     std::vector<mlir::Attribute> opAttrs;
-    // if (auto operandAttrs = op.getOperandAttrs()) {
-    //   for (auto attr : *operandAttrs) {
-    //     if (isa<mlir::cir::OptNoneAttr>(attr)) {
-    //       opAttrs.push_back(mlir::Attribute());
-    //       continue;
-    //     }
-
-    //     mlir::DictionaryAttr dict = cast<mlir::DictionaryAttr>(attr);
-    //     mlir::TypeAttr tAttr = cast<mlir::TypeAttr>(dict.get(oldAttrName));
-    //     std::vector<mlir::NamedAttribute> attrs;
-    //     auto typAttr = rewriter.getTypeAttr(
-    //       getTypeConverter()->convertType(tAttr.getValue()));
-
-    //     attrs.push_back(rewriter.getNamedAttr(newAttrName, typAttr));
-    //     auto newDict = rewriter.getDictionaryAttr(attrs);
-    //     opAttrs.push_back(newDict);
-    //   }
-    // }
 
     rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
       op,

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2222,7 +2222,7 @@ public:
 class CIRInlineAsmOpLowering
     : public mlir::OpConversionPattern<mlir::cir::InlineAsmOp> {
 
-using mlir::OpConversionPattern<mlir::cir::InlineAsmOp>::OpConversionPattern;
+  using mlir::OpConversionPattern<mlir::cir::InlineAsmOp>::OpConversionPattern;
 
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::InlineAsmOp op, OpAdaptor adaptor,
@@ -2230,26 +2230,21 @@ using mlir::OpConversionPattern<mlir::cir::InlineAsmOp>::OpConversionPattern;
 
     mlir::Type llResTy;
     if (op.getNumResults())
-        llResTy = getTypeConverter()->convertType(op.getType(0));
+      llResTy = getTypeConverter()->convertType(op.getType(0));
 
     auto dialect = op.getAsmFlavor();
-    auto llDialect =
-      dialect == mlir::cir::AsmFlavor::x86_att
-        ? mlir::LLVM::AsmDialect::AD_ATT
-        : mlir::LLVM::AsmDialect::AD_Intel;
+    auto llDialect = dialect == mlir::cir::AsmFlavor::x86_att
+                         ? mlir::LLVM::AsmDialect::AD_ATT
+                         : mlir::LLVM::AsmDialect::AD_Intel;
 
     std::vector<mlir::Attribute> opAttrs;
 
     rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
-      op,
-      llResTy,
-      adaptor.getOperands(),
-      op.getAsmStringAttr(),
-      op.getConstraintsAttr(),
-      op.getHasSideEffectsAttr(),
-      op.getIsAlignStackAttr(),
-      mlir::LLVM::AsmDialectAttr::get(getContext(),llDialect),
-      rewriter.getArrayAttr(opAttrs));
+        op, llResTy, adaptor.getOperands(), op.getAsmStringAttr(),
+        op.getConstraintsAttr(), op.getHasSideEffectsAttr(),
+        op.getIsAlignStackAttr(),
+        mlir::LLVM::AsmDialectAttr::get(getContext(), llDialect),
+        rewriter.getArrayAttr(opAttrs));
 
     return mlir::success();
   }
@@ -2271,8 +2266,7 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRFAbsOpLowering, CIRVTableAddrPointOpLowering, CIRVectorCreateLowering,
       CIRVectorInsertLowering, CIRVectorExtractLowering, CIRVectorCmpOpLowering,
       CIRStackSaveLowering, CIRStackRestoreLowering, CIRUnreachableLowering,
-      CIRInlineAsmOpLowering>(
-      converter, patterns.getContext());
+      CIRInlineAsmOpLowering>(converter, patterns.getContext());
 }
 
 namespace {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2219,6 +2219,63 @@ public:
   }
 };
 
+class CIRInlineAsmOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::InlineAsmOp> {
+
+using mlir::OpConversionPattern<mlir::cir::InlineAsmOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::InlineAsmOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+
+    mlir::Type llResTy;
+    if (op.getNumResults())
+        llResTy = getTypeConverter()->convertType(op.getType(0));
+
+    auto dialect = op.getAsmFlavor();
+    auto llDialect =
+      dialect == mlir::cir::AsmFlavor::x86_att
+        ? mlir::LLVM::AsmDialect::AD_ATT
+        : mlir::LLVM::AsmDialect::AD_Intel;
+
+    // auto oldAttrName = mlir::cir::InlineAsmOp::getElementTypeAttrName();
+    // auto newAttrName = mlir::LLVM::InlineAsmOp::getElementTypeAttrName();
+
+    std::vector<mlir::Attribute> opAttrs;
+    // if (auto operandAttrs = op.getOperandAttrs()) {
+    //   for (auto attr : *operandAttrs) {
+    //     if (isa<mlir::cir::OptNoneAttr>(attr)) {
+    //       opAttrs.push_back(mlir::Attribute());
+    //       continue;
+    //     }
+
+    //     mlir::DictionaryAttr dict = cast<mlir::DictionaryAttr>(attr);
+    //     mlir::TypeAttr tAttr = cast<mlir::TypeAttr>(dict.get(oldAttrName));
+    //     std::vector<mlir::NamedAttribute> attrs;
+    //     auto typAttr = rewriter.getTypeAttr(
+    //       getTypeConverter()->convertType(tAttr.getValue()));
+
+    //     attrs.push_back(rewriter.getNamedAttr(newAttrName, typAttr));
+    //     auto newDict = rewriter.getDictionaryAttr(attrs);
+    //     opAttrs.push_back(newDict);
+    //   }
+    // }
+
+    rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
+      op,
+      llResTy,
+      adaptor.getOperands(),
+      op.getAsmStringAttr(),
+      op.getConstraintsAttr(),
+      op.getHasSideEffectsAttr(),
+      op.getIsAlignStackAttr(),
+      mlir::LLVM::AsmDialectAttr::get(getContext(),llDialect),
+      rewriter.getArrayAttr(opAttrs));
+
+    return mlir::success();
+  }
+};
+
 void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter) {
   patterns.add<CIRReturnLowering>(patterns.getContext());
@@ -2234,7 +2291,8 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRPtrDiffOpLowering, CIRCopyOpLowering, CIRMemCpyOpLowering,
       CIRFAbsOpLowering, CIRVTableAddrPointOpLowering, CIRVectorCreateLowering,
       CIRVectorInsertLowering, CIRVectorExtractLowering, CIRVectorCmpOpLowering,
-      CIRStackSaveLowering, CIRStackRestoreLowering, CIRUnreachableLowering>(
+      CIRStackSaveLowering, CIRStackRestoreLowering, CIRUnreachableLowering,
+      CIRInlineAsmOpLowering>(
       converter, patterns.getContext());
 }
 

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -1,32 +1,32 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-//CHECK: cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) side_effects,  : () -> ()
+//CHECK: cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) side_effects  : () -> ()
 void empty1() {
   __asm__ volatile("" : : : );
 }
 
-//CHECK: cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects,  : () -> ()
+//CHECK: cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects  : () -> ()
 void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
 void t1(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0 : (!cir.ptr<!s32i>) -> ()
 void t2(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0 : (!cir.ptr<!s32i>) -> ()
 void t3(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects, %1 : (!s32i) -> ()
+//CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects %1 : (!s32i) -> ()
 void t4(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -1,32 +1,32 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-//CHECK: cir.asm(has_side_effects, x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
+//CHECK: cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) side_effects,  : () -> ()
 void empty1() {
   __asm__ volatile("" : : : );
 }
 
-//CHECK: cir.asm(has_side_effects, x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
+//CHECK: cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects,  : () -> ()
 void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-//CHECK: cir.asm(has_side_effects, x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
 void t1(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-//CHECK: cir.asm(has_side_effects, x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0 : (!cir.ptr<!s32i>) -> ()
 void t2(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-//CHECK: cir.asm(has_side_effects, x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0 : (!cir.ptr<!s32i>) -> ()
 void t3(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
-//CHECK: cir.asm(has_side_effects, x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %1 : (!s32i) -> ()
+//CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects, %1 : (!s32i) -> ()
 void t4(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -1,32 +1,32 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-//CHECK: cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
+//CHECK: cir.asm(has_side_effects, x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
 void empty1() {
   __asm__ volatile("" : : : );
 }
 
-//CHECK: cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"})  : () -> () 
+//CHECK: cir.asm(has_side_effects, x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
 void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(has_side_effects, x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
 void t1(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(has_side_effects, x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
 void t2(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(has_side_effects, x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
 void t3(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %1 : (!s32i) -> ()
+//CHECK: cir.asm(has_side_effects, x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %1 : (!s32i) -> ()
 void t4(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -8,23 +8,23 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
 
-    cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
+    cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) : () -> ()
     // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
     
-    cir.asm(has_side_effects, x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
+    cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects, : () -> ()
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}" : () -> ()
 
-    cir.asm(has_side_effects, x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+    cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> ()    
 
-    cir.asm(has_side_effects, x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
+    cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0 : (!cir.ptr<!s32i>) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
 
-    cir.asm(has_side_effects, x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
+    cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0 : (!cir.ptr<!s32i>) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
 
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    cir.asm(has_side_effects, x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %1 : (!s32i) -> ()
+    cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects, %1 : (!s32i) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
     
     cir.return

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -11,20 +11,20 @@ module {
     cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) : () -> ()
     // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
     
-    cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects, : () -> ()
+    cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects : () -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}" : () -> ()
 
-    cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+    cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> ()    
 
-    cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0 : (!cir.ptr<!s32i>) -> ()
+    cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0 : (!cir.ptr<!s32i>) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
 
-    cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects, %0 : (!cir.ptr<!s32i>) -> ()
+    cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0 : (!cir.ptr<!s32i>) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
 
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects, %1 : (!s32i) -> ()
+    cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects %1 : (!s32i) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
     
     cir.return

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -8,8 +8,8 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
 
-    cir.asm(has_side_effects, x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
+    cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
+    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
     
     cir.asm(has_side_effects, x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}"  : () -> ()

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -4,48 +4,30 @@
 
 module {
 
-  cir.func no_proto @empty1() {
+  cir.func @simple(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+
     cir.asm(has_side_effects, x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
-    cir.return
-  }
-
-  cir.func no_proto @empty2() {
+    
     cir.asm(has_side_effects, x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
-    cir.return
-  }
 
-  cir.func @t1(%arg0: !s32i) {
-    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
-    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     cir.asm(has_side_effects, x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> ()
-    cir.return
-  }
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> ()    
 
-  cir.func @t2(%arg0: !s32i) {
-    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
-    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     cir.asm(has_side_effects, x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
-    cir.return
-  }
 
-  cir.func @t3(%arg0: !s32i) {
-    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
-    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     cir.asm(has_side_effects, x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
-    cir.return
-  }
 
-  cir.func @t4(%arg0: !s32i) {
-    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
-    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
     cir.asm(has_side_effects, x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %1 : (!s32i) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
+    
     cir.return
   }
+
 }

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -1,0 +1,51 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+
+module {
+
+  cir.func no_proto @empty1() {
+    cir.asm(has_side_effects, x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
+    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
+    cir.return
+  }
+
+  cir.func no_proto @empty2() {
+    cir.asm(has_side_effects, x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
+    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
+    cir.return
+  }
+
+  cir.func @t1(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    cir.asm(has_side_effects, x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> ()
+    cir.return
+  }
+
+  cir.func @t2(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    cir.asm(has_side_effects, x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
+    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
+    cir.return
+  }
+
+  cir.func @t3(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    cir.asm(has_side_effects, x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
+    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
+    cir.return
+  }
+
+  cir.func @t4(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+    cir.asm(has_side_effects, x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %1 : (!s32i) -> ()
+    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -6,13 +6,13 @@ module {
 
   cir.func no_proto @empty1() {
     cir.asm(has_side_effects, x86_att, {"" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
-    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
     cir.return
   }
 
   cir.func no_proto @empty2() {
     cir.asm(has_side_effects, x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"})  : () -> ()
-    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
     cir.return
   }
 
@@ -20,7 +20,7 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     cir.asm(has_side_effects, x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
-    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> ()
     cir.return
   }
 
@@ -28,7 +28,7 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     cir.asm(has_side_effects, x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
-    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
     cir.return
   }
 
@@ -36,7 +36,7 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     cir.asm(has_side_effects, x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) %0 : (!cir.ptr<!s32i>) -> ()
-    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
     cir.return
   }
 
@@ -45,7 +45,7 @@ module {
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
     cir.asm(has_side_effects, x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %1 : (!s32i) -> ()
-    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
     cir.return
   }
 }


### PR DESCRIPTION
This PR adds lowering for `cir.asm`.

Also, two flags were added to the `cir.asm` : `hasSideEffects` and `isStackAligned` in order to match with the llvm dialect. 

Also, I added several simple tests for lowering.

I'm not sure but most likely the next PR will be the last one in this story about assembly support )