### PR TITLE
[CIR] Add initial support for bit-precise integer types

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -144,7 +144,7 @@ def ObjSizeOp : CIR_Op<"objsize", [Pure]> {
 
   let arguments = (ins CIR_PointerType:$ptr, SizeInfoType:$kind,
                    UnitAttr:$dynamic);
-  let results = (outs CIR_IntType:$result);
+  let results = (outs StdInt:$result);
 
   let assemblyFormat = [{
     `(`
@@ -180,7 +180,7 @@ def PtrDiffOp : CIR_Op<"ptr_diff", [Pure, SameTypeOperands]> {
     ```
   }];
 
-  let results = (outs CIR_IntType:$result);
+  let results = (outs StdInt:$result);
   let arguments = (ins CIR_PointerType:$lhs, CIR_PointerType:$rhs);
 
   let assemblyFormat = [{
@@ -208,7 +208,7 @@ def PtrStrideOp : CIR_Op<"ptr_stride",
     ```
   }];
 
-  let arguments = (ins CIR_PointerType:$base, CIR_IntType:$stride);
+  let arguments = (ins CIR_PointerType:$base, StdInt:$stride);
   let results = (outs CIR_PointerType:$result);
 
   let assemblyFormat = [{
@@ -337,7 +337,7 @@ def AllocaOp : CIR_Op<"alloca", [
   }];
 
   let arguments = (ins
-    Optional<CIR_IntType>:$dynAllocSize,
+    Optional<StdInt>:$dynAllocSize,
     TypeAttr:$allocaType,
     StrAttr:$name,
     UnitAttr:$init,
@@ -1252,7 +1252,7 @@ def CmpThreeWayOp : CIR_Op<"cmp3way", [Pure, SameTypeOperands]> {
     ```
   }];
 
-  let results = (outs CIR_IntType:$result);
+  let results = (outs StdSInt:$result);
   let arguments = (ins CIR_AnyType:$lhs, CIR_AnyType:$rhs,
                        CmpThreeWayInfoAttr:$info);
 
@@ -1261,7 +1261,7 @@ def CmpThreeWayOp : CIR_Op<"cmp3way", [Pure, SameTypeOperands]> {
     `:` type($result) attr-dict
   }];
 
-  let hasVerifier = 1;
+  let hasVerifier = 0;
 }
 
 //===----------------------------------------------------------------------===//
@@ -2122,7 +2122,7 @@ def VecInsertOp : CIR_Op<"vec.insert", [Pure,
     element is returned.
   }];
 
-  let arguments = (ins CIR_VectorType:$vec, AnyType:$value, CIR_IntType:$index);
+  let arguments = (ins CIR_VectorType:$vec, AnyType:$value, StdInt:$index);
   let results = (outs CIR_VectorType:$result);
 
   let assemblyFormat = [{
@@ -2147,7 +2147,7 @@ def VecExtractOp : CIR_Op<"vec.extract", [Pure,
     from a vector object.
   }];
 
-  let arguments = (ins CIR_VectorType:$vec, CIR_IntType:$index);
+  let arguments = (ins CIR_VectorType:$vec, StdInt:$index);
   let results = (outs CIR_AnyType:$result);
 
   let assemblyFormat = [{
@@ -2935,7 +2935,7 @@ def CopyOp : CIR_Op<"copy", [SameTypeOperands]> {
 def MemCpyOp : CIR_Op<"libc.memcpy"> {
   let arguments = (ins Arg<CIR_PointerType, "", [MemWrite]>:$dst,
                        Arg<CIR_PointerType, "", [MemRead]>:$src,
-                       CIR_IntType:$len);
+                       StdInt:$len);
   let summary = "Equivalent to libc's `memcpy`";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.libc.memcpy` will copy `len`
@@ -3115,10 +3115,10 @@ def ExpectOp : CIR_Op<"expect",
     where probability = $prob.
   }];
 
-  let arguments = (ins CIR_IntType:$val,
-                       CIR_IntType:$expected,
+  let arguments = (ins StdInt:$val,
+                       StdInt:$expected,
                        OptionalAttr<F64Attr>:$prob);
-  let results = (outs CIR_IntType:$result);
+  let results = (outs StdInt:$result);
   let assemblyFormat = [{
     `(` $val`,` $expected (`,` $prob^)? `)` `:` type($val) attr-dict
   }];
@@ -3524,7 +3524,7 @@ def AtomicFetch : CIR_Op<"atomic.fetch",
     of the computation (`__atomic_binop_fetch`).
   }];
   let results = (outs CIR_AnyIntOrFloat:$result);
-  let arguments = (ins IntOrFPPtr:$ptr, CIR_AnyIntOrFloat:$val,
+  let arguments = (ins StdIntOrFPPtr:$ptr, CIR_AnyIntOrFloat:$val,
                        AtomicFetchKind:$binop,
                        Arg<MemOrder, "memory order">:$mem_order,
                        UnitAttr:$is_volatile,

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -144,7 +144,7 @@ def ObjSizeOp : CIR_Op<"objsize", [Pure]> {
 
   let arguments = (ins CIR_PointerType:$ptr, SizeInfoType:$kind,
                    UnitAttr:$dynamic);
-  let results = (outs StdInt:$result);
+  let results = (outs PrimitiveInt:$result);
 
   let assemblyFormat = [{
     `(`
@@ -180,7 +180,7 @@ def PtrDiffOp : CIR_Op<"ptr_diff", [Pure, SameTypeOperands]> {
     ```
   }];
 
-  let results = (outs StdInt:$result);
+  let results = (outs PrimitiveInt:$result);
   let arguments = (ins CIR_PointerType:$lhs, CIR_PointerType:$rhs);
 
   let assemblyFormat = [{
@@ -208,7 +208,7 @@ def PtrStrideOp : CIR_Op<"ptr_stride",
     ```
   }];
 
-  let arguments = (ins CIR_PointerType:$base, StdInt:$stride);
+  let arguments = (ins CIR_PointerType:$base, PrimitiveInt:$stride);
   let results = (outs CIR_PointerType:$result);
 
   let assemblyFormat = [{
@@ -337,7 +337,7 @@ def AllocaOp : CIR_Op<"alloca", [
   }];
 
   let arguments = (ins
-    Optional<StdInt>:$dynAllocSize,
+    Optional<PrimitiveInt>:$dynAllocSize,
     TypeAttr:$allocaType,
     StrAttr:$name,
     UnitAttr:$init,
@@ -1034,7 +1034,7 @@ class CIR_BitOp<string mnemonic, TypeConstraint inputTy>
   }];
 }
 
-def BitClrsbOp : CIR_BitOp<"bit.clrsb", SIntOfWidths<[32, 64]>> {
+def BitClrsbOp : CIR_BitOp<"bit.clrsb", AnyTypeOf<[SInt32, SInt64]>> {
   let summary = "Get the number of leading redundant sign bits in the input";
   let description = [{
     Compute the number of leading redundant sign bits in the input integer.
@@ -1065,7 +1065,7 @@ def BitClrsbOp : CIR_BitOp<"bit.clrsb", SIntOfWidths<[32, 64]>> {
   }];
 }
 
-def BitClzOp : CIR_BitOp<"bit.clz", UIntOfWidths<[16, 32, 64]>> {
+def BitClzOp : CIR_BitOp<"bit.clz", AnyTypeOf<[UInt16, UInt32, UInt64]>> {
   let summary = "Get the number of leading 0-bits in the input";
   let description = [{
     Compute the number of leading 0-bits in the input.
@@ -1090,7 +1090,7 @@ def BitClzOp : CIR_BitOp<"bit.clz", UIntOfWidths<[16, 32, 64]>> {
   }];
 }
 
-def BitCtzOp : CIR_BitOp<"bit.ctz", UIntOfWidths<[16, 32, 64]>> {
+def BitCtzOp : CIR_BitOp<"bit.ctz", AnyTypeOf<[UInt16, UInt32, UInt64]>> {
   let summary = "Get the number of trailing 0-bits in the input";
   let description = [{
     Compute the number of trailing 0-bits in the input.
@@ -1115,7 +1115,7 @@ def BitCtzOp : CIR_BitOp<"bit.ctz", UIntOfWidths<[16, 32, 64]>> {
   }];
 }
 
-def BitFfsOp : CIR_BitOp<"bit.ffs", SIntOfWidths<[32, 64]>> {
+def BitFfsOp : CIR_BitOp<"bit.ffs", AnyTypeOf<[SInt32, SInt64]>> {
   let summary = "Get the position of the least significant 1-bit of input";
   let description = [{
     Compute the position of the least significant 1-bit of the input.
@@ -1138,7 +1138,7 @@ def BitFfsOp : CIR_BitOp<"bit.ffs", SIntOfWidths<[32, 64]>> {
   }];
 }
 
-def BitParityOp : CIR_BitOp<"bit.parity", UIntOfWidths<[32, 64]>> {
+def BitParityOp : CIR_BitOp<"bit.parity", AnyTypeOf<[UInt32, UInt64]>> {
   let summary = "Get the parity of input";
   let description = [{
     Compute the parity of the input. The parity of an integer is the number of
@@ -1160,7 +1160,8 @@ def BitParityOp : CIR_BitOp<"bit.parity", UIntOfWidths<[32, 64]>> {
   }];
 }
 
-def BitPopcountOp : CIR_BitOp<"bit.popcount", UIntOfWidths<[16, 32, 64]>> {
+def BitPopcountOp
+    : CIR_BitOp<"bit.popcount", AnyTypeOf<[UInt16, UInt32, UInt64]>> {
   let summary = "Get the number of 1-bits in input";
   let description = [{
     Compute the number of 1-bits in the input.
@@ -1208,7 +1209,7 @@ def ByteswapOp : CIR_Op<"bswap", [Pure, SameOperandsAndResultType]> {
   }];
 
   let results = (outs CIR_IntType:$result);
-  let arguments = (ins UIntOfWidths<[16, 32, 64]>:$input);
+  let arguments = (ins AnyTypeOf<[UInt16, UInt32, UInt64]>:$input);
 
   let assemblyFormat = [{
     `(` $input `:` type($input) `)` `:` type($result) attr-dict
@@ -1252,7 +1253,7 @@ def CmpThreeWayOp : CIR_Op<"cmp3way", [Pure, SameTypeOperands]> {
     ```
   }];
 
-  let results = (outs StdSInt:$result);
+  let results = (outs PrimitiveSInt:$result);
   let arguments = (ins CIR_AnyType:$lhs, CIR_AnyType:$rhs,
                        CmpThreeWayInfoAttr:$info);
 
@@ -2122,7 +2123,7 @@ def VecInsertOp : CIR_Op<"vec.insert", [Pure,
     element is returned.
   }];
 
-  let arguments = (ins CIR_VectorType:$vec, AnyType:$value, StdInt:$index);
+  let arguments = (ins CIR_VectorType:$vec, AnyType:$value, PrimitiveInt:$index);
   let results = (outs CIR_VectorType:$result);
 
   let assemblyFormat = [{
@@ -2147,7 +2148,7 @@ def VecExtractOp : CIR_Op<"vec.extract", [Pure,
     from a vector object.
   }];
 
-  let arguments = (ins CIR_VectorType:$vec, StdInt:$index);
+  let arguments = (ins CIR_VectorType:$vec, PrimitiveInt:$index);
   let results = (outs CIR_AnyType:$result);
 
   let assemblyFormat = [{
@@ -2935,7 +2936,7 @@ def CopyOp : CIR_Op<"copy", [SameTypeOperands]> {
 def MemCpyOp : CIR_Op<"libc.memcpy"> {
   let arguments = (ins Arg<CIR_PointerType, "", [MemWrite]>:$dst,
                        Arg<CIR_PointerType, "", [MemRead]>:$src,
-                       StdInt:$len);
+                       PrimitiveInt:$len);
   let summary = "Equivalent to libc's `memcpy`";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.libc.memcpy` will copy `len`
@@ -3115,10 +3116,10 @@ def ExpectOp : CIR_Op<"expect",
     where probability = $prob.
   }];
 
-  let arguments = (ins StdInt:$val,
-                       StdInt:$expected,
+  let arguments = (ins PrimitiveInt:$val,
+                       PrimitiveInt:$expected,
                        OptionalAttr<F64Attr>:$prob);
-  let results = (outs StdInt:$result);
+  let results = (outs PrimitiveInt:$result);
   let assemblyFormat = [{
     `(` $val`,` $expected (`,` $prob^)? `)` `:` type($val) attr-dict
   }];
@@ -3524,7 +3525,7 @@ def AtomicFetch : CIR_Op<"atomic.fetch",
     of the computation (`__atomic_binop_fetch`).
   }];
   let results = (outs CIR_AnyIntOrFloat:$result);
-  let arguments = (ins StdIntOrFPPtr:$ptr, CIR_AnyIntOrFloat:$val,
+  let arguments = (ins PrimitiveIntOrFPPtr:$ptr, CIR_AnyIntOrFloat:$val,
                        AtomicFetchKind:$binop,
                        Arg<MemOrder, "memory order">:$mem_order,
                        UnitAttr:$is_volatile,

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -53,10 +53,10 @@ def CIR_IntType : CIR_Type<"Int", "int",
     std::string getAlias() const {
       return (isSigned() ? 's' : 'u') + std::to_string(getWidth()) + 'i';
     };
-    /// Return true if this is a standard integer type (i.e. not a bit-precise
-    /// integer type).
-    bool isStandard() const {
-      return isValidStdIntBitwidth(getWidth());
+    /// Return true if this is a primitive integer type (i.e. signed or unsigned
+    /// integer types whose bit width is 8, 16, 32, or 64).
+    bool isPrimitive() const {
+      return isValidPrimitiveIntBitwidth(getWidth());
     }
 
     /// Returns a minimum bitwidth of cir::IntType
@@ -64,9 +64,9 @@ def CIR_IntType : CIR_Type<"Int", "int",
     /// Returns a maximum bitwidth of cir::IntType
     static unsigned maxBitwidth() { return 64; }
 
-    /// Returns true if cir::IntType that represents a standard integer type
+    /// Returns true if cir::IntType that represents a primitive integer type
     /// can be constructed from the provided bitwidth.
-    static bool isValidStdIntBitwidth(unsigned width) {
+    static bool isValidPrimitiveIntBitwidth(unsigned width) {
       return width == 8 || width == 16 || width == 32 || width == 64;
     }
   }];
@@ -113,55 +113,15 @@ def SInt16 : SInt<16>;
 def SInt32 : SInt<32>;
 def SInt64 : SInt<64>;
 
-// A type constraint that allows unsigned integer type whose width is among the
-// specified list of possible widths.
-class UIntOfWidths<list<int> widths>
-  : Type<And<[
-            CPred<"$_self.isa<::mlir::cir::IntType>()">,
-            CPred<"$_self.cast<::mlir::cir::IntType>().isUnsigned()">,
-            Or<!foreach(
-              w, widths,
-              CPred<"$_self.cast<::mlir::cir::IntType>().getWidth() == " # w>
-            )>
-        ]>,
-        !interleave(!foreach(w, widths, w # "-bit"), " or ") # " uint",
-        "::mlir::cir::IntType"
-    > {}
-
-// A type constraint that allows unsigned integer type whose width is among the
-// specified list of possible widths.
-class SIntOfWidths<list<int> widths>
-  : Type<And<[
-            CPred<"$_self.isa<::mlir::cir::IntType>()">,
-            CPred<"$_self.cast<::mlir::cir::IntType>().isSigned()">,
-            Or<!foreach(
-              w, widths,
-              CPred<"$_self.cast<::mlir::cir::IntType>().getWidth() == " # w>
-            )>
-        ]>,
-        !interleave(!foreach(w, widths, w # "-bit"), " or ") # " sint",
-        "::mlir::cir::IntType"
-    > {}
-
-// A type constraint that allows integer type whose width is among the specified
-// list of possible widths. The signedness of the integer type is not
-// constrained.
-class IntOfWidths<list<int> widths>
-  : Type<And<[
-            CPred<"$_self.isa<::mlir::cir::IntType>()">,
-            Or<!foreach(
-              w, widths,
-              CPred<"$_self.cast<::mlir::cir::IntType>().getWidth() == " # w>
-            )>
-        ]>,
-        !interleave(!foreach(w, widths, w # "-bit"), " or ") #
-            " signed or unsigned int",
-        "::mlir::cir::IntType"
-    > {}
-
-def StdUInt : UIntOfWidths<[8, 16, 32, 64]>;
-def StdSInt : SIntOfWidths<[8, 16, 32, 64]>;
-def StdInt : IntOfWidths<[8, 16, 32, 64]>;
+def PrimitiveUInt
+    : AnyTypeOf<[UInt8, UInt16, UInt32, UInt64], "primitive unsigned int",
+                "::mlir::cir::IntType">;
+def PrimitiveSInt
+    : AnyTypeOf<[SInt8, SInt16, SInt32, SInt64], "primitive signed int",
+                "::mlir::cir::IntType">;
+def PrimitiveInt
+    : AnyTypeOf<[UInt8, UInt16, UInt32, UInt64, SInt8, SInt16, SInt32, SInt64],
+                "primitive int", "::mlir::cir::IntType">;
 
 //===----------------------------------------------------------------------===//
 // FloatType
@@ -398,8 +358,8 @@ def VoidPtr : Type<
       "mlir::cir::VoidType::get($_builder.getContext()))"> {
 }
 
-// Pointer to int, float or double
-def StdIntOrFPPtr : Type<
+// Pointer to a primitive int, float or double
+def PrimitiveIntOrFPPtr : Type<
     And<[
       CPred<"$_self.isa<::mlir::cir::PointerType>()">,
       CPred<"$_self.cast<::mlir::cir::PointerType>()"
@@ -455,7 +415,7 @@ def IntegerVector : Type<
             ".getEltType().isa<::mlir::cir::IntType>()">,
       CPred<"$_self.cast<::mlir::cir::VectorType>()"
             ".getEltType().cast<::mlir::cir::IntType>()"
-            ".isStandard()">
+            ".isPrimitive()">
     ]>, "!cir.vector of !cir.int"> {
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -53,17 +53,21 @@ def CIR_IntType : CIR_Type<"Int", "int",
     std::string getAlias() const {
       return (isSigned() ? 's' : 'u') + std::to_string(getWidth()) + 'i';
     };
+    /// Return true if this is a standard integer type (i.e. not a bit-precise
+    /// integer type).
+    bool isStandard() const {
+      return isValidStdIntBitwidth(getWidth());
+    }
 
     /// Returns a minimum bitwidth of cir::IntType
     static unsigned minBitwidth() { return 1; }
     /// Returns a maximum bitwidth of cir::IntType
     static unsigned maxBitwidth() { return 64; }
 
-    /// Returns true if cir::IntType can be constructed from the provided bitwidth
-    static bool isValidBitwidth(unsigned width) {
-      return width >= minBitwidth()
-        && width <= maxBitwidth()
-        && llvm::isPowerOf2_32(width);
+    /// Returns true if cir::IntType that represents a standard integer type
+    /// can be constructed from the provided bitwidth.
+    static bool isValidStdIntBitwidth(unsigned width) {
+      return width == 8 || width == 16 || width == 32 || width == 64;
     }
   }];
   let genVerifyDecl = 1;
@@ -138,6 +142,26 @@ class SIntOfWidths<list<int> widths>
         !interleave(!foreach(w, widths, w # "-bit"), " or ") # " sint",
         "::mlir::cir::IntType"
     > {}
+
+// A type constraint that allows integer type whose width is among the specified
+// list of possible widths. The signedness of the integer type is not
+// constrained.
+class IntOfWidths<list<int> widths>
+  : Type<And<[
+            CPred<"$_self.isa<::mlir::cir::IntType>()">,
+            Or<!foreach(
+              w, widths,
+              CPred<"$_self.cast<::mlir::cir::IntType>().getWidth() == " # w>
+            )>
+        ]>,
+        !interleave(!foreach(w, widths, w # "-bit"), " or ") #
+            " signed or unsigned int",
+        "::mlir::cir::IntType"
+    > {}
+
+def StdUInt : UIntOfWidths<[8, 16, 32, 64]>;
+def StdSInt : SIntOfWidths<[8, 16, 32, 64]>;
+def StdInt : IntOfWidths<[8, 16, 32, 64]>;
 
 //===----------------------------------------------------------------------===//
 // FloatType
@@ -375,7 +399,7 @@ def VoidPtr : Type<
 }
 
 // Pointer to int, float or double
-def IntOrFPPtr : Type<
+def StdIntOrFPPtr : Type<
     And<[
       CPred<"$_self.isa<::mlir::cir::PointerType>()">,
       CPred<"$_self.cast<::mlir::cir::PointerType>()"
@@ -429,6 +453,9 @@ def IntegerVector : Type<
       CPred<"$_self.isa<::mlir::cir::VectorType>()">,
       CPred<"$_self.cast<::mlir::cir::VectorType>()"
             ".getEltType().isa<::mlir::cir::IntType>()">,
+      CPred<"$_self.cast<::mlir::cir::VectorType>()"
+            ".getEltType().cast<::mlir::cir::IntType>()"
+            ".isStandard()">
     ]>, "!cir.vector of !cir.int"> {
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -55,7 +55,7 @@ def CIR_IntType : CIR_Type<"Int", "int",
     };
 
     /// Returns a minimum bitwidth of cir::IntType
-    static unsigned minBitwidth() { return 8; }
+    static unsigned minBitwidth() { return 1; }
     /// Returns a maximum bitwidth of cir::IntType
     static unsigned maxBitwidth() { return 64; }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -328,7 +328,7 @@ public:
     case 64:
       return getUInt64Ty();
     default:
-      llvm_unreachable("Unknown bit-width");
+      return mlir::cir::IntType::get(getContext(), N, false);
     }
   }
 
@@ -343,7 +343,7 @@ public:
     case 64:
       return getSInt64Ty();
     default:
-      llvm_unreachable("Unknown bit-width");
+      return mlir::cir::IntType::get(getContext(), N, true);
     }
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -251,7 +251,11 @@ mlir::Type CIRGenTypes::convertTypeForMem(clang::QualType qualType,
   mlir::Type convertedType = ConvertType(qualType);
 
   assert(!forBitField && "Bit fields NYI");
-  assert(!qualType->isBitIntType() && "BitIntType NYI");
+
+  // If this is a bit-precise integer type in a bitfield representation, map
+  // this integer to the target-specified size.
+  if (forBitField && qualType->isBitIntType())
+    assert(!qualType->isBitIntType() && "Bit field with type _BitInt NYI");
 
   return convertedType;
 }
@@ -725,7 +729,9 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
     break;
   }
   case Type::BitInt: {
-    assert(0 && "not implemented");
+    const auto *bitIntTy = cast<BitIntType>(Ty);
+    ResultType = mlir::cir::IntType::get(
+        Builder.getContext(), bitIntTy->getNumBits(), bitIntTy->isSigned());
     break;
   }
   }

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -159,7 +159,7 @@ struct CIRRecordLowering final {
   // structures support.
   mlir::Type getBitfieldStorageType(unsigned numBits) {
     unsigned alignedBits = llvm::alignTo(numBits, astContext.getCharWidth());
-    if (mlir::cir::IntType::isValidBitwidth(alignedBits)) {
+    if (mlir::cir::IntType::isValidStdIntBitwidth(alignedBits)) {
       return builder.getUIntNTy(alignedBits);
     } else {
       mlir::Type type = getCharType();

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -159,7 +159,7 @@ struct CIRRecordLowering final {
   // structures support.
   mlir::Type getBitfieldStorageType(unsigned numBits) {
     unsigned alignedBits = llvm::alignTo(numBits, astContext.getCharWidth());
-    if (mlir::cir::IntType::isValidStdIntBitwidth(alignedBits)) {
+    if (mlir::cir::IntType::isValidPrimitiveIntBitwidth(alignedBits)) {
       return builder.getUIntNTy(alignedBits);
     } else {
       mlir::Type type = getCharType();

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -945,20 +945,6 @@ Block *BrCondOp::getSuccessorForOperands(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
-// CmpThreeWayOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult CmpThreeWayOp::verify() {
-  // Type of the result must be a signed integer type.
-  if (!getType().isSigned()) {
-    emitOpError() << "result type of cir.cmp3way must be a signed integer type";
-    return failure();
-  }
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // SwitchOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -64,6 +64,10 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
       return AliasResult::OverridableAlias;
     }
     if (auto intType = type.dyn_cast<IntType>()) {
+      // We only provide alias for standard integer types (i.e. integer types
+      // whose width is divisible by 8).
+      if (intType.getWidth() % 8 != 0)
+        return AliasResult::NoAlias;
       os << intType.getAlias();
       return AliasResult::OverridableAlias;
     }

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -647,10 +647,6 @@ IntType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
                 << IntType::minBitwidth() << "up to " << IntType::maxBitwidth();
     return mlir::failure();
   }
-  if (width % 8 != 0) {
-    emitError() << "IntType width is not a multiple of 8";
-    return mlir::failure();
-  }
 
   return mlir::success();
 }

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -601,12 +601,8 @@ Type IntType::parse(mlir::AsmParser &parser) {
   // Fetch integer size.
   if (parser.parseInteger(width))
     return {};
-  if (width % 8 != 0) {
-    parser.emitError(loc, "expected integer width to be a multiple of 8");
-    return {};
-  }
-  if (width < 8 || width > 64) {
-    parser.emitError(loc, "expected integer width to be from 8 up to 64");
+  if (width < 1 || width > 64) {
+    parser.emitError(loc, "expected integer width to be from 1 up to 64");
     return {};
   }
 

--- a/clang/test/CIR/CodeGen/bitint.c
+++ b/clang/test/CIR/CodeGen/bitint.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void VLATest(_BitInt(3) A, _BitInt(42) B, _BitInt(17) C) {
+  int AR1[A];
+  int AR2[B];
+  int AR3[C];
+}
+
+//      CHECK: cir.func @VLATest
+//      CHECK:   %[[#A:]] = cir.load %{{.+}} : cir.ptr <!cir.int<s, 3>>, !cir.int<s, 3>
+// CHECK-NEXT:   %[[#A_PROMOTED:]] = cir.cast(integral, %[[#A]] : !cir.int<s, 3>), !u64i
+// CHECK-NEXT:   %[[#SP:]] = cir.stack_save : !cir.ptr<!u8i>
+// CHECK-NEXT:   cir.store %[[#SP]], %{{.+}} : !cir.ptr<!u8i>, cir.ptr <!cir.ptr<!u8i>>
+// CHECK-NEXT:   %{{.+}} = cir.alloca !s32i, cir.ptr <!s32i>, %[[#A_PROMOTED]] : !u64i
+// CHECK-NEXT:   %[[#B:]] = cir.load %1 : cir.ptr <!cir.int<s, 42>>, !cir.int<s, 42>
+// CHECK-NEXT:   %[[#B_PROMOTED:]] = cir.cast(integral, %[[#B]] : !cir.int<s, 42>), !u64i
+// CHECK-NEXT:   %{{.+}} = cir.alloca !s32i, cir.ptr <!s32i>, %[[#B_PROMOTED]] : !u64i
+// CHECK-NEXT:   %[[#C:]] = cir.load %2 : cir.ptr <!cir.int<s, 17>>, !cir.int<s, 17>
+// CHECK-NEXT:   %[[#C_PROMOTED:]] = cir.cast(integral, %[[#C]] : !cir.int<s, 17>), !u64i
+// CHECK-NEXT:   %{{.+}} = cir.alloca !s32i, cir.ptr <!s32i>, %[[#C_PROMOTED]] : !u64i
+//      CHECK: }

--- a/clang/test/CIR/CodeGen/bitint.cpp
+++ b/clang/test/CIR/CodeGen/bitint.cpp
@@ -4,6 +4,9 @@
 using i10 = signed _BitInt(10);
 using u10 = unsigned _BitInt(10);
 
+unsigned _BitInt(1) GlobSize1 = 0;
+// CHECK: cir.global external @GlobSize1 = #cir.int<0> : !cir.int<u, 1>
+
 i10 test_signed(i10 arg) {
   return arg;
 }
@@ -46,3 +49,38 @@ i10 test_arith(i10 lhs, i10 rhs) {
 // CHECK-NEXT:   %[[#RHS:]] = cir.load %{{.+}} : cir.ptr <!cir.int<s, 10>>, !cir.int<s, 10>
 // CHECK-NEXT:   %{{.+}} = cir.binop(add, %[[#LHS]], %[[#RHS]]) : !cir.int<s, 10>
 //      CHECK: }
+
+void Size1ExtIntParam(unsigned _BitInt(1) A) {
+  unsigned _BitInt(1) B[5];
+  B[2] = A;
+}
+
+//      CHECK: cir.func @_Z16Size1ExtIntParamDU1_
+//      CHECK:   %[[#A:]] = cir.load %{{.+}} : cir.ptr <!cir.int<u, 1>>, !cir.int<u, 1>
+// CHECK-NEXT:   %[[#IDX:]] = cir.const(#cir.int<2> : !s32i) : !s32i
+// CHECK-NEXT:   %[[#ARRAY:]] = cir.cast(array_to_ptrdecay, %1 : !cir.ptr<!cir.array<!cir.int<u, 1> x 5>>), !cir.ptr<!cir.int<u, 1>>
+// CHECK-NEXT:   %[[#PTR:]] = cir.ptr_stride(%[[#ARRAY]] : !cir.ptr<!cir.int<u, 1>>, %[[#IDX]] : !s32i), !cir.ptr<!cir.int<u, 1>>
+// CHECK-NEXT:   cir.store %[[#A]], %[[#PTR]] : !cir.int<u, 1>, cir.ptr <!cir.int<u, 1>>
+//      CHECK: }
+
+struct S {
+  _BitInt(17) A;
+  _BitInt(10) B;
+  _BitInt(17) C;
+};
+
+void OffsetOfTest(void) {
+  int A = __builtin_offsetof(struct S,A);
+  int B = __builtin_offsetof(struct S,B);
+  int C = __builtin_offsetof(struct S,C);
+}
+
+// CHECK: cir.func @_Z12OffsetOfTestv()
+// CHECK:   %{{.+}} = cir.const(#cir.int<0> : !u64i) : !u64i
+// CHECK:   %{{.+}} = cir.const(#cir.int<4> : !u64i) : !u64i
+// CHECK:   %{{.+}} = cir.const(#cir.int<8> : !u64i) : !u64i
+// CHECK: }
+
+_BitInt(2) ParamPassing(_BitInt(15) a, _BitInt(31) b) {}
+
+// CHECK: cir.func @_Z12ParamPassingDB15_DB31_(%arg0: !cir.int<s, 15> loc({{.+}}), %arg1: !cir.int<s, 31> loc({{.+}})) -> !cir.int<s, 2>

--- a/clang/test/CIR/CodeGen/bitint.cpp
+++ b/clang/test/CIR/CodeGen/bitint.cpp
@@ -1,0 +1,48 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+using i10 = signed _BitInt(10);
+using u10 = unsigned _BitInt(10);
+
+i10 test_signed(i10 arg) {
+  return arg;
+}
+
+// CHECK: cir.func @_Z11test_signedDB10_(%arg0: !cir.int<s, 10> loc({{.*}}) -> !cir.int<s, 10>
+// CHECK: }
+
+u10 test_unsigned(u10 arg) {
+  return arg;
+}
+
+// CHECK: cir.func @_Z13test_unsignedDU10_(%arg0: !cir.int<u, 10> loc({{.*}}) -> !cir.int<u, 10>
+// CHECK: }
+
+i10 test_init() {
+  return 42;
+}
+
+//      CHECK: cir.func @_Z9test_initv() -> !cir.int<s, 10>
+//      CHECK:   %[[#LITERAL:]] = cir.const(#cir.int<42> : !s32i) : !s32i
+// CHECK-NEXT:   %{{.+}} = cir.cast(integral, %[[#LITERAL]] : !s32i), !cir.int<s, 10>
+//      CHECK: }
+
+void test_init_for_mem() {
+  i10 x = 42;
+}
+
+//      CHECK: cir.func @_Z17test_init_for_memv()
+//      CHECK:   %[[#LITERAL:]] = cir.const(#cir.int<42> : !s32i) : !s32i
+// CHECK-NEXT:   %[[#INIT:]] = cir.cast(integral, %[[#LITERAL]] : !s32i), !cir.int<s, 10>
+// CHECK-NEXT:   cir.store %[[#INIT]], %{{.+}} : !cir.int<s, 10>, cir.ptr <!cir.int<s, 10>>
+//      CHECK: }
+
+i10 test_arith(i10 lhs, i10 rhs) {
+  return lhs + rhs;
+}
+
+//      CHECK: cir.func @_Z10test_arithDB10_S_(%arg0: !cir.int<s, 10> loc({{.+}}), %arg1: !cir.int<s, 10> loc({{.+}})) -> !cir.int<s, 10>
+//      CHECK:   %[[#LHS:]] = cir.load %{{.+}} : cir.ptr <!cir.int<s, 10>>, !cir.int<s, 10>
+// CHECK-NEXT:   %[[#RHS:]] = cir.load %{{.+}} : cir.ptr <!cir.int<s, 10>>, !cir.int<s, 10>
+// CHECK-NEXT:   %{{.+}} = cir.binop(add, %[[#LHS]], %[[#RHS]]) : !cir.int<s, 10>
+//      CHECK: }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -794,7 +794,7 @@ module {
 !s32i = !cir.int<s, 32>
 module {
   cir.func @tmp(%arg0: !cir.float) {
-    // expected-error@+1 {{operand #0 must be Integer type}}
+    // expected-error@+1 {{operand #0 must be 8-bit or 16-bit or 32-bit or 64-bit signed or unsigned int}}
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, %arg0 : !cir.float, ["tmp"]
     cir.return
   }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -564,17 +564,8 @@ module {
 // // -----
 
 module {
-  // expected-error@below {{expected integer width to be from 8 up to 64}}
+  // expected-error@below {{expected integer width to be from 1 up to 64}}
   cir.func @l0(%arg0: !cir.int<s, 128>) -> () {
-    cir.return
-  }
-}
-
-// -----
-
-module {
-  // expected-error@below {{expected integer width to be a multiple of 8}}
-  cir.func @l0(%arg0: !cir.int<s, 13>) -> () {
     cir.return
   }
 }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -794,7 +794,7 @@ module {
 !s32i = !cir.int<s, 32>
 module {
   cir.func @tmp(%arg0: !cir.float) {
-    // expected-error@+1 {{operand #0 must be 8-bit or 16-bit or 32-bit or 64-bit signed or unsigned int}}
+    // expected-error@+1 {{operand #0 must be primitive int}}
     %0 = cir.alloca !s32i, cir.ptr <!s32i>, %arg0 : !cir.float, ["tmp"]
     cir.return
   }
@@ -908,7 +908,7 @@ module {
 !u32i = !cir.int<u, 32>
 
 cir.func @clrsb_invalid_input_ty(%arg0 : !u32i) -> () {
-  // expected-error@+1 {{'cir.bit.clrsb' op operand #0 must be 32-bit or 64-bit sint, but got '!cir.int<u, 32>'}}
+  // expected-error@+1 {{'cir.bit.clrsb' op operand #0 must be 32-bit signed integer or 64-bit signed integer, but got '!cir.int<u, 32>'}}
   %0 = cir.bit.clrsb(%arg0 : !u32i) : !s32i
   cir.return
 }
@@ -929,7 +929,7 @@ cir.func @clrsb_invalid_result_ty(%arg0 : !s32i) -> () {
 !s32i = !cir.int<s, 32>
 
 cir.func @clz_invalid_input_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.clz' op operand #0 must be 16-bit or 32-bit or 64-bit uint, but got '!cir.int<s, 32>'}}
+  // expected-error@+1 {{'cir.bit.clz' op operand #0 must be 16-bit unsigned integer or 32-bit unsigned integer or 64-bit unsigned integer, but got '!cir.int<s, 32>'}}
   %0 = cir.bit.clz(%arg0 : !s32i) : !s32i
   cir.return
 }
@@ -949,7 +949,7 @@ cir.func @clz_invalid_result_ty(%arg0 : !u32i) -> () {
 !s32i = !cir.int<s, 32>
 
 cir.func @ctz_invalid_input_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.ctz' op operand #0 must be 16-bit or 32-bit or 64-bit uint, but got '!cir.int<s, 32>'}}
+  // expected-error@+1 {{'cir.bit.ctz' op operand #0 must be 16-bit unsigned integer or 32-bit unsigned integer or 64-bit unsigned integer, but got '!cir.int<s, 32>'}}
   %0 = cir.bit.ctz(%arg0 : !s32i) : !s32i
   cir.return
 }
@@ -970,7 +970,7 @@ cir.func @ctz_invalid_result_ty(%arg0 : !u32i) -> () {
 !u32i = !cir.int<u, 32>
 
 cir.func @ffs_invalid_input_ty(%arg0 : !u32i) -> () {
-  // expected-error@+1 {{'cir.bit.ffs' op operand #0 must be 32-bit or 64-bit sint, but got '!cir.int<u, 32>'}}
+  // expected-error@+1 {{'cir.bit.ffs' op operand #0 must be 32-bit signed integer or 64-bit signed integer, but got '!cir.int<u, 32>'}}
   %0 = cir.bit.ffs(%arg0 : !u32i) : !s32i
   cir.return
 }
@@ -991,7 +991,7 @@ cir.func @ffs_invalid_result_ty(%arg0 : !s32i) -> () {
 !s32i = !cir.int<s, 32>
 
 cir.func @parity_invalid_input_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.parity' op operand #0 must be 32-bit or 64-bit uint, but got '!cir.int<s, 32>'}}
+  // expected-error@+1 {{'cir.bit.parity' op operand #0 must be 32-bit unsigned integer or 64-bit unsigned integer, but got '!cir.int<s, 32>'}}
   %0 = cir.bit.parity(%arg0 : !s32i) : !s32i
   cir.return
 }
@@ -1011,7 +1011,7 @@ cir.func @parity_invalid_result_ty(%arg0 : !u32i) -> () {
 !s32i = !cir.int<s, 32>
 
 cir.func @popcount_invalid_input_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.popcount' op operand #0 must be 16-bit or 32-bit or 64-bit uint, but got '!cir.int<s, 32>'}}
+  // expected-error@+1 {{'cir.bit.popcount' op operand #0 must be 16-bit unsigned integer or 32-bit unsigned integer or 64-bit unsigned integer, but got '!cir.int<s, 32>'}}
   %0 = cir.bit.popcount(%arg0 : !s32i) : !s32i
   cir.return
 }

--- a/clang/test/CIR/Lowering/bitint.cir
+++ b/clang/test/CIR/Lowering/bitint.cir
@@ -1,0 +1,30 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.func @ParamPassing(%arg0: !cir.int<s, 15>, %arg1: !cir.int<s, 31>) -> !cir.int<s, 2> {
+    %0 = cir.cast(integral, %arg0 : !cir.int<s, 15>), !s32i
+    %1 = cir.cast(integral, %arg1 : !cir.int<s, 31>), !s32i
+    %2 = cir.binop(add, %0, %1) : !s32i
+    %3 = cir.cast(integral, %2 : !s32i), !cir.int<s, 2>
+    cir.return %3 : !cir.int<s, 2>
+  }
+}
+
+//      MLIR: llvm.func @ParamPassing(%arg0: i15, %arg1: i31) -> i2
+// MLIR-NEXT:   %0 = llvm.sext %arg0 : i15 to i32
+// MLIR-NEXT:   %1 = llvm.sext %arg1 : i31 to i32
+// MLIR-NEXT:   %2 = llvm.add %0, %1  : i32
+// MLIR-NEXT:   %3 = llvm.trunc %2 : i32 to i2
+// MLIR-NEXT:   llvm.return %3 : i2
+// MLIR-NEXT: }
+
+//      LLVM: define i2 @ParamPassing(i15 %0, i31 %1) !dbg !3 {
+// LLVM-NEXT:   %3 = sext i15 %0 to i32, !dbg !6
+// LLVM-NEXT:   %4 = sext i31 %1 to i32, !dbg !7
+// LLVM-NEXT:   %5 = add i32 %3, %4, !dbg !8
+// LLVM-NEXT:   %6 = trunc i32 %5 to i2, !dbg !9
+// LLVM-NEXT:   ret i2 %6, !dbg !10
+// LLVM-NEXT: }


### PR DESCRIPTION
This PR adds initial support for the bit-precise integer type `_BitInt(N)`. This type goes into the C23 standard, and has already been supported by clang since 2020, previously known as `_ExtInt(N)`.

This PR is quite simple and straight-forward. Basically it leverages the existing `cir.int` type to represent such types. Previously `cir.int` verifies that its width must be a multiple of 8, and this verification has been removed in this PR.