### PR TITLE
[CIR][CodeGen] Inline assembler: service PR before the result obtaining

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3093,6 +3093,10 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     - the output variable index referenced by the input operands.
     - the index of early-clobber operand
 
+    Operand attributes is a storage of attributes, where each element corresponds
+    to the operand with the same index. The first index relates to the operation
+    result.
+
     Example:
     ```C++
     __asm__("foo" : : : );
@@ -3133,11 +3137,6 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     operands `:` functional-type(operands, results)
    }];
 
-   let extraClassDeclaration = [{
-    static StringRef getElementTypeAttrName() {
-      return "elementtype";
-    }
-  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2903,17 +2903,25 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
         StrAttr:$asm_string,
         StrAttr:$constraints,
         UnitAttr:$side_effects,
-        AsmFlavor:$asm_flavor);
+        AsmFlavor:$asm_flavor,
+        OptionalAttr<ArrayAttr>:$operand_attrs);
 
   let assemblyFormat = [{
     `(`
     $asm_flavor`,`
     `{` $asm_string $constraints `}`
     `)`
+    (`operand_attrs` `=` $operand_attrs^)?
     (`side_effects` $side_effects^)?
     attr-dict
     operands `:` functional-type(operands, results)
-   }];  
+   }];
+
+   let extraClassDeclaration = [{
+    static StringRef getElementTypeAttrName() {
+      return "elementtype";
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/Address.h
+++ b/clang/lib/CIR/CodeGen/Address.h
@@ -95,7 +95,7 @@ public:
 
   /// Return the type of the pointer value.
   mlir::cir::PointerType getType() const {
-    return getPointer().getType().cast<mlir::cir::PointerType>();    
+    return getPointer().getType().cast<mlir::cir::PointerType>();
   }
 
   mlir::Type getElementType() const {

--- a/clang/lib/CIR/CodeGen/Address.h
+++ b/clang/lib/CIR/CodeGen/Address.h
@@ -93,6 +93,11 @@ public:
     return Alignment;
   }
 
+  /// Return the type of the pointer value.
+  mlir::cir::PointerType getType() const {
+    return getPointer().getType().cast<mlir::cir::PointerType>();    
+  }
+
   mlir::Type getElementType() const {
     assert(isValid());
     return ElementType;

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -209,8 +209,7 @@ static void collectInOutConstrainsInfos(const CIRGenFunction &cgf,
   }
 }
 
-std::pair<mlir::Value, mlir::Type>
-CIRGenFunction::buildAsmInputLValue(
+std::pair<mlir::Value, mlir::Type> CIRGenFunction::buildAsmInputLValue(
     const TargetInfo::ConstraintInfo &Info, LValue InputValue,
     QualType InputType, std::string &ConstraintStr, SourceLocation Loc) {
 
@@ -225,7 +224,7 @@ CIRGenFunction::buildAsmInputLValue(
       Ty = mlir::cir::IntType::get(builder.getContext(), Size, false);
 
       return {builder.createLoad(getLoc(Loc),
-                                InputValue.getAddress().withElementType(Ty)),
+                                 InputValue.getAddress().withElementType(Ty)),
               mlir::Type()};
     }
   }
@@ -286,7 +285,7 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
   std::vector<mlir::Type> ResultRegTypes;
   std::vector<mlir::Type> ResultTruncRegTypes;
   std::vector<mlir::Type> ArgTypes;
-  std::vector<mlir::Type> ArgElemTypes;  
+  std::vector<mlir::Type> ArgElemTypes;
   std::vector<mlir::Value> Args;
   llvm::BitVector ResultTypeRequiresCast;
   llvm::BitVector ResultRegIsFlagReg;
@@ -399,9 +398,10 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
       // input-argument which is represented as vector.
       if (isa<MatrixType>(OutExpr->getType().getCanonicalType()))
         DestAddr = DestAddr.withElementType(ConvertType(OutExpr->getType()));
-      
-      auto ptrTy = //TODO: looks weird
-        llvm::dyn_cast<mlir::cir::PointerType>(DestAddr.getPointer().getType());
+
+      auto ptrTy = // TODO: looks weird
+          llvm::dyn_cast<mlir::cir::PointerType>(
+              DestAddr.getPointer().getType());
       ArgTypes.push_back(ptrTy);
       ArgElemTypes.push_back(DestAddr.getElementType());
       Args.push_back(DestAddr.getPointer());
@@ -523,10 +523,8 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
   bool HasSideEffect = S.isVolatile() || S.getNumOutputs() == 0;
 
   auto IA = builder.create<mlir::cir::InlineAsmOp>(
-              getLoc(S.getAsmLoc()), ResultType,
-              Args, AsmString, Constraints,
-              HasSideEffect, inferFlavor(CGM, S), 
-              mlir::ArrayAttr());
+      getLoc(S.getAsmLoc()), ResultType, Args, AsmString, Constraints,
+      HasSideEffect, inferFlavor(CGM, S), mlir::ArrayAttr());
 
   if (false /*IsGCCAsmGoto*/) {
     assert(!AsmUnimplemented::Goto());
@@ -542,9 +540,10 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
     std::vector<mlir::Attribute> operandAttrs;
     auto attrName = mlir::cir::InlineAsmOp::getElementTypeAttrName();
 
-    // this is for the lowering to LLVM from LLVm dialect. Otherwise, if we don't
-    // have the result (i.e. void type as a result of operation), the element type
-    // attribute will be attached to the whole instruction, but not to the operand
+    // this is for the lowering to LLVM from LLVm dialect. Otherwise, if we
+    // don't have the result (i.e. void type as a result of operation), the
+    // element type attribute will be attached to the whole instruction, but not
+    // to the operand
     if (!IA.getNumResults())
       operandAttrs.push_back(OptNoneAttr::get(builder.getContext()));
 

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -399,10 +399,7 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
       if (isa<MatrixType>(OutExpr->getType().getCanonicalType()))
         DestAddr = DestAddr.withElementType(ConvertType(OutExpr->getType()));
 
-      auto ptrTy = // TODO: looks weird
-          llvm::dyn_cast<mlir::cir::PointerType>(
-              DestAddr.getPointer().getType());
-      ArgTypes.push_back(ptrTy);
+      ArgTypes.push_back(DestAddr.getType());
       ArgElemTypes.push_back(DestAddr.getElementType());
       Args.push_back(DestAddr.getPointer());
       Constraints += "=*";

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -950,13 +950,16 @@ public:
 
   mlir::LogicalResult buildAsmStmt(const clang::AsmStmt &S);
 
-  mlir::Value buildAsmInputLValue(const TargetInfo::ConstraintInfo &Info,
-                                  LValue InputValue, QualType InputType,
-                                  std::string &ConstraintStr,
-                                  SourceLocation Loc);
+  
+  std::pair<mlir::Value, mlir::Type>
+  buildAsmInputLValue(const TargetInfo::ConstraintInfo &Info,
+                      LValue InputValue, QualType InputType,
+                      std::string &ConstraintStr,
+                      SourceLocation Loc);
 
-  mlir::Value buildAsmInput(const TargetInfo::ConstraintInfo &Info,
-                            const Expr *InputExpr, std::string &ConstraintStr);
+  std::pair<mlir::Value, mlir::Type>
+  buildAsmInput(const TargetInfo::ConstraintInfo &Info,
+                const Expr *InputExpr, std::string &ConstraintStr);
 
   mlir::LogicalResult buildIfStmt(const clang::IfStmt &S);
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -950,16 +950,14 @@ public:
 
   mlir::LogicalResult buildAsmStmt(const clang::AsmStmt &S);
 
-  
   std::pair<mlir::Value, mlir::Type>
-  buildAsmInputLValue(const TargetInfo::ConstraintInfo &Info,
-                      LValue InputValue, QualType InputType,
-                      std::string &ConstraintStr,
+  buildAsmInputLValue(const TargetInfo::ConstraintInfo &Info, LValue InputValue,
+                      QualType InputType, std::string &ConstraintStr,
                       SourceLocation Loc);
 
   std::pair<mlir::Value, mlir::Type>
-  buildAsmInput(const TargetInfo::ConstraintInfo &Info,
-                const Expr *InputExpr, std::string &ConstraintStr);
+  buildAsmInput(const TargetInfo::ConstraintInfo &Info, const Expr *InputExpr,
+                std::string &ConstraintStr);
 
   mlir::LogicalResult buildIfStmt(const clang::IfStmt &S);
 

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -166,6 +166,12 @@ struct UnimplementedFeature {
   static bool escapedLocals() { return false; }
   static bool deferredReplacements() { return false; }
   static bool shouldInstrumentFunction() { return false; }
+
+  // Inline assembly
+  static bool asm_goto() { return false; }
+  static bool asm_unwind_clobber() { return false; }
+  static bool asm_memory_effects() { return false; }
+  static bool asm_vector_type() { return false; }
 };
 } // namespace cir
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2264,7 +2264,7 @@ class CIRInlineAsmOpLowering
         mlir::TypeAttr tAttr = cast<mlir::TypeAttr>(dict.get(cirAttrName));
         std::vector<mlir::NamedAttribute> attrs;
         auto typAttr = mlir::TypeAttr::get(
-          getTypeConverter()->convertType(tAttr.getValue()));
+            getTypeConverter()->convertType(tAttr.getValue()));
 
         attrs.push_back(rewriter.getNamedAttr(llvmAttrName, typAttr));
         auto newDict = rewriter.getDictionaryAttr(attrs);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2336,7 +2336,6 @@ class CIRInlineAsmOpLowering
                          : mlir::LLVM::AsmDialect::AD_Intel;
 
     std::vector<mlir::Attribute> opAttrs;
-    auto cirAttrName = mlir::cir::InlineAsmOp::getElementTypeAttrName();
     auto llvmAttrName = mlir::LLVM::InlineAsmOp::getElementTypeAttrName();
 
     if (auto operandAttrs = op.getOperandAttrs()) {
@@ -2346,8 +2345,7 @@ class CIRInlineAsmOpLowering
           continue;
         }
 
-        mlir::DictionaryAttr dict = cast<mlir::DictionaryAttr>(attr);
-        mlir::TypeAttr tAttr = cast<mlir::TypeAttr>(dict.get(cirAttrName));
+        mlir::TypeAttr tAttr = cast<mlir::TypeAttr>(attr);
         std::vector<mlir::NamedAttribute> attrs;
         auto typAttr = mlir::TypeAttr::get(
             getTypeConverter()->convertType(tAttr.getValue()));

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -1,32 +1,32 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-//CHECK: cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) side_effects  : () -> ()
+//CHECK: cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] side_effects  : () -> ()
 void empty1() {
   __asm__ volatile("" : : : );
 }
 
-//CHECK: cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects  : () -> ()
+//CHECK: cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] side_effects  : () -> ()
 void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, {elementtype = !s32i}, {elementtype = !s32i}]  side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
 void t1(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, {elementtype = !s32i}] side_effects %0 : (!cir.ptr<!s32i>) -> ()
 void t2(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, {elementtype = !s32i}] side_effects %0 : (!cir.ptr<!s32i>) -> ()
 void t3(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects %1 : (!s32i) -> ()
+//CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] side_effects %1 : (!s32i) -> !ty_22anon2E022
 void t4(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -11,17 +11,17 @@ void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, {elementtype = !s32i}, {elementtype = !s32i}] side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, !s32i, !s32i] side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
 void t1(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, {elementtype = !s32i}] side_effects %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, !s32i] side_effects %0 : (!cir.ptr<!s32i>) -> ()
 void t2(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, {elementtype = !s32i}] side_effects %0 : (!cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, !s32i] side_effects %0 : (!cir.ptr<!s32i>) -> ()
 void t3(int x) {
   __asm__ volatile("" : "=m"(x));
 }

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -11,7 +11,7 @@ void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, {elementtype = !s32i}, {elementtype = !s32i}]  side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
+//CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, {elementtype = !s32i}, {elementtype = !s32i}] side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
 void t1(int x) {
   __asm__ volatile("" : "+m"(x));
 }

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -27,7 +27,7 @@ module {
     cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects %1 : (!s32i) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
 
-    cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [{elementtype = !s32i}] side_effects  : () -> ()
+    cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [!s32i] side_effects  : () -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
     cir.return
   }

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -26,7 +26,9 @@ module {
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
     cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects %1 : (!s32i) -> ()
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
-    
+
+    cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [{elementtype = !s32i}] side_effects  : () -> ()
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
     cir.return
   }
 


### PR DESCRIPTION
This is the next step in inline assembly support and it's more like a service PR and mostly dedicated to the in/out argument types.

Also, operand attributes are added and it's the last change in the `cir.asm` operation afaik. But I would wait untill the next PR,
which will contain more examples and maybe will help us to get more readable format for the operation.
Note, that we have to add an attribute for each operand  - because the lowering of the llvm dialect to LLVM IR iterates over them in the same order.

The next PR will be last one (so far) in the series of PRs dedicated to the inline assembly support. It will add storing of the results. 

