### PR TITLE
[CIR][OpenMP] Implementation of taskwait, taskyield and barrier

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -975,6 +975,8 @@ public:
   // OpenMP gen functions:
   mlir::LogicalResult buildOMPParallelDirective(const OMPParallelDirective &S);
   mlir::LogicalResult buildOMPTaskwaitDirective(const OMPTaskwaitDirective &S);
+  mlir::LogicalResult buildOMPTaskyieldDirective(const OMPTaskyieldDirective &S);
+  
   LValue buildOpaqueValueLValue(const OpaqueValueExpr *e);
 
   /// Emit code to compute a designator that specifies the location

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -974,7 +974,7 @@ public:
 
   // OpenMP gen functions:
   mlir::LogicalResult buildOMPParallelDirective(const OMPParallelDirective &S);
-
+  mlir::LogicalResult buildOMPTaskwaitDirective(const OMPTaskwaitDirective &S);
   LValue buildOpaqueValueLValue(const OpaqueValueExpr *e);
 
   /// Emit code to compute a designator that specifies the location

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -976,6 +976,7 @@ public:
   mlir::LogicalResult buildOMPParallelDirective(const OMPParallelDirective &S);
   mlir::LogicalResult buildOMPTaskwaitDirective(const OMPTaskwaitDirective &S);
   mlir::LogicalResult buildOMPTaskyieldDirective(const OMPTaskyieldDirective &S);
+  mlir::LogicalResult buildOMPBarrierDirective(const OMPBarrierDirective &S);
   
   LValue buildOpaqueValueLValue(const OpaqueValueExpr *e);
 

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -180,6 +180,8 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
     return buildOMPTaskwaitDirective(cast<OMPTaskwaitDirective>(*S));
   case Stmt::OMPTaskyieldDirectiveClass:
     return buildOMPTaskyieldDirective(cast<OMPTaskyieldDirective>(*S));
+  case Stmt::OMPBarrierDirectiveClass: 
+    return buildOMPBarrierDirective(cast<OMPBarrierDirective>(*S)); 
   // Unsupported AST nodes:
   case Stmt::CapturedStmtClass:
   case Stmt::ObjCAtTryStmtClass:
@@ -207,7 +209,6 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
   case Stmt::OMPParallelMasterDirectiveClass:
   case Stmt::OMPParallelSectionsDirectiveClass:
   case Stmt::OMPTaskDirectiveClass:
-  case Stmt::OMPBarrierDirectiveClass:
   case Stmt::OMPTaskgroupDirectiveClass:
   case Stmt::OMPFlushDirectiveClass:
   case Stmt::OMPDepobjDirectiveClass:

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -178,6 +178,8 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
     return buildOMPParallelDirective(cast<OMPParallelDirective>(*S));
   case Stmt::OMPTaskwaitDirectiveClass:
     return buildOMPTaskwaitDirective(cast<OMPTaskwaitDirective>(*S));
+  case Stmt::OMPTaskyieldDirectiveClass:
+    return buildOMPTaskyieldDirective(cast<OMPTaskyieldDirective>(*S));
   // Unsupported AST nodes:
   case Stmt::CapturedStmtClass:
   case Stmt::ObjCAtTryStmtClass:
@@ -205,7 +207,6 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
   case Stmt::OMPParallelMasterDirectiveClass:
   case Stmt::OMPParallelSectionsDirectiveClass:
   case Stmt::OMPTaskDirectiveClass:
-  case Stmt::OMPTaskyieldDirectiveClass:
   case Stmt::OMPBarrierDirectiveClass:
   case Stmt::OMPTaskgroupDirectiveClass:
   case Stmt::OMPFlushDirectiveClass:

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -176,6 +176,8 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
   // OMP directives:
   case Stmt::OMPParallelDirectiveClass:
     return buildOMPParallelDirective(cast<OMPParallelDirective>(*S));
+  case Stmt::OMPTaskwaitDirectiveClass:
+    return buildOMPTaskwaitDirective(cast<OMPTaskwaitDirective>(*S));
   // Unsupported AST nodes:
   case Stmt::CapturedStmtClass:
   case Stmt::ObjCAtTryStmtClass:
