### PR TITLE
[CIR][CodeGen] Inline assembly: store the results

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3367,11 +3367,9 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     $asm_flavor`,`
     `operands` `=` `[` operands `:` type($operands) `]`
     (`attrs` `=` $operand_attrs^)?
-    `\n`  ` `  ` `  ` `  ` `  ` `  ` `
-
+    `\n`  ` `  ` `  ` `  ` `  ` `  ` `  ` `
     `{` $asm_string $constraints `}`
     `)`
-
     (`side_effects` $side_effects^)?
     attr-dict
     (`->` type($res)^)?

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3365,7 +3365,7 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
   let assemblyFormat = [{
     `(`
     $asm_flavor`,`
-    `operands` `=` `[` operands `:` type($operands) `]`
+    `operands` `=` `[` $operands (`:`  type($operands)^)? `]`
     (`attrs` `=` $operand_attrs^)?
     `\n`  ` `  ` `  ` `  ` `  ` `  ` `  ` `
     `{` $asm_string $constraints `}`

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3376,20 +3376,6 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
   ];
   
   let hasCustomAssemblyFormat = 1;
-
-  // let assemblyFormat = [{
-  //   `(`
-  //   $asm_flavor`,`
-  //   `operands` `=` `[` $operands (`:`  type($operands)^)? `]` `,`
-  //   (`attrs` `=` $operand_attrs^)?
-  //   `)` `{` `\n`
-  //   $asm_string $constraints
-  //   `}`
-  //   (`side_effects` $side_effects^)?
-  //   (`->` type($res)^)?
-  //   attr-dict
-  //  }];
-
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -31,6 +31,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/IR/CommonAttrConstraints.td"
 
 //===----------------------------------------------------------------------===//
 // CIR Ops
@@ -3355,25 +3356,39 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
   let results = (outs Optional<CIR_AnyType>:$res);
 
   let arguments = (
-    ins Variadic<AnyType>:$operands,
+    ins VariadicOfVariadic<AnyType, "operands_segments">:$operands,
         StrAttr:$asm_string,
         StrAttr:$constraints,
         UnitAttr:$side_effects,
         AsmFlavor:$asm_flavor,
-        OptionalAttr<ArrayAttr>:$operand_attrs);
+        ArrayAttr:$operand_attrs,
+        DenseI32ArrayAttr:$operands_segments
+        );
 
-  let assemblyFormat = [{
-    `(`
-    $asm_flavor`,`
-    `operands` `=` `[` $operands (`:`  type($operands)^)? `]` `,`
-    (`attrs` `=` $operand_attrs^)?
-    `)` `{` `\n`
-    $asm_string $constraints
-    `}`
-    (`side_effects` $side_effects^)?
-    (`->` type($res)^)?
-    attr-dict
-   }];
+  let builders = [OpBuilder<(ins
+    "ArrayRef<ValueRange>":$operands,
+    "StringRef":$asm_string,
+    "StringRef":$constraints,
+    "bool":$side_effects,
+    "AsmFlavor":$asm_flavor,
+    "ArrayRef<Attribute>":$operand_attrs
+  )>
+  ];
+  
+  let hasCustomAssemblyFormat = 1;
+
+  // let assemblyFormat = [{
+  //   `(`
+  //   $asm_flavor`,`
+  //   `operands` `=` `[` $operands (`:`  type($operands)^)? `]` `,`
+  //   (`attrs` `=` $operand_attrs^)?
+  //   `)` `{` `\n`
+  //   $asm_string $constraints
+  //   `}`
+  //   (`side_effects` $side_effects^)?
+  //   (`->` type($res)^)?
+  //   attr-dict
+  //  }];
 
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3330,9 +3330,11 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     - the output variable index referenced by the input operands.
     - the index of early-clobber operand
 
-    Operand attributes is a storage of attributes, where each element corresponds
-    to the operand with the same index. The first index relates to the operation
-    result.
+    Operand attributes is a storage, where each element corresponds to the operand with
+    the same index. The first index relates to the operation result (if any).
+
+    Note, when several output operands are present, the result type may be represented as
+    an anon struct type.
 
     Example:
     ```C++
@@ -3342,14 +3344,32 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     ```
     
     ```mlir
+    !ty_22anon2E022 = !cir.struct<struct "anon.0" {!cir.int<s, 32>, !cir.int<s, 32>}>
+    !ty_22anon2E122 = !cir.struct<struct "anon.1" {!cir.int<s, 32>, !cir.int<s, 32>}>
+    ...
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] 
     %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["y", init]
     ... 
     %2 = cir.load %0 : cir.ptr <!s32i>, !s32i
     %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
-    cir.asm(x86_att, {"foo" "~{dirflag},~{fpsr},~{flags}"}) side_effects : () -> ()
-    cir.asm(x86_att, {"bar $$42 $0" "=r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) %2 : (!s32i) -> ()
-    cir.asm(x86_att, {"baz $$42 $0" "=r,=&r,0,1,~{dirflag},~{fpsr},~{flags}"}) %3, %2 : (!s32i, !s32i) -> ()
+
+    cir.asm(x86_att,
+      out = [],
+      in = [],
+      in_out = [],
+      {"foo" "~{dirflag},~{fpsr},~{flags}"}) side_effects
+
+    cir.asm(x86_att,
+      out = [],
+      in = [],
+      in_out = [%2 : !s32i],
+      {"bar $$42 $0" "=r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) -> !ty_22anon2E022
+
+    cir.asm(x86_att,
+      out = [],
+      in = [%3 : !s32i],
+      in_out = [%2 : !s32i],
+      {"baz $$42 $0" "=r,=&r,0,1,~{dirflag},~{fpsr},~{flags}"}) -> !ty_22anon2E122
     ```
   }];
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3367,12 +3367,12 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     $asm_flavor`,`
     `operands` `=` `[` $operands (`:`  type($operands)^)? `]`
     (`attrs` `=` $operand_attrs^)?
-    `\n`  ` `  ` `  ` `  ` `  ` `  ` `  ` `
-    `{` $asm_string $constraints `}`
-    `)`
+    `)` `{` `\n`
+    $asm_string $constraints
+    `}`
     (`side_effects` $side_effects^)?
-    attr-dict
     (`->` type($res)^)?
+    attr-dict
    }];
 
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3331,7 +3331,9 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     - the index of early-clobber operand
 
     Operand attributes is a storage, where each element corresponds to the operand with
-    the same index. The first index relates to the operation result (if any).
+    the same index. The first index relates to the operation result (if any). 
+    Note, the operands themselves are stored as VariadicOfVariadic in the next order:
+    output, input and then in/out operands.
 
     Note, when several output operands are present, the result type may be represented as
     an anon struct type.

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3365,7 +3365,7 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
   let assemblyFormat = [{
     `(`
     $asm_flavor`,`
-    `operands` `=` `[` $operands (`:`  type($operands)^)? `]`
+    `operands` `=` `[` $operands (`:`  type($operands)^)? `]` `,`
     (`attrs` `=` $operand_attrs^)?
     `)` `{` `\n`
     $asm_string $constraints

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3365,12 +3365,16 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
   let assemblyFormat = [{
     `(`
     $asm_flavor`,`
+    `operands` `=` `[` operands `:` type($operands) `]`
+    (`attrs` `=` $operand_attrs^)?
+    `\n`  ` `  ` `  ` `  ` `  ` `  ` `
+
     `{` $asm_string $constraints `}`
     `)`
-    (`operand_attrs` `=` $operand_attrs^)?
+
     (`side_effects` $side_effects^)?
     attr-dict
-    operands `:` functional-type(operands, results)
+    (`->` type($res)^)?
    }];
 
 }

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -650,8 +650,8 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
       }
     }
 
