### PR TITLE
[CIR][Codegen] Fixes bitfields unary and binary ops

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -833,10 +833,6 @@ def UnaryOp : CIR_Op<"unary", [Pure, SameOperandsAndResultType]> {
     `cir.unary` performs the unary operation according to
     the specified opcode kind: [inc, dec, plus, minus, not].
 
-    Note for inc and dec: the operation corresponds only to the
-    addition/subtraction, its input is expect to come from a load
-    and the result to be used by a corresponding store.
-
     It requires one input operand and has one result, both types
     should be the same.
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1833,7 +1833,7 @@ LValue ScalarExprEmitter::buildCompoundAssignLValue(
   // specially because the result is altered by the store, i.e., [C99 6.5.16p1]
   // 'An assignment expression has the value of the left operand after the
   // assignment...'.
-  if (LHSLV.isBitField())    
+  if (LHSLV.isBitField())
     CGF.buildStoreThroughBitfieldLValue(RValue::get(Result), LHSLV, Result);
   else
     CGF.buildStoreThroughLValue(RValue::get(Result), LHSLV);

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -461,7 +461,7 @@ public:
 
     // Store the updated result through the lvalue
     if (LV.isBitField())
-      llvm_unreachable("no bitfield inc/dec yet");
+      CGF.buildStoreThroughBitfieldLValue(RValue::get(value), LV, value);
     else
       CGF.buildStoreThroughLValue(RValue::get(value), LV);
 
@@ -1833,8 +1833,8 @@ LValue ScalarExprEmitter::buildCompoundAssignLValue(
   // specially because the result is altered by the store, i.e., [C99 6.5.16p1]
   // 'An assignment expression has the value of the left operand after the
   // assignment...'.
-  if (LHSLV.isBitField())
-    assert(0 && "not yet implemented");
+  if (LHSLV.isBitField())    
+    CGF.buildStoreThroughBitfieldLValue(RValue::get(Result), LHSLV, Result);
   else
     CGF.buildStoreThroughLValue(RValue::get(Result), LHSLV);
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2186,22 +2186,7 @@ void TryCallOp::print(::mlir::OpAsmPrinter &state) {
 LogicalResult UnaryOp::verify() {
   switch (getKind()) {
   case cir::UnaryOpKind::Inc:
-    LLVM_FALLTHROUGH;
-  case cir::UnaryOpKind::Dec: {
-    // TODO: Consider looking at the memory interface instead of
-    // LoadOp/StoreOp.
-    if (auto loadOp = getInput().getDefiningOp<cir::LoadOp>()) {
-      for (const auto user : getResult().getUsers()) {
-        auto storeOp = dyn_cast<cir::StoreOp>(user);
-        if (storeOp && storeOp.getAddr() == loadOp.getAddr())
-          return success();
-      }
-      return emitOpError() << "requires result to be used by a memory store "
-                              "to the same address as the input memory load";
-    } else {
-      return success();
-    }
-  }
+  case cir::UnaryOpKind::Dec:
   case cir::UnaryOpKind::Plus:
   case cir::UnaryOpKind::Minus:
   case cir::UnaryOpKind::Not:

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -17,7 +17,6 @@
 #include "clang/CIR/Interfaces/CIRLoopOpInterface.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <optional>
-#include <iostream>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -17,6 +17,7 @@
 #include "clang/CIR/Interfaces/CIRLoopOpInterface.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <optional>
+#include <iostream>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -2188,9 +2189,17 @@ LogicalResult UnaryOp::verify() {
   case cir::UnaryOpKind::Inc:
     LLVM_FALLTHROUGH;
   case cir::UnaryOpKind::Dec: {
+    auto v = getInput();
+    if (!v)
+      std::cout << "no input\n";
+    else
+      std::cout << "HAS input\n";
+
+    return success();
     // TODO: Consider looking at the memory interface instead of
     // LoadOp/StoreOp.
-    auto loadOp = getInput().getDefiningOp<cir::LoadOp>();
+    ///auto loadOp = getInput().getDefiningOp<cir::LoadOp>();
+    auto loadOp = getInput().getDefiningOp()->getParentOfType<cir::LoadOp>();    
     if (!loadOp)
       return emitOpError() << "requires input to be defined by a memory load";
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -24,7 +24,6 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
 
-#include <iostream>
 
 using cir::CIRBaseBuilderTy;
 using namespace mlir;
@@ -306,7 +305,6 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
 }
 
 void LoweringPreparePass::lowerGetBitfieldOp(GetBitfieldOp op) {
-  std::cout << "LoweringPreparePass::lowerGetBitfieldOp" << std::endl;
   CIRBaseBuilderTy builder(getContext());
   builder.setInsertionPointAfter(op.getOperation());
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -24,7 +24,6 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
 
-
 using cir::CIRBaseBuilderTy;
 using namespace mlir;
 using namespace mlir::cir;

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -24,6 +24,8 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
 
+#include <iostream>
+
 using cir::CIRBaseBuilderTy;
 using namespace mlir;
 using namespace mlir::cir;
@@ -304,6 +306,7 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
 }
 
 void LoweringPreparePass::lowerGetBitfieldOp(GetBitfieldOp op) {
+  std::cout << "LoweringPreparePass::lowerGetBitfieldOp" << std::endl;
   CIRBaseBuilderTy builder(getContext());
   builder.setInsertionPointAfter(op.getOperation());
 

--- a/clang/test/CIR/CodeGen/bitfield-ops.c
+++ b/clang/test/CIR/CodeGen/bitfield-ops.c
@@ -31,3 +31,22 @@ void store_field() {
 int load_field(S* s) {
   return s->d;
 }
+
+// CHECK: cir.func {{.*@unOp}}
+// CHECK:   [[TMP0:%.*]] = cir.get_member {{.*}}[1] {name = "d"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!u32i>
+// CHECK:   [[TMP1:%.*]] = cir.get_bitfield(#bfi_d, [[TMP0]] : !cir.ptr<!u32i>) -> !s32i
+// CHECK:   [[TMP2:%.*]] = cir.unary(inc, [[TMP1]]) : !s32i, !s32i
+// CHECK:   [[TMP3:%.*]] = cir.set_bitfield(#bfi_d, [[TMP0]] : !cir.ptr<!u32i>, [[TMP2]] : !s32i) -> !s32i
+void unOp(S* s) {
+  s->d++;
+}
+
+// CHECK: cir.func {{.*@binOp}}
+// CHECK:   [[TMP0:%.*]] = cir.const(#cir.int<42> : !s32i) : !s32i
+// CHECK:   [[TMP1:%.*]] = cir.get_member {{.*}}[1] {name = "d"} : !cir.ptr<!ty_22S22> -> !cir.ptr<!u32i>
+// CHECK:   [[TMP2:%.*]] = cir.get_bitfield(#bfi_d, [[TMP1]] : !cir.ptr<!u32i>) -> !s32i
+// CHECK:   [[TMP3:%.*]] = cir.binop(or, [[TMP2]], [[TMP0]]) : !s32i
+// CHECK:   [[TMP4:%.*]] = cir.set_bitfield(#bfi_d, [[TMP1]] : !cir.ptr<!u32i>, [[TMP3]] : !s32i) -> !s32i
+void binOp(S* s) {
+   s->d |= 42;
+}

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -352,19 +352,6 @@ module {
 // -----
 
 !u32i = !cir.int<u, 32>
-cir.func @unary1() {
-  %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["a", init] {alignment = 4 : i64}
-  %1 = cir.const(#cir.int<2> : !u32i) : !u32i
-  cir.store %1, %0 : !u32i, cir.ptr <!u32i>
-
-  %2 = cir.load %0 : cir.ptr <!u32i>, !u32i
-  %3 = cir.unary(dec, %2) : !u32i, !u32i //  // expected-error {{'cir.unary' op requires result to be used by a memory store to the same address as the input memory load}}
-  cir.return
-}
-
-// -----
-
-!u32i = !cir.int<u, 32>
 module {
   cir.global external @v = #cir.zero : !u32i // expected-error {{zero expects struct or array type}}
 }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -352,18 +352,6 @@ module {
 // -----
 
 !u32i = !cir.int<u, 32>
-cir.func @unary0() {
-  %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["a", init] {alignment = 4 : i64}
-  %1 = cir.const(#cir.int<2> : !u32i) : !u32i
-
-  %3 = cir.unary(inc, %1) : !u32i, !u32i // expected-error {{'cir.unary' op requires input to be defined by a memory load}}
-  cir.store %3, %0 : !u32i, cir.ptr <!u32i>
-  cir.return
-}
-
-// -----
-
-!u32i = !cir.int<u, 32>
 cir.func @unary1() {
   %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["a", init] {alignment = 4 : i64}
   %1 = cir.const(#cir.int<2> : !u32i) : !u32i


### PR DESCRIPTION
This PR fixes a couple of  NIY features for bit fields. 

Basically, such expressions with bit fields `x->a++` and `x->a |= 42`  are supported now.

The main problem is `UnOp` verification - now it can be defined both by `loadOp` and by `GetBitfieldOp` or even by `CastOp`. So shame on me, I removed a test from `invalid.cir`