### PR TITLE
[CIR] Vector type cleanup and refactoring

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2008,7 +2008,8 @@ def VecInsertOp : CIR_Op<"vec.insert", [Pure,
   let results = (outs CIR_VectorType:$result);
 
   let assemblyFormat = [{
-    $value `,` $vec `[` $index `:` type($index) `]` attr-dict `:` type($vec)
+    $value `,` $vec `[` $index `:` type($index) `]` attr-dict `:`
+    qualified(type($vec))
   }];
 
   let hasVerifier = 0;
@@ -2032,7 +2033,7 @@ def VecExtractOp : CIR_Op<"vec.extract", [Pure,
   let results = (outs CIR_AnyType:$result);
 
   let assemblyFormat = [{
-    $vec `[` $index `:` type($index) `]` attr-dict `:` type($vec)
+    $vec `[` $index `:` type($index) `]` attr-dict `:` qualified(type($vec))
   }];
 
   let hasVerifier = 0;
@@ -2055,10 +2056,39 @@ def VecCreateOp : CIR_Op<"vec.create", [Pure]> {
   let results = (outs CIR_VectorType:$result);
 
   let assemblyFormat = [{
-    `(` ($elements^ `:` type($elements))? `)` `:` type($result) attr-dict
+    `(` ($elements^ `:` type($elements))? `)` `:` qualified(type($result))
+    attr-dict
   }];
 
   let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// VecSplat
+//===----------------------------------------------------------------------===//
+
+// cir.vec.splat is a separate operation from cir.vec.create because more
+// efficient LLVM IR can be generated for it, and because some optimization and
+// analysis passes can benefit from knowing that all elements of the vector
+// have the same value.
+
+def VecSplatOp : CIR_Op<"vec.splat", [Pure,
+  TypesMatchWith<"type of 'value' matches element type of 'result'", "result",
+                 "value", "$_self.cast<VectorType>().getEltType()">]> {
+
+  let summary = "Convert a scalar into a vector";
+  let description = [{
+    The `cir.vec.splat` operation creates a vector value from a scalar value.
+    All elements of the vector have the same value, that of the given scalar.
+  }];
+
+  let arguments = (ins CIR_AnyType:$value);
+  let results = (outs CIR_VectorType:$result);
+
+  let assemblyFormat = [{
+    $value `:` type($value) `,` qualified(type($result)) attr-dict
+  }];
+  let hasVerifier = 0;
 }
 
 //===----------------------------------------------------------------------===//
@@ -2080,7 +2110,8 @@ def VecCmpOp : CIR_Op<"vec.cmp", [Pure, SameTypeOperands]> {
   let results = (outs CIR_VectorType:$result);
 
   let assemblyFormat = [{
-    `(` $kind `,` $lhs `,` $rhs `)` `:` type($lhs) `,` type($result) attr-dict
+    `(` $kind `,` $lhs `,` $rhs `)` `:` qualified(type($lhs)) `,`
+    qualified(type($result)) attr-dict
   }];
 
   let hasVerifier = 0;
@@ -2107,11 +2138,12 @@ def VecTernaryOp : CIR_Op<"vec.ternary",
     The result is a vector of the same type as the second and third arguments.
     Each element of the result is `(bool)a[n] ? b[n] : c[n]`.
   }];
-  let arguments = (ins CIR_VectorType:$cond, CIR_VectorType:$vec1,
+  let arguments = (ins IntegerVector:$cond, CIR_VectorType:$vec1,
 		       CIR_VectorType:$vec2);
   let results = (outs CIR_VectorType:$result);
   let assemblyFormat = [{
-    `(` $cond `,` $vec1 `,` $vec2 `)` `:` type($cond) `,` type($vec1) attr-dict
+    `(` $cond `,` $vec1 `,` $vec2 `)` `:` qualified(type($cond)) `,`
+    qualified(type($vec1)) attr-dict
   }];
   let hasVerifier = 1;
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -400,6 +400,15 @@ def ExceptionInfoPtrPtr : Type<
       "mlir::cir::ExceptionInfoType::get($_builder.getContext())))"> {
 }
 
+// Vector of integral type
+def IntegerVector : Type<
+    And<[
+      CPred<"$_self.isa<::mlir::cir::VectorType>()">,
+      CPred<"$_self.cast<::mlir::cir::VectorType>()"
+            ".getEltType().isa<::mlir::cir::IntType>()">,
+    ]>, "!cir.vector of !cir.int"> {
+}
+
 //===----------------------------------------------------------------------===//
 // StructType (defined in cpp files)
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1545,15 +1545,8 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
   case CK_VectorSplat: {
     // Create a vector object and fill all elements with the same scalar value.
     assert(DestTy->isVectorType() && "CK_VectorSplat to non-vector type");
-    mlir::Value Value = Visit(E);
-    SmallVector<mlir::Value, 16> Elements;
-    auto VecType = CGF.getCIRType(DestTy).dyn_cast<mlir::cir::VectorType>();
-    auto NumElements = VecType.getSize();
-    for (uint64_t Index = 0; Index < NumElements; ++Index) {
-      Elements.push_back(Value);
-    }
-    return CGF.getBuilder().create<mlir::cir::VecCreateOp>(
-        CGF.getLoc(E->getSourceRange()), VecType, Elements);
+    return CGF.getBuilder().create<mlir::cir::VecSplatOp>(
+        CGF.getLoc(E->getSourceRange()), CGF.getCIRType(DestTy), Visit(E));
   }
   case CK_FixedPointCast:
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -526,19 +526,15 @@ LogicalResult VecCreateOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult VecTernaryOp::verify() {
-  // Verify that the condition operand is a vector of integral type.
-  if (!getCond().getType().getEltType().isa<mlir::cir::IntType>()) {
-    return emitOpError() << "condition operand of type " << getCond().getType()
-                         << " must be a vector type of !cir.int";
-  }
-
   // Verify that the condition operand has the same number of elements as the
   // other operands.  (The automatic verification already checked that all
   // operands are vector types and that the second and third operands are the
   // same type.)
-  if (getCond().getType().getSize() != getVec1().getType().getSize()) {
-    return emitOpError() << "the number of elements in " << getCond().getType()
-                         << " and " << getVec1().getType() << " don't match";
+  if (getCond().getType().cast<mlir::cir::VectorType>().getSize() !=
+      getVec1().getType().getSize()) {
+    return emitOpError() << ": the number of elements in "
+                         << getCond().getType() << " and "
+                         << getVec1().getType() << " don't match";
   }
   return success();
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1319,6 +1319,37 @@ public:
   }
 };
 
+class CIRVectorSplatLowering
+    : public mlir::OpConversionPattern<mlir::cir::VecSplatOp> {
+public:
+  using OpConversionPattern<mlir::cir::VecSplatOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::VecSplatOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    // Vector splat can be implemented with an `insertelement` and a
+    // `shufflevector`, which is better than an `insertelement` for each
+    // element in vector.  Start with an undef vector.  Insert the value into
+    // the first element.  Then use a `shufflevector` with a mask of all 0 to
+    // fill out the entire vector with that value.
+    auto vecTy = op.getType().dyn_cast<mlir::cir::VectorType>();
+    assert(vecTy && "result type of cir.vec.splat op is not VectorType");
+    auto llvmTy = typeConverter->convertType(vecTy);
+    auto loc = op.getLoc();
+    mlir::Value undef = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
+    mlir::Value indexValue =
+        rewriter.create<mlir::LLVM::ConstantOp>(loc, rewriter.getI64Type(), 0);
+    mlir::Value elementValue = adaptor.getValue();
+    mlir::Value oneElement = rewriter.create<mlir::LLVM::InsertElementOp>(
+        loc, undef, elementValue, indexValue);
+    SmallVector<int32_t> zeroValues(vecTy.getSize(), 0);
+    mlir::Value shuffled = rewriter.create<mlir::LLVM::ShuffleVectorOp>(
+        loc, oneElement, undef, zeroValues);
+    rewriter.replaceOp(op, shuffled);
+    return mlir::success();
+  }
+};
+
 class CIRVectorTernaryLowering
     : public mlir::OpConversionPattern<mlir::cir::VecTernaryOp> {
 public:
@@ -2363,7 +2394,7 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRPtrDiffOpLowering, CIRCopyOpLowering, CIRMemCpyOpLowering,
       CIRFAbsOpLowering, CIRExpectOpLowering, CIRVTableAddrPointOpLowering,
       CIRVectorCreateLowering, CIRVectorInsertLowering,
-      CIRVectorExtractLowering, CIRVectorCmpOpLowering,
+      CIRVectorExtractLowering, CIRVectorCmpOpLowering, CIRVectorSplatLowering,
       CIRVectorTernaryLowering, CIRStackSaveLowering, CIRStackRestoreLowering,
       CIRUnreachableLowering, CIRTrapLowering, CIRInlineAsmOpLowering>(
       converter, patterns.getContext());

--- a/clang/test/CIR/CodeGen/vectype.cpp
+++ b/clang/test/CIR/CodeGen/vectype.cpp
@@ -9,22 +9,22 @@ void vector_int_test(int x) {
   // Vector constant. Not yet implemented. Expected results will change from
   // cir.vec.create to cir.const.
   vi4 a = { 1, 2, 3, 4 };
-  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : !s32i, !s32i, !s32i, !s32i) : <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : !s32i, !s32i, !s32i, !s32i) : !cir.vector<!s32i x 4>
 
   // Non-const vector initialization.
   vi4 b = { x, 5, 6, x + 1 };
-  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : !s32i, !s32i, !s32i, !s32i) : <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : !s32i, !s32i, !s32i, !s32i) : !cir.vector<!s32i x 4>
 
   // Incomplete vector initialization.
   vi4 bb = { x, x + 1 };
   // CHECK: %[[#zero:]] = cir.const(#cir.int<0> : !s32i) : !s32i
