### PR TITLE
[CIR][CIRGen] Support for __builtin_prefetch

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3205,6 +3205,41 @@ def TrapOp : CIR_Op<"trap", [Terminator]> {
 }
 
 //===----------------------------------------------------------------------===//
+// PrefetchOp
+//===----------------------------------------------------------------------===//
+
+def PrefetchOp : CIR_Op<"prefetch"> {
+  let summary = "prefetch operation";
+  let description = [{
+    The `cir.prefetch` op prefetches data from the memmory address.
+
+    ```mlir
+    cir.prefetch(%0 : !cir.ptr<!void>) locality(1) write
+    ```
+
+    This opcode has the three attributes:
+    1. The $locality is a temporal locality specifier
+    ranging from (0) - no locality, to (3) - extremely local keep in cache.
+    2. The $isWrite is the specifier determining if the prefetch is prepaired
+    for a 'read' or 'write'.
+    If $isWrite doesn't specified it means that prefetch is prepared for 'read'.
+  }];
+
+  let arguments = (
+    ins VoidPtr:$addr,
+        ConfinedAttr<I32Attr, [IntMinValue<0>,
+          IntMaxValue<3>]>:$locality,
+        UnitAttr:$isWrite);
+
+  let assemblyFormat = [{
+    `(` $addr `:` qualified(type($addr)) `)`
+        `locality``(` $locality `)`
+        (`write` $isWrite^) : (`read`)?
+        attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Operations Lowered Directly to LLVM IR
 //
 // These operations are hacks to get around missing features in LLVM's dialect.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2575,7 +2575,21 @@ class CIRInlineAsmOpLowering
         /*is_align_stack*/ mlir::UnitAttr(),
         mlir::LLVM::AsmDialectAttr::get(getContext(), llDialect),
         rewriter.getArrayAttr(opAttrs));
+    return mlir::success();
+  }
+};
 
+class CIRPrefetchLowering
+    : public mlir::OpConversionPattern<mlir::cir::PrefetchOp> {
+public:
+  using OpConversionPattern<mlir::cir::PrefetchOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::PrefetchOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::Prefetch>(
+        op, adaptor.getAddr(), adaptor.getIsWrite(), adaptor.getLocality(),
+        /*DataCache*/ 1);
     return mlir::success();
   }
 };
@@ -2731,8 +2745,8 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRVectorExtractLowering, CIRVectorCmpOpLowering, CIRVectorSplatLowering,
       CIRVectorTernaryLowering, CIRStackSaveLowering, CIRStackRestoreLowering,
       CIRUnreachableLowering, CIRTrapLowering, CIRInlineAsmOpLowering,
-      CIRSetBitfieldLowering, CIRGetBitfieldLowering>(converter,
-                                                      patterns.getContext());
+      CIRSetBitfieldLowering, CIRGetBitfieldLowering, CIRPrefetchLowering>(
+      converter, patterns.getContext());
 }
 
 namespace {

--- a/clang/test/CIR/CodeGen/builtin-prefetch.c
+++ b/clang/test/CIR/CodeGen/builtin-prefetch.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
+
+void foo(void *a) {
+  __builtin_prefetch(a, 1, 1);
+}
+
+// CIR:  cir.func @foo(%arg0: !cir.ptr<!void> loc({{.*}}))
+// CIR:    [[PTR_ALLOC:%.*]] = cir.alloca !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>, ["a", init] {alignment = 8 : i64}
+// CIR:    cir.store %arg0, [[PTR_ALLOC]] : !cir.ptr<!void>, cir.ptr <!cir.ptr<!void>>
+// CIR:    [[PTR:%.*]] = cir.load [[PTR_ALLOC]] : cir.ptr <!cir.ptr<!void>>, !cir.ptr<!void>
+// CIR:    cir.prefetch([[PTR]] : !cir.ptr<!void>) locality(1) write
+// CIR:    cir.return
+
+// LLVM:  define void @foo(ptr [[ARG0:%.*]])
+// LLVM:    [[PTR_ALLOC:%.*]] = alloca ptr, i64 1
+// LLVM:    store ptr [[ARG0]], ptr [[PTR_ALLOC]]
+// LLVM:    [[PTR:%.*]] = load ptr, ptr [[PTR_ALLOC]]
+// LLVM:    call void @llvm.prefetch.p0(ptr [[PTR]], i32 1, i32 1, i32 1)
+// LLVM:    ret void


### PR DESCRIPTION
This PR adds support for `__builtin_prefetch`. CIRGen of this builtin emits the new 'cir.prefetch' opcode. Then `cir.prefetch` lowers to `llvm.prefetch` intrinsic.