### PR TITLE
[CIR] Add `cir.trap` operation

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3119,6 +3119,23 @@ def UnreachableOp : CIR_Op<"unreachable", [Terminator]> {
 }
 
 //===----------------------------------------------------------------------===//
+// TrapOp
+//===----------------------------------------------------------------------===//
+
+def TrapOp : CIR_Op<"trap", [Terminator]> {
+  let summary = "Exit the program abnormally";
+  let description = [{
+    The cir.trap operation causes the program to exit abnormally. The
+    implementations may implement this operation with different mechanisms. For
+    example, an implementation may implement this operation by calling abort,
+    while another implementation may implement this operation by executing an
+    illegal instruction.
+  }];
+
+  let assemblyFormat = "attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
 // Operations Lowered Directly to LLVM IR
 //
 // These operations are hacks to get around missing features in LLVM's dialect.

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -505,6 +505,15 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
 
     return RValue::get(nullptr);
   }
+  case Builtin::BI__builtin_trap: {
+    builder.create<mlir::cir::TrapOp>(getLoc(E->getExprLoc()));
+
+    // Note that cir.trap is a terminator so we need to start a new block to
+    // preserve the insertion point.
+    builder.createBlock(builder.getBlock()->getParent());
+
+    return RValue::get(nullptr);
+  }
   case Builtin::BImemcpy:
   case Builtin::BI__builtin_memcpy:
   case Builtin::BImempcpy:

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -460,8 +460,9 @@ void CIRGenFunction::LexicalScope::buildImplicitReturn() {
       llvm_unreachable("NYI");
     } else if (shouldEmitUnreachable) {
       if (CGF.CGM.getCodeGenOpts().OptimizationLevel == 0) {
-        // TODO: buildTrapCall(llvm::Intrinsic::trap);
-        assert(!UnimplementedFeature::trap());
+        builder.create<mlir::cir::TrapOp>(localScope->EndLoc);
+        builder.clearInsertionPoint();
+        return;
       }
     }
 

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -166,7 +166,6 @@ struct UnimplementedFeature {
   static bool escapedLocals() { return false; }
   static bool deferredReplacements() { return false; }
   static bool shouldInstrumentFunction() { return false; }
-  static bool trap() { return false; }
 };
 } // namespace cir
 

--- a/clang/test/CIR/CodeGen/implicit-return.cpp
+++ b/clang/test/CIR/CodeGen/implicit-return.cpp
@@ -1,15 +1,26 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -O0 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CHECK-O0
+// RUN: %clang_cc1 -O2 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CHECK-O2
 
 void ret_void() {}
 
-//      CHECK: cir.func @_Z8ret_voidv()
-// CHECK-NEXT:   cir.return
-// CHECK-NEXT: }
+//      CHECK-O0: cir.func @_Z8ret_voidv()
+// CHECK-O0-NEXT:   cir.return
+// CHECK-O0-NEXT: }
+
+//      CHECK-O2: cir.func @_Z8ret_voidv()
+// CHECK-O2-NEXT:   cir.return
+// CHECK-O2-NEXT: }
 
 int ret_non_void() {}
 
-//      CHECK: cir.func @_Z12ret_non_voidv() -> !s32i
-// CHECK-NEXT:   %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"]
-// CHECK-NEXT:   cir.unreachable
-// CHECK-NEXT: }
+//      CHECK-O0: cir.func @_Z12ret_non_voidv() -> !s32i
+// CHECK-O0-NEXT:   %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"]
+// CHECK-O0-NEXT:   cir.trap
+// CHECK-O0-NEXT: }
+
+//      CHECK-O2: cir.func @_Z12ret_non_voidv() -> !s32i
+// CHECK-O2-NEXT:   %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"]
+// CHECK-O2-NEXT:   cir.unreachable
+// CHECK-O2-NEXT: }

--- a/clang/test/CIR/CodeGen/trap.cpp
+++ b/clang/test/CIR/CodeGen/trap.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void foo();
+
+void basic() {
+  foo();
+  __builtin_trap();
+}
+
+//      CHECK: cir.func @_Z5basicv()
+// CHECK-NEXT:   cir.call @_Z3foov() : () -> ()
+// CHECK-NEXT:   cir.trap
+// CHECK-NEXT: }
+
+void code_after_unreachable() {
+  foo();
+  __builtin_trap();
+  foo();
+}
+
+//      CHECK: cir.func @_Z22code_after_unreachablev()
+// CHECK-NEXT:   cir.call @_Z3foov() : () -> ()
+// CHECK-NEXT:   cir.trap
+// CHECK-NEXT: ^bb1:
+// CHECK-NEXT:   cir.call @_Z3foov() : () -> ()
+// CHECK-NEXT:   cir.return
+// CHECK-NEXT: }

--- a/clang/test/CIR/Lowering/intrinsics.cir
+++ b/clang/test/CIR/Lowering/intrinsics.cir
@@ -1,4 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
 
 module {
   cir.func @test_unreachable() {
@@ -7,4 +8,16 @@ module {
 
   //      MLIR: llvm.func @test_unreachable()
   // MLIR-NEXT:   llvm.unreachable
+
+  cir.func @test_trap() {
+    cir.trap
+  }
+
+  //      MLIR: llvm.func @test_trap()
+  // MLIR-NEXT:   llvm.call_intrinsic "llvm.trap"() : () -> !llvm.void
+  // MLIR-NEXT:   llvm.unreachable
+
+  //      LLVM: define void @test_trap()
+  // LLVM-NEXT:   call void @llvm.trap()
+  // LLVM-NEXT:   unreachable
 }


### PR DESCRIPTION
This PR adds the `cir.trap` operation, which corresponds to the `__builtin_trap` builtin function. When executed, the operation terminates the program abnormally in an implementation-defined manner.

This PR also includes CIRGen and LLVM lowering support for the new operation.