### PR TITLE
[CIR] Introduce a flattening pass

### DIFF
--- a/clang/include/clang/CIR/CIRToCIRPasses.h
+++ b/clang/include/clang/CIR/CIRToCIRPasses.h
@@ -33,10 +33,8 @@ mlir::LogicalResult runCIRToCIRPasses(
     clang::ASTContext &astCtx, bool enableVerifier, bool enableLifetime,
     llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
     llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
-    llvm::StringRef libOptOpts, std::string &passOptParsingFailure);
-
-mlir::LogicalResult runCIRToFlatCIRPasses(
-    mlir::ModuleOp &theModule, mlir::MLIRContext *mlirCtx);
+    llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
+    bool flattenCIR);
 
 } // namespace cir
 

--- a/clang/include/clang/CIR/CIRToCIRPasses.h
+++ b/clang/include/clang/CIR/CIRToCIRPasses.h
@@ -28,13 +28,14 @@ class ModuleOp;
 namespace cir {
 
 // Run set of cleanup/prepare/etc passes CIR <-> CIR.
-mlir::LogicalResult runCIRToCIRPasses(
-    mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
-    clang::ASTContext &astCtx, bool enableVerifier, bool enableLifetime,
-    llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
-    llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
-    llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
-    bool flattenCIR);
+mlir::LogicalResult
+runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
+                  clang::ASTContext &astCtx, bool enableVerifier,
+                  bool enableLifetime, llvm::StringRef lifetimeOpts,
+                  bool enableIdiomRecognizer,
+                  llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
+                  llvm::StringRef libOptOpts,
+                  std::string &passOptParsingFailure, bool flattenCIR);
 
 } // namespace cir
 

--- a/clang/include/clang/CIR/CIRToCIRPasses.h
+++ b/clang/include/clang/CIR/CIRToCIRPasses.h
@@ -34,6 +34,10 @@ mlir::LogicalResult runCIRToCIRPasses(
     llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
     llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
     llvm::StringRef libOptOpts, std::string &passOptParsingFailure);
+
+mlir::LogicalResult runCIRToFlatCIRPasses(
+    mlir::ModuleOp &theModule, mlir::MLIRContext *mlirCtx);
+
 } // namespace cir
 
 #endif // CLANG_CIR_CIRTOCIRPASSES_H_

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -36,6 +36,8 @@ std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createStructuredCFGPass();
 
+void populateCIRFlatteningPasses(mlir::OpPassManager &pm);
+
 //===----------------------------------------------------------------------===//
 // Registration
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -34,6 +34,7 @@ std::unique_ptr<Pass> createIdiomRecognizerPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
+std::unique_ptr<Pass> createStructuredCFGPass();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -34,7 +34,7 @@ std::unique_ptr<Pass> createIdiomRecognizerPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
-std::unique_ptr<Pass> createStructuredCFGPass();
+std::unique_ptr<Pass> createFlattenCFGPass();
 
 void populateCIRFlatteningPasses(mlir::OpPassManager &pm);
 

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -36,7 +36,7 @@ std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createFlattenCFGPass();
 