-    assert(Args.size() == operandAttrs.size() 
-      && "The number of attributes is not even with the number of operands");
+    assert(Args.size() == operandAttrs.size() &&
+           "The number of attributes is not even with the number of operands");
 
     IA.setOperandAttrsAttr(builder.getArrayAttr(operandAttrs));
 

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -653,10 +653,9 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
       if (typ) {
         auto op = Args[i++];
         assert(op.getType().isa<mlir::cir::PointerType>() &&
-          "pointer type expected"
-        );
-        assert(cast<mlir::cir::PointerType>(op.getType()).getPointee() == typ
-          && "element type differs from pointee type!");
+               "pointer type expected");
+        assert(cast<mlir::cir::PointerType>(op.getType()).getPointee() == typ &&
+               "element type differs from pointee type!");
 
         operandAttrs.push_back(mlir::UnitAttr::get(builder.getContext()));
       } else {

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -639,13 +639,6 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
 
     std::vector<mlir::Attribute> operandAttrs;
 
-    // this is for the lowering to LLVM from LLVm dialect. Otherwise, if we
-    // don't have the result (i.e. void type as a result of operation), the
-    // element type attribute will be attached to the whole instruction, but not
-    // to the operand
-    if (!IA.getNumResults())
-      operandAttrs.push_back(OptNoneAttr::get(builder.getContext()));
-
     for (auto typ : ArgElemTypes) {
       if (typ) {
         operandAttrs.push_back(mlir::TypeAttr::get(typ));

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -650,6 +650,9 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
       }
     }
 
+    assert(Args.size() == operandAttrs.size() 
+      && "The number of attributes is not even with the number of operands");
+
     IA.setOperandAttrsAttr(builder.getArrayAttr(operandAttrs));
 
     if (ResultRegTypes.size() == 1) {

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -669,7 +669,7 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
       auto addr = Address(dest, alignment);
       builder.createStore(getLoc(S.getAsmLoc()), result, addr);
 
-      for (unsigned i = 0, e = ResultRegTypes.size(); i != e; ++i) {        
+      for (unsigned i = 0, e = ResultRegTypes.size(); i != e; ++i) {
         auto typ = builder.getPointerTo(ResultRegTypes[i]);
         auto ptr =
             builder.createGetMember(getLoc(S.getAsmLoc()), typ, dest, "", i);

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -653,8 +653,6 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
         // the lowering to LLVM IR the attributes will be assigned to the
         // CallInsn argument by index, i.e. we can't skip null type here
         operandAttrs.push_back(mlir::Attribute());
-        //operandAttrs.push_back(mlir::UnitAttr::get(builder.getContext()));
-        //operandAttrs.push_back(OptNoneAttr::get(builder.getContext()));
       }
     }
 

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -639,17 +639,12 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
       auto addr = Address(dest, alignment);
       builder.createStore(getLoc(S.getAsmLoc()), result, addr);
 
-      for (unsigned i = 0, e = ResultRegTypes.size(); i != e; ++i) {
-        // TODO: double check. The point is the elt in the reg types should be
-        // the same that is returned by getMember, i.e. should be a pointer.
+      for (unsigned i = 0, e = ResultRegTypes.size(); i != e; ++i) {        
         auto typ = builder.getPointerTo(ResultRegTypes[i]);
-
         auto ptr =
             builder.createGetMember(getLoc(S.getAsmLoc()), typ, dest, "", i);
-
         auto tmp =
             builder.createLoad(getLoc(S.getAsmLoc()), Address(ptr, alignment));
-        // TODO: do we need to load after the getMember?
         RegResults.push_back(tmp);
       }
     }

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -603,7 +603,6 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
   for (unsigned i = 0, e = InOutArgs.size(); i != e; i++) {
     ArgTypes.push_back(InOutArgTypes[i]);
     ArgElemTypes.push_back(InOutArgElemTypes[i]);
-    //Args.push_back(InOutArgs[i]);
   }
   Constraints += InOutConstraints;
 
@@ -656,8 +655,9 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
       }
     }
 
-    // assert(Args.size() == operandAttrs.size() &&
-    //        "The number of attributes is not even with the number of operands");
+    auto size = OutArgs.size() + InOutArgs.size() + InArgs.size();
+    assert(size == operandAttrs.size() &&
+           "The number of attributes is not even with the number of operands");
 
     IA.setOperandAttrsAttr(builder.getArrayAttr(operandAttrs));
 

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -52,6 +52,13 @@ public:
     return Ty;
   }
 
+  virtual void addReturnRegisterOutputs(
+      CIRGenFunction &CGF, LValue ReturnValue,
+      std::string &Constraints, std::vector<mlir::Type> &ResultRegTypes,
+      std::vector<mlir::Type> &ResultTruncRegTypes,
+      std::vector<LValue> &ResultRegDests, std::string &AsmString,
+      unsigned NumOutputs) const {}
+
   virtual ~TargetCIRGenInfo() {}
 };
 

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -52,12 +52,13 @@ public:
     return Ty;
   }
 
-  virtual void addReturnRegisterOutputs(
-      CIRGenFunction &CGF, LValue ReturnValue,
-      std::string &Constraints, std::vector<mlir::Type> &ResultRegTypes,
-      std::vector<mlir::Type> &ResultTruncRegTypes,
-      std::vector<LValue> &ResultRegDests, std::string &AsmString,
-      unsigned NumOutputs) const {}
+  virtual void
+  addReturnRegisterOutputs(CIRGenFunction &CGF, LValue ReturnValue,
+                           std::string &Constraints,
+                           std::vector<mlir::Type> &ResultRegTypes,
+                           std::vector<mlir::Type> &ResultTruncRegTypes,
+                           std::vector<LValue> &ResultRegDests,
+                           std::string &AsmString, unsigned NumOutputs) const {}
 
   virtual ~TargetCIRGenInfo() {}
 };

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -171,6 +171,7 @@ struct UnimplementedFeature {
   static bool asm_unwind_clobber() { return false; }
   static bool asm_memory_effects() { return false; }
   static bool asm_vector_type() { return false; }
+  static bool asm_llvm_assume() { return false; }
 };
 } // namespace cir
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2916,7 +2916,7 @@ ParseResult cir::InlineAsmOp::parse(OpAsmParser &parser, OperationState &result)
     
   if (parser.parseOptionalArrow().succeeded());
     parser.parseType(resType);
-  
+
   if (parser.parseOptionalAttrDict(result.attributes))
     return mlir::failure();
 
@@ -2925,7 +2925,9 @@ ParseResult cir::InlineAsmOp::parse(OpAsmParser &parser, OperationState &result)
   result.attributes.set("constraints", StringAttr::get(ctxt, constraints));
   result.attributes.set("operand_attrs", ArrayAttr::get(ctxt, operand_attrs));
   result.getOrAddProperties<InlineAsmOp::Properties>().operands_segments = parser.getBuilder().getDenseI32ArrayAttr(operandsGroupSizes);
-
+  if (resType)
+    result.addTypes(TypeRange{resType});
+    
   return mlir::success();
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2853,6 +2853,13 @@ class CIRInlineAsmOpLowering
     std::vector<mlir::Attribute> opAttrs;
     auto llvmAttrName = mlir::LLVM::InlineAsmOp::getElementTypeAttrName();
 
