### PR TITLE
[CIR][CIRGen] Add dynamic builtin alloca intrinsics support

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -152,6 +152,36 @@ public:
     return create<mlir::cir::StoreOp>(loc, val, dst, _volatile, order);
   }
 
+  mlir::Value createAlloca(mlir::Location loc, mlir::cir::PointerType addrType,
+                           mlir::Type type, llvm::StringRef name,
+                           mlir::IntegerAttr alignment,
+                           mlir::Value dynAllocSize) {
+    return create<mlir::cir::AllocaOp>(loc, addrType, type, name, alignment,
+                                       dynAllocSize);
+  }
+
+  mlir::Value createAlloca(mlir::Location loc, mlir::cir::PointerType addrType,
+                           mlir::Type type, llvm::StringRef name,
+                           clang::CharUnits alignment,
+                           mlir::Value dynAllocSize) {
+    auto alignmentIntAttr = getSizeFromCharUnits(getContext(), alignment);
+    return createAlloca(loc, addrType, type, name, alignmentIntAttr,
+                        dynAllocSize);
+  }
+
+  mlir::Value createAlloca(mlir::Location loc, mlir::cir::PointerType addrType,
+                           mlir::Type type, llvm::StringRef name,
+                           mlir::IntegerAttr alignment) {
+    return create<mlir::cir::AllocaOp>(loc, addrType, type, name, alignment);
+  }
+
+  mlir::Value createAlloca(mlir::Location loc, mlir::cir::PointerType addrType,
+                           mlir::Type type, llvm::StringRef name,
+                           clang::CharUnits alignment) {
+    auto alignmentIntAttr = getSizeFromCharUnits(getContext(), alignment);
+    return createAlloca(loc, addrType, type, name, alignmentIntAttr);
+  }
+
   mlir::Value createSub(mlir::Value lhs, mlir::Value rhs, bool hasNUW = false,
                         bool hasNSW = false) {
     auto op = create<mlir::cir::BinOp>(lhs.getLoc(), lhs.getType(),

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2475,9 +2475,8 @@ mlir::Value CIRGenFunction::buildAlloca(StringRef name, mlir::Type ty,
   {
     mlir::OpBuilder::InsertionGuard guard(builder);
     builder.restoreInsertionPoint(ip);
-    addr = builder.create<mlir::cir::AllocaOp>(loc, /*addr type*/ localVarPtrTy,
-                                               /*var type*/ ty, name,
-                                               alignIntAttr, arraySize);
+    addr = builder.createAlloca(loc, /*addr type*/ localVarPtrTy,
+                                /*var type*/ ty, name, alignIntAttr, arraySize);
     if (currVarDecl) {
       auto alloca = cast<mlir::cir::AllocaOp>(addr.getDefiningOp());
       alloca.setAstAttr(ASTVarDeclAttr::get(builder.getContext(), currVarDecl));

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -425,20 +425,16 @@ static void lowerArrayDtorCtorIntoLoop(CIRBaseBuilderTy &builder,
   mlir::Value end = builder.create<mlir::cir::PtrStrideOp>(
       loc, eltTy, begin, numArrayElementsConst);
 
-  auto tmpAddr = builder.create<mlir::cir::AllocaOp>(
+  auto tmpAddr = builder.createAlloca(
       loc, /*addr type*/ builder.getPointerTo(eltTy),
-      /*var type*/ eltTy, "__array_idx",
-      builder.getSizeFromCharUnits(builder.getContext(),
-                                   clang::CharUnits::One()),
-      nullptr);
+      /*var type*/ eltTy, "__array_idx", clang::CharUnits::One());
   builder.createStore(loc, begin, tmpAddr);
 
   auto loop = builder.createDoWhile(
       loc,
       /*condBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto currentElement =
-            b.create<mlir::cir::LoadOp>(loc, eltTy, tmpAddr.getResult());
+        auto currentElement = b.create<mlir::cir::LoadOp>(loc, eltTy, tmpAddr);
         mlir::Type boolTy = mlir::cir::BoolType::get(b.getContext());
         auto cmp = builder.create<mlir::cir::CmpOp>(
             loc, boolTy, mlir::cir::CmpOpKind::eq, currentElement, end);
@@ -446,8 +442,7 @@ static void lowerArrayDtorCtorIntoLoop(CIRBaseBuilderTy &builder,
       },
       /*bodyBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
-        auto currentElement =
-            b.create<mlir::cir::LoadOp>(loc, eltTy, tmpAddr.getResult());
+        auto currentElement = b.create<mlir::cir::LoadOp>(loc, eltTy, tmpAddr);
 
         CallOp ctorCall;
         op->walk([&](CallOp c) { ctorCall = c; });

--- a/clang/test/CIR/CodeGen/builtin-alloca.c
+++ b/clang/test/CIR/CodeGen/builtin-alloca.c
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir-enable -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
+
+typedef __SIZE_TYPE__ size_t;
+void *alloca(size_t size);
+void *_alloca(size_t size);
+
+void my_alloca(size_t n)
+{
+  int *c1 = alloca(n);
+}
+// CIR:       cir.func @my_alloca([[ALLOCA_SIZE:%.*]]: !u64i
+// CIR:       cir.store [[ALLOCA_SIZE]], [[LOCAL_VAR_ALLOCA_SIZE:%.*]] : !u64i, cir.ptr <!u64i>
+// CIR:       [[TMP_ALLOCA_SIZE:%.*]] = cir.load [[LOCAL_VAR_ALLOCA_SIZE]] : cir.ptr <!u64i>, !u64i
+// CIR:       [[ALLOCA_RES:%.*]] = cir.alloca !u8i, cir.ptr <!u8i>, [[TMP_ALLOCA_SIZE]] : !u64i, ["bi_alloca"] {alignment = 16 : i64}
+// CIR-NEXT:  cir.cast(bitcast, [[ALLOCA_RES]] : !cir.ptr<!u8i>), !cir.ptr<!void>
+// CIR: }
+
+
+// LLVM:       define void @my_alloca(i64 [[ALLOCA_SIZE:%.*]])
+// LLVM:       store i64 [[ALLOCA_SIZE]], ptr [[LOCAL_VAR_ALLOCA_SIZE:%.*]],
+// LLVM:       [[TMP_ALLOCA_SIZE:%.*]] =  load i64, ptr [[LOCAL_VAR_ALLOCA_SIZE]],
+// LLVM:       [[ALLOCA_RES:%.*]] = alloca i8, i64 [[TMP_ALLOCA_SIZE]], align 16
+// LLVM: }
+
+void my___builtin_alloca(size_t n)
+{
+  int *c1 = (int *)__builtin_alloca(n);
+}
+
+// CIR:       cir.func @my___builtin_alloca([[ALLOCA_SIZE:%.*]]: !u64i
+// CIR:       cir.store [[ALLOCA_SIZE]], [[LOCAL_VAR_ALLOCA_SIZE:%.*]] : !u64i, cir.ptr <!u64i>
+// CIR:       [[TMP_ALLOCA_SIZE:%.*]] = cir.load [[LOCAL_VAR_ALLOCA_SIZE]] : cir.ptr <!u64i>, !u64i
+// CIR:       [[ALLOCA_RES:%.*]] = cir.alloca !u8i, cir.ptr <!u8i>, [[TMP_ALLOCA_SIZE]] : !u64i, ["bi_alloca"] {alignment = 16 : i64}
+// CIR-NEXT:  cir.cast(bitcast, [[ALLOCA_RES]] : !cir.ptr<!u8i>), !cir.ptr<!void>
+// CIR: }
+
+
+// LLVM:       define void @my___builtin_alloca(i64 [[ALLOCA_SIZE:%.*]])
+// LLVM:       store i64 [[ALLOCA_SIZE]], ptr [[LOCAL_VAR_ALLOCA_SIZE:%.*]],
+// LLVM:       [[TMP_ALLOCA_SIZE:%.*]] =  load i64, ptr [[LOCAL_VAR_ALLOCA_SIZE]],
+// LLVM:       [[ALLOCA_RES:%.*]] = alloca i8, i64 [[TMP_ALLOCA_SIZE]], align 16
+// LLVM: }
+
+void my__builtin_alloca_uninitialized(size_t n)
+{
+  int *c1 = (int *)__builtin_alloca_uninitialized(n);
+}
+
+// CIR:       cir.func @my__builtin_alloca_uninitialized([[ALLOCA_SIZE:%.*]]: !u64i
+// CIR:       cir.store [[ALLOCA_SIZE]], [[LOCAL_VAR_ALLOCA_SIZE:%.*]] : !u64i, cir.ptr <!u64i>
+// CIR:       [[TMP_ALLOCA_SIZE:%.*]] = cir.load [[LOCAL_VAR_ALLOCA_SIZE]] : cir.ptr <!u64i>, !u64i
+// CIR:       [[ALLOCA_RES:%.*]] = cir.alloca !u8i, cir.ptr <!u8i>, [[TMP_ALLOCA_SIZE]] : !u64i, ["bi_alloca"] {alignment = 16 : i64}
+// CIR-NEXT:  cir.cast(bitcast, [[ALLOCA_RES]] : !cir.ptr<!u8i>), !cir.ptr<!void>
+// CIR: }
+
+
+// LLVM:       define void @my__builtin_alloca_uninitialized(i64 [[ALLOCA_SIZE:%.*]])
+// LLVM:       store i64 [[ALLOCA_SIZE]], ptr [[LOCAL_VAR_ALLOCA_SIZE:%.*]],
+// LLVM:       [[TMP_ALLOCA_SIZE:%.*]] =  load i64, ptr [[LOCAL_VAR_ALLOCA_SIZE]],
+// LLVM:       [[ALLOCA_RES:%.*]] = alloca i8, i64 [[TMP_ALLOCA_SIZE]], align 16
+// LLVM: }

--- a/clang/test/CIR/CodeGen/builtin-ms-alloca.c
+++ b/clang/test/CIR/CodeGen/builtin-ms-alloca.c
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fms-extensions -emit-cir %s -o - | FileCheck %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fms-extensions -fclangir-enable -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
+
+typedef __SIZE_TYPE__ size_t;
+
+void my_win_alloca(size_t n)
+{
+  int *c1 = (int *)_alloca(n);
+}
+
+// CIR:       cir.func @my_win_alloca([[ALLOCA_SIZE:%.*]]: !u64i
+// CIR:       cir.store [[ALLOCA_SIZE]], [[LOCAL_VAR_ALLOCA_SIZE:%.*]] : !u64i, cir.ptr <!u64i>
+// CIR:       [[TMP_ALLOCA_SIZE:%.*]] = cir.load [[LOCAL_VAR_ALLOCA_SIZE]] : cir.ptr <!u64i>, !u64i
+// CIR:       [[ALLOCA_RES:%.*]] = cir.alloca !u8i, cir.ptr <!u8i>, [[TMP_ALLOCA_SIZE]] : !u64i, ["bi_alloca"] {alignment = 16 : i64}
+// CIR-NEXT:  cir.cast(bitcast, [[ALLOCA_RES]] : !cir.ptr<!u8i>), !cir.ptr<!void>
+// CIR: }
+
+
+// LLVM:       define void @my_win_alloca(i64 [[ALLOCA_SIZE:%.*]])
+// LLVM:       store i64 [[ALLOCA_SIZE]], ptr [[LOCAL_VAR_ALLOCA_SIZE:%.*]],
+// LLVM:       [[TMP_ALLOCA_SIZE:%.*]] =  load i64, ptr [[LOCAL_VAR_ALLOCA_SIZE]],
+// LLVM:       [[ALLOCA_RES:%.*]] = alloca i8, i64 [[TMP_ALLOCA_SIZE]], align 16
+// LLVM: }


### PR DESCRIPTION
This patch adds the CIRGen for the following builtin functions:

- `alloca`;
- `_alloca`;
- `__builtin_alloca`;
- `__builtin_alloca_uninitialized`.

Missing support to add in the future:
- Non-default auto initialization setting. The default is to not initialize the allocated buffer, which is simpler to implement. This commit is leaving the skeleton to implement this feature following clang's codegen pattern.
- It may be possible that the frontend has set non-default address space for the alloca's return value. This is the case for OpenCL or AMDGPU codes for example. This is handled in clang codegen via address space cast, and is left for future implementation. This commit introduces a guard-rail around this behaviour.

----------------

P.S.:
I'm aware this is rather an "esoteric" feature to be supported and I'm sure there are more valuable features to implement before that! Implementing this feature was my method of learning more about the development flow for CIR - working along side clang's codegen, testing and debugging flow, etc.