### PR TITLE
[CIR][CIRGen] Add handling __extension__ keyword for lvalue

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -985,7 +985,8 @@ mlir::Value CIRGenFunction::evaluateExprAsBool(const Expr *E) {
 
 LValue CIRGenFunction::buildUnaryOpLValue(const UnaryOperator *E) {
   // __extension__ doesn't affect lvalue-ness.
-  assert(E->getOpcode() != UO_Extension && "not implemented");
+  if (E->getOpcode() == UO_Extension)
+    return buildLValue(E->getSubExpr());
 
   switch (E->getOpcode()) {
   default:

--- a/clang/test/CIR/CodeGen/gnu-extension.c
+++ b/clang/test/CIR/CodeGen/gnu-extension.c
@@ -9,3 +9,11 @@ int foo(void) { return __extension__ 0b101010; }
 //CHECK-NEXT:    cir.store [[VAL]], [[ADDR]] : !s32i, cir.ptr <!s32i>
 //CHECK-NEXT:    [[LOAD_VAL:%.*]] = cir.load [[ADDR]] : cir.ptr <!s32i>, !s32i
 //CHECK-NEXT:    cir.return [[LOAD_VAL]] : !s32i
+
+void bar(void) {
+  __extension__ bar;
+}
+
+//CHECK:  cir.func @bar()
+//CHECK:    {{.*}} = cir.get_global @bar : cir.ptr <!cir.func<!void ()>>
+//CHECK:    cir.return


### PR DESCRIPTION
This change is taken from the original codegen