### PR TITLE
[CIR] Vector ternary operator

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2087,6 +2087,36 @@ def VecCmpOp : CIR_Op<"vec.cmp", [Pure, SameTypeOperands]> {
 }
 
 //===----------------------------------------------------------------------===//
+// VecTernary
+//===----------------------------------------------------------------------===//
+
+def VecTernaryOp : CIR_Op<"vec.ternary",
+                   [Pure, AllTypesMatch<["result", "vec1", "vec2"]>]> {
+  let summary = "The `cond ? a : b` ternary operator for vector types";
+  let description = [{
+    The `cir.vec.ternary` operation represents the C/C++ ternary operator,
+    `?:`, for vector types, which does a `select` on individual elements of the
+    vectors. Unlike a regular `?:` operator, there is no short circuiting. All
+    three arguments are always evaluated.  Because there is no short
+    circuiting, there are no regions in this operation, unlike cir.ternary.
+
+    The first argument is a vector of integral type. The second and third
+    arguments are vectors of the same type and have the same number of elements
+    as the first argument.
+
+    The result is a vector of the same type as the second and third arguments.
+    Each element of the result is `(bool)a[n] ? b[n] : c[n]`.
+  }];
+  let arguments = (ins CIR_VectorType:$cond, CIR_VectorType:$vec1,
+		       CIR_VectorType:$vec2);
+  let results = (outs CIR_VectorType:$result);
+  let assemblyFormat = [{
+    `(` $cond `,` $vec1 `,` $vec2 `)` `:` type($cond) `,` type($vec1) attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // BaseClassAddr
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2059,7 +2059,12 @@ mlir::Value ScalarExprEmitter::VisitAbstractConditionalOperator(
 
   if (condExpr->getType()->isVectorType() ||
       condExpr->getType()->isSveVLSBuiltinType()) {
-    llvm_unreachable("NYI");
+    assert(condExpr->getType()->isVectorType() && "?: op for SVE vector NYI");
+    mlir::Value condValue = Visit(condExpr);
+    mlir::Value lhsValue = Visit(lhsExpr);
+    mlir::Value rhsValue = Visit(rhsExpr);
+    return builder.create<mlir::cir::VecTernaryOp>(loc, condValue, lhsValue,
+                                                   rhsValue);
   }
 
   // If this is a really simple expression (like x ? 4 : 5), emit this as a

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -522,6 +522,28 @@ LogicalResult VecCreateOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// VecTernaryOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult VecTernaryOp::verify() {
+  // Verify that the condition operand is a vector of integral type.
+  if (!getCond().getType().getEltType().isa<mlir::cir::IntType>()) {
+    return emitOpError() << "condition operand of type " << getCond().getType()
+                         << " must be a vector type of !cir.int";
+  }
+
+  // Verify that the condition operand has the same number of elements as the
+  // other operands.  (The automatic verification already checked that all
+  // operands are vector types and that the second and third operands are the
+  // same type.)
+  if (getCond().getType().getSize() != getVec1().getType().getSize()) {
+    return emitOpError() << "the number of elements in " << getCond().getType()
+                         << " and " << getVec1().getType() << " don't match";
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ReturnOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/test/CIR/CodeGen/vectype.cpp
+++ b/clang/test/CIR/CodeGen/vectype.cpp
@@ -67,6 +67,10 @@ void vector_int_test(int x) {
   vi4 n = ~a;
   // CHECK: %{{[0-9]+}} = cir.unary(not, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
 
+  // Ternary conditional operator
+  vi4 tc = a ? b : d;
+  // CHECK: %{{[0-9]+}} = cir.vec.ternary(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>
+
   // Comparisons
   vi4 o = a == b;
   // CHECK: %{{[0-9]+}} = cir.vec.cmp(eq, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -432,6 +432,45 @@ cir.func @vec_insert_non_vector() {
 
 // -----
 
+!s32i = !cir.int<s, 32>
+cir.func @vec_ternary_non_vector1() {
+  %0 = cir.const(#cir.int<0> : !s32i) : !s32i
+  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : <!s32i x 2>
+  %2 = cir.vec.ternary(%0, %1, %1) : !s32i, <!s32i x 2> // expected-error {{custom op 'cir.vec.ternary' invalid kind of Type specified}}
+  cir.return
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+cir.func @vec_ternary_non_vector2() {
+  %0 = cir.const(#cir.int<0> : !s32i) : !s32i
+  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : <!s32i x 2>
+  %2 = cir.vec.ternary(%1, %0, %0) : <!s32i x 2>, !s32i // expected-error {{custom op 'cir.vec.ternary' invalid kind of Type specified}}
+  cir.return
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+cir.func @vec_ternary_different_size() {
+  %0 = cir.const(#cir.int<0> : !s32i) : !s32i
+  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : <!s32i x 2>
+  %2 = cir.vec.create(%0, %0, %0, %0 : !s32i, !s32i, !s32i, !s32i) : <!s32i x 4>
+  %3 = cir.vec.ternary(%1, %2, %2) : <!s32i x 2>, <!s32i x 4> // expected-error {{'cir.vec.ternary' op the number of elements in '!cir.vector<!cir.int<s, 32> x 2>' and '!cir.vector<!cir.int<s, 32> x 4>' don't match}}
+  cir.return
+}
+
+// -----
+
+cir.func @vec_ternary_not_int(%p : !cir.float) {
+  %0 = cir.vec.create(%p, %p : !cir.float, !cir.float) : <!cir.float x 2>
+  %1 = cir.vec.ternary(%0, %0, %0) : <!cir.float x 2>, <!cir.float x 2> // expected-error {{'cir.vec.ternary' op condition operand of type '!cir.vector<!cir.float x 2>' must be a vector type of !cir.int}}
+  cir.return
+}
+
+// -----
+
 cir.func coroutine @bad_task() { // expected-error {{coroutine body must use at least one cir.await op}}
   cir.return
 }

--- a/clang/test/CIR/Lowering/vectype.cpp
+++ b/clang/test/CIR/Lowering/vectype.cpp
@@ -132,6 +132,12 @@ void vector_int_test(int x) {
   // CHECK: %[[#T104:]] = llvm.xor %[[#T103]], %[[#T93]]  : vector<4xi32>
   // CHECK: llvm.store %[[#T104]], %[[#T29:]] : vector<4xi32>, !llvm.ptr
 
+  // Ternary conditional operator
+  vi4 tc = a ? b : d;
+  // CHECK: %[[#Zero:]] = llvm.mlir.zero : vector<4xi32>
+  // CHECK: %[[#BitVec:]] = llvm.icmp "ne" %[[#A:]], %[[#Zero]] : vector<4xi32>
+  // CHECK: %[[#Res:]] = llvm.select %[[#BitVec]], %[[#B:]], %[[#D:]] : vector<4xi1>, vector<4xi32>
+
   // Comparisons
   vi4 o = a == b;
   // CHECK: %[[#T105:]] = llvm.load %[[#T3]] : !llvm.ptr -> vector<4xi32>


### PR DESCRIPTION
Implement the vector version of the ternary (`?:`) operator.  This is a separate MLIR op than the regular `?:` operator because the vector version is not short-circuiting and always evaluates all its arguments.