### PR TITLE
[CIR][Codegen] fix union init with constant

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -380,7 +380,11 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
     NaturalLayout = false;
     Packed = true;
   } else if (DesiredSize > AlignedSize) {
-    llvm_unreachable("NYI");
+    // The natural layout would be too small. Add padding to fix it. (This
+    // is ignored if we choose a packed layout.)
+    UnpackedElemStorage.assign(Elems.begin(), Elems.end());
+    UnpackedElemStorage.push_back(Utils.getPadding(DesiredSize - Size));
+    UnpackedElems = UnpackedElemStorage;
   }
 
   // If we don't have a natural layout, insert padding as necessary.

--- a/clang/test/CIR/CodeGen/union.cpp
+++ b/clang/test/CIR/CodeGen/union.cpp
@@ -76,3 +76,16 @@ void shouldGenerateUnionAccess(union U u) {
   u.d;
   // CHECK: %[[#BASE:]] = cir.get_member %0[4] {name = "d"} : !cir.ptr<!ty_22U22> -> !cir.ptr<!cir.double>
 }
+
+typedef union {
+  short a;
+  int b;
+} A;
+ 
+void noCrushOnDifferentSizes() {
+  A a = {0};
+  // CHECK:  %[[#TMP0:]] = cir.alloca !ty_22A22, cir.ptr <!ty_22A22>, ["a"] {alignment = 4 : i64}
+  // CHECK:  %[[#TMP1:]] = cir.cast(bitcast, %[[#TMP0]] : !cir.ptr<!ty_22A22>), !cir.ptr<!ty_anon_struct>
+  // CHECK:  %[[#TMP2:]] = cir.const(#cir.zero : !ty_anon_struct) : !ty_anon_struct
+  // CHECK:  cir.store %[[#TMP2]], %[[#TMP1]] : !ty_anon_struct, cir.ptr <!ty_anon_struct>
+}


### PR DESCRIPTION
Minor fix for the case when union fields have different sizes and union is inited with a constant. 
Example:
``
typedef union {
  short a;
  int b;
} A;`
```