### PR TITLE
[CIR][CIRGen] Partial support for `offsetof`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -195,7 +195,17 @@ public:
   mlir::Value VisitGNUNullExpr(const GNUNullExpr *E) {
     llvm_unreachable("NYI");
   }
-  mlir::Value VisitOffsetOfExpr(OffsetOfExpr *E) { llvm_unreachable("NYI"); }
+  mlir::Value VisitOffsetOfExpr(OffsetOfExpr *E) {
+    // Try folding the offsetof to a constant.
+    Expr::EvalResult EVResult;
+    if (E->EvaluateAsInt(EVResult, CGF.getContext())) {
+      llvm::APSInt Value = EVResult.Val.getInt();
+      return Builder.getConstInt(CGF.getLoc(E->getExprLoc()), Value);
+    }
+
+    llvm_unreachable("NYI");
+  }
+
   mlir::Value VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *E);
   mlir::Value VisitAddrLabelExpr(const AddrLabelExpr *E) {
     llvm_unreachable("NYI");

--- a/clang/test/CIR/CodeGen/offsetof.c
+++ b/clang/test/CIR/CodeGen/offsetof.c
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s
+
+#include <stddef.h>
+
+typedef struct {
+  int a;
+  int b;
+} A;
+
+void foo() {
+  offsetof(A, a);
+  offsetof(A, b);
+}
+
+// CHECK:  cir.func no_proto @foo()
+// CHECK:    {{.*}} = cir.const(#cir.int<0> : !u64i) : !u64i
+// CHECK:    {{.*}} = cir.const(#cir.int<4> : !u64i) : !u64i
+// CHECK:    cir.return
+


### PR DESCRIPTION
Support `offset` expression in case when we can evaluate offset expression as integer.