+    // this is for the lowering to LLVM from LLVm dialect. Otherwise, if we
+    // don't have the result (i.e. void type as a result of operation), the
+    // element type attribute will be attached to the whole instruction, but not
+    // to the operand
+    if (!op.getNumResults())
+      opAttrs.push_back(mlir::Attribute());
+
     if (auto operandAttrs = op.getOperandAttrs()) {
       for (auto attr : *operandAttrs) {
         if (isa<mlir::cir::OptNoneAttr>(attr)) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2879,16 +2879,16 @@ class CIRInlineAsmOpLowering
       std::vector<mlir::NamedAttribute> attrs;
       auto typ = cast<mlir::cir::PointerType>(cirOperands[i].getType());
       auto typAttr = mlir::TypeAttr::get(
-        getTypeConverter()->convertType(typ.getPointee()));
+          getTypeConverter()->convertType(typ.getPointee()));
 
       attrs.push_back(rewriter.getNamedAttr(llvmAttrName, typAttr));
       auto newDict = rewriter.getDictionaryAttr(attrs);
       opAttrs.push_back(newDict);
-    }    
+    }
 
     rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
-        op, llResTy, llvmOperands, op.getAsmStringAttr(), op.getConstraintsAttr(),
-        op.getSideEffectsAttr(),
+        op, llResTy, llvmOperands, op.getAsmStringAttr(),
+        op.getConstraintsAttr(), op.getSideEffectsAttr(),
         /*is_align_stack*/ mlir::UnitAttr(),
         mlir::LLVM::AsmDialectAttr::get(getContext(), llDialect),
         rewriter.getArrayAttr(opAttrs));

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -65,6 +65,7 @@
 #include <deque>
 #include <optional>
 #include <set>
+#include <iostream>
 
 using namespace cir;
 using namespace llvm;
@@ -2840,7 +2841,7 @@ class CIRInlineAsmOpLowering
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::InlineAsmOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-
+    std::cout << "CIRInlineAsmOpLowering\n";
     mlir::Type llResTy;
     if (op.getNumResults())
       llResTy = getTypeConverter()->convertType(op.getType(0));

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2860,7 +2860,7 @@ class CIRInlineAsmOpLowering
     // to the operand
     if (!op.getNumResults())
       opAttrs.push_back(mlir::Attribute());
-  
+
     for (auto attr : op.getOperandAttrs()) {
       if (!attr) {
         opAttrs.push_back(mlir::Attribute());

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -65,7 +65,6 @@
 #include <deque>
 #include <optional>
 #include <set>
-#include <iostream>
 
 using namespace cir;
 using namespace llvm;
@@ -2885,8 +2884,8 @@ class CIRInlineAsmOpLowering
     }
 
     rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
-        op, llResTy, operands, op.getAsmStringAttr(),
-        op.getConstraintsAttr(), op.getSideEffectsAttr(),
+        op, llResTy, operands, op.getAsmStringAttr(), op.getConstraintsAttr(),
+        op.getSideEffectsAttr(),
         /*is_align_stack*/ mlir::UnitAttr(),
         mlir::LLVM::AsmDialectAttr::get(getContext(), llDialect),
         rewriter.getArrayAttr(opAttrs));

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2840,7 +2840,6 @@ class CIRInlineAsmOpLowering
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::InlineAsmOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    std::cout << "CIRInlineAsmOpLowering\n";
     mlir::Type llResTy;
     if (op.getNumResults())
       llResTy = getTypeConverter()->convertType(op.getType(0));

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -65,7 +65,6 @@
 #include <deque>
 #include <optional>
 #include <set>
-#include <iostream>
 
 using namespace cir;
 using namespace llvm;
@@ -2841,7 +2840,6 @@ class CIRInlineAsmOpLowering
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::InlineAsmOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    std::cout << "CIRInlineAsmOpLowering\n";
     mlir::Type llResTy;
     if (op.getNumResults())
       llResTy = getTypeConverter()->convertType(op.getType(0));
@@ -2870,31 +2868,30 @@ class CIRInlineAsmOpLowering
       cirOperands.insert(cirOperands.end(), cirOps.begin(), cirOps.end());
     }
 
+    // so far we infer the llvm dialect element type attr from
+    // CIR operand type.
     for (std::size_t i = 0; i < op.getOperandAttrs().size(); ++i) {
-      if (op.getOperandAttrs()[i]) {
+      if (!op.getOperandAttrs()[i]) {
         opAttrs.push_back(mlir::Attribute());
-        std::cout << "here!\n";
         continue;
       }
-      std::cout << "here!!\n";
+
       std::vector<mlir::NamedAttribute> attrs;
       auto typ = cast<mlir::cir::PointerType>(cirOperands[i].getType());
       auto typAttr = mlir::TypeAttr::get(
-        getTypeConverter()->convertType(typ));
+        getTypeConverter()->convertType(typ.getPointee()));
 
       attrs.push_back(rewriter.getNamedAttr(llvmAttrName, typAttr));
       auto newDict = rewriter.getDictionaryAttr(attrs);
       opAttrs.push_back(newDict);
     }    
 
-    auto newOp = rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
+    rewriter.replaceOpWithNewOp<mlir::LLVM::InlineAsmOp>(
         op, llResTy, llvmOperands, op.getAsmStringAttr(), op.getConstraintsAttr(),
         op.getSideEffectsAttr(),
         /*is_align_stack*/ mlir::UnitAttr(),
         mlir::LLVM::AsmDialectAttr::get(getContext(), llDialect),
         rewriter.getArrayAttr(opAttrs));
-
-    newOp.dump();
 
     return mlir::success();
   }

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -2,32 +2,32 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 
-// CHECK: cir.asm(x86_att, operands = [ : ] attrs = [#cir.optnone]
+// CHECK: cir.asm(x86_att, operands = [] attrs = []
 // CHECK:        {"" "~{dirflag},~{fpsr},~{flags}"})
 void empty1() {
   __asm__ volatile("" : : : );
 }
 
-// CHECK: cir.asm(x86_att, operands = [ : ] attrs = [#cir.optnone]
+// CHECK: cir.asm(x86_att, operands = [] attrs = []
 // CHECK:         {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
 
-// CHECK: cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [#cir.optnone, !s32i, !s32i]
+// CHECK: cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]
 // CHECK:        {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty3(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [#cir.optnone, !s32i]
+// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]
 // CHECK:        {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty4(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [#cir.optnone, !s32i]
+// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]
 // CHECK:        {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty5(int x) {
   __asm__ volatile("" : "=m"(x));
@@ -85,7 +85,7 @@ unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
 // CHECK: [[TMP0:%.*]] = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["x", init] 
 // CHECK: cir.store %arg0, [[TMP0]] : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK: [[TMP1:%.*]] = cir.load deref [[TMP0]] : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
