### PR TITLE
[CIR][Lowering] Add LLVMIR lowering support for CIR bit operations

### DIFF
--- a/clang/test/CIR/Lowering/bit.cir
+++ b/clang/test/CIR/Lowering/bit.cir
@@ -1,0 +1,206 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s
+!s16i = !cir.int<s, 16>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
+
+cir.func @clrsb_s32(%arg : !s32i) {
+  %0 = cir.bit.clrsb(%arg : !s32i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @clrsb_s32(%arg0: i32)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:   %1 = llvm.icmp "slt" %arg0, %0 : i32
+// CHECK-NEXT:   %2 = llvm.mlir.constant(-1 : i32) : i32
+// CHECK-NEXT:   %3 = llvm.xor %arg0, %2  : i32
+// CHECK-NEXT:   %4 = llvm.select %1, %3, %arg0 : i1, i32
+// CHECK-NEXT:   %5 = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:   %6 = llvm.call_intrinsic "llvm.ctlz.i32"(%4, %5) : (i32, i1) -> i32
+// CHECK-NEXT:   %7 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:   %8 = llvm.sub %6, %7  : i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @clrsb_s64(%arg : !s64i) {
+  %0 = cir.bit.clrsb(%arg : !s64i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @clrsb_s64(%arg0: i64)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:   %1 = llvm.icmp "slt" %arg0, %0 : i64
+// CHECK-NEXT:   %2 = llvm.mlir.constant(-1 : i64) : i64
+// CHECK-NEXT:   %3 = llvm.xor %arg0, %2  : i64
+// CHECK-NEXT:   %4 = llvm.select %1, %3, %arg0 : i1, i64
+// CHECK-NEXT:   %5 = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:   %6 = llvm.call_intrinsic "llvm.ctlz.i64"(%4, %5) : (i64, i1) -> i64
+// CHECK-NEXT:   %7 = llvm.trunc %6 : i64 to i32
+// CHECK-NEXT:   %8 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:   %9 = llvm.sub %7, %8  : i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @clz_u16(%arg : !u16i) {
+  %0 = cir.bit.clz(%arg : !u16i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @clz_u16(%arg0: i16)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(true) : i1
+// CHECK-NEXT:   %1 = llvm.call_intrinsic "llvm.ctlz.i16"(%arg0, %0) : (i16, i1) -> i16
+// CHECK-NEXT:   %2 = llvm.zext %1 : i16 to i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @clz_u32(%arg : !u32i) {
+  %0 = cir.bit.clz(%arg : !u32i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @clz_u32(%arg0: i32)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(true) : i1
+// CHECK-NEXT:   %1 = llvm.call_intrinsic "llvm.ctlz.i32"(%arg0, %0) : (i32, i1) -> i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @clz_u64(%arg : !u64i) {
+  %0 = cir.bit.clz(%arg : !u64i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @clz_u64(%arg0: i64)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(true) : i1
+// CHECK-NEXT:   %1 = llvm.call_intrinsic "llvm.ctlz.i64"(%arg0, %0) : (i64, i1) -> i64
+// CHECK-NEXT:   %2 = llvm.trunc %1 : i64 to i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @ctz_u16(%arg : !u16i) {
+  %0 = cir.bit.ctz(%arg : !u16i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @ctz_u16(%arg0: i16)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(true) : i1
+// CHECK-NEXT:   %1 = llvm.call_intrinsic "llvm.cttz.i16"(%arg0, %0) : (i16, i1) -> i16
+// CHECK-NEXT:   %2 = llvm.zext %1 : i16 to i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @ctz_u32(%arg : !u32i) {
+  %0 = cir.bit.ctz(%arg : !u32i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @ctz_u32(%arg0: i32)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(true) : i1
+// CHECK-NEXT:   %1 = llvm.call_intrinsic "llvm.cttz.i32"(%arg0, %0) : (i32, i1) -> i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @ctz_u64(%arg : !u64i) {
+  %0 = cir.bit.ctz(%arg : !u64i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @ctz_u64(%arg0: i64)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(true) : i1
+// CHECK-NEXT:   %1 = llvm.call_intrinsic "llvm.cttz.i64"(%arg0, %0) : (i64, i1) -> i64
+// CHECK-NEXT:   %2 = llvm.trunc %1 : i64 to i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @ffs_s32(%arg : !s32i) {
+  %0 = cir.bit.ffs(%arg : !s32i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @ffs_s32(%arg0: i32)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:   %1 = llvm.call_intrinsic "llvm.cttz.i32"(%arg0, %0) : (i32, i1) -> i32
+// CHECK-NEXT:   %2 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:   %3 = llvm.add %1, %2  : i32
+// CHECK-NEXT:   %4 = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:   %5 = llvm.icmp "eq" %arg0, %4 : i32
+// CHECK-NEXT:   %6 = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:   %7 = llvm.select %5, %6, %3 : i1, i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @ffs_s64(%arg : !s64i) {
+  %0 = cir.bit.ffs(%arg : !s64i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @ffs_s64(%arg0: i64)
+// CHECK-NEXT:   %0 = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:   %1 = llvm.call_intrinsic "llvm.cttz.i64"(%arg0, %0) : (i64, i1) -> i64
+// CHECK-NEXT:   %2 = llvm.trunc %1 : i64 to i32
+// CHECK-NEXT:   %3 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:   %4 = llvm.add %2, %3  : i32
+// CHECK-NEXT:   %5 = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:   %6 = llvm.icmp "eq" %arg0, %5 : i64
+// CHECK-NEXT:   %7 = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:   %8 = llvm.select %6, %7, %4 : i1, i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @parity_s32(%arg : !u32i) {
+  %0 = cir.bit.parity(%arg : !u32i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @parity_s32(%arg0: i32)
+// CHECK-NEXT:   %0 = llvm.call_intrinsic "llvm.ctpop.i32"(%arg0) : (i32) -> i32
+// CHECK-NEXT:   %1 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:   %2 = llvm.and %0, %1  : i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @parity_s64(%arg : !u64i) {
+  %0 = cir.bit.parity(%arg : !u64i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @parity_s64(%arg0: i64)
+// CHECK-NEXT:   %0 = llvm.call_intrinsic "llvm.ctpop.i64"(%arg0) : (i64) -> i64
+// CHECK-NEXT:   %1 = llvm.trunc %0 : i64 to i32
+// CHECK-NEXT:   %2 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:   %3 = llvm.and %1, %2  : i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @popcount_u16(%arg : !u16i) {
+  %0 = cir.bit.popcount(%arg : !u16i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @popcount_u16(%arg0: i16)
+// CHECK-NEXT:   %0 = llvm.call_intrinsic "llvm.ctpop.i16"(%arg0) : (i16) -> i16
+// CHECK-NEXT:   %1 = llvm.zext %0 : i16 to i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @popcount_u32(%arg : !u32i) {
+  %0 = cir.bit.popcount(%arg : !u32i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @popcount_u32(%arg0: i32)
+// CHECK-NEXT:   %0 = llvm.call_intrinsic "llvm.ctpop.i32"(%arg0) : (i32) -> i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+cir.func @popcount_u64(%arg : !u64i) {
+  %0 = cir.bit.popcount(%arg : !u64i) : !s32i
+  cir.return
+}
+
+//      CHECK: llvm.func @popcount_u64(%arg0: i64)
+// CHECK-NEXT:   %0 = llvm.call_intrinsic "llvm.ctpop.i64"(%arg0) : (i64) -> i64
+// CHECK-NEXT:   %1 = llvm.trunc %0 : i64 to i32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }


### PR DESCRIPTION
This PR adds the LLVMIR lowering support for CIR bit operations.

For `cir.bit.clz`, `cir.bit.ctz`, and `cir.bit.popcount`, they can be lowered directly to LLVM intrinsic calls to `@llvm.ctlz`, `@llvm.cttz`, and `@llvm.ctpop`, respectively.

For the other three bit operations, namely `cir.bit.clrsb`, `cir.bit.ffs`, and `cir.bit.parity`, they are lowered to a sequence of LLVM IR instructions that implements their functionalities. This lowering scheme is also used by the original clang CodeGen.