### PR TITLE
[CIR][CIRGen] Add missing CIRGen for generic bit operation builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -567,12 +567,14 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_ctz:
   case Builtin::BI__builtin_ctzl:
   case Builtin::BI__builtin_ctzll:
+  case Builtin::BI__builtin_ctzg:
     return buildBuiltinBitOp<mlir::cir::BitCtzOp>(*this, E, BCK_CTZPassedZero);
 
   case Builtin::BI__builtin_clzs:
   case Builtin::BI__builtin_clz:
   case Builtin::BI__builtin_clzl:
   case Builtin::BI__builtin_clzll:
+  case Builtin::BI__builtin_clzg:
     return buildBuiltinBitOp<mlir::cir::BitClzOp>(*this, E, BCK_CLZPassedZero);
 
   case Builtin::BI__builtin_ffs:
@@ -591,6 +593,7 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_popcount:
   case Builtin::BI__builtin_popcountl:
   case Builtin::BI__builtin_popcountll:
+  case Builtin::BI__builtin_popcountg:
     return buildBuiltinBitOp<mlir::cir::BitPopcountOp>(*this, E, std::nullopt);
 
   case Builtin::BI__builtin_bswap16:

--- a/clang/test/CIR/CodeGen/builtin-bits.cpp
+++ b/clang/test/CIR/CodeGen/builtin-bits.cpp
@@ -57,6 +57,14 @@ int test_builtin_ctzll(unsigned long long x) {
 // CHECK:   %{{.+}} = cir.bit.ctz(%{{.+}} : !u64i) : !s32i
 // CHECK: }
 
+int test_builtin_ctzg(unsigned x) {
+  return __builtin_ctzg(x);
+}
+
+// CHECK: cir.func @_Z17test_builtin_ctzgj
+// CHECK:   %{{.+}} = cir.bit.ctz(%{{.+}} : !u32i) : !s32i
+// CHECK: }
+
 int test_builtin_clzs(unsigned short x) {
   return __builtin_clzs(x);
 }
@@ -87,6 +95,14 @@ int test_builtin_clzll(unsigned long long x) {
 
 // CHECK: cir.func @_Z18test_builtin_clzlly
 // CHECK:   %{{.+}} = cir.bit.clz(%{{.+}} : !u64i) : !s32i
+// CHECK: }
+
+int test_builtin_clzg(unsigned x) {
+  return __builtin_clzg(x);
+}
+
+// CHECK: cir.func @_Z17test_builtin_clzgj
+// CHECK:   %{{.+}} = cir.bit.clz(%{{.+}} : !u32i) : !s32i
 // CHECK: }
 
 int test_builtin_ffs(int x) {
@@ -159,4 +175,12 @@ int test_builtin_popcountll(unsigned long long x) {
 
 // CHECK: cir.func @_Z23test_builtin_popcountlly
 // CHECK:   %{{.+}} = cir.bit.popcount(%{{.+}} : !u64i) : !s32i
+// CHECK: }
+
+int test_builtin_popcountg(unsigned x) {
+  return __builtin_popcountg(x);
+}
+
+// CHECK: cir.func @_Z22test_builtin_popcountgj
+// CHECK:   %{{.+}} = cir.bit.popcount(%{{.+}} : !u32i) : !s32i
 // CHECK: }


### PR DESCRIPTION
This patch adds the CIRGen for the following builtin functions:

- `__builtin_clzg`;
- `__builtin_ctzg`;
- `__builtin_popcountg`.

CIRGen for these three functions are missing in the original PR which introduces CIR bit ops.