### PR TITLE
[CIR] adds MemRead/MemWrite markers to bitfield ops

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1758,7 +1758,7 @@ def SetBitfieldOp : CIR_Op<"set_bitfield"> {
    }];
 
   let arguments = (ins
-    CIR_PointerType:$dst,
+    Arg<CIR_PointerType, "the address to store the value", [MemWrite]>:$addr,
     CIR_AnyType:$src,
     BitfieldInfoAttr:$bitfield_info,
     UnitAttr:$is_volatile
@@ -1766,12 +1766,12 @@ def SetBitfieldOp : CIR_Op<"set_bitfield"> {
 
   let results = (outs CIR_IntType:$result);
 
-  let assemblyFormat = [{ `(`$bitfield_info`,` $dst`:`qualified(type($dst))`,`
+  let assemblyFormat = [{ `(`$bitfield_info`,` $addr`:`qualified(type($addr))`,`
     $src`:`type($src) `)`  attr-dict `->` type($result) }];
 
   let builders = [
     OpBuilder<(ins "Type":$type,
-                   "Value":$dst,
+                   "Value":$addr,
                    "Type":$storage_type,
                    "Value":$src,
                    "StringRef":$name,
@@ -1785,7 +1785,7 @@ def SetBitfieldOp : CIR_Op<"set_bitfield"> {
         BitfieldInfoAttr::get($_builder.getContext(),
                               name, storage_type,
                               size, offset, is_signed);
-      build($_builder, $_state, type, dst, src, info, is_volatile);
+      build($_builder, $_state, type, addr, src, info, is_volatile);
     }]>
   ];
 }
@@ -1837,7 +1837,7 @@ def GetBitfieldOp : CIR_Op<"get_bitfield"> {
     }];
 
   let arguments = (ins
-    CIR_PointerType:$addr,
+    Arg<CIR_PointerType, "the address to load from", [MemRead]>:$addr,
     BitfieldInfoAttr:$bitfield_info,
     UnitAttr:$is_volatile
     );

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2591,7 +2591,7 @@ public:
     mlir::OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
 
-    auto addr = op.getDst();
+    auto addr = op.getAddr();
     auto info = op.getBitfieldInfo();
     auto size = info.getSize();
     auto offset = info.getOffset();
@@ -2617,7 +2617,7 @@ public:
       assert(storageSize > size && "Invalid bitfield size.");
 
       mlir::Value val = rewriter.create<mlir::LLVM::LoadOp>(
-          op.getLoc(), intType, adaptor.getDst(), /* alignment */ 0,
+          op.getLoc(), intType, adaptor.getAddr(), /* alignment */ 0,
           op.getIsVolatile());
 
       srcVal = createAnd(rewriter, srcVal,
@@ -2634,7 +2634,8 @@ public:
       srcVal = rewriter.create<mlir::LLVM::OrOp>(op.getLoc(), val, srcVal);
     }
 
-    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), srcVal, adaptor.getDst(),
+    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), srcVal, 
+                                         adaptor.getAddr(),
                                          /* alignment */ 0, op.getIsVolatile());
 
     auto resultTy = getTypeConverter()->convertType(op.getType());

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2634,8 +2634,7 @@ public:
       srcVal = rewriter.create<mlir::LLVM::OrOp>(op.getLoc(), val, srcVal);
     }
 
-    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), srcVal, 
-                                         adaptor.getAddr(),
+    rewriter.create<mlir::LLVM::StoreOp>(op.getLoc(), srcVal, adaptor.getAddr(),
                                          /* alignment */ 0, op.getIsVolatile());
 
     auto resultTy = getTypeConverter()->convertType(op.getType());


### PR DESCRIPTION
This PR adds MemRead/MemWrite  markers to the `GetBitfieldOp` and `SetBitfieldOp` (as discussed in #487)
Also, minor renaming in the `SetBitfieldOp`