-void populateCIRFlatteningPasses(mlir::OpPassManager &pm);
+void populateCIRPreLoweringPasses(mlir::OpPassManager &pm);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -80,10 +80,10 @@ def StructuredCFG : Pass<"cir-structured-cfg"> {
   let description = [{ 
     This pass transforms CIR and inline all the nested regions. Thus,
     the next post condtions are met after the pass applied:
-    - there are not any nested region in a function body
+    - there is not any nested region in a function body
     - all the blocks in a function belong to the parent region
     In other words, this pass removes such CIR operations like IfOp, LoopOp,
-    ScopeOp and etc. and produce flat CIR.
+    ScopeOp and etc. and produces a flat CIR.
   }];
   let constructor = "mlir::createStructuredCFGPass()";
   let dependentDialects = ["cir::CIRDialect"];

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -75,8 +75,8 @@ def LoweringPrepare : Pass<"cir-lowering-prepare"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
-def StructuredCFG : Pass<"cir-structured-cfg"> {
-  let summary = "Produces structured cfg";
+def FlattenCFG : Pass<"cir-flatten-cfg"> {
+  let summary = "Produces flatten cfg";
   let description = [{ 
     This pass transforms CIR and inline all the nested regions. Thus,
     the next post condtions are met after the pass applied:
@@ -85,7 +85,7 @@ def StructuredCFG : Pass<"cir-structured-cfg"> {
     In other words, this pass removes such CIR operations like IfOp, LoopOp,
     ScopeOp and etc. and produces a flat CIR.
   }];
-  let constructor = "mlir::createStructuredCFGPass()";
+  let constructor = "mlir::createFlattenCFGPass()";
   let dependentDialects = ["cir::CIRDialect"];
 }
 

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -75,6 +75,20 @@ def LoweringPrepare : Pass<"cir-lowering-prepare"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def StructuredCFG : Pass<"cir-structured-cfg"> {
+  let summary = "Produces structured cfg";
+  let description = [{ 
+    This pass transforms CIR and inline all the nested regions. Thus,
+    the next post condtions are met after the pass applied:
+    - there are not any nested region in a function body
+    - all the blocks in a function belong to the parent region
+    In other words, this pass removes such CIR operations like IfOp, LoopOp,
+    ScopeOp and etc. and produce flat CIR.
+  }];
+  let constructor = "mlir::createStructuredCFGPass()";
+  let dependentDialects = ["cir::CIRDialect"];
+}
+
 def IdiomRecognizer : Pass<"cir-idiom-recognizer"> {
   let summary = "Raise calls to C/C++ libraries to CIR operations";
   let description = [{

--- a/clang/include/clang/CIR/Passes.h
+++ b/clang/include/clang/CIR/Passes.h
@@ -29,8 +29,8 @@ namespace direct {
 /// Create a pass that fully lowers CIR to the LLVMIR dialect.
 std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass();
 
-/// Create a pass pipeline that fully lowers CIR to the LLVMIR dialect.
-void createCIRToLLVMPipeline(mlir::OpPassManager &pm);
+/// Adds passes that fully lower CIR to the LLVMIR dialect.
+void populateCIRToLLVMPasses(mlir::OpPassManager &pm);
 
 } // namespace direct
 } // end namespace cir

--- a/clang/include/clang/CIR/Passes.h
+++ b/clang/include/clang/CIR/Passes.h
@@ -28,6 +28,10 @@ std::unique_ptr<mlir::Pass> createConvertCIRToMLIRPass();
 namespace direct {
 /// Create a pass that fully lowers CIR to the LLVMIR dialect.
 std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass();
+
+/// Create a pass pipeline that fully lowers CIR to the LLVMIR dialect.
+void createCIRToLLVMPipeline(mlir::OpPassManager &pm);
+
 } // namespace direct
 } // end namespace cir
 

--- a/clang/include/clang/CIRFrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIRFrontendAction/CIRGenAction.h
@@ -32,6 +32,7 @@ public:
   enum class OutputType {
     EmitAssembly,
     EmitCIR,
+    EmitFlatCIR,
     EmitLLVM,
     EmitMLIR,
     EmitObj,

--- a/clang/include/clang/CIRFrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIRFrontendAction/CIRGenAction.h
@@ -78,6 +78,13 @@ public:
   EmitCIRAction(mlir::MLIRContext *mlirCtx = nullptr);
 };
 
+class EmitFlatCIRAction : public CIRGenAction {
+  virtual void anchor();
+
+public:
+  EmitFlatCIRAction(mlir::MLIRContext *mlirCtx = nullptr);
+};
+
 class EmitCIROnlyAction : public CIRGenAction {
   virtual void anchor();
 

--- a/clang/include/clang/CIRFrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIRFrontendAction/CIRGenAction.h
@@ -32,7 +32,7 @@ public:
   enum class OutputType {
     EmitAssembly,
     EmitCIR,
-    EmitFlatCIR,
+    EmitCIRFlat,
     EmitLLVM,
     EmitMLIR,
     EmitObj,
@@ -78,11 +78,11 @@ public:
   EmitCIRAction(mlir::MLIRContext *mlirCtx = nullptr);
 };
 
-class EmitFlatCIRAction : public CIRGenAction {
+class EmitCIRFlatAction : public CIRGenAction {
   virtual void anchor();
 
 public:
-  EmitFlatCIRAction(mlir::MLIRContext *mlirCtx = nullptr);
+  EmitCIRFlatAction(mlir::MLIRContext *mlirCtx = nullptr);
 };
 
 class EmitCIROnlyAction : public CIRGenAction {

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2926,8 +2926,8 @@ defm clangir_direct_lowering : BoolFOption<"clangir-direct-lowering",
 
 def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR, emit the .cir file">;
-def emit_flat_cir : Flag<["-"], "emit-flat-cir">, Visibility<[ClangOption, CC1Option]>,
-  Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR with no nested regions, then emit the .cir file">;
+def emit_cir_flat : Flag<["-"], "emit-cir-flat">, Visibility<[ClangOption, CC1Option]>,
+  Group<Action_Group>, HelpText<"Similar to -emit-cir but also lowers structured CFG into basic blocks.">;
 def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to MLIR, emit the .milr file">;
 /// ClangIR-specific options - END

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2926,6 +2926,8 @@ defm clangir_direct_lowering : BoolFOption<"clangir-direct-lowering",
 
 def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR, emit the .cir file">;
+def emit_flat_cir : Flag<["-"], "emit-flat-cir">, Visibility<[ClangOption, CC1Option]>,
+  Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR with no nested regions, then emit the .cir file">;
 def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to MLIR, emit the .milr file">;
 /// ClangIR-specific options - END

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -91,7 +91,7 @@ TYPE("lto-ir",                   LTO_IR,       INVALID,         "s",      phases
 TYPE("lto-bc",                   LTO_BC,       INVALID,         "o",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
 TYPE("cir",                      CIR,          INVALID,         "cir",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
-TYPE("flat-cir",                 FLAT_CIR,     INVALID,         "cir",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("cir-flat",                 CIR_FLAT,     INVALID,         "cir",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("mlir",                     MLIR,         INVALID,         "mlir",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
 // Misc.

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -91,6 +91,7 @@ TYPE("lto-ir",                   LTO_IR,       INVALID,         "s",      phases
 TYPE("lto-bc",                   LTO_BC,       INVALID,         "o",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
 TYPE("cir",                      CIR,          INVALID,         "cir",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("flat-cir",                 FLAT_CIR,     INVALID,         "cir",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("mlir",                     MLIR,         INVALID,         "mlir",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
 // Misc.

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -67,6 +67,9 @@ enum ActionKind {
   /// Emit a .cir file
   EmitCIR,
 
+  /// Emit a .cir file with flat ClangIR
+  EmitFlatCIR,
+
   /// Generate CIR, bud don't emit anything.
   EmitCIROnly,
 

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -68,7 +68,7 @@ enum ActionKind {
   EmitCIR,
 
   /// Emit a .cir file with flat ClangIR
-  EmitFlatCIR,
+  EmitCIRFlat,
 
   /// Generate CIR, bud don't emit anything.
   EmitCIROnly,

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -18,13 +18,14 @@
 #include "mlir/Pass/PassManager.h"
 
 namespace cir {
-mlir::LogicalResult runCIRToCIRPasses(
-    mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
-    clang::ASTContext &astCtx, bool enableVerifier, bool enableLifetime,
-    llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
-    llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
-    llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
-    bool flattenCIR) {
+mlir::LogicalResult
+runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
+                  clang::ASTContext &astCtx, bool enableVerifier,
+                  bool enableLifetime, llvm::StringRef lifetimeOpts,
+                  bool enableIdiomRecognizer,
+                  llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
+                  llvm::StringRef libOptOpts,
+                  std::string &passOptParsingFailure, bool flattenCIR) {
   mlir::PassManager pm(mlirCtx);
   pm.addPass(mlir::createMergeCleanupsPass());
 

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -77,4 +77,4 @@ void populateCIRPreLoweringPasses(OpPassManager &pm) {
   // add other passes here
 }
 
-} // namespace mlir {
+} // namespace mlir

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -58,7 +58,7 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
 
   pm.addPass(mlir::createLoweringPreparePass(&astCtx));
   if (flattenCIR)
-    mlir::populateCIRFlatteningPasses(pm);
+    mlir::populateCIRPreLoweringPasses(pm);
 
   // FIXME: once CIRCodenAction fixes emission other than CIR we
   // need to run this right before dialect emission.
@@ -69,3 +69,13 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
 }
 
 } // namespace cir
+
+
+namespace mlir {
+
+void populateCIRPreLoweringPasses(OpPassManager &pm) {
+  pm.addPass(createFlattenCFGPass());
+  // add other passes here
+}
+
+} // namespace mlir {

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -23,7 +23,8 @@ mlir::LogicalResult runCIRToCIRPasses(
     clang::ASTContext &astCtx, bool enableVerifier, bool enableLifetime,
     llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
     llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
-    llvm::StringRef libOptOpts, std::string &passOptParsingFailure) {    
+    llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
+    bool flattenCIR) {
   mlir::PassManager pm(mlirCtx);
   pm.addPass(mlir::createMergeCleanupsPass());
 
@@ -55,6 +56,8 @@ mlir::LogicalResult runCIRToCIRPasses(
   }
 
   pm.addPass(mlir::createLoweringPreparePass(&astCtx));
+  if (flattenCIR)
+    mlir::populateCIRFlatteningPasses(pm);
 
   // FIXME: once CIRCodenAction fixes emission other than CIR we
   // need to run this right before dialect emission.
@@ -64,11 +67,4 @@ mlir::LogicalResult runCIRToCIRPasses(
   return pm.run(theModule);
 }
 
-mlir::LogicalResult runCIRToFlatCIRPasses(
-  mlir::ModuleOp &theModule, mlir::MLIRContext *mlirCtx) {
-  mlir::PassManager pm(mlirCtx);  
-  mlir::populateCIRFlatteningPasses(pm);
-  pm.addPass(mlir::createStructuredCFGPass());
-  return pm.run(theModule);
-}
 } // namespace cir

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -55,7 +55,7 @@ mlir::LogicalResult runCIRToCIRPasses(
   }
 
   pm.addPass(mlir::createLoweringPreparePass(&astCtx));
-  //pm.addPass(mlir::createStructuredCFGPass());
+  pm.addPass(mlir::createStructuredCFGPass());
 
   // FIXME: once CIRCodenAction fixes emission other than CIR we
   // need to run this right before dialect emission.

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -70,7 +70,6 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
 
 } // namespace cir
 
-
 namespace mlir {
 
 void populateCIRPreLoweringPasses(OpPassManager &pm) {

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -55,6 +55,7 @@ mlir::LogicalResult runCIRToCIRPasses(
   }
 
   pm.addPass(mlir::createLoweringPreparePass(&astCtx));
+  //pm.addPass(mlir::createStructuredCFGPass());
 
   // FIXME: once CIRCodenAction fixes emission other than CIR we
   // need to run this right before dialect emission.

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -23,7 +23,7 @@ mlir::LogicalResult runCIRToCIRPasses(
     clang::ASTContext &astCtx, bool enableVerifier, bool enableLifetime,
     llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
     llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
-    llvm::StringRef libOptOpts, std::string &passOptParsingFailure) {
+    llvm::StringRef libOptOpts, std::string &passOptParsingFailure) {    
   mlir::PassManager pm(mlirCtx);
   pm.addPass(mlir::createMergeCleanupsPass());
 
@@ -55,13 +55,20 @@ mlir::LogicalResult runCIRToCIRPasses(
   }
 
   pm.addPass(mlir::createLoweringPreparePass(&astCtx));
-  pm.addPass(mlir::createStructuredCFGPass());
 
   // FIXME: once CIRCodenAction fixes emission other than CIR we
   // need to run this right before dialect emission.
   pm.addPass(mlir::createDropASTPass());
   pm.enableVerifier(enableVerifier);
   (void)mlir::applyPassManagerCLOptions(pm);
+  return pm.run(theModule);
+}
+
+mlir::LogicalResult runCIRToFlatCIRPasses(
+  mlir::ModuleOp &theModule, mlir::MLIRContext *mlirCtx) {
+  mlir::PassManager pm(mlirCtx);  
+  mlir::populateCIRFlatteningPasses(pm);
+  pm.addPass(mlir::createStructuredCFGPass());
   return pm.run(theModule);
 }
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/CIRFlattening.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRFlattening.cpp
@@ -2,5 +2,5 @@
 #include "clang/CIR/Dialect/Passes.h"
 
 void mlir::populateCIRFlatteningPasses(mlir::OpPassManager &pm) {
-  pm.addPass(mlir::createStructuredCFGPass());
+  pm.addPass(mlir::createFlattenCFGPass());
 }

--- a/clang/lib/CIR/Dialect/Transforms/CIRFlattening.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRFlattening.cpp
@@ -1,6 +1,0 @@
-#include "mlir/Pass/PassManager.h"
-#include "clang/CIR/Dialect/Passes.h"
-
-void mlir::populateCIRFlatteningPasses(mlir::OpPassManager &pm) {
-  pm.addPass(mlir::createFlattenCFGPass());
-}

--- a/clang/lib/CIR/Dialect/Transforms/CIRFlattening.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRFlattening.cpp
@@ -1,7 +1,6 @@
-#include "clang/CIR/Dialect/Passes.h"
 #include "mlir/Pass/PassManager.h"
-
+#include "clang/CIR/Dialect/Passes.h"
 
 void mlir::populateCIRFlatteningPasses(mlir::OpPassManager &pm) {
-    pm.addPass(mlir::createStructuredCFGPass());
+  pm.addPass(mlir::createStructuredCFGPass());
 }

--- a/clang/lib/CIR/Dialect/Transforms/CIRFlattening.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRFlattening.cpp
@@ -1,0 +1,7 @@
+#include "clang/CIR/Dialect/Passes.h"
+#include "mlir/Pass/PassManager.h"
+
+
+void mlir::populateCIRFlatteningPasses(mlir::OpPassManager &pm) {
+    pm.addPass(mlir::createStructuredCFGPass());
+}

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_clang_library(MLIRCIRTransforms
   IdiomRecognizer.cpp
   LibOpt.cpp
   StdHelpers.cpp
+  StructuredCFG.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_clang_library(MLIRCIRTransforms
-  CIRFlattening.cpp
   LifetimeCheck.cpp
   LoweringPrepare.cpp
   MergeCleanups.cpp

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -7,7 +7,7 @@ add_clang_library(MLIRCIRTransforms
   IdiomRecognizer.cpp
   LibOpt.cpp
   StdHelpers.cpp
-  StructuredCFG.cpp
+  FlattenCFG.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_clang_library(MLIRCIRTransforms
+  CIRFlattening.cpp
   LifetimeCheck.cpp
   LoweringPrepare.cpp
   MergeCleanups.cpp

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1,3 +1,15 @@
+//====- FlattenCFG.cpp - Flatten CIR CFG ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements pass that inlines CIR operations regions into the parent
+// function region.
+//
+//===----------------------------------------------------------------------===//
 #include "PassDetail.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -12,19 +12,19 @@ using namespace mlir::cir;
 
 namespace {
 
-struct StructuredCFGPass : public StructuredCFGBase<StructuredCFGPass> {
+struct FlattenCFGPass : public FlattenCFGBase<FlattenCFGPass> {
 
-  StructuredCFGPass() = default;
+  FlattenCFGPass() = default;
   void runOnOperation() override;
 };
 
-void populateStructuredCFGPatterns(RewritePatternSet &patterns) {
+void populateFlattenCFGPatterns(RewritePatternSet &patterns) {
   // TODO: add patterns here
 }
 
-void StructuredCFGPass::runOnOperation() {
+void FlattenCFGPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
-  populateStructuredCFGPatterns(patterns);
+  populateFlattenCFGPatterns(patterns);
 
   // Collect operations to apply patterns.
   SmallVector<Operation *, 16> ops;
@@ -41,8 +41,8 @@ void StructuredCFGPass::runOnOperation() {
 
 namespace mlir {
 
-std::unique_ptr<Pass> createStructuredCFGPass() {
-  return std::make_unique<StructuredCFGPass>();
+std::unique_ptr<Pass> createFlattenCFGPass() {
+  return std::make_unique<FlattenCFGPass>();
 }
 
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/StructuredCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/StructuredCFG.cpp
@@ -7,7 +7,6 @@
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
 
-
 using namespace mlir;
 using namespace mlir::cir;
 

--- a/clang/lib/CIR/Dialect/Transforms/StructuredCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/StructuredCFG.cpp
@@ -1,0 +1,50 @@
+#include "PassDetail.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+
+
+using namespace mlir;
+using namespace mlir::cir;
+
+namespace {
+
+struct StructuredCFGPass : public StructuredCFGBase<StructuredCFGPass> {
+  
+  StructuredCFGPass() = default;
+  void runOnOperation() override;
+};
+
+void populateStructuredCFGPatterns(RewritePatternSet &patterns) { 
+  //TODO: add patterns here
+}
+
+void StructuredCFGPass::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  populateStructuredCFGPatterns(patterns);
+
+  // Collect operations to apply patterns.  
+  SmallVector<Operation *, 16> ops;
+  getOperation()->walk<mlir::WalkOrder::PostOrder>([&](Operation *op) {
+     //TODO: push back operations here
+  });
+  
+  // Apply patterns.
+  if (applyOpPatternsAndFold(ops, std::move(patterns)).failed())
+    signalPassFailure();
+}
+
+} // namespace
+
+
+namespace mlir {
+
+std::unique_ptr<Pass> createStructuredCFGPass() {
+  return std::make_unique<StructuredCFGPass>();
+}
+
+}

--- a/clang/lib/CIR/Dialect/Transforms/StructuredCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/StructuredCFG.cpp
@@ -2,8 +2,8 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
 
@@ -13,25 +13,25 @@ using namespace mlir::cir;
 namespace {
 
 struct StructuredCFGPass : public StructuredCFGBase<StructuredCFGPass> {
-  
+
   StructuredCFGPass() = default;
   void runOnOperation() override;
 };
 
-void populateStructuredCFGPatterns(RewritePatternSet &patterns) { 
-  //TODO: add patterns here
+void populateStructuredCFGPatterns(RewritePatternSet &patterns) {
+  // TODO: add patterns here
 }
 
 void StructuredCFGPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   populateStructuredCFGPatterns(patterns);
 
-  // Collect operations to apply patterns.  
+  // Collect operations to apply patterns.
   SmallVector<Operation *, 16> ops;
   getOperation()->walk<mlir::WalkOrder::PostOrder>([&](Operation *op) {
-     //TODO: push back operations here
+    // TODO: push back operations here
   });
-  
+
   // Apply patterns.
   if (applyOpPatternsAndFold(ops, std::move(patterns)).failed())
     signalPassFailure();
@@ -39,11 +39,10 @@ void StructuredCFGPass::runOnOperation() {
 
 } // namespace
 
-
 namespace mlir {
 
 std::unique_ptr<Pass> createStructuredCFGPass() {
   return std::make_unique<StructuredCFGPass>();
 }
 
-}
+} // namespace mlir

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -185,7 +185,8 @@ public:
               mlirMod, mlirCtx.get(), C, !feOptions.ClangIRDisableCIRVerifier,
               feOptions.ClangIRLifetimeCheck, lifetimeOpts,
               feOptions.ClangIRIdiomRecognizer, idiomRecognizerOpts,
-              feOptions.ClangIRLibOpt, libOptOpts, passOptParsingFailure)
+              feOptions.ClangIRLibOpt, libOptOpts, passOptParsingFailure,
+              action==CIRGenAction::OutputType::EmitFlatCIR)
               .failed()) {
         if (!passOptParsingFailure.empty())
           diagnosticsEngine.Report(diag::err_drv_cir_pass_opt_parsing)
@@ -233,6 +234,7 @@ public:
 
     switch (action) {
     case CIRGenAction::OutputType::EmitCIR:
+    case CIRGenAction::OutputType::EmitFlatCIR:
       if (outputStream && mlirMod) {
         // Emit remaining defaulted C++ methods
         if (!feOptions.ClangIRDisableEmitCXXDefault)
@@ -244,15 +246,6 @@ public:
         mlirMod->print(*outputStream, flags);
       }
       break;
-    case CIRGenAction::OutputType::EmitFlatCIR: {
-      auto flatCIRModule = runCIRToFlatCIRPasses(mlirMod, mlirCtx.get());        
-
-      // FIXME: we cannot roundtrip prettyForm=true right now.
-      mlir::OpPrintingFlags flags;
-      flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
-      mlirMod->print(*outputStream, flags);
-      break;
-    }
     case CIRGenAction::OutputType::EmitMLIR: {
       auto loweredMlirModule = lowerFromCIRToMLIR(mlirMod, mlirCtx.get());
       assert(outputStream && "Why are we here without an output stream?");

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -244,6 +244,15 @@ public:
         mlirMod->print(*outputStream, flags);
       }
       break;
+    case CIRGenAction::OutputType::EmitFlatCIR: {
+      auto flatCIRModule = runCIRToFlatCIRPasses(mlirMod, mlirCtx.get());        
+
+      // FIXME: we cannot roundtrip prettyForm=true right now.
+      mlir::OpPrintingFlags flags;
+      flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
+      mlirMod->print(*outputStream, flags);
+    }    
+    break;
     case CIRGenAction::OutputType::EmitMLIR: {
       auto loweredMlirModule = lowerFromCIRToMLIR(mlirMod, mlirCtx.get());
       assert(outputStream && "Why are we here without an output stream?");
@@ -352,6 +361,8 @@ getOutputStream(CompilerInstance &ci, StringRef inFile,
   case CIRGenAction::OutputType::EmitAssembly:
     return ci.createDefaultOutputFile(false, inFile, "s");
   case CIRGenAction::OutputType::EmitCIR:
+    return ci.createDefaultOutputFile(false, inFile, "cir");
+  case CIRGenAction::OutputType::EmitFlatCIR:
     return ci.createDefaultOutputFile(false, inFile, "cir");
   case CIRGenAction::OutputType::EmitMLIR:
     return ci.createDefaultOutputFile(false, inFile, "mlir");

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -186,7 +186,7 @@ public:
               feOptions.ClangIRLifetimeCheck, lifetimeOpts,
               feOptions.ClangIRIdiomRecognizer, idiomRecognizerOpts,
               feOptions.ClangIRLibOpt, libOptOpts, passOptParsingFailure,
-              action == CIRGenAction::OutputType::EmitFlatCIR)
+              action == CIRGenAction::OutputType::EmitCIRFlat)
               .failed()) {
         if (!passOptParsingFailure.empty())
           diagnosticsEngine.Report(diag::err_drv_cir_pass_opt_parsing)
@@ -234,7 +234,7 @@ public:
 
     switch (action) {
     case CIRGenAction::OutputType::EmitCIR:
-    case CIRGenAction::OutputType::EmitFlatCIR:
+    case CIRGenAction::OutputType::EmitCIRFlat:
       if (outputStream && mlirMod) {
         // Emit remaining defaulted C++ methods
         if (!feOptions.ClangIRDisableEmitCXXDefault)
@@ -355,7 +355,7 @@ getOutputStream(CompilerInstance &ci, StringRef inFile,
     return ci.createDefaultOutputFile(false, inFile, "s");
   case CIRGenAction::OutputType::EmitCIR:
     return ci.createDefaultOutputFile(false, inFile, "cir");
-  case CIRGenAction::OutputType::EmitFlatCIR:
+  case CIRGenAction::OutputType::EmitCIRFlat:
     return ci.createDefaultOutputFile(false, inFile, "cir");
   case CIRGenAction::OutputType::EmitMLIR:
     return ci.createDefaultOutputFile(false, inFile, "mlir");
@@ -450,9 +450,9 @@ void EmitCIRAction::anchor() {}
 EmitCIRAction::EmitCIRAction(mlir::MLIRContext *_MLIRContext)
     : CIRGenAction(OutputType::EmitCIR, _MLIRContext) {}
 
-void EmitFlatCIRAction::anchor() {}
-EmitFlatCIRAction::EmitFlatCIRAction(mlir::MLIRContext *_MLIRContext)
-    : CIRGenAction(OutputType::EmitFlatCIR, _MLIRContext) {}
+void EmitCIRFlatAction::anchor() {}
+EmitCIRFlatAction::EmitCIRFlatAction(mlir::MLIRContext *_MLIRContext)
+    : CIRGenAction(OutputType::EmitCIRFlat, _MLIRContext) {}
 
 void EmitCIROnlyAction::anchor() {}
 EmitCIROnlyAction::EmitCIROnlyAction(mlir::MLIRContext *_MLIRContext)

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -186,7 +186,7 @@ public:
               feOptions.ClangIRLifetimeCheck, lifetimeOpts,
               feOptions.ClangIRIdiomRecognizer, idiomRecognizerOpts,
               feOptions.ClangIRLibOpt, libOptOpts, passOptParsingFailure,
-              action==CIRGenAction::OutputType::EmitFlatCIR)
+              action == CIRGenAction::OutputType::EmitFlatCIR)
               .failed()) {
         if (!passOptParsingFailure.empty())
           diagnosticsEngine.Report(diag::err_drv_cir_pass_opt_parsing)

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -251,8 +251,8 @@ public:
       mlir::OpPrintingFlags flags;
       flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
       mlirMod->print(*outputStream, flags);
-    }    
-    break;
+      break;
+    }
     case CIRGenAction::OutputType::EmitMLIR: {
       auto loweredMlirModule = lowerFromCIRToMLIR(mlirMod, mlirCtx.get());
       assert(outputStream && "Why are we here without an output stream?");
@@ -456,6 +456,10 @@ EmitAssemblyAction::EmitAssemblyAction(mlir::MLIRContext *_MLIRContext)
 void EmitCIRAction::anchor() {}
 EmitCIRAction::EmitCIRAction(mlir::MLIRContext *_MLIRContext)
     : CIRGenAction(OutputType::EmitCIR, _MLIRContext) {}
+
+void EmitFlatCIRAction::anchor() {}
+EmitFlatCIRAction::EmitFlatCIRAction(mlir::MLIRContext *_MLIRContext)
+    : CIRGenAction(OutputType::EmitFlatCIR, _MLIRContext) {}
 
 void EmitCIROnlyAction::anchor() {}
 EmitCIROnlyAction::EmitCIROnlyAction(mlir::MLIRContext *_MLIRContext)

--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -29,6 +29,7 @@ add_clang_library(clangCIRLoweringDirectToLLVM
   ${dialect_libs}
   MLIRCIR
   MLIRAnalysis
+  MLIRCIRTransforms
   MLIRIR
   MLIRParser
   MLIRSideEffectInterfaces

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -917,7 +917,9 @@ struct ConvertCIRToLLVMPass
   }
   void runOnOperation() final;
 
-  virtual StringRef getArgument() const override { return "cir-to-llvm-internal"; }
+  virtual StringRef getArgument() const override {
+    return "cir-to-llvm-internal";
+  }
 };
 
 class CIRCallLowering : public mlir::OpConversionPattern<mlir::cir::CallOp> {
@@ -2981,7 +2983,7 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx,
                              bool disableVerifier) {
   mlir::MLIRContext *mlirCtx = theModule.getContext();
   mlir::PassManager pm(mlirCtx);
-  populateCIRToLLVMPasses(pm);  
+  populateCIRToLLVMPasses(pm);
 
   // This is necessary to have line tables emitted and basic
   // debugger working. In the future we will add proper debug information

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2969,7 +2969,7 @@ std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass() {
   return std::make_unique<ConvertCIRToLLVMPass>();
 }
 
-void createCIRToLLVMPipeline(mlir::OpPassManager &pm) {
+void populateCIRToLLVMPasses(mlir::OpPassManager &pm) {
   populateCIRFlatteningPasses(pm);
   pm.addPass(createConvertCIRToLLVMPass());
 }
@@ -2981,7 +2981,7 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx,
                              bool disableVerifier) {
   mlir::MLIRContext *mlirCtx = theModule.getContext();
   mlir::PassManager pm(mlirCtx);
-  createCIRToLLVMPipeline(pm);  
+  populateCIRToLLVMPasses(pm);  
 
   // This is necessary to have line tables emitted and basic
   // debugger working. In the future we will add proper debug information

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2972,7 +2972,7 @@ std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass() {
 }
 
 void populateCIRToLLVMPasses(mlir::OpPassManager &pm) {
-  populateCIRFlatteningPasses(pm);
+  populateCIRPreLoweringPasses(pm);
   pm.addPass(createConvertCIRToLLVMPass());
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -50,6 +50,7 @@
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/Passes.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -916,7 +917,7 @@ struct ConvertCIRToLLVMPass
   }
   void runOnOperation() final;
 
-  virtual StringRef getArgument() const override { return "cir-to-llvm"; }
+  virtual StringRef getArgument() const override { return "cir-to-llvm-internal"; }
 };
 
 class CIRCallLowering : public mlir::OpConversionPattern<mlir::cir::CallOp> {
@@ -2968,6 +2969,11 @@ std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass() {
   return std::make_unique<ConvertCIRToLLVMPass>();
 }
 
+void createCIRToLLVMPipeline(mlir::OpPassManager &pm) {
+  populateCIRFlatteningPasses(pm);
+  pm.addPass(createConvertCIRToLLVMPass());
+}
+
 extern void registerCIRDialectTranslation(mlir::MLIRContext &context);
 
 std::unique_ptr<llvm::Module>
@@ -2975,8 +2981,7 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx,
                              bool disableVerifier) {
   mlir::MLIRContext *mlirCtx = theModule.getContext();
   mlir::PassManager pm(mlirCtx);
-
-  pm.addPass(createConvertCIRToLLVMPass());
+  createCIRToLLVMPipeline(pm);  
 
   // This is necessary to have line tables emitted and basic
   // debugger working. In the future we will add proper debug information

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -361,6 +361,7 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
              (PhaseArg = DAL.getLastArg(options::OPT__migrate)) ||
              (PhaseArg = DAL.getLastArg(options::OPT__analyze)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_cir)) ||
+             (PhaseArg = DAL.getLastArg(options::OPT_emit_flat_cir)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_ast))) {
     FinalPhase = phases::Compile;
 
@@ -4785,9 +4786,10 @@ Action *Driver::ConstructPhaseAction(
       return C.MakeAction<MigrateJobAction>(Input, types::TY_Remap);
     if (Args.hasArg(options::OPT_emit_ast))
       return C.MakeAction<CompileJobAction>(Input, types::TY_AST);
-    if (Args.hasArg(options::OPT_emit_cir)) {
+    if (Args.hasArg(options::OPT_emit_cir))
       return C.MakeAction<CompileJobAction>(Input, types::TY_CIR);
-    }
+    if (Args.hasArg(options::OPT_emit_flat_cir))
+      return C.MakeAction<CompileJobAction>(Input, types::TY_FLAT_CIR);
     if (Args.hasArg(options::OPT_module_file_info))
       return C.MakeAction<CompileJobAction>(Input, types::TY_ModuleFile);
     if (Args.hasArg(options::OPT_verify_pch))

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -361,7 +361,7 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
              (PhaseArg = DAL.getLastArg(options::OPT__migrate)) ||
              (PhaseArg = DAL.getLastArg(options::OPT__analyze)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_cir)) ||
-             (PhaseArg = DAL.getLastArg(options::OPT_emit_flat_cir)) ||
+             (PhaseArg = DAL.getLastArg(options::OPT_emit_cir_flat)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_ast))) {
     FinalPhase = phases::Compile;
 
@@ -4788,8 +4788,8 @@ Action *Driver::ConstructPhaseAction(
       return C.MakeAction<CompileJobAction>(Input, types::TY_AST);
     if (Args.hasArg(options::OPT_emit_cir))
       return C.MakeAction<CompileJobAction>(Input, types::TY_CIR);
-    if (Args.hasArg(options::OPT_emit_flat_cir))
-      return C.MakeAction<CompileJobAction>(Input, types::TY_FLAT_CIR);
+    if (Args.hasArg(options::OPT_emit_cir_flat))
+      return C.MakeAction<CompileJobAction>(Input, types::TY_CIR_FLAT);
     if (Args.hasArg(options::OPT_module_file_info))
       return C.MakeAction<CompileJobAction>(Input, types::TY_ModuleFile);
     if (Args.hasArg(options::OPT_verify_pch))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4910,7 +4910,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   if (Args.hasArg(options::OPT_fclangir_enable) ||
-      Args.hasArg(options::OPT_emit_cir))
+      Args.hasArg(options::OPT_emit_cir) ||
+      Args.hasArg(options::OPT_emit_flat_cir))
     CmdArgs.push_back("-fclangir-enable");
 
   if (Args.hasArg(options::OPT_fclangir_direct_lowering))
@@ -5052,6 +5053,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-emit-llvm");
     } else if (JA.getType() == types::TY_CIR) {
       CmdArgs.push_back("-emit-cir");
+    } else if (JA.getType() == types::TY_FLAT_CIR) {
+      CmdArgs.push_back("-emit-flat-cir");
     } else if (JA.getType() == types::TY_LLVM_BC ||
                JA.getType() == types::TY_LTO_BC) {
       // Emit textual llvm IR for AMDGPU offloading for -emit-llvm -S

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5054,7 +5054,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     } else if (JA.getType() == types::TY_CIR) {
       CmdArgs.push_back("-emit-cir");
     } else if (JA.getType() == types::TY_CIR_FLAT) {
-      CmdArgs.push_back("-emit-flat-cir");
+      CmdArgs.push_back("-emit-cir-flat");
     } else if (JA.getType() == types::TY_LLVM_BC ||
                JA.getType() == types::TY_LTO_BC) {
       // Emit textual llvm IR for AMDGPU offloading for -emit-llvm -S

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4911,7 +4911,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (Args.hasArg(options::OPT_fclangir_enable) ||
       Args.hasArg(options::OPT_emit_cir) ||
-      Args.hasArg(options::OPT_emit_flat_cir))
+      Args.hasArg(options::OPT_emit_cir_flat))
     CmdArgs.push_back("-fclangir-enable");
 
   if (Args.hasArg(options::OPT_fclangir_direct_lowering))
@@ -5053,7 +5053,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-emit-llvm");
     } else if (JA.getType() == types::TY_CIR) {
       CmdArgs.push_back("-emit-cir");
-    } else if (JA.getType() == types::TY_FLAT_CIR) {
+    } else if (JA.getType() == types::TY_CIR_FLAT) {
       CmdArgs.push_back("-emit-flat-cir");
     } else if (JA.getType() == types::TY_LLVM_BC ||
                JA.getType() == types::TY_LTO_BC) {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2908,9 +2908,8 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)
     Diags.Report(diag::err_drv_argument_only_allowed_with) << "-fsystem-module"
                                                            << "-emit-module";
-  if (Args.hasArg(OPT_fclangir_enable)
-      || Args.hasArg(OPT_emit_cir)
-      || Args.hasArg(OPT_emit_flat_cir))
+  if (Args.hasArg(OPT_fclangir_enable) || Args.hasArg(OPT_emit_cir) ||
+      Args.hasArg(OPT_emit_flat_cir))
     Opts.UseClangIRPipeline = true;
 
   if (Args.hasArg(OPT_fclangir_direct_lowering))

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2552,6 +2552,7 @@ static const auto &getFrontendActionTable() {
       {frontend::EmitAssembly, OPT_S},
       {frontend::EmitBC, OPT_emit_llvm_bc},
       {frontend::EmitCIR, OPT_emit_cir},
+      {frontend::EmitFlatCIR, OPT_emit_flat_cir},
       {frontend::EmitCIROnly, OPT_emit_cir_only},
       {frontend::EmitMLIR, OPT_emit_mlir},
       {frontend::EmitHTML, OPT_emit_html},
@@ -2907,7 +2908,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)
     Diags.Report(diag::err_drv_argument_only_allowed_with) << "-fsystem-module"
                                                            << "-emit-module";
-  if (Args.hasArg(OPT_fclangir_enable) || Args.hasArg(OPT_emit_cir))
+  if (Args.hasArg(OPT_fclangir_enable)
+      || Args.hasArg(OPT_emit_cir)
+      || Args.hasArg(OPT_emit_flat_cir))
     Opts.UseClangIRPipeline = true;
 
   if (Args.hasArg(OPT_fclangir_direct_lowering))
@@ -4383,6 +4386,7 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::EmitAssembly:
   case frontend::EmitBC:
   case frontend::EmitCIR:
+  case frontend::EmitFlatCIR:
   case frontend::EmitCIROnly:
   case frontend::EmitMLIR:
   case frontend::EmitHTML:

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2552,7 +2552,7 @@ static const auto &getFrontendActionTable() {
       {frontend::EmitAssembly, OPT_S},
       {frontend::EmitBC, OPT_emit_llvm_bc},
       {frontend::EmitCIR, OPT_emit_cir},
-      {frontend::EmitFlatCIR, OPT_emit_flat_cir},
+      {frontend::EmitCIRFlat, OPT_emit_cir_flat},
       {frontend::EmitCIROnly, OPT_emit_cir_only},
       {frontend::EmitMLIR, OPT_emit_mlir},
       {frontend::EmitHTML, OPT_emit_html},
@@ -2909,7 +2909,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     Diags.Report(diag::err_drv_argument_only_allowed_with) << "-fsystem-module"
                                                            << "-emit-module";
   if (Args.hasArg(OPT_fclangir_enable) || Args.hasArg(OPT_emit_cir) ||
-      Args.hasArg(OPT_emit_flat_cir))
+      Args.hasArg(OPT_emit_cir_flat))
     Opts.UseClangIRPipeline = true;
 
   if (Args.hasArg(OPT_fclangir_direct_lowering))
@@ -4385,7 +4385,7 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::EmitAssembly:
   case frontend::EmitBC:
   case frontend::EmitCIR:
-  case frontend::EmitFlatCIR:
+  case frontend::EmitCIRFlat:
   case frontend::EmitCIROnly:
   case frontend::EmitMLIR:
   case frontend::EmitHTML:

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -81,7 +81,8 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
   case EmitBC:                 return std::make_unique<EmitBCAction>();
 #if CLANG_ENABLE_CIR
   case EmitCIR:                return std::make_unique<::cir::EmitCIRAction>();
-  case EmitFlatCIR:            return std::make_unique<::cir::EmitFlatCIRAction>();
+  case EmitFlatCIR:
+    return std::make_unique<::cir::EmitFlatCIRAction>();
   case EmitCIROnly:            return std::make_unique<::cir::EmitCIROnlyAction>();
   case EmitMLIR:               return std::make_unique<::cir::EmitMLIRAction>();
 #else

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -53,7 +53,7 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
 
   auto UseCIR = CI.getFrontendOpts().UseClangIRPipeline;
   auto Act = CI.getFrontendOpts().ProgramAction;
-  auto EmitsCIR = Act == EmitCIR || Act == EmitFlatCIR || Act == EmitCIROnly;
+  auto EmitsCIR = Act == EmitCIR || Act == EmitCIRFlat || Act == EmitCIROnly;
 
   if (!UseCIR && EmitsCIR)
     llvm::report_fatal_error(
@@ -81,13 +81,13 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
   case EmitBC:                 return std::make_unique<EmitBCAction>();
 #if CLANG_ENABLE_CIR
   case EmitCIR:                return std::make_unique<::cir::EmitCIRAction>();
-  case EmitFlatCIR:
-    return std::make_unique<::cir::EmitFlatCIRAction>();
+  case EmitCIRFlat:
+    return std::make_unique<::cir::EmitCIRFlatAction>();
   case EmitCIROnly:            return std::make_unique<::cir::EmitCIROnlyAction>();
   case EmitMLIR:               return std::make_unique<::cir::EmitMLIRAction>();
 #else
   case EmitCIR:
-  case EmitFlatCIR:
+  case EmitCIRFlat:
   case EmitCIROnly:
     llvm_unreachable("CIR suppport not built into clang");
 #endif

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -53,7 +53,7 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
 
   auto UseCIR = CI.getFrontendOpts().UseClangIRPipeline;
   auto Act = CI.getFrontendOpts().ProgramAction;
-  auto EmitsCIR = Act == EmitCIR || Act == EmitCIROnly;
+  auto EmitsCIR = Act == EmitCIR || Act == EmitFlatCIR || Act == EmitCIROnly;
 
   if (!UseCIR && EmitsCIR)
     llvm::report_fatal_error(
@@ -81,10 +81,12 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
   case EmitBC:                 return std::make_unique<EmitBCAction>();
 #if CLANG_ENABLE_CIR
   case EmitCIR:                return std::make_unique<::cir::EmitCIRAction>();
+  case EmitFlatCIR:            return std::make_unique<::cir::EmitFlatCIRAction>();
   case EmitCIROnly:            return std::make_unique<::cir::EmitCIROnlyAction>();
   case EmitMLIR:               return std::make_unique<::cir::EmitMLIRAction>();
 #else
   case EmitCIR:
+  case EmitFlatCIR:
   case EmitCIROnly:
     llvm_unreachable("CIR suppport not built into clang");
 #endif

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -14,14 +14,14 @@ int foo(void) {
 // CIR:  cir.func @foo() -> !s32i
 // CIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
 // CIR:  cir.func @foo() -> !s32i
-// CIR-NOT: IR Dump After StructuredCFG (cir-structured-cfg)
+// CIR-NOT: IR Dump After StructuredCFG
 // CIR:  IR Dump After DropAST (cir-drop-ast)
 // CIR:  cir.func @foo() -> !s32i
 // FLATCIR:  IR Dump After MergeCleanups (cir-merge-cleanups)
 // FLATCIR:  cir.func @foo() -> !s32i
 // FLATCIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
 // FLATCIR:  cir.func @foo() -> !s32i
-// FLATCIR:  IR Dump After StructuredCFG
+// FLATCIR:  IR Dump After StructuredCFG (cir-structured-cfg)
 // FLATCIR:  IR Dump After DropAST (cir-drop-ast)
 // FLATCIR:  cir.func @foo() -> !s32i
 // LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-to-llvm-internal)
@@ -32,4 +32,4 @@ int foo(void) {
 // CIRPASS-NOT:  IR Dump After MergeCleanups
 // CIRPASS:      IR Dump After DropAST
 
-// CFGPASS: IR Dump Before StructuredCFG
+// CFGPASS: IR Dump Before StructuredCFG (cir-structured-cfg)

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-flat-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=FLATCIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm -mmlir --mlir-print-ir-after-all -mllvm -print-after-all  %s -o %t.ll 2>&1 | FileCheck %s -check-prefix=CIR -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after=cir-drop-ast %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRPASS
 
@@ -12,8 +13,16 @@ int foo(void) {
 // CIR:  cir.func @foo() -> !s32i
 // CIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
 // CIR:  cir.func @foo() -> !s32i
+// CIR-NOT: IR Dump After StructuredCFG
 // CIR:  IR Dump After DropAST (cir-drop-ast)
 // CIR:  cir.func @foo() -> !s32i
+// FLATCIR:  IR Dump After MergeCleanups (cir-merge-cleanups)
+// FLATCIR:  cir.func @foo() -> !s32i
+// FLATCIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
+// FLATCIR:  cir.func @foo() -> !s32i
+// FLATCIR:  IR Dump After StructuredCFG
+// FLATCIR:  IR Dump After DropAST (cir-drop-ast)
+// FLATCIR:  cir.func @foo() -> !s32i
 // LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-to-llvm-internal)
 // LLVM: llvm.func @foo() -> i32
 // LLVM: IR Dump After

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-flat-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=FLATCIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir-flat -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRFLAT
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm -mmlir --mlir-print-ir-after-all -mllvm -print-after-all  %s -o %t.ll 2>&1 | FileCheck %s -check-prefix=CIR -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after=cir-drop-ast %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRPASS
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-flat-cir -mmlir --mlir-print-ir-before=cir-structured-cfg %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CFGPASS
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir-flat -mmlir --mlir-print-ir-before=cir-structured-cfg %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CFGPASS
 
 int foo(void) {
   int i = 3;
@@ -17,13 +17,13 @@ int foo(void) {
 // CIR-NOT: IR Dump After StructuredCFG
 // CIR:  IR Dump After DropAST (cir-drop-ast)
 // CIR:  cir.func @foo() -> !s32i
-// FLATCIR:  IR Dump After MergeCleanups (cir-merge-cleanups)
-// FLATCIR:  cir.func @foo() -> !s32i
-// FLATCIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
-// FLATCIR:  cir.func @foo() -> !s32i
-// FLATCIR:  IR Dump After StructuredCFG (cir-structured-cfg)
-// FLATCIR:  IR Dump After DropAST (cir-drop-ast)
-// FLATCIR:  cir.func @foo() -> !s32i
+// CIRFLAT:  IR Dump After MergeCleanups (cir-merge-cleanups)
+// CIRFLAT:  cir.func @foo() -> !s32i
+// CIRFLAT:  IR Dump After LoweringPrepare (cir-lowering-prepare)
+// CIRFLAT:  cir.func @foo() -> !s32i
+// CIRFLAT:  IR Dump After StructuredCFG (cir-structured-cfg)
+// CIRFLAT:  IR Dump After DropAST (cir-drop-ast)
+// CIRFLAT:  cir.func @foo() -> !s32i
 // LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-to-llvm-internal)
 // LLVM: llvm.func @foo() -> i32
 // LLVM: IR Dump After

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -2,6 +2,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-flat-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=FLATCIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm -mmlir --mlir-print-ir-after-all -mllvm -print-after-all  %s -o %t.ll 2>&1 | FileCheck %s -check-prefix=CIR -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after=cir-drop-ast %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRPASS
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-flat-cir -mmlir --mlir-print-ir-before=cir-structured-cfg %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CFGPASS
 
 int foo(void) {
   int i = 3;
@@ -13,7 +14,7 @@ int foo(void) {
 // CIR:  cir.func @foo() -> !s32i
 // CIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
 // CIR:  cir.func @foo() -> !s32i
-// CIR-NOT: IR Dump After StructuredCFG
+// CIR-NOT: IR Dump After StructuredCFG (cir-structured-cfg)
 // CIR:  IR Dump After DropAST (cir-drop-ast)
 // CIR:  cir.func @foo() -> !s32i
 // FLATCIR:  IR Dump After MergeCleanups (cir-merge-cleanups)
@@ -30,3 +31,5 @@ int foo(void) {
 
 // CIRPASS-NOT:  IR Dump After MergeCleanups
 // CIRPASS:      IR Dump After DropAST
+
+// CFGPASS: IR Dump Before StructuredCFG

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -2,7 +2,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir-flat -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRFLAT
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm -mmlir --mlir-print-ir-after-all -mllvm -print-after-all  %s -o %t.ll 2>&1 | FileCheck %s -check-prefix=CIR -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir -mmlir --mlir-print-ir-after=cir-drop-ast %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRPASS
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir-flat -mmlir --mlir-print-ir-before=cir-structured-cfg %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CFGPASS
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir-flat -mmlir --mlir-print-ir-before=cir-flatten-cfg %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CFGPASS
 
 int foo(void) {
   int i = 3;
@@ -14,14 +14,14 @@ int foo(void) {
 // CIR:  cir.func @foo() -> !s32i
 // CIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
 // CIR:  cir.func @foo() -> !s32i
-// CIR-NOT: IR Dump After StructuredCFG
+// CIR-NOT: IR Dump After FlattenCFG
 // CIR:  IR Dump After DropAST (cir-drop-ast)
 // CIR:  cir.func @foo() -> !s32i
 // CIRFLAT:  IR Dump After MergeCleanups (cir-merge-cleanups)
 // CIRFLAT:  cir.func @foo() -> !s32i
 // CIRFLAT:  IR Dump After LoweringPrepare (cir-lowering-prepare)
 // CIRFLAT:  cir.func @foo() -> !s32i
-// CIRFLAT:  IR Dump After StructuredCFG (cir-structured-cfg)
+// CIRFLAT:  IR Dump After FlattenCFG (cir-flatten-cfg)
 // CIRFLAT:  IR Dump After DropAST (cir-drop-ast)
 // CIRFLAT:  cir.func @foo() -> !s32i
 // LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-to-llvm-internal)
@@ -32,4 +32,4 @@ int foo(void) {
 // CIRPASS-NOT:  IR Dump After MergeCleanups
 // CIRPASS:      IR Dump After DropAST
 
-// CFGPASS: IR Dump Before StructuredCFG (cir-structured-cfg)
+// CFGPASS: IR Dump Before FlattenCFG (cir-flatten-cfg)

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -14,7 +14,7 @@ int foo(void) {
 // CIR:  cir.func @foo() -> !s32i
 // CIR:  IR Dump After DropAST (cir-drop-ast)
 // CIR:  cir.func @foo() -> !s32i
-// LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-to-llvm)
+// LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-to-llvm-internal)
 // LLVM: llvm.func @foo() -> i32
 // LLVM: IR Dump After
 // LLVM: define i32 @foo()

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
   mlir::PassPipelineRegistration<mlir::EmptyPipelineOptions> pipeline(
     "cir-to-llvm", "", 
       [](mlir::OpPassManager &pm) {
-        cir::direct::createCIRToLLVMPipeline(pm);
+        cir::direct::populateCIRToLLVMPasses(pm);
   });
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Pass/PassRegistry.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
@@ -45,8 +46,10 @@ int main(int argc, char **argv) {
     return cir::createConvertCIRToMLIRPass();
   });
 
-  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
-    return cir::direct::createConvertCIRToLLVMPass();
+  mlir::PassPipelineRegistration<mlir::EmptyPipelineOptions> pipeline(
+    "cir-to-llvm", "", 
+      [](mlir::OpPassManager &pm) {
+        cir::direct::createCIRToLLVMPipeline(pm);
   });
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -20,8 +20,8 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/InitAllPasses.h"
-#include "mlir/Pass/PassRegistry.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
@@ -47,10 +47,9 @@ int main(int argc, char **argv) {
   });
 
   mlir::PassPipelineRegistration<mlir::EmptyPipelineOptions> pipeline(
-    "cir-to-llvm", "", 
-      [](mlir::OpPassManager &pm) {
+      "cir-to-llvm", "", [](mlir::OpPassManager &pm) {
         cir::direct::populateCIRToLLVMPasses(pm);
-  });
+      });
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return mlir::createReconcileUnrealizedCastsPass();


### PR DESCRIPTION
We start our journey towards `goto` support and this is a first step on this way.

There are some discussion in #508  and according to the plan we do the following here:
1) a new pass called `StructuredCFG`  that is a stub now but later will be responsible for the regions inlining. The pass works only if `emit-cir` is not passed in cmd line. Thus, the clang behavior  is not changed here from the user's point of view.
2)  The pass will be accomplished with `goto` solver later, so we talk about several passes that are mandatory for the lowering into `llvm` dialect. There are at least two clients of this pass that will be affected: `clang` itself and `cir-opt`, so we need a common point for them: and `populateCIRFlatteningPasses` and `populateCIRToLLVMPasses` guarantee that `CIR` will be in the correct state for all the clients, whatever new passes we will add later. 
3) new option `-emit-flat-cir` to dump CIR after all the flattening and structuring and goto-solving.