-// CHECK: cir.asm(x86_att, operands = [[[TMP1]] : !cir.ptr<!s32i>] attrs = [#cir.optnone, !s32i]
+// CHECK: cir.asm(x86_att, operands = [[[TMP1]] : !cir.ptr<!s32i>] attrs = [!s32i]
 // CHECK:            {"addl $$42, $0" "=*m,~{dirflag},~{fpsr},~{flags}"})
 // CHECK-NEXT: cir.return
 void add4(int *x) {    
@@ -100,7 +100,7 @@ void add4(int *x) {
 // CHECK: cir.store %arg1, [[TMP1]] : !cir.float, cir.ptr <!cir.float>
 // CHECK: [[TMP3:%.*]] = cir.load [[TMP0]] : cir.ptr <!cir.float>, !cir.float
 // CHECK: [[TMP4:%.*]] = cir.load [[TMP1]] : cir.ptr <!cir.float>, !cir.float
-// CHECK: [[TMP5:%.*]] = cir.asm(x86_att, operands = [[[TMP3]], [[TMP4]] : !cir.float, !cir.float] attrs = [#cir.optnone, #cir.optnone]
+// CHECK: [[TMP5:%.*]] = cir.asm(x86_att, operands = [%4, %5 : !cir.float, !cir.float] attrs = [#cir.optnone, #cir.optnone]
 // CHECK:         {"flds $1; flds $2; faddp" "=&{st},imr,imr,~{dirflag},~{fpsr},~{flags}"}) -> !cir.float
 // CHECK: cir.store [[TMP5]], [[TMP2]] : !cir.float, cir.ptr <!cir.float>
 float add5(float x, float y) {
@@ -108,7 +108,7 @@ float add5(float x, float y) {
   __asm__("flds %[x]; flds %[y]; faddp"
           : "=&t" (r)
           : [x] "g" (x), [y] "g" (y));
-  return x;
+  return r;
 }
 
 /*

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -2,37 +2,37 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 
-// CHECK: cir.asm(x86_att, operands = [] attrs = []) {
+// CHECK: cir.asm(x86_att, operands = [], attrs = []) {
 // CHECK: "" "~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty1() {
   __asm__ volatile("" : : : );
 }
 
-// CHECK: cir.asm(x86_att, operands = [] attrs = []) {
+// CHECK: cir.asm(x86_att, operands = [], attrs = []) {
 // CHECK: "xyz" "~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]) {
+// CHECK: cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>], attrs = [!s32i, !s32i]) {
 // CHECK: "" "=*m,*m,~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty3(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]) {
+// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>], attrs = [!s32i]) {
 // CHECK: "" "*m,~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty4(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]) {
+// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>], attrs = [!s32i]) {
 // CHECK: "" "=*m,~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty5(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
-// CHECK: %3 = cir.asm(x86_att, operands = [%2 : !s32i] attrs = [#cir.optnone]) {
+// CHECK: %3 = cir.asm(x86_att, operands = [%2 : !s32i], attrs = [#cir.optnone]) {
 // CHECK: "" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"} side_effects -> !ty_22anon2E022
 void empty6(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
@@ -40,7 +40,7 @@ void empty6(int x) {
 
 // CHECK: [[TMP0:%.*]] = cir.alloca !s32i, cir.ptr <!s32i>, ["a"] 
 // CHECK: [[TMP1:%.*]] = cir.load %0 : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]) {
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i], attrs = [#cir.optnone]) {
 // CHECK: "addl $$42, $1" "=r,r,~{dirflag},~{fpsr},~{flags}"} -> !s32i
 // CHECK: cir.store [[TMP2]], [[TMP0]] : !s32i, cir.ptr <!s32i> loc(#loc42)
 unsigned add1(unsigned int x) {  
@@ -56,7 +56,7 @@ unsigned add1(unsigned int x) {
 // CHECK: [[TMP0:%.*]] = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init] {alignment = 4 : i64}
 // CHECK: cir.store %arg0, [[TMP0]] : !u32i, cir.ptr <!u32i>
 // CHECK: [[TMP1:%.*]] = cir.load [[TMP0]] : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]) {
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i], attrs = [#cir.optnone]) {
 // CHECK: "addl $$42, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"} -> !u32i
 // CHECK: cir.store [[TMP2]], [[TMP0]] : !u32i, cir.ptr <!u32i>
 unsigned add2(unsigned int x) {
@@ -69,7 +69,7 @@ unsigned add2(unsigned int x) {
 
 // CHECK: [[TMP0:%.*]] = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init]
 // CHECK: [[TMP1:%.*]] = cir.load [[TMP0]] : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]) {
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i], attrs = [#cir.optnone]) {
 // CHECK: "addl $$42, $0  \0A\09          subl $$1, $0    \0A\09          imul $$2, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"} -> !u32i
 // CHECK: cir.store [[TMP2]], [[TMP0]]  : !u32i, cir.ptr <!u32i>
 unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
@@ -84,7 +84,7 @@ unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
 // CHECK: [[TMP0:%.*]] = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["x", init] 
 // CHECK: cir.store %arg0, [[TMP0]] : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK: [[TMP1:%.*]] = cir.load deref [[TMP0]] : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
-// CHECK: cir.asm(x86_att, operands = [[[TMP1]] : !cir.ptr<!s32i>] attrs = [!s32i]) {
+// CHECK: cir.asm(x86_att, operands = [[[TMP1]] : !cir.ptr<!s32i>], attrs = [!s32i]) {
 // CHECK: "addl $$42, $0" "=*m,~{dirflag},~{fpsr},~{flags}"}
 // CHECK-NEXT: cir.return
 void add4(int *x) {    
@@ -99,7 +99,7 @@ void add4(int *x) {
 // CHECK: cir.store %arg1, [[TMP1]] : !cir.float, cir.ptr <!cir.float>
 // CHECK: [[TMP3:%.*]] = cir.load [[TMP0]] : cir.ptr <!cir.float>, !cir.float
 // CHECK: [[TMP4:%.*]] = cir.load [[TMP1]] : cir.ptr <!cir.float>, !cir.float
-// CHECK: [[TMP5:%.*]] = cir.asm(x86_att, operands = [%4, %5 : !cir.float, !cir.float] attrs = [#cir.optnone, #cir.optnone]) {
+// CHECK: [[TMP5:%.*]] = cir.asm(x86_att, operands = [%4, %5 : !cir.float, !cir.float], attrs = [#cir.optnone, #cir.optnone]) {
 // CHECK: "flds $1; flds $2; faddp" "=&{st},imr,imr,~{dirflag},~{fpsr},~{flags}"} -> !cir.float
 // CHECK: cir.store [[TMP5]], [[TMP2]] : !cir.float, cir.ptr <!cir.float>
 float add5(float x, float y) {

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -12,22 +12,22 @@ void empty2() {
 }
 
 //CHECK: cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, !s32i, !s32i] side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
-void t1(int x) {
+void empty3(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
 //CHECK: cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, !s32i] side_effects %0 : (!cir.ptr<!s32i>) -> ()
-void t2(int x) {
+void empty4(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
 //CHECK: cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, !s32i] side_effects %0 : (!cir.ptr<!s32i>) -> ()
-void t3(int x) {
+void empty5(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
 //CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] side_effects %2 : (!s32i) -> !ty_22anon2E022
-void t4(int x) {
+void empty6(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }
 
@@ -73,4 +73,209 @@ float add5(float x, float y) {
       : [y] "f" (y)
       );
   return x;
+}
+
+/*
+There are tests from clang/test/CodeGen/asm.c. No checks for now - we just make
+sure no crushes happen
+*/
+
+
+void t1(int len) {
+  __asm__ volatile("" : "=&r"(len), "+&r"(len));
+}
+
+void t2(unsigned long long t)  {
+  __asm__ volatile("" : "+m"(t));
+}
+
+void t3(unsigned char *src, unsigned long long temp) {
+  __asm__ volatile("" : "+m"(temp), "+r"(src));
+}
+
+void t4(void) {
+  unsigned long long a;
+  struct reg { unsigned long long a, b; } b;
+
+  __asm__ volatile ("":: "m"(a), "m"(b));
+}
+
+void t5(int i) {
+  asm("nop" : "=r"(i) : "0"(t5));
+}
+
+void t6(void) {
+  __asm__ volatile("" : : "i" (t6));
+}
+
+void t7(int a) {
+  __asm__ volatile("T7 NAMED: %[input]" : "+r"(a): [input] "i" (4));  
+}
+
+void t8(void) {
+  __asm__ volatile("T8 NAMED MODIFIER: %c[input]" :: [input] "i" (4));  
+}
+
+unsigned t9(unsigned int a) {
+  asm("bswap %0 %1" : "+r" (a));
+  return a;
+}
+
+void t10(int r) {
+  __asm__("PR3908 %[lf] %[xx] %[li] %[r]" : [r] "+r" (r) : [lf] "mx" (0), [li] "mr" (0), [xx] "x" ((double)(0)));
+}
+
+unsigned t11(signed char input) {
+  unsigned  output;
+  __asm__("xyz"
+          : "=a" (output)
+          : "0" (input));
+  return output;
+}
+
+unsigned char t12(unsigned input) {
+  unsigned char output;
+  __asm__("xyz"
+          : "=a" (output)
+          : "0" (input));
+  return output;
+}
+
+unsigned char t13(unsigned input) {
+  unsigned char output;
+  __asm__("xyz %1"
+          : "=a" (output)
+          : "0" (input));
+  return output;
+}
+
+struct large {
+  int x[1000];
+};
+
+unsigned long t15(int x, struct large *P) {
+  __asm__("xyz "
+          : "=r" (x)
+          : "m" (*P), "0" (x));
+  return x;
+}
+
+// bitfield destination of an asm.
+struct S {
+  int a : 4;
+};
+
+void t14(struct S *P) {
+  __asm__("abc %0" : "=r"(P->a) );
+}
+
+int t16(void) {
+  int a,b;
+  asm ( "nop;"
+       :"=%c" (a)
+       : "r" (b)
+       );
+  return 0;
+}
+
+void t17(void) {
+  int i;
+  __asm__ ( "nop": "=m"(i));
+}
+
+int t18(unsigned data) {
+  int a, b;
+
+  asm("xyz" :"=a"(a), "=d"(b) : "a"(data));
+  return a + b;
+}
+
+int t19(unsigned data) {
+  int a, b;
+
+  asm("x{abc|def|ghi}z" :"=r"(a): "r"(data));
+  return a + b;
+}
+
+// skip t20 and t21: long double is not supported
+
+// accept 'l' constraint
+unsigned char t22(unsigned char a, unsigned char b) {
+  unsigned int la = a;
+  unsigned int lb = b;
+  unsigned int bigres;
+  unsigned char res;
+  __asm__ ("0:\n1:\n" : [bigres] "=la"(bigres) : [la] "0"(la), [lb] "c"(lb) :
+                        "edx", "cc");
+  res = bigres;
+  return res;
+}
+
+// accept 'l' constraint
+unsigned char t23(unsigned char a, unsigned char b) {
+  unsigned int la = a;
+  unsigned int lb = b;
+  unsigned char res;
+  __asm__ ("0:\n1:\n" : [res] "=la"(res) : [la] "0"(la), [lb] "c"(lb) :
+                        "edx", "cc");
+  return res;
+}
+
+void *t24(char c) {
+  void *addr;
+  __asm__ ("foobar" : "=a" (addr) : "0" (c));
+  return addr;
+}
+
+void t25(void)
+{
+  __asm__ __volatile__(					   \
+		       "finit"				   \
+		       :				   \
+		       :				   \
+		       :"st","st(1)","st(2)","st(3)",	   \
+			"st(4)","st(5)","st(6)","st(7)",   \
+			"fpsr","fpcr"			   \
+							   );
+}
+
+//t26 skipped - no vector type support
+
+// Check to make sure the inline asm non-standard dialect attribute _not_ is
+// emitted.
+void t27(void) {
+  asm volatile("nop");
+}
+
+// Check handling of '*' and '#' constraint modifiers.
+void t28(void)
+{
+  asm volatile ("/* %0 */" : : "i#*X,*r" (1));
+}
+
+static unsigned t29_var[1];
+
+void t29(void) {
+  asm volatile("movl %%eax, %0"
+               :
+               : "m"(t29_var));
+}
+
+void t30(int len) {
+  __asm__ volatile(""
+                   : "+&&rm"(len));
+}
+
+void t31(int len) {
+  __asm__ volatile(""
+                   : "+%%rm"(len), "+rm"(len));
+}
+
+//t32 skipped: no goto
+
+void *t33(void *ptr)
+{
+  void *ret;
+  asm ("lea %1, %0" : "=r" (ret) : "p" (ptr));
+  return ret;  
 }

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -77,7 +77,7 @@ float add5(float x, float y) {
 
 /*
 There are tests from clang/test/CodeGen/asm.c. No checks for now - we just make
-sure no crushes happen
+sure no crashes happen
 */
 
 

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -21,9 +21,9 @@ void empty2() {
 }
 
 // CHECK: cir.asm(x86_att, 
-// CHECK:   out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:   out = [%0 : !cir.ptr<!s32i> (maybe_memory)],
 // CHECK:   in = [],
-// CHECK:   in_out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:   in_out = [%0 : !cir.ptr<!s32i> (maybe_memory)],
 // CHECK:   {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty3(int x) {
   __asm__ volatile("" : "+m"(x));
@@ -31,7 +31,7 @@ void empty3(int x) {
 
 // CHECK: cir.asm(x86_att, 
 // CHECK:   out = [],
-// CHECK:   in = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:   in = [%0 : !cir.ptr<!s32i> (maybe_memory)],
 // CHECK:   in_out = [],
 // CHECK:   {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty4(int x) {
@@ -39,7 +39,7 @@ void empty4(int x) {
 }
 
 // CHECK: cir.asm(x86_att, 
-// CHECK:   out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:   out = [%0 : !cir.ptr<!s32i> (maybe_memory)],
 // CHECK:   in = [],
 // CHECK:   in_out = [],
 // CHECK:   {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
@@ -112,7 +112,7 @@ unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
 // CHECK: cir.store %arg0, [[TMP0]] : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK: [[TMP1:%.*]] = cir.load deref [[TMP0]] : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: cir.asm(x86_att, 
-// CHECK:       out = [%1 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:       out = [%1 : !cir.ptr<!s32i> (maybe_memory)],
 // CHECK:       in = [],
 // CHECK:       in_out = [],
 // CHECK:       {"addl $$42, $0" "=*m,~{dirflag},~{fpsr},~{flags}"}) 

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -2,47 +2,47 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 
-// CHECK: cir.asm(x86_att, operands = [] attrs = []
-// CHECK:        {"" "~{dirflag},~{fpsr},~{flags}"})
+// CHECK: cir.asm(x86_att, operands = [] attrs = []) {
+// CHECK: "" "~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty1() {
   __asm__ volatile("" : : : );
 }
 
-// CHECK: cir.asm(x86_att, operands = [] attrs = []
-// CHECK:         {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects
+// CHECK: cir.asm(x86_att, operands = [] attrs = []) {
+// CHECK: "xyz" "~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]
-// CHECK:        {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
+// CHECK: cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]) {
+// CHECK: "" "=*m,*m,~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty3(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]
-// CHECK:        {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
+// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]) {
+// CHECK: "" "*m,~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty4(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]
-// CHECK:        {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
+// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]) {
+// CHECK: "" "=*m,~{dirflag},~{fpsr},~{flags}"} side_effects
 void empty5(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
-// CHECK: %3 = cir.asm(x86_att, operands = [%2 : !s32i] attrs = [#cir.optnone]
-// CHECK:        {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !ty_22anon2E022
+// CHECK: %3 = cir.asm(x86_att, operands = [%2 : !s32i] attrs = [#cir.optnone]) {
+// CHECK: "" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"} side_effects -> !ty_22anon2E022
 void empty6(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }
 
 // CHECK: [[TMP0:%.*]] = cir.alloca !s32i, cir.ptr <!s32i>, ["a"] 
 // CHECK: [[TMP1:%.*]] = cir.load %0 : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]
-// CHECK:                  {"addl $$42, $1" "=r,r,~{dirflag},~{fpsr},~{flags}"}) -> !s32i
-// CHECK:  cir.store [[TMP2]], [[TMP0]] : !s32i, cir.ptr <!s32i> loc(#loc42)
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]) {
+// CHECK: "addl $$42, $1" "=r,r,~{dirflag},~{fpsr},~{flags}"} -> !s32i
+// CHECK: cir.store [[TMP2]], [[TMP0]] : !s32i, cir.ptr <!s32i> loc(#loc42)
 unsigned add1(unsigned int x) {  
   int a;
   __asm__("addl $42, %[val]"
@@ -56,8 +56,8 @@ unsigned add1(unsigned int x) {
 // CHECK: [[TMP0:%.*]] = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init] {alignment = 4 : i64}
 // CHECK: cir.store %arg0, [[TMP0]] : !u32i, cir.ptr <!u32i>
 // CHECK: [[TMP1:%.*]] = cir.load [[TMP0]] : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]
-// CHECK:                  {"addl $$42, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"}) -> !u32i
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]) {
+// CHECK: "addl $$42, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"} -> !u32i
 // CHECK: cir.store [[TMP2]], [[TMP0]] : !u32i, cir.ptr <!u32i>
 unsigned add2(unsigned int x) {
   __asm__("addl $42, %[val]"
@@ -69,8 +69,8 @@ unsigned add2(unsigned int x) {
 
 // CHECK: [[TMP0:%.*]] = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init]
 // CHECK: [[TMP1:%.*]] = cir.load [[TMP0]] : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]
-// CHECK:                      {"addl $$42, $0  \0A\09          subl $$1, $0    \0A\09          imul $$2, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"}) -> !u32i
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i] attrs = [#cir.optnone]) {
+// CHECK: "addl $$42, $0  \0A\09          subl $$1, $0    \0A\09          imul $$2, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"} -> !u32i
 // CHECK: cir.store [[TMP2]], [[TMP0]]  : !u32i, cir.ptr <!u32i>
 unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
   __asm__("addl $42, %[val]  \n\t\
@@ -84,8 +84,8 @@ unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
 // CHECK: [[TMP0:%.*]] = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["x", init] 
 // CHECK: cir.store %arg0, [[TMP0]] : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK: [[TMP1:%.*]] = cir.load deref [[TMP0]] : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
-// CHECK: cir.asm(x86_att, operands = [[[TMP1]] : !cir.ptr<!s32i>] attrs = [!s32i]
-// CHECK:            {"addl $$42, $0" "=*m,~{dirflag},~{fpsr},~{flags}"})
+// CHECK: cir.asm(x86_att, operands = [[[TMP1]] : !cir.ptr<!s32i>] attrs = [!s32i]) {
+// CHECK: "addl $$42, $0" "=*m,~{dirflag},~{fpsr},~{flags}"}
 // CHECK-NEXT: cir.return
 void add4(int *x) {    
   __asm__("addl $42, %[addr]" : [addr] "=m" (*x));
@@ -99,8 +99,8 @@ void add4(int *x) {
 // CHECK: cir.store %arg1, [[TMP1]] : !cir.float, cir.ptr <!cir.float>
 // CHECK: [[TMP3:%.*]] = cir.load [[TMP0]] : cir.ptr <!cir.float>, !cir.float
 // CHECK: [[TMP4:%.*]] = cir.load [[TMP1]] : cir.ptr <!cir.float>, !cir.float
-// CHECK: [[TMP5:%.*]] = cir.asm(x86_att, operands = [%4, %5 : !cir.float, !cir.float] attrs = [#cir.optnone, #cir.optnone]
-// CHECK:         {"flds $1; flds $2; faddp" "=&{st},imr,imr,~{dirflag},~{fpsr},~{flags}"}) -> !cir.float
+// CHECK: [[TMP5:%.*]] = cir.asm(x86_att, operands = [%4, %5 : !cir.float, !cir.float] attrs = [#cir.optnone, #cir.optnone]) {
+// CHECK: "flds $1; flds $2; faddp" "=&{st},imr,imr,~{dirflag},~{fpsr},~{flags}"} -> !cir.float
 // CHECK: cir.store [[TMP5]], [[TMP2]] : !cir.float, cir.ptr <!cir.float>
 float add5(float x, float y) {
    float r;

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -26,11 +26,12 @@ void t3(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
-//CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] side_effects %1 : (!s32i) -> !ty_22anon2E022
+//CHECK: cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] side_effects %2 : (!s32i) -> !ty_22anon2E022
 void t4(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }
 
+// CHECK: {{.*}} = cir.asm(x86_att, {"addl $$42, $1" "=r,r,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] {{.*}} : (!u32i) -> !s32i
 unsigned add1(unsigned int x) {  
   int a;
   __asm__("addl $42, %[val]"
@@ -41,6 +42,7 @@ unsigned add1(unsigned int x) {
   return a;
 }
 
+// CHECK: {{.*}} = cir.asm(x86_att, {"addl $$42, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] {{.*}} : (!u32i) -> !u32i
 unsigned add2(unsigned int x) {
   __asm__("addl $42, %[val]"
       : [val] "+r" (x)
@@ -48,7 +50,8 @@ unsigned add2(unsigned int x) {
   return x;
 }
 
-unsigned add3(unsigned int x) {
+// CHECK: {{.*}} = cir.asm(x86_att, {"addl $$42, $0  \0A\09          subl $$1, $0    \0A\09          imul $$2, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] {{.*}} : (!u32i) -> !u32i
+unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
   __asm__("addl $42, %[val]  \n\t\
           subl $1, %[val]    \n\t\
           imul $2, %[val]"
@@ -57,8 +60,17 @@ unsigned add3(unsigned int x) {
   return x;
 }
 
+// CHECK: [[TMP:%.*]] = cir.load deref {{.*}} : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
+// CHECK: cir.asm(x86_att, {"addl $$42, $0" "=*m,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone, !s32i] [[TMP]] : (!cir.ptr<!s32i>) -> ()
 void add4(int *x) {    
   __asm__("addl $42, %[addr]" : [addr] "=m" (*x));
 }
 
-
+// CHECK: {{.*}} = cir.asm(x86_att, {"fadd $0, $1" "=&{st},f,~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [#cir.optnone] {{.*}} : (!cir.float) -> !cir.float
+float add5(float x, float y) {
+  __asm__("fadd %[x], %[y]"
+      : [x] "=&t" (x)
+      : [y] "f" (y)
+      );
+  return x;
+}

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -14,7 +14,6 @@ void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-
 // CHECK: cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]
 // CHECK:        {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty3(int x) {

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -2,48 +2,69 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 
-// CHECK: cir.asm(x86_att, operands = [], attrs = []) {
-// CHECK: "" "~{dirflag},~{fpsr},~{flags}"} side_effects
+// CHECK: cir.asm(x86_att, 
+// CHECK:   out = [],
+// CHECK:   in = [],
+// CHECK:   in_out = [],
+// CHECK:   {"" "~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty1() {
   __asm__ volatile("" : : : );
 }
 
-// CHECK: cir.asm(x86_att, operands = [], attrs = []) {
-// CHECK: "xyz" "~{dirflag},~{fpsr},~{flags}"} side_effects
+// CHECK: cir.asm(x86_att, 
+// CHECK:   out = [],
+// CHECK:   in = [],
+// CHECK:   in_out = [],
+// CHECK:   {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty2() {
   __asm__ volatile("xyz" : : : );
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>], attrs = [!s32i, !s32i]) {
-// CHECK: "" "=*m,*m,~{dirflag},~{fpsr},~{flags}"} side_effects
+// CHECK: cir.asm(x86_att, 
+// CHECK:   out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:   in = [],
+// CHECK:   in_out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:   {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty3(int x) {
   __asm__ volatile("" : "+m"(x));
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>], attrs = [!s32i]) {
-// CHECK: "" "*m,~{dirflag},~{fpsr},~{flags}"} side_effects
+// CHECK: cir.asm(x86_att, 
+// CHECK:   out = [],
+// CHECK:   in = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:   in_out = [],
+// CHECK:   {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty4(int x) {
   __asm__ volatile("" : : "m"(x));
 }
 
-// CHECK: cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>], attrs = [!s32i]) {
-// CHECK: "" "=*m,~{dirflag},~{fpsr},~{flags}"} side_effects
+// CHECK: cir.asm(x86_att, 
+// CHECK:   out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:   in = [],
+// CHECK:   in_out = [],
+// CHECK:   {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
 void empty5(int x) {
   __asm__ volatile("" : "=m"(x));
 }
 
-// CHECK: %3 = cir.asm(x86_att, operands = [%2 : !s32i], attrs = [#cir.optnone]) {
-// CHECK: "" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"} side_effects -> !ty_22anon2E022
+// CHECK: %3 = cir.asm(x86_att, 
+// CHECK:   out = [],
+// CHECK:   in = [],
+// CHECK:   in_out = [%2 : !s32i],
+// CHECK:   {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !ty_22anon2E022
 void empty6(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }
 
 // CHECK: [[TMP0:%.*]] = cir.alloca !s32i, cir.ptr <!s32i>, ["a"] 
 // CHECK: [[TMP1:%.*]] = cir.load %0 : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i], attrs = [#cir.optnone]) {
-// CHECK: "addl $$42, $1" "=r,r,~{dirflag},~{fpsr},~{flags}"} -> !s32i
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, 
+// CHECK:       out = [],
+// CHECK:       in = [%3 : !u32i],
+// CHECK:       in_out = [],
+// CHECK:       {"addl $$42, $1" "=r,r,~{dirflag},~{fpsr},~{flags}"}) -> !s32i
 // CHECK: cir.store [[TMP2]], [[TMP0]] : !s32i, cir.ptr <!s32i> loc(#loc42)
-unsigned add1(unsigned int x) {  
+unsigned add1(unsigned int x) {
   int a;
   __asm__("addl $42, %[val]"
       : "=r" (a)
@@ -56,8 +77,11 @@ unsigned add1(unsigned int x) {
 // CHECK: [[TMP0:%.*]] = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init] {alignment = 4 : i64}
 // CHECK: cir.store %arg0, [[TMP0]] : !u32i, cir.ptr <!u32i>
 // CHECK: [[TMP1:%.*]] = cir.load [[TMP0]] : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i], attrs = [#cir.optnone]) {
-// CHECK: "addl $$42, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"} -> !u32i
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, 
+// CHECK:       out = [],
+// CHECK:       in = [],
+// CHECK:       in_out = [%2 : !u32i],
+// CHECK:       {"addl $$42, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"}) -> !u32i
 // CHECK: cir.store [[TMP2]], [[TMP0]] : !u32i, cir.ptr <!u32i>
 unsigned add2(unsigned int x) {
   __asm__("addl $42, %[val]"
@@ -69,8 +93,11 @@ unsigned add2(unsigned int x) {
 
 // CHECK: [[TMP0:%.*]] = cir.alloca !u32i, cir.ptr <!u32i>, ["x", init]
 // CHECK: [[TMP1:%.*]] = cir.load [[TMP0]] : cir.ptr <!u32i>, !u32i
-// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, operands = [[[TMP1]] : !u32i], attrs = [#cir.optnone]) {
-// CHECK: "addl $$42, $0  \0A\09          subl $$1, $0    \0A\09          imul $$2, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"} -> !u32i
+// CHECK: [[TMP2:%.*]] = cir.asm(x86_att, 
+// CHECK:       out = [],
+// CHECK:       in = [],
+// CHECK:       in_out = [%2 : !u32i],
+// CHECK:       {"addl $$42, $0  \0A\09          subl $$1, $0    \0A\09          imul $$2, $0" "=r,0,~{dirflag},~{fpsr},~{flags}"}) -> !u32i
 // CHECK: cir.store [[TMP2]], [[TMP0]]  : !u32i, cir.ptr <!u32i>
 unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
   __asm__("addl $42, %[val]  \n\t\
@@ -84,8 +111,11 @@ unsigned add3(unsigned int x) { // ((42 + x) - 1) * 2
 // CHECK: [[TMP0:%.*]] = cir.alloca !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>, ["x", init] 
 // CHECK: cir.store %arg0, [[TMP0]] : !cir.ptr<!s32i>, cir.ptr <!cir.ptr<!s32i>>
 // CHECK: [[TMP1:%.*]] = cir.load deref [[TMP0]] : cir.ptr <!cir.ptr<!s32i>>, !cir.ptr<!s32i>
-// CHECK: cir.asm(x86_att, operands = [[[TMP1]] : !cir.ptr<!s32i>], attrs = [!s32i]) {
-// CHECK: "addl $$42, $0" "=*m,~{dirflag},~{fpsr},~{flags}"}
+// CHECK: cir.asm(x86_att, 
+// CHECK:       out = [%1 : !cir.ptr<!s32i> : ElementType !s32i],
+// CHECK:       in = [],
+// CHECK:       in_out = [],
+// CHECK:       {"addl $$42, $0" "=*m,~{dirflag},~{fpsr},~{flags}"}) 
 // CHECK-NEXT: cir.return
 void add4(int *x) {    
   __asm__("addl $42, %[addr]" : [addr] "=m" (*x));
@@ -99,8 +129,11 @@ void add4(int *x) {
 // CHECK: cir.store %arg1, [[TMP1]] : !cir.float, cir.ptr <!cir.float>
 // CHECK: [[TMP3:%.*]] = cir.load [[TMP0]] : cir.ptr <!cir.float>, !cir.float
 // CHECK: [[TMP4:%.*]] = cir.load [[TMP1]] : cir.ptr <!cir.float>, !cir.float
-// CHECK: [[TMP5:%.*]] = cir.asm(x86_att, operands = [%4, %5 : !cir.float, !cir.float], attrs = [#cir.optnone, #cir.optnone]) {
-// CHECK: "flds $1; flds $2; faddp" "=&{st},imr,imr,~{dirflag},~{fpsr},~{flags}"} -> !cir.float
+// CHECK: [[TMP5:%.*]] = cir.asm(x86_att, 
+// CHECK:       out = [],
+// CHECK:       in = [%4 : !cir.float, %5 : !cir.float],
+// CHECK:       in_out = [],
+// CHECK:       {"flds $1; flds $2; faddp" "=&{st},imr,imr,~{dirflag},~{fpsr},~{flags}"}) -> !cir.float
 // CHECK: cir.store [[TMP5]], [[TMP2]] : !cir.float, cir.ptr <!cir.float>
 float add5(float x, float y) {
    float r;

--- a/clang/test/CIR/CodeGen/asm.c
+++ b/clang/test/CIR/CodeGen/asm.c
@@ -30,3 +30,35 @@ void t3(int x) {
 void t4(int x) {
   __asm__ volatile("" : "=&r"(x), "+&r"(x));
 }
+
+unsigned add1(unsigned int x) {  
+  int a;
+  __asm__("addl $42, %[val]"
+      : "=r" (a)
+      : [val] "r" (x)
+      );
+  
+  return a;
+}
+
+unsigned add2(unsigned int x) {
+  __asm__("addl $42, %[val]"
+      : [val] "+r" (x)
+      );
+  return x;
+}
+
+unsigned add3(unsigned int x) {
+  __asm__("addl $42, %[val]  \n\t\
+          subl $1, %[val]    \n\t\
+          imul $2, %[val]"
+      : [val] "+r" (x)
+      );  
+  return x;
+}
+
+void add4(int *x) {    
+  __asm__("addl $42, %[addr]" : [addr] "=m" (*x));
+}
+
+

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -8,28 +8,28 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
 
-    cir.asm(x86_att, operands = [] attrs = []) {
+    cir.asm(x86_att, operands = [], attrs = []) {
     "" "~{dirflag},~{fpsr},~{flags}"} -> !s32i
     // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> i32
     
-    cir.asm(x86_att, operands = [] attrs = []) {
+    cir.asm(x86_att, operands = [], attrs = []) {
     "xyz" "~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}" : () -> i32
 
-    cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]) {
+    cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>], attrs = [!s32i, !s32i]) {
     "" "=*m,*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}, {elementtype = i32}] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> i32
 
-    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]) {
+    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>], attrs = [!s32i]) {
     "" "*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
-    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]) {
+    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>], attrs = [!s32i]) {
     "" "=*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    cir.asm(x86_att, operands = [%1 : !s32i] attrs = []) {
+    cir.asm(x86_att, operands = [%1 : !s32i], attrs = []) {
     "" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" {{.*}} : (i32) -> i32
 

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -8,29 +8,47 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
 
-    cir.asm(x86_att, operands = [], attrs = []) {
-    "" "~{dirflag},~{fpsr},~{flags}"} -> !s32i
+    cir.asm(x86_att, 
+      out = [],
+      in = [],
+      in_out = [],
+      {"" "~{dirflag},~{fpsr},~{flags}"}) -> !s32i
     // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> i32
-    
-    cir.asm(x86_att, operands = [], attrs = []) {
-    "xyz" "~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
+        
+    cir.asm(x86_att, 
+      out = [],
+      in = [],
+      in_out = [],
+      {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}" : () -> i32
 
-    cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>], attrs = [!s32i, !s32i]) {
-    "" "=*m,*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
+    cir.asm(x86_att, 
+      out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+      in = [],
+      in_out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+      {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}, {elementtype = i32}] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> i32
 
-    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>], attrs = [!s32i]) {
-    "" "*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
+    cir.asm(x86_att, 
+      out = [],
+      in = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+      in_out = [],
+      {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i      
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
-    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>], attrs = [!s32i]) {
-    "" "=*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
+    cir.asm(x86_att, 
+      out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+      in = [],
+      in_out = [],
+      {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    cir.asm(x86_att, operands = [%1 : !s32i], attrs = []) {
-    "" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
+    cir.asm(x86_att, 
+      out = [],
+      in = [],
+      in_out = [%1 : !s32i],
+      {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" {{.*}} : (i32) -> i32
 
     cir.return

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -42,15 +42,13 @@ module {
       in_out = [],
       {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
-
-    %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+   
     cir.asm(x86_att, 
       out = [],
       in = [],
-      in_out = [%1 : !s32i],
+      in_out = [],
       {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" {{.*}} : (i32) -> i32
-
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"  : () -> i32
     cir.return
   }
 

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -8,27 +8,31 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
 
-    cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) : () -> ()
-    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
+    cir.asm(x86_att, operands = [] attrs = []
+           {"" "~{dirflag},~{fpsr},~{flags}"}) -> !s32i
+    // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> i32
     
-    cir.asm(x86_att, {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects : () -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}" : () -> ()
+    cir.asm(x86_att, operands = [] attrs = []
+           {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}" : () -> i32
 
-    cir.asm(x86_att, {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0, %0 : (!cir.ptr<!s32i>, !cir.ptr<!s32i>) -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> ()    
+    cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]
+           {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}, {elementtype = i32}] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> i32
 
-    cir.asm(x86_att, {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0 : (!cir.ptr<!s32i>) -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
+    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]
+            {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
-    cir.asm(x86_att, {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects %0 : (!cir.ptr<!s32i>) -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> ()
+    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]
+           {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    cir.asm(x86_att, {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects %1 : (!s32i) -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" %2 : (i32) -> ()
+    cir.asm(x86_att, operands = [%1 : !s32i] attrs = []
+           {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" {{.*}} : (i32) -> i32
 
-    cir.asm(x86_att, {"" "~{dirflag},~{fpsr},~{flags}"}) operand_attrs = [!s32i] side_effects  : () -> ()
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "~{dirflag},~{fpsr},~{flags}"  : () -> ()
     cir.return
   }
 

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -23,21 +23,21 @@ module {
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}" : () -> i32
 
     cir.asm(x86_att, 
-      out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+      out = [%0 : !cir.ptr<!s32i> (maybe_memory)],
       in = [],
-      in_out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+      in_out = [%0 : !cir.ptr<!s32i> (maybe_memory)],
       {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}, {elementtype = i32}] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> i32
 
     cir.asm(x86_att, 
       out = [],
-      in = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+      in = [%0 : !cir.ptr<!s32i> (maybe_memory)],
       in_out = [],
       {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i      
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
     cir.asm(x86_att, 
-      out = [%0 : !cir.ptr<!s32i> : ElementType !s32i],
+      out = [%0 : !cir.ptr<!s32i> (maybe_memory)],
       in = [],
       in_out = [],
       {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i

--- a/clang/test/CIR/Lowering/asm.cir
+++ b/clang/test/CIR/Lowering/asm.cir
@@ -8,29 +8,29 @@ module {
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
 
-    cir.asm(x86_att, operands = [] attrs = []
-           {"" "~{dirflag},~{fpsr},~{flags}"}) -> !s32i
+    cir.asm(x86_att, operands = [] attrs = []) {
+    "" "~{dirflag},~{fpsr},~{flags}"} -> !s32i
     // CHECK: llvm.inline_asm asm_dialect = att operand_attrs = [] "", "~{dirflag},~{fpsr},~{flags}"  : () -> i32
     
-    cir.asm(x86_att, operands = [] attrs = []
-           {"xyz" "~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    cir.asm(x86_att, operands = [] attrs = []) {
+    "xyz" "~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "xyz", "~{dirflag},~{fpsr},~{flags}" : () -> i32
 
-    cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]
-           {"" "=*m,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    cir.asm(x86_att, operands = [%0, %0 : !cir.ptr<!s32i>, !cir.ptr<!s32i>] attrs = [!s32i, !s32i]) {
+    "" "=*m,*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}, {elementtype = i32}] "", "=*m,*m,~{dirflag},~{fpsr},~{flags}" %1, %1 : (!llvm.ptr, !llvm.ptr) -> i32
 
-    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]
-            {"" "*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]) {
+    "" "*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
-    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]
-           {"" "=*m,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    cir.asm(x86_att, operands = [%0 : !cir.ptr<!s32i>] attrs = [!s32i]) {
+    "" "=*m,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [{elementtype = i32}] "", "=*m,~{dirflag},~{fpsr},~{flags}" %1 : (!llvm.ptr) -> i32
 
     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-    cir.asm(x86_att, operands = [%1 : !s32i] attrs = []
-           {"" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"}) side_effects -> !s32i
+    cir.asm(x86_att, operands = [%1 : !s32i] attrs = []) {
+    "" "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}"} side_effects -> !s32i
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "", "=&r,=&r,1,~{dirflag},~{fpsr},~{flags}" {{.*}} : (i32) -> i32
 
     cir.return


### PR DESCRIPTION
This PR adds storing of the results of inline assembly operation. 

This is a **final** step (I hope: ) ) from my side to support inline assembly.

There are some features that remains unimplemented, but basic things should work now, For example, we can do addition and get the results - I explicitly added several tests for that, so you can test them in real.
For instance, the next program being compiled with CIR should give you 7 as the result:
```
int add(int x, int y) {  
  int a;
  __asm__("addl %[y], %[x]"
      : "=r" (a)
      : [x] "r" (x), 
        [y] "r" (y)
      );
  
  return a;
}


int main() {
  printf("run %d\n", add(3, 4));
  return 0;
}
```

So, the main thing remains is pretty printing. As I said I added several examples, and may be it will become more clear how to print better.

Also, I added several tests from original codegen in order to check that we don't fail. And I can add some checks there as well when we come to better solution on printing.