@@ -205,7 +207,6 @@ mlir::LogicalResult CIRGenFunction::buildStmt(const Stmt *S,
   case Stmt::OMPTaskDirectiveClass:
   case Stmt::OMPTaskyieldDirectiveClass:
   case Stmt::OMPBarrierDirectiveClass:
-  case Stmt::OMPTaskwaitDirectiveClass:
   case Stmt::OMPTaskgroupDirectiveClass:
   case Stmt::OMPFlushDirectiveClass:
   case Stmt::OMPDepobjDirectiveClass:

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -43,3 +43,15 @@ CIRGenFunction::buildOMPParallelDirective(const OMPParallelDirective &S) {
   builder.create<TerminatorOp>(getLoc(S.getSourceRange().getEnd()));
   return res;
 }
+
+mlir::LogicalResult 
+CIRGenFunction::buildOMPTaskwaitDirective(const OMPTaskwaitDirective &S) {
+  mlir::LogicalResult res = mlir::success();
+  //Getting the source location information of AST node S scope
+  auto scopeLoc = getLoc(S.getSourceRange());
+  //Creation of an omp.taskwait operation
+  auto taskwaitOp = builder.create<mlir::omp::TaskwaitOp>(scopeLoc);
+
+  return res;
+
+}

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -47,11 +47,21 @@ CIRGenFunction::buildOMPParallelDirective(const OMPParallelDirective &S) {
 mlir::LogicalResult 
 CIRGenFunction::buildOMPTaskwaitDirective(const OMPTaskwaitDirective &S) {
   mlir::LogicalResult res = mlir::success();
-  //Getting the source location information of AST node S scope
+  // Getting the source location information of AST node S scope
   auto scopeLoc = getLoc(S.getSourceRange());
-  //Creation of an omp.taskwait operation
+  // Creation of an omp.taskwait operation
   auto taskwaitOp = builder.create<mlir::omp::TaskwaitOp>(scopeLoc);
 
   return res;
 
+}
+mlir::LogicalResult 
+CIRGenFunction::buildOMPTaskyieldDirective(const OMPTaskyieldDirective &S){
+  mlir::LogicalResult res = mlir::success();
+  // Getting the source location information of AST node S scope
+  auto scopeLoc = getLoc(S.getSourceRange());
+  // Creation of an omp.taskyield operation
+  auto taskyieldOp = builder.create<mlir::omp::TaskyieldOp>(scopeLoc);
+
+  return res;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -65,3 +65,14 @@ CIRGenFunction::buildOMPTaskyieldDirective(const OMPTaskyieldDirective &S){
 
   return res;
 }
+
+mlir::LogicalResult
+CIRGenFunction::buildOMPBarrierDirective(const OMPBarrierDirective &S){
+  mlir::LogicalResult res = mlir::success();
+  // Getting the source location information of AST node S scope
+  auto scopeLoc = getLoc(S.getSourceRange());
+  // Creation of an omp.barrier operation
+  auto barrierOp = builder.create<mlir::omp::BarrierOp>(scopeLoc);
+
+  return res;
+}

--- a/clang/test/CIR/CodeGen/barrier.cpp
+++ b/clang/test/CIR/CodeGen/barrier.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fopenmp -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// CHECK: cir.func
+void omp_barrier_1(){
+// CHECK: omp.barrier
+  #pragma omp barrier
+}

--- a/clang/test/CIR/CodeGen/taskwait.cpp
+++ b/clang/test/CIR/CodeGen/taskwait.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fopenmp -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// CHECK: cir.func
+void omp_taskwait_1(){
+// CHECK: omp.taskwait
+  #pragma omp taskwait
+}

--- a/clang/test/CIR/CodeGen/taskyield.cpp
+++ b/clang/test/CIR/CodeGen/taskyield.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fopenmp -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// CHECK: cir.func
+void omp_taskyield_1(){
+// CHECK: omp.taskyield
+  #pragma omp taskyield
+}

--- a/clang/test/CIR/Lowering/barrier.cir
+++ b/clang/test/CIR/Lowering/barrier.cir
@@ -1,0 +1,14 @@
+// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+
+
+module {
+  cir.func @omp_barrier_1() {
+    omp.barrier
+    cir.return
+  }
+}
+
+// CHECK: define void @omp_barrier_1()
+// CHECK: call i32 @__kmpc_global_thread_num(ptr {{.*}})
+// CHECK: call void @__kmpc_barrier(ptr {{.*}}, i32 {{.*}})
+// CHECK: ret void

--- a/clang/test/CIR/Lowering/taskwait.cir
+++ b/clang/test/CIR/Lowering/taskwait.cir
@@ -1,0 +1,14 @@
+// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+
+
+module {
+  cir.func @omp_taskwait_1() {
+    omp.taskwait
+    cir.return
+  }
+}
+
+// CHECK: define void @omp_taskwait_1()
+// CHECK: call i32 @__kmpc_global_thread_num(ptr {{.*}})
+// CHECK: call i32 @__kmpc_omp_taskwait(ptr {{.*}}, i32 {{.*}})
+// CHECK: ret void

--- a/clang/test/CIR/Lowering/taskyield.cir
+++ b/clang/test/CIR/Lowering/taskyield.cir
@@ -1,0 +1,14 @@
+// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+
+
+module {
+  cir.func @omp_taskyield_1() {
+    omp.taskyield
+    cir.return
+  }
+}
+
+// CHECK: define void @omp_taskyield_1()
+// CHECK: call i32 @__kmpc_global_thread_num(ptr {{.*}})
+// CHECK: call i32 @__kmpc_omp_taskyield(ptr {{.*}}, i32 {{.*}}, i32 {{.*}})
+// CHECK: ret void

--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -139,6 +139,10 @@ libomp_get_asmflags(LIBOMP_CONFIGURED_ASMFLAGS)
 set_source_files_properties(${LIBOMP_CXXFILES} PROPERTIES COMPILE_FLAGS "${LIBOMP_CONFIGURED_CXXFLAGS}")
 set_source_files_properties(${LIBOMP_ASMFILES} ${LIBOMP_GNUASMFILES} PROPERTIES COMPILE_FLAGS "${LIBOMP_CONFIGURED_ASMFLAGS}")
 
+add_definitions(-U_GLIBCXX_ASSERTIONS)
+add_definitions(-U_LIBCPP_ENABLE_ASSERTIONS)
+
+
 # Remove any cmake-automatic linking of the standard C++ library.
 # We neither need (nor want) the standard C++ library dependency even though we compile c++ files.
 if(NOT ${LIBOMP_USE_STDCPPLIB})


### PR DESCRIPTION
This solves #499. I think this might be unnecessary, but I wasn't able to correctly compile the ClangIR project without the definitions I've added to openmp cmake as described in https://github.com/llvm/llvm-project/pull/73249. Feedback is greatly appreciated!