### PR TITLE
[CIR][CIRGen] Support for __builtin_constant_p

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3284,6 +3284,23 @@ def ArrayDtor : CIR_ArrayInitDestroy<"array.dtor"> {
 }
 
 //===----------------------------------------------------------------------===//
+// IsConstantOp
+//===----------------------------------------------------------------------===//
+
+def IsConstantOp : CIR_Op<"is_constant", [Pure]> {
+  let description = [{
+    Returns `true` if the argument is known to be a compile-time constant
+    otherwise returns 'false'.
+  }];
+  let arguments = (ins CIR_AnyType:$val);
+  let results = (outs CIR_BoolType:$result);
+
+  let assemblyFormat = [{
+    `(` $val `:` type($val) `)` `:` type($result) attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Operations Lowered Directly to LLVM IR
 //
 // These operations are hacks to get around missing features in LLVM's dialect.

--- a/clang/test/CIR/CodeGen/builtin-constant-p.c
+++ b/clang/test/CIR/CodeGen/builtin-constant-p.c
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
+
+int a = 0;
+int foo() {
+  return __builtin_constant_p(a);
+}
+
+// CIR:  cir.func no_proto @foo() -> !s32i extra(#fn_attr)
+// CIR:    [[TMP0:%.*]] = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
+// CIR:    [[TMP1:%.*]] = cir.get_global @a : cir.ptr <!s32i>
+// CIR:    [[TMP2:%.*]] = cir.load [[TMP1]] : cir.ptr <!s32i>, !s32i
+// CIR:    [[TMP3:%.*]] = cir.is_constant([[TMP2]] : !s32i) : !cir.bool
+// CIR:    [[TMP4:%.*]] = cir.cast(bool_to_int, [[TMP3]] : !cir.bool), !s32i
+// CIR:    cir.store [[TMP4]], [[TMP0]] : !s32i, cir.ptr <!s32i>
+// CIR:    [[TMP5:%.*]] = cir.load [[TMP0]] : cir.ptr <!s32i>, !s32i
+// CIR:    cir.return [[TMP5]] : !s32i
+
+// LLVM:define i32 @foo()
+// LLVM:  [[TMP1:%.*]] = alloca i32, i64 1
+// LLVM:  [[TMP2:%.*]] = load i32, ptr @a
+// LLVM:  [[TMP3:%.*]] = call i1 @llvm.is.constant.i32(i32 [[TMP2]])
+// LLVM:  [[TMP4:%.*]] = zext i1 [[TMP3]] to i8
+// LLVM:  [[TMP5:%.*]] = zext i8 [[TMP4]] to i32
+// LLVM:  store i32 [[TMP5]], ptr [[TMP1]]
+// LLVM:  [[TMP6:%.*]] = load i32, ptr [[TMP1]]
+// LLVM:  ret i32 [[TMP6]]
+


### PR DESCRIPTION
This PR adds support for `__builtin_constant_p`.
Implementation introduces the new `cr.is_constant` opcode to it during the codegeneration of builtin.
Codegeneration is taken from the original llvm codegen.