### PR TITLE
[CIR][CIRGen] Enable support of bool increment

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -358,10 +358,6 @@ public:
     // An interesting aspect of this is that increment is always true.
     // Decrement does not have this property.
     if (isInc && type->isBooleanType()) {
-      llvm_unreachable("inc simplification for booleans not implemented yet");
-
-      // NOTE: We likely want the code below, but loading/store booleans need to
-      // work first. See CIRGenFunction::buildFromMemory().
       value = Builder.create<mlir::cir::ConstantOp>(
           CGF.getLoc(E->getExprLoc()), CGF.getCIRType(type),
           Builder.getCIRBoolAttr(true));

--- a/clang/test/CIR/CodeGen/inc-bool.cpp
+++ b/clang/test/CIR/CodeGen/inc-bool.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++14 -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void foo(bool x) {
+  x++;
+}
+
+// CHECK:  cir.func @_Z3foob(%arg0: !cir.bool loc({{.*}}))
+// CHECK:    [[ALLOC_X:%.*]] = cir.alloca !cir.bool, cir.ptr <!cir.bool>, ["x", init] {alignment = 1 : i64}
+// CHECK:    cir.store %arg0, [[ALLOC_X]] : !cir.bool, cir.ptr <!cir.bool>
+// CHECK:    {{.*}} = cir.load [[ALLOC_X]] : cir.ptr <!cir.bool>, !cir.bool
+// CHECK:    [[TRUE:%.*]] = cir.const(#true) : !cir.bool
+// CHECK:    cir.store [[TRUE]], [[ALLOC_X]] : !cir.bool, cir.ptr <!cir.bool>
+// CHECK:    cir.return


### PR DESCRIPTION
CIRGenFunction::buildFromMemory can handle the `cir.bool` values. So we no longer need to emit the `NIY` error here.