### PR TITLE
[CIR][NFC] Add unimplemented feature guard for dialect code

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "UnimplementedFeatureGuarding.h"
+#include "MissingFeatures.h"
 
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
@@ -34,7 +34,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <optional>
 
-using cir::CIRDialectUnimplementedFeature;
+using cir::MissingFeatures;
 
 //===----------------------------------------------------------------------===//
 // CIR Custom Parser/Printer Signatures
@@ -412,7 +412,7 @@ llvm::TypeSize
 DataMemberType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
                                   ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider size differences under different ABIs
-  assert(!CIRDialectUnimplementedFeature::cxxABI());
+  assert(!MissingFeatures::cxxABI());
   return llvm::TypeSize::getFixed(64);
 }
 
@@ -420,7 +420,7 @@ uint64_t
 DataMemberType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
                                 ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider alignment differences under different ABIs
-  assert(!CIRDialectUnimplementedFeature::cxxABI());
+  assert(!MissingFeatures::cxxABI());
   return 8;
 }
 
@@ -428,7 +428,7 @@ uint64_t DataMemberType::getPreferredAlignment(
     const ::mlir::DataLayout &dataLayout,
     ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider alignment differences under different ABIs
-  assert(!CIRDialectUnimplementedFeature::cxxABI());
+  assert(!MissingFeatures::cxxABI());
   return 8;
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "UnimplementedFeatureGuarding.h"
+
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
@@ -31,6 +33,8 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <optional>
+
+using cir::CIRDialectUnimplementedFeature;
 
 //===----------------------------------------------------------------------===//
 // CIR Custom Parser/Printer Signatures
@@ -408,6 +412,7 @@ llvm::TypeSize
 DataMemberType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
                                   ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider size differences under different ABIs
+  assert(!CIRDialectUnimplementedFeature::cxxABI());
   return llvm::TypeSize::getFixed(64);
 }
 
@@ -415,6 +420,7 @@ uint64_t
 DataMemberType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
                                 ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider alignment differences under different ABIs
+  assert(!CIRDialectUnimplementedFeature::cxxABI());
   return 8;
 }
 
@@ -422,6 +428,7 @@ uint64_t DataMemberType::getPreferredAlignment(
     const ::mlir::DataLayout &dataLayout,
     ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: consider alignment differences under different ABIs
+  assert(!CIRDialectUnimplementedFeature::cxxABI());
   return 8;
 }
 
@@ -443,20 +450,20 @@ ArrayType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
   return dataLayout.getTypePreferredAlignment(getEltType());
 }
 
-llvm::TypeSize cir::VectorType::getTypeSizeInBits(
+llvm::TypeSize mlir::cir::VectorType::getTypeSizeInBits(
     const ::mlir::DataLayout &dataLayout,
     ::mlir::DataLayoutEntryListRef params) const {
   return llvm::TypeSize::getFixed(getSize() *
                                   dataLayout.getTypeSizeInBits(getEltType()));
 }
 
-uint64_t
-cir::VectorType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
-                                 ::mlir::DataLayoutEntryListRef params) const {
+uint64_t mlir::cir::VectorType::getABIAlignment(
+    const ::mlir::DataLayout &dataLayout,
+    ::mlir::DataLayoutEntryListRef params) const {
   return getSize() * dataLayout.getTypeABIAlignment(getEltType());
 }
 
-uint64_t cir::VectorType::getPreferredAlignment(
+uint64_t mlir::cir::VectorType::getPreferredAlignment(
     const ::mlir::DataLayout &dataLayout,
     ::mlir::DataLayoutEntryListRef params) const {
   return getSize() * dataLayout.getTypePreferredAlignment(getEltType());

--- a/clang/lib/CIR/Dialect/IR/MissingFeatures.h
+++ b/clang/lib/CIR/Dialect/IR/MissingFeatures.h
@@ -17,7 +17,7 @@
 
 namespace cir {
 
-struct CIRDialectUnimplementedFeature {
+struct MissingFeatures {
   // C++ ABI support
   static bool cxxABI() { return false; }
 };

--- a/clang/lib/CIR/Dialect/IR/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/Dialect/IR/UnimplementedFeatureGuarding.h
@@ -1,0 +1,27 @@
+//===---- UnimplementedFeatureGuarding.h - Checks against NYI ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file introduces some helper classes to guard against features that
+// CIR dialect supports that we do not have and also do not have great ways to
+// assert against.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_CIR_DIALECT_IR_UFG
+#define LLVM_CLANG_LIB_CIR_DIALECT_IR_UFG
+
+namespace cir {
+
+struct CIRDialectUnimplementedFeature {
+  // C++ ABI support
+  static bool cxxABI() { return false; }
+};
+
+} // namespace cir
+
+#endif // LLVM_CLANG_LIB_CIR_DIALECT_IR_UFG


### PR DESCRIPTION
As discussed in pull #401 , The present `UnimplementedFeature` class is made for the CIRGen submodule and we need similar facilities for code under `clang/lib/CIR/Dialect/IR`. This NFC patch adds a new `CIRDialectUnimplementedFeature` class that provides unimplemented feature guards for CIR dialect code.