### PR TITLE
[CIR] GNU vector type cleanup

### DIFF
--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -23,10 +23,7 @@ struct UnimplementedFeature {
   static bool tbaa() { return false; }
   static bool cleanups() { return false; }
 
-  // cir::VectorType is in progress, so cirVectorType() will go away soon.
-  // Start adding feature flags for more advanced vector types and operations
-  // that will take longer to implement.
-  static bool cirVectorType() { return false; }
+  // GNU vectors are done, but other kinds of vectors haven't been implemented.
   static bool scalableVectors() { return false; }
   static bool vectorConstants() { return false; }
 


### PR DESCRIPTION
This is the final commit for issue #284.  Vector types other than GNU vector types will be covered by other yet-to-be-created issues.

Now that GNU vector types (the ones defined via the vector_size attribute) are implemented, do a final cleanup of the assertions and other checks related to vector types.

Remove `UnimplementedFeature::cirVectorType()`.  Deal with the remaining calls to that function.  When the that is not yet implemented has to do with Arm SVE vectors, the assert was changed to `UnimplementedFeature::scalableVectors()` instead.  The assertion was removed in cases where the code correctly handle GNU vector types.

While cleaning up the assertion checks, I noticed that BinOp handling of vector types wasn't quite complete.  Any special handling for integer or floating-point types wasn't happening when the operands were vector types.  To fix this, split `BinOpInfo::Ty` into two fields, `FullType` and `CompType`.  `FullType` is the type of the operands.  `CompType` is normally the same as `FullType`, but is the element type when `FullType` is a vector type.