-  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}}, %[[#zero]], %[[#zero]] : !s32i, !s32i, !s32i, !s32i) : <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}}, %[[#zero]], %[[#zero]] : !s32i, !s32i, !s32i, !s32i) : !cir.vector<!s32i x 4>
 
   // Scalar to vector conversion, a.k.a. vector splat.  Only valid as an
   // operand of a binary operator, not as a regular conversion.
   bb = a + 7;
   // CHECK: %[[#seven:]] = cir.const(#cir.int<7> : !s32i) : !s32i
-  // CHECK: %{{[0-9]+}} = cir.vec.create(%[[#seven]], %[[#seven]], %[[#seven]], %[[#seven]] : !s32i, !s32i, !s32i, !s32i) : <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.splat %[[#seven]] : !s32i, !cir.vector<!s32i x 4>
 
   // Vector to vector conversion
   vd2 bbb = { };
@@ -33,12 +33,12 @@ void vector_int_test(int x) {
 
   // Extract element
   int c = a[x];
-  // CHECK: %{{[0-9]+}} = cir.vec.extract %{{[0-9]+}}[%{{[0-9]+}} : !s32i] : <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.extract %{{[0-9]+}}[%{{[0-9]+}} : !s32i] : !cir.vector<!s32i x 4>
 
   // Insert element
   a[x] = x;
   // CHECK: %[[#LOADEDVI:]] = cir.load %[[#STORAGEVI:]] : cir.ptr <!cir.vector<!s32i x 4>>, !cir.vector<!s32i x 4>
-  // CHECK: %[[#UPDATEDVI:]] = cir.vec.insert %{{[0-9]+}}, %[[#LOADEDVI]][%{{[0-9]+}} : !s32i] : <!s32i x 4>
+  // CHECK: %[[#UPDATEDVI:]] = cir.vec.insert %{{[0-9]+}}, %[[#LOADEDVI]][%{{[0-9]+}} : !s32i] : !cir.vector<!s32i x 4>
   // CHECK: cir.store %[[#UPDATEDVI]], %[[#STORAGEVI]] : !cir.vector<!s32i x 4>, cir.ptr <!cir.vector<!s32i x 4>>
 
   // Binary arithmetic operations
@@ -69,52 +69,52 @@ void vector_int_test(int x) {
 
   // Ternary conditional operator
   vi4 tc = a ? b : d;
-  // CHECK: %{{[0-9]+}} = cir.vec.ternary(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.ternary(%{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
 
   // Comparisons
   vi4 o = a == b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(eq, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(eq, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
   vi4 p = a != b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(ne, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(ne, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
   vi4 q = a < b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(lt, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(lt, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
   vi4 r = a > b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(gt, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(gt, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
   vi4 s = a <= b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(le, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(le, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
   vi4 t = a >= b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(ge, %{{[0-9]+}}, %{{[0-9]+}}) : <!s32i x 4>, <!s32i x 4>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(ge, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
 }
 
 void vector_double_test(int x, double y) {
   // Vector constant. Not yet implemented. Expected results will change from
   // cir.vec.create to cir.const.
   vd2 a = { 1.5, 2.5 };
-  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}} : !cir.double, !cir.double) : <!cir.double x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}} : !cir.double, !cir.double) : !cir.vector<!cir.double x 2>
 
   // Non-const vector initialization.
   vd2 b = { y, y + 1.0 };
-  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}} : !cir.double, !cir.double) : <!cir.double x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}} : !cir.double, !cir.double) : !cir.vector<!cir.double x 2>
 
   // Incomplete vector initialization
   vd2 bb = { y };
   // CHECK: [[#dzero:]] = cir.const(#cir.fp<0.000000e+00> : !cir.double) : !cir.double
-  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %[[#dzero]] : !cir.double, !cir.double) : <!cir.double x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %[[#dzero]] : !cir.double, !cir.double) : !cir.vector<!cir.double x 2>
 
   // Scalar to vector conversion, a.k.a. vector splat.  Only valid as an
   // operand of a binary operator, not as a regular conversion.
   bb = a + 2.5;
   // CHECK: %[[#twohalf:]] = cir.const(#cir.fp<2.500000e+00> : !cir.double) : !cir.double
-  // CHECK: %{{[0-9]+}} = cir.vec.create(%[[#twohalf]], %[[#twohalf]] : !cir.double, !cir.double) : <!cir.double x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.splat %[[#twohalf]] : !cir.double, !cir.vector<!cir.double x 2>
 
   // Extract element
   double c = a[x];
-  // CHECK: %{{[0-9]+}} = cir.vec.extract %{{[0-9]+}}[%{{[0-9]+}} : !s32i] : <!cir.double x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.extract %{{[0-9]+}}[%{{[0-9]+}} : !s32i] : !cir.vector<!cir.double x 2>
 
   // Insert element
   a[x] = y;
   // CHECK: %[[#LOADEDVF:]] = cir.load %[[#STORAGEVF:]] : cir.ptr <!cir.vector<!cir.double x 2>>, !cir.vector<!cir.double x 2>
-  // CHECK: %[[#UPDATEDVF:]] = cir.vec.insert %{{[0-9]+}}, %[[#LOADEDVF]][%{{[0-9]+}} : !s32i] : <!cir.double x 2>
+  // CHECK: %[[#UPDATEDVF:]] = cir.vec.insert %{{[0-9]+}}, %[[#LOADEDVF]][%{{[0-9]+}} : !s32i] : !cir.vector<!cir.double x 2>
   // CHECK: cir.store %[[#UPDATEDVF]], %[[#STORAGEVF]] : !cir.vector<!cir.double x 2>, cir.ptr <!cir.vector<!cir.double x 2>>
 
   // Binary arithmetic operations
@@ -135,15 +135,15 @@ void vector_double_test(int x, double y) {
 
   // Comparisons
   vll2 o = a == b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(eq, %{{[0-9]+}}, %{{[0-9]+}}) : <!cir.double x 2>, <!s64i x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(eq, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!cir.double x 2>, !cir.vector<!s64i x 2>
   vll2 p = a != b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(ne, %{{[0-9]+}}, %{{[0-9]+}}) : <!cir.double x 2>, <!s64i x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(ne, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!cir.double x 2>, !cir.vector<!s64i x 2>
   vll2 q = a < b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(lt, %{{[0-9]+}}, %{{[0-9]+}}) : <!cir.double x 2>, <!s64i x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(lt, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!cir.double x 2>, !cir.vector<!s64i x 2>
   vll2 r = a > b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(gt, %{{[0-9]+}}, %{{[0-9]+}}) : <!cir.double x 2>, <!s64i x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(gt, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!cir.double x 2>, !cir.vector<!s64i x 2>
   vll2 s = a <= b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(le, %{{[0-9]+}}, %{{[0-9]+}}) : <!cir.double x 2>, <!s64i x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(le, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!cir.double x 2>, !cir.vector<!s64i x 2>
   vll2 t = a >= b;
-  // CHECK: %{{[0-9]+}} = cir.vec.cmp(ge, %{{[0-9]+}}, %{{[0-9]+}}) : <!cir.double x 2>, <!s64i x 2>
+  // CHECK: %{{[0-9]+}} = cir.vec.cmp(ge, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!cir.double x 2>, !cir.vector<!s64i x 2>
 }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -361,7 +361,7 @@ module {
 !s32i = !cir.int<s, 32>
 cir.func @vec_op_size() {
   %0 = cir.const(#cir.int<1> : !s32i) : !s32i
-  %1 = cir.vec.create(%0 : !s32i) : <!s32i x 2> // expected-error {{'cir.vec.create' op operand count of 1 doesn't match vector type '!cir.vector<!cir.int<s, 32> x 2>' element count of 2}}
+  %1 = cir.vec.create(%0 : !s32i) : !cir.vector<!s32i x 2> // expected-error {{'cir.vec.create' op operand count of 1 doesn't match vector type '!cir.vector<!cir.int<s, 32> x 2>' element count of 2}}
   cir.return
 }
 
@@ -372,7 +372,7 @@ cir.func @vec_op_size() {
 cir.func @vec_op_type() {
   %0 = cir.const(#cir.int<1> : !s32i) : !s32i
   %1 = cir.const(#cir.int<2> : !u32i) : !u32i
-  %2 = cir.vec.create(%0, %1 : !s32i, !u32i) : <!s32i x 2> // expected-error {{'cir.vec.create' op operand type '!cir.int<u, 32>' doesn't match vector element type '!cir.int<s, 32>'}}
+  %2 = cir.vec.create(%0, %1 : !s32i, !u32i) : !cir.vector<!s32i x 2> // expected-error {{'cir.vec.create' op operand type '!cir.int<u, 32>' doesn't match vector element type '!cir.int<s, 32>'}}
   cir.return
 }
 
@@ -382,8 +382,8 @@ cir.func @vec_op_type() {
 cir.func @vec_extract_non_int_idx() {
   %0 = cir.const(1.5e+00 : f64) : f64
   %1 = cir.const(#cir.int<0> : !s32i) : !s32i
-  %2 = cir.vec.create(%1, %1 : !s32i, !s32i) : <!s32i x 2>
-  %3 = cir.vec.extract %2[%0 : f64] : <!s32i x 2> // expected-error {{expected '<'}}
+  %2 = cir.vec.create(%1, %1 : !s32i, !s32i) : !cir.vector<!s32i x 2>
+  %3 = cir.vec.extract %2[%0 : f64] : !cir.vector<!s32i x 2> // expected-error {{expected '<'}}
   cir.return
 }
 
@@ -394,8 +394,8 @@ cir.func @vec_extract_non_int_idx() {
 cir.func @vec_extract_bad_type() {
   %0 = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init] {alignment = 4 : i64}
   %1 = cir.const(#cir.int<0> : !s32i) : !s32i
-  %2 = cir.vec.create(%1, %1 : !s32i, !s32i) : <!s32i x 2>
-  %3 = cir.vec.extract %2[%1 : !s32i] : <!s32i x 2> // expected-note {{prior use here}}
+  %2 = cir.vec.create(%1, %1 : !s32i, !s32i) : !cir.vector<!s32i x 2>
+  %3 = cir.vec.extract %2[%1 : !s32i] : !cir.vector<!s32i x 2> // expected-note {{prior use here}}
   cir.store %3, %0 : !u32i, cir.ptr<!u32i> // expected-error {{use of value '%3' expects different type than prior uses: '!cir.int<u, 32>' vs '!cir.int<s, 32>'}}
   cir.return
 }
@@ -405,7 +405,7 @@ cir.func @vec_extract_bad_type() {
 !s32i = !cir.int<s, 32>
 cir.func @vec_extract_non_vector() {
   %0 = cir.const(#cir.int<0> : !s32i) : !s32i
-  %1 = cir.vec.extract %0[%0 : !s32i] : !s32i // expected-error {{custom op 'cir.vec.extract' invalid kind of Type specified}}
+  %1 = cir.vec.extract %0[%0 : !s32i] : !s32i // expected-error {{custom op 'cir.vec.extract' 'vec' must be CIR vector type, but got '!cir.int<s, 32>'}}
   cir.return
 }
 
@@ -415,9 +415,9 @@ cir.func @vec_extract_non_vector() {
 !u32i = !cir.int<u, 32>
 cir.func @vec_insert_bad_type() {
   %0 = cir.const(#cir.int<0> : !s32i) : !s32i
-  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : <!s32i x 2>
+  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : !cir.vector<!s32i x 2>
   %2 = cir.const(#cir.int<0> : !u32i) : !u32i // expected-note {{prior use here}}
-  %3 = cir.vec.insert %2, %1[%0 : !s32i] : <!s32i x 2> // expected-error {{use of value '%2' expects different type than prior uses: '!cir.int<s, 32>' vs '!cir.int<u, 32>'}}
+  %3 = cir.vec.insert %2, %1[%0 : !s32i] : !cir.vector<!s32i x 2> // expected-error {{use of value '%2' expects different type than prior uses: '!cir.int<s, 32>' vs '!cir.int<u, 32>'}}
   cir.return
 }
 
@@ -426,7 +426,7 @@ cir.func @vec_insert_bad_type() {
 !s32i = !cir.int<s, 32>
 cir.func @vec_insert_non_vector() {
   %0 = cir.const(#cir.int<0> : !s32i) : !s32i
-  %1 = cir.vec.insert %0, %0[%0 : !s32i] : !s32i // expected-error {{custom op 'cir.vec.insert' invalid kind of Type specified}}
+  %1 = cir.vec.insert %0, %0[%0 : !s32i] : !s32i // expected-error {{custom op 'cir.vec.insert' 'vec' must be CIR vector type, but got '!cir.int<s, 32>'}}
   cir.return
 }
 
@@ -435,8 +435,8 @@ cir.func @vec_insert_non_vector() {
 !s32i = !cir.int<s, 32>
 cir.func @vec_ternary_non_vector1() {
   %0 = cir.const(#cir.int<0> : !s32i) : !s32i
-  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : <!s32i x 2>
-  %2 = cir.vec.ternary(%0, %1, %1) : !s32i, <!s32i x 2> // expected-error {{custom op 'cir.vec.ternary' invalid kind of Type specified}}
+  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : !cir.vector<!s32i x 2>
+  %2 = cir.vec.ternary(%0, %1, %1) : !s32i, !cir.vector<!s32i x 2> // expected-error {{'cir.vec.ternary' op operand #0 must be !cir.vector of !cir.int, but got '!cir.int<s, 32>'}}
   cir.return
 }
 
@@ -445,8 +445,8 @@ cir.func @vec_ternary_non_vector1() {
 !s32i = !cir.int<s, 32>
 cir.func @vec_ternary_non_vector2() {
   %0 = cir.const(#cir.int<0> : !s32i) : !s32i
-  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : <!s32i x 2>
-  %2 = cir.vec.ternary(%1, %0, %0) : <!s32i x 2>, !s32i // expected-error {{custom op 'cir.vec.ternary' invalid kind of Type specified}}
+  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : !cir.vector<!s32i x 2>
+  %2 = cir.vec.ternary(%1, %0, %0) : !cir.vector<!s32i x 2>, !s32i // expected-error {{'cir.vec.ternary' op operand #1 must be CIR vector type, but got '!cir.int<s, 32>'}}
   cir.return
 }
 
@@ -455,17 +455,17 @@ cir.func @vec_ternary_non_vector2() {
 !s32i = !cir.int<s, 32>
 cir.func @vec_ternary_different_size() {
   %0 = cir.const(#cir.int<0> : !s32i) : !s32i
-  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : <!s32i x 2>
-  %2 = cir.vec.create(%0, %0, %0, %0 : !s32i, !s32i, !s32i, !s32i) : <!s32i x 4>
-  %3 = cir.vec.ternary(%1, %2, %2) : <!s32i x 2>, <!s32i x 4> // expected-error {{'cir.vec.ternary' op the number of elements in '!cir.vector<!cir.int<s, 32> x 2>' and '!cir.vector<!cir.int<s, 32> x 4>' don't match}}
+  %1 = cir.vec.create(%0, %0 : !s32i, !s32i) : !cir.vector<!s32i x 2>
+  %2 = cir.vec.create(%0, %0, %0, %0 : !s32i, !s32i, !s32i, !s32i) : !cir.vector<!s32i x 4>
+  %3 = cir.vec.ternary(%1, %2, %2) : !cir.vector<!s32i x 2>, !cir.vector<!s32i x 4> // expected-error {{'cir.vec.ternary' op : the number of elements in '!cir.vector<!cir.int<s, 32> x 2>' and '!cir.vector<!cir.int<s, 32> x 4>' don't match}}
   cir.return
 }
 
 // -----
 
 cir.func @vec_ternary_not_int(%p : !cir.float) {
-  %0 = cir.vec.create(%p, %p : !cir.float, !cir.float) : <!cir.float x 2>
-  %1 = cir.vec.ternary(%0, %0, %0) : <!cir.float x 2>, <!cir.float x 2> // expected-error {{'cir.vec.ternary' op condition operand of type '!cir.vector<!cir.float x 2>' must be a vector type of !cir.int}}
+  %0 = cir.vec.create(%p, %p : !cir.float, !cir.float) : !cir.vector<!cir.float x 2>
+  %1 = cir.vec.ternary(%0, %0, %0) : !cir.vector<!cir.float x 2>, !cir.vector<!cir.float x 2> // expected-error {{'cir.vec.ternary' op operand #0 must be !cir.vector of !cir.int, but got '!cir.vector<!cir.float x 2>'}}
   cir.return
 }
 

--- a/clang/test/CIR/Lowering/vectype.cpp
+++ b/clang/test/CIR/Lowering/vectype.cpp
@@ -51,6 +51,13 @@ void vector_int_test(int x) {
   // CHECK: %[[#bbval:]] = llvm.bitcast %[[#bval]] : vector<4xi32> to vector<2xf64>
   // CHECK: llvm.store %[[#bbval]], %[[#bbmem:]] : vector<2xf64>, !llvm.ptr
 
+  // Scalar to vector conversion, a.k.a. vector splat.
+  b = a + 7;
+  // CHECK: %[[#undef:]] = llvm.mlir.undef : vector<4xi32>
+  // CHECK: %[[#zeroInt:]] = llvm.mlir.constant(0 : i64) : i64
+  // CHECK: %[[#inserted:]] = llvm.insertelement %[[#seven:]], %[[#undef]][%[[#zeroInt]] : i64] : vector<4xi32>
+  // CHECK: %[[#shuffled:]] = llvm.shufflevector %[[#inserted]], %[[#undef]] [0, 0, 0, 0] : vector<4xi32>
+
   // Extract element.
   int c = a[x];
   // CHECK: %[[#T58:]] = llvm.load %[[#T3]] : !llvm.ptr -> vector<4xi32>


### PR DESCRIPTION
Three small changes, all cleanup or refactoring in nature.

1. Fix the assemblyFormat for all the vector operations in the ClangIR dialect so that vector types appear in ClangIR as `!cir.vector<type x n>` instead of as just `<type x n>`. When I first created the vector ops, I forgot to use `qualified` as necessary when writing out types. This change fixes that. There is no change in behavior, but there is a change to the text version of ClangIR, which required changing the ClangIR expected results and ClangIR inputs in the tests.

2. Create a new `cir.vec.splat` operation and use that for "vector splat", i.e. a conversion from a scalar to a vector. A "vector splat" conversion had been implemented with `cir.vec.create` before. This change results in different ClangIR and different LLVM IR, which again required updating the tests, but no noticeable change in compiler behavior.

3. Create an `IntegerVector` type constraint, which requires that the given type be a vector whose element type is an integer. It can be any integral type, and the vector can be of any size.  Use the new type constraint in the definition of `cir.vec.ternary`, whose condition operand must be an `IntegerVector`.  Remove the integral type check from `VecTernaryOp::verify`, since doing the check there is now redundant. The only possibly visible change is to the text of an error message when validation of `cir.vec.ternary` fails.  The expected output of a validation test was updated with the new message.