### PR TITLE
[CIR][CodeGen] Adds SwitchOp flattening

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3542,6 +3542,11 @@ def IsConstantOp : CIR_Op<"is_constant", [Pure]> {
 
 def CIR_FlatSwitchOp : CIR_Op<"flat.switch", [AttrSizedOperandSegments, Terminator]> {
 
+  let description = [{
+    The `cir.flat.switch` operation is a region-less of the `cir.switch` and is a 
+    intermediate between codegen and lowering. 
+  }];
+
   let arguments = (ins
     CIR_IntType:$condition,
     Variadic<AnyType>:$defaultOperands,

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3605,11 +3605,11 @@ def IsConstantOp : CIR_Op<"is_constant", [Pure]> {
 }
 
 
-def CIR_FlatSwitchOp : CIR_Op<"flat.switch", [AttrSizedOperandSegments, Terminator]> {
+def CIR_SwitchFlatOp : CIR_Op<"switch.flat", [AttrSizedOperandSegments, Terminator]> {
 
   let description = [{
-    The `cir.flat.switch` operation is a region-less of the `cir.switch` and is a 
-    intermediate between codegen and lowering. 
+    The `cir.switch.flat` operation is a region-less and simplified version of the `cir.switch`.
+    It's representation is closer to LLVM IR dialect than the C/C++ language feature.
   }];
 
   let arguments = (ins
@@ -3628,7 +3628,7 @@ def CIR_FlatSwitchOp : CIR_Op<"flat.switch", [AttrSizedOperandSegments, Terminat
   let assemblyFormat = [{
     $condition `:` type($condition) `,`
     $defaultDestination (`(` $defaultOperands^ `:` type($defaultOperands) `)`)?
-    custom<FlatSwitchOpCases>(ref(type($condition)), $case_values, $caseDestinations,
+    custom<SwitchFlatOpCases>(ref(type($condition)), $case_values, $caseDestinations,
                                    $caseOperands, type($caseOperands))
     attr-dict
   }];

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3605,7 +3605,7 @@ def IsConstantOp : CIR_Op<"is_constant", [Pure]> {
 }
 
 
-def CIR_SwitchFlatOp : CIR_Op<"switch.flat", [AttrSizedOperandSegments, Terminator]> {
+def SwitchFlatOp : CIR_Op<"switch.flat", [AttrSizedOperandSegments, Terminator]> {
 
   let description = [{
     The `cir.switch.flat` operation is a region-less and simplified version of the `cir.switch`.

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3539,6 +3539,40 @@ def IsConstantOp : CIR_Op<"is_constant", [Pure]> {
   }];
 }
 
+
+def CIR_FlatSwitchOp : CIR_Op<"flat.switch", [AttrSizedOperandSegments, Terminator]> {
+
+  let arguments = (ins
+    CIR_IntType:$condition,
+    Variadic<AnyType>:$defaultOperands,
+    VariadicOfVariadic<AnyType, "case_operand_segments">:$caseOperands,
+    OptionalAttr<ArrayAttr>:$case_values,
+    DenseI32ArrayAttr:$case_operand_segments
+  );
+
+  let successors = (successor
+    AnySuccessor:$defaultDestination,
+    VariadicSuccessor<AnySuccessor>:$caseDestinations
+  );
+
+  let assemblyFormat = [{
+    $condition `:` type($condition) `,`
+    $defaultDestination (`(` $defaultOperands^ `:` type($defaultOperands) `)`)?
+    custom<FlatSwitchOpCases>(ref(type($condition)), $case_values, $caseDestinations,
+                                   $caseOperands, type($caseOperands))
+    attr-dict
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$condition,
+      "Block *":$defaultDestination,
+      "ValueRange":$defaultOperands,
+      CArg<"ArrayRef<APInt>", "{}">:$caseValues,
+      CArg<"BlockRange", "{}">:$caseDestinations,
+      CArg<"ArrayRef<ValueRange>", "{}">:$caseOperands)>
+  ];
+}
+
 //===----------------------------------------------------------------------===//
 // Atomic operations
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3551,7 +3551,7 @@ def CIR_FlatSwitchOp : CIR_Op<"flat.switch", [AttrSizedOperandSegments, Terminat
     CIR_IntType:$condition,
     Variadic<AnyType>:$defaultOperands,
     VariadicOfVariadic<AnyType, "case_operand_segments">:$caseOperands,
-    OptionalAttr<ArrayAttr>:$case_values,
+    ArrayAttr:$case_values,
     DenseI32ArrayAttr:$case_operand_segments
   );
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -17,6 +17,8 @@
 #include "clang/CIR/Interfaces/CIRLoopOpInterface.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <optional>
+#include <numeric>
+#include <iostream>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -1214,6 +1216,103 @@ void SwitchOp::build(
   OpBuilder::InsertionGuard guardSwitch(builder);
   result.addOperands({cond});
   switchBuilder(builder, result.location, result);
+}
+
+//===----------------------------------------------------------------------===//
+// FlatSwitchOp
+//===----------------------------------------------------------------------===//
+
+void FlatSwitchOp::build(OpBuilder &builder, OperationState &result, Value value,
+                     Block *defaultDestination, ValueRange defaultOperands,
+                     ArrayRef<APInt> caseValues, BlockRange caseDestinations,
+                     ArrayRef<ValueRange> caseOperands) {
+
+  std::vector<mlir::Attribute> caseValuesAttrs;
+  for (auto& val : caseValues) {
+      caseValuesAttrs.push_back(mlir::cir::IntAttr::get(value.getType(), val));
+  }
+  auto attrs = ArrayAttr::get(builder.getContext(), caseValuesAttrs);
+  
+  build(builder, result, value, defaultOperands, caseOperands, attrs,
+         defaultDestination, caseDestinations);
+}
+
+/// <cases> ::= `[` (case (`,` case )* )? `]`
+/// <case>  ::= integer `:` bb-id (`(` ssa-use-and-type-list `)`)?
+static ParseResult parseFlatSwitchOpCases(
+    OpAsmParser &parser, Type flagType, mlir::ArrayAttr &caseValues,
+    SmallVectorImpl<Block *> &caseDestinations,
+    SmallVectorImpl<SmallVector<OpAsmParser::UnresolvedOperand>> &caseOperands,
+    SmallVectorImpl<SmallVector<Type>> &caseOperandTypes) {
+  if (failed(parser.parseLSquare()))
+    return failure();
+  if (succeeded(parser.parseOptionalRSquare()))
+    return success();
+  SmallVector<mlir::Attribute> values;
+  unsigned bitWidth = flagType.getIntOrFloatBitWidth();
+  
+  auto parseCase = [&]() {
+    int64_t value = 0;
+    if (failed(parser.parseInteger(value)))
+      return failure();
+    //values.push_back(APInt(bitWidth, value));
+    values.push_back(IntAttr::get(flagType, value));
+
+    Block *destination;
+    SmallVector<OpAsmParser::UnresolvedOperand> operands;
+    SmallVector<Type> operandTypes;
+    if (parser.parseColon() || parser.parseSuccessor(destination))
+      return failure();
+    if (!parser.parseOptionalLParen()) {
+      if (parser.parseOperandList(operands, OpAsmParser::Delimiter::None,
+                                  /*allowResultNumber=*/false) ||
+          parser.parseColonTypeList(operandTypes) || parser.parseRParen())
+        return failure();
+    }
+    caseDestinations.push_back(destination);
+    caseOperands.emplace_back(operands);
+    caseOperandTypes.emplace_back(operandTypes);
+    return success();
+  };
+  if (failed(parser.parseCommaSeparatedList(parseCase)))
+    return failure();
+
+  // ShapedType caseValueType =
+  //     mlir::VectorType::get(static_cast<int64_t>(values.size()), flagType);
+  // caseValues = DenseIntElementsAttr::get(caseValueType, values);
+
+  caseValues = ArrayAttr::get(flagType.getContext(), values);
+
+  return parser.parseRSquare();
+}
+
+static void printFlatSwitchOpCases(OpAsmPrinter &p, FlatSwitchOp op, Type flagType,
+                               mlir::ArrayAttr caseValues,
+                               SuccessorRange caseDestinations,
+                               OperandRangeRange caseOperands,
+                               const TypeRangeRange &caseOperandTypes) {
+  p << '[';
+  p.printNewline();
+  if (!caseValues) {
+    p << ']';
+    return;
+  }
+
+  size_t index = 0;
+  llvm::interleave(
+      llvm::zip(caseValues, caseDestinations),
+      [&](auto i) {
+        p << "  ";
+        p << std::get<0>(i);
+        p << ": ";
+        p.printSuccessorAndUseList(std::get<1>(i), caseOperands[index++]);
+      },
+      [&] {
+        p << ',';
+        p.printNewline();
+      });
+  p.printNewline();
+  p << ']';
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -16,8 +16,8 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Interfaces/CIRLoopOpInterface.h"
 #include "llvm/Support/ErrorHandling.h"
-#include <optional>
 #include <numeric>
+#include <optional>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -1221,19 +1221,20 @@ void SwitchOp::build(
 // FlatSwitchOp
 //===----------------------------------------------------------------------===//
 
-void FlatSwitchOp::build(OpBuilder &builder, OperationState &result, Value value,
-                     Block *defaultDestination, ValueRange defaultOperands,
-                     ArrayRef<APInt> caseValues, BlockRange caseDestinations,
-                     ArrayRef<ValueRange> caseOperands) {
+void FlatSwitchOp::build(OpBuilder &builder, OperationState &result,
+                         Value value, Block *defaultDestination,
+                         ValueRange defaultOperands, ArrayRef<APInt> caseValues,
+                         BlockRange caseDestinations,
+                         ArrayRef<ValueRange> caseOperands) {
 
   std::vector<mlir::Attribute> caseValuesAttrs;
-  for (auto& val : caseValues) {
-      caseValuesAttrs.push_back(mlir::cir::IntAttr::get(value.getType(), val));
+  for (auto &val : caseValues) {
+    caseValuesAttrs.push_back(mlir::cir::IntAttr::get(value.getType(), val));
   }
   auto attrs = ArrayAttr::get(builder.getContext(), caseValuesAttrs);
-  
+
   build(builder, result, value, defaultOperands, caseOperands, attrs,
-         defaultDestination, caseDestinations);
+        defaultDestination, caseDestinations);
 }
 
 /// <cases> ::= `[` (case (`,` case )* )? `]`
@@ -1248,7 +1249,7 @@ static ParseResult parseFlatSwitchOpCases(
   if (succeeded(parser.parseOptionalRSquare()))
     return success();
   SmallVector<mlir::Attribute> values;
- 
+
   auto parseCase = [&]() {
     int64_t value = 0;
     if (failed(parser.parseInteger(value)))
@@ -1280,11 +1281,11 @@ static ParseResult parseFlatSwitchOpCases(
   return parser.parseRSquare();
 }
 
-static void printFlatSwitchOpCases(OpAsmPrinter &p, FlatSwitchOp op, Type flagType,
-                               mlir::ArrayAttr caseValues,
-                               SuccessorRange caseDestinations,
-                               OperandRangeRange caseOperands,
-                               const TypeRangeRange &caseOperandTypes) {
+static void printFlatSwitchOpCases(OpAsmPrinter &p, FlatSwitchOp op,
+                                   Type flagType, mlir::ArrayAttr caseValues,
+                                   SuccessorRange caseDestinations,
+                                   OperandRangeRange caseOperands,
+                                   const TypeRangeRange &caseOperandTypes) {
   p << '[';
   p.printNewline();
   if (!caseValues) {

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -259,7 +259,7 @@ public:
 
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::SwitchOp op,
-                  mlir::PatternRewriter &rewriter) const override {  
+                  mlir::PatternRewriter &rewriter) const override {
     // Empty switch statement: just erase it.
     if (!op.getCases().has_value() || op.getCases()->empty()) {
       rewriter.eraseOp(op);
@@ -335,19 +335,18 @@ public:
     }
 
     // Set switch op to branch to the newly created blocks.
-    rewriter.setInsertionPoint(op);    
+    rewriter.setInsertionPoint(op);
     rewriter.replaceOpWithNewOp<mlir::cir::FlatSwitchOp>(
-        op, op.getCondition(), defaultDestination, defaultOperands,
-        caseValues, caseDestinations, caseOperands);
+        op, op.getCondition(), defaultDestination, defaultOperands, caseValues,
+        caseDestinations, caseOperands);
     return mlir::success();
   }
 };
 
 void populateFlattenCFGPatterns(RewritePatternSet &patterns) {
-  patterns
-      .add<CIRIfFlattening, CIRLoopOpInterfaceFlattening, 
-      CIRScopeOpFlattening, CIRSwitchOpFlattening>(
-          patterns.getContext());
+  patterns.add<CIRIfFlattening, CIRLoopOpInterfaceFlattening,
+               CIRScopeOpFlattening, CIRSwitchOpFlattening>(
+      patterns.getContext());
 }
 
 void FlattenCFGPass::runOnOperation() {
@@ -364,7 +363,6 @@ void FlattenCFGPass::runOnOperation() {
   // Apply patterns.
   if (applyOpPatternsAndFold(ops, std::move(patterns)).failed())
     signalPassFailure();
-
 }
 
 } // namespace

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -365,7 +365,6 @@ void FlattenCFGPass::runOnOperation() {
   if (applyOpPatternsAndFold(ops, std::move(patterns)).failed())
     signalPassFailure();
 
-    getOperation()->dump();
 }
 
 } // namespace

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -339,7 +339,7 @@ public:
     rewriter.replaceOpWithNewOp<mlir::cir::SwitchFlatOp>(
         op, op.getCondition(), defaultDestination, defaultOperands, caseValues,
         caseDestinations, caseOperands);
-    
+
     return mlir::success();
   }
 };
@@ -393,10 +393,10 @@ public:
 };
 
 void populateFlattenCFGPatterns(RewritePatternSet &patterns) {
-  patterns.add<CIRIfFlattening, CIRLoopOpInterfaceFlattening,
-               CIRScopeOpFlattening, CIRSwitchOpFlattening,
-               CIRTernaryOpFlattening>(
-      patterns.getContext());
+  patterns
+      .add<CIRIfFlattening, CIRLoopOpInterfaceFlattening, CIRScopeOpFlattening,
+           CIRSwitchOpFlattening, CIRTernaryOpFlattening>(
+          patterns.getContext());
 }
 
 void FlattenCFGPass::runOnOperation() {

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -244,9 +244,109 @@ public:
   }
 };
 
+class CIRSwitchOpFlattening
+    : public mlir::OpRewritePattern<mlir::cir::SwitchOp> {
+public:
+  using OpRewritePattern<mlir::cir::SwitchOp>::OpRewritePattern;
+
+  inline void rewriteYieldOp(mlir::PatternRewriter &rewriter,
+                             mlir::cir::YieldOp yieldOp,
+                             mlir::Block *destination) const {
+    rewriter.setInsertionPoint(yieldOp);
+    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldOp, yieldOp.getOperands(),
+                                                 destination);
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::SwitchOp op,
+                  mlir::PatternRewriter &rewriter) const override {  
+    // Empty switch statement: just erase it.
+    if (!op.getCases().has_value() || op.getCases()->empty()) {
+      rewriter.eraseOp(op);
+      return mlir::success();
+    }
+
+    // Create exit block.
+    rewriter.setInsertionPointAfter(op);
+    auto *exitBlock =
+        rewriter.splitBlock(rewriter.getBlock(), rewriter.getInsertionPoint());
+
+    // Allocate required data structures (disconsider default case in
+    // vectors).
+    llvm::SmallVector<mlir::APInt, 8> caseValues;
+    llvm::SmallVector<mlir::Block *, 8> caseDestinations;
+    llvm::SmallVector<mlir::ValueRange, 8> caseOperands;
+
+    // Initialize default case as optional.
+    mlir::Block *defaultDestination = exitBlock;
+    mlir::ValueRange defaultOperands = exitBlock->getArguments();
+
+    // Track fallthrough between cases.
+    mlir::cir::YieldOp fallthroughYieldOp = nullptr;
+
+    // Digest the case statements values and bodies.
+    for (size_t i = 0; i < op.getCases()->size(); ++i) {
+      auto &region = op.getRegion(i);
+      auto caseAttr = op.getCases()->getValue()[i].cast<mlir::cir::CaseAttr>();
+
+      // Found default case: save destination and operands.
+      if (caseAttr.getKind().getValue() == mlir::cir::CaseOpKind::Default) {
+        defaultDestination = &region.front();
+        defaultOperands = region.getArguments();
+      } else {
+        // AnyOf cases kind can have multiple values, hence the loop below.
+        for (auto &value : caseAttr.getValue()) {
+          caseValues.push_back(value.cast<mlir::cir::IntAttr>().getValue());
+          caseOperands.push_back(region.getArguments());
+          caseDestinations.push_back(&region.front());
+        }
+      }
+
+      // Previous case is a fallthrough: branch it to this case.
+      if (fallthroughYieldOp) {
+        rewriteYieldOp(rewriter, fallthroughYieldOp, &region.front());
+        fallthroughYieldOp = nullptr;
+      }
+
+      for (auto &blk : region.getBlocks()) {
+        if (blk.getNumSuccessors())
+          continue;
+
+        // Handle switch-case yields.
+        if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(blk.getTerminator()))
+          fallthroughYieldOp = yieldOp;
+      }
+
+      // Handle break statements.
+      walkRegionSkipping<mlir::cir::LoopOpInterface, mlir::cir::SwitchOp>(
+          region, [&](mlir::Operation *op) {
+            if (isa<mlir::cir::BreakOp>(op))
+              lowerTerminator(op, exitBlock, rewriter);
+          });
+
+      // Extract region contents before erasing the switch op.
+      rewriter.inlineRegionBefore(region, exitBlock);
+    }
+
+    // Last case is a fallthrough: branch it to exit.
+    if (fallthroughYieldOp) {
+      rewriteYieldOp(rewriter, fallthroughYieldOp, exitBlock);
+      fallthroughYieldOp = nullptr;
+    }
+
+    // Set switch op to branch to the newly created blocks.
+    rewriter.setInsertionPoint(op);    
+    rewriter.replaceOpWithNewOp<mlir::cir::FlatSwitchOp>(
+        op, op.getCondition(), defaultDestination, defaultOperands,
+        caseValues, caseDestinations, caseOperands);
+    return mlir::success();
+  }
+};
+
 void populateFlattenCFGPatterns(RewritePatternSet &patterns) {
   patterns
-      .add<CIRIfFlattening, CIRLoopOpInterfaceFlattening, CIRScopeOpFlattening>(
+      .add<CIRIfFlattening, CIRLoopOpInterfaceFlattening, 
+      CIRScopeOpFlattening, CIRSwitchOpFlattening>(
           patterns.getContext());
 }
 
@@ -257,13 +357,15 @@ void FlattenCFGPass::runOnOperation() {
   // Collect operations to apply patterns.
   SmallVector<Operation *, 16> ops;
   getOperation()->walk<mlir::WalkOrder::PostOrder>([&](Operation *op) {
-    if (isa<IfOp, ScopeOp, LoopOpInterface>(op))
+    if (isa<IfOp, ScopeOp, SwitchOp, LoopOpInterface>(op))
       ops.push_back(op);
   });
 
   // Apply patterns.
   if (applyOpPatternsAndFold(ops, std::move(patterns)).failed())
     signalPassFailure();
+
+    getOperation()->dump();
 }
 
 } // namespace

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1512,11 +1512,10 @@ class CIRFlatSwitchOpLowering
 public:
   using OpConversionPattern<mlir::cir::FlatSwitchOp>::OpConversionPattern;
 
-  
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::FlatSwitchOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-                    
+
     llvm::SmallVector<mlir::APInt, 8> caseValues;
     if (op.getCaseValues()) {
       for (auto val : *op.getCaseValues()) {
@@ -1535,15 +1534,12 @@ public:
     for (auto x : op.getCaseOperands()) {
       caseOperands.push_back(x);
     }
-    
+
     // Set switch op to branch to the newly created blocks.
     rewriter.setInsertionPoint(op);
     rewriter.replaceOpWithNewOp<mlir::LLVM::SwitchOp>(
-        op, adaptor.getCondition(), op.getDefaultDestination(), 
-        op.getDefaultOperands(), 
-        caseValues, 
-        caseDestinations,
-        caseOperands);
+        op, adaptor.getCondition(), op.getDefaultDestination(),
+        op.getDefaultOperands(), caseValues, caseDestinations, caseOperands);
     return mlir::success();
   }
 };

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1518,7 +1518,7 @@ public:
 
     llvm::SmallVector<mlir::APInt, 8> caseValues;
     if (op.getCaseValues()) {
-      for (auto val : *op.getCaseValues()) {
+      for (auto val : op.getCaseValues()) {
         auto intAttr = dyn_cast<mlir::cir::IntAttr>(val);
         caseValues.push_back(intAttr.getValue());
       }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2852,17 +2852,17 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRConstantLowering, CIRStoreLowering, CIRAllocaLowering, CIRFuncLowering,
       CIRCastOpLowering, CIRGlobalOpLowering, CIRGetGlobalOpLowering,
       CIRVAStartLowering, CIRVAEndLowering, CIRVACopyLowering, CIRVAArgLowering,
-      CIRBrOpLowering, CIRGetMemberOpLowering,
-      CIRSwitchFlatOpLowering, CIRPtrDiffOpLowering, CIRCopyOpLowering,
-      CIRMemCpyOpLowering, CIRFAbsOpLowering, CIRExpectOpLowering,
-      CIRVTableAddrPointOpLowering, CIRVectorCreateLowering,
-      CIRVectorInsertLowering, CIRVectorExtractLowering, CIRVectorCmpOpLowering,
-      CIRVectorSplatLowering, CIRVectorTernaryLowering,
-      CIRVectorShuffleIntsLowering, CIRVectorShuffleVecLowering,
-      CIRStackSaveLowering, CIRStackRestoreLowering, CIRUnreachableLowering,
-      CIRTrapLowering, CIRInlineAsmOpLowering, CIRSetBitfieldLowering,
-      CIRGetBitfieldLowering, CIRPrefetchLowering, CIRObjSizeOpLowering,
-      CIRIsConstantOpLowering>(converter, patterns.getContext());
+      CIRBrOpLowering, CIRGetMemberOpLowering, CIRSwitchFlatOpLowering,
+      CIRPtrDiffOpLowering, CIRCopyOpLowering, CIRMemCpyOpLowering,
+      CIRFAbsOpLowering, CIRExpectOpLowering, CIRVTableAddrPointOpLowering,
+      CIRVectorCreateLowering, CIRVectorInsertLowering,
+      CIRVectorExtractLowering, CIRVectorCmpOpLowering, CIRVectorSplatLowering,
+      CIRVectorTernaryLowering, CIRVectorShuffleIntsLowering,
+      CIRVectorShuffleVecLowering, CIRStackSaveLowering,
+      CIRStackRestoreLowering, CIRUnreachableLowering, CIRTrapLowering,
+      CIRInlineAsmOpLowering, CIRSetBitfieldLowering, CIRGetBitfieldLowering,
+      CIRPrefetchLowering, CIRObjSizeOpLowering, CIRIsConstantOpLowering>(
+      converter, patterns.getContext());
 }
 
 namespace {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1517,12 +1517,6 @@ public:
   matchAndRewrite(mlir::cir::FlatSwitchOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
                     
-    // Empty switch statement: just erase it.
-    // if (!op.getCases().has_value() || op.getCases()->empty()) {
-    //   rewriter.eraseOp(op);
-    //   return mlir::success();
-    // }
-
     llvm::SmallVector<mlir::APInt, 8> caseValues;
     if (op.getCaseValues()) {
       for (auto val : *op.getCaseValues()) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1507,101 +1507,49 @@ public:
   }
 };
 
-class CIRSwitchOpLowering
-    : public mlir::OpConversionPattern<mlir::cir::SwitchOp> {
+class CIRFlatSwitchOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::FlatSwitchOp> {
 public:
-  using OpConversionPattern<mlir::cir::SwitchOp>::OpConversionPattern;
+  using OpConversionPattern<mlir::cir::FlatSwitchOp>::OpConversionPattern;
 
-  inline void rewriteYieldOp(mlir::ConversionPatternRewriter &rewriter,
-                             mlir::cir::YieldOp yieldOp,
-                             mlir::Block *destination) const {
-    rewriter.setInsertionPoint(yieldOp);
-    rewriter.replaceOpWithNewOp<mlir::cir::BrOp>(yieldOp, yieldOp.getOperands(),
-                                                 destination);
-  }
-
+  
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::SwitchOp op, OpAdaptor adaptor,
+  matchAndRewrite(mlir::cir::FlatSwitchOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
+                    
     // Empty switch statement: just erase it.
-    if (!op.getCases().has_value() || op.getCases()->empty()) {
-      rewriter.eraseOp(op);
-      return mlir::success();
+    // if (!op.getCases().has_value() || op.getCases()->empty()) {
+    //   rewriter.eraseOp(op);
+    //   return mlir::success();
+    // }
+
+    llvm::SmallVector<mlir::APInt, 8> caseValues;
+    if (op.getCaseValues()) {
+      for (auto val : *op.getCaseValues()) {
+        auto intAttr = dyn_cast<mlir::cir::IntAttr>(val);
+        caseValues.push_back(intAttr.getValue());
+      }
     }
 
-    // Create exit block.
-    rewriter.setInsertionPointAfter(op);
-    auto *exitBlock =
-        rewriter.splitBlock(rewriter.getBlock(), rewriter.getInsertionPoint());
-
-    // Allocate required data structures (disconsider default case in
-    // vectors).
-    llvm::SmallVector<mlir::APInt, 8> caseValues;
     llvm::SmallVector<mlir::Block *, 8> caseDestinations;
     llvm::SmallVector<mlir::ValueRange, 8> caseOperands;
 
-    // Initialize default case as optional.
-    mlir::Block *defaultDestination = exitBlock;
-    mlir::ValueRange defaultOperands = exitBlock->getArguments();
-
-    // Track fallthrough between cases.
-    mlir::cir::YieldOp fallthroughYieldOp = nullptr;
-
-    // Digest the case statements values and bodies.
-    for (size_t i = 0; i < op.getCases()->size(); ++i) {
-      auto &region = op.getRegion(i);
-      auto caseAttr = op.getCases()->getValue()[i].cast<mlir::cir::CaseAttr>();
-
-      // Found default case: save destination and operands.
-      if (caseAttr.getKind().getValue() == mlir::cir::CaseOpKind::Default) {
-        defaultDestination = &region.front();
-        defaultOperands = region.getArguments();
-      } else {
-        // AnyOf cases kind can have multiple values, hence the loop below.
-        for (auto &value : caseAttr.getValue()) {
-          caseValues.push_back(value.cast<mlir::cir::IntAttr>().getValue());
-          caseOperands.push_back(region.getArguments());
-          caseDestinations.push_back(&region.front());
-        }
-      }
-
-      // Previous case is a fallthrough: branch it to this case.
-      if (fallthroughYieldOp) {
-        rewriteYieldOp(rewriter, fallthroughYieldOp, &region.front());
-        fallthroughYieldOp = nullptr;
-      }
-
-      for (auto &blk : region.getBlocks()) {
-        if (blk.getNumSuccessors())
-          continue;
-
-        // Handle switch-case yields.
-        if (auto yieldOp = dyn_cast<mlir::cir::YieldOp>(blk.getTerminator()))
-          fallthroughYieldOp = yieldOp;
-      }
-
-      // Handle break statements.
-      walkRegionSkipping<mlir::cir::LoopOpInterface, mlir::cir::SwitchOp>(
-          region, [&](mlir::Operation *op) {
-            if (isa<mlir::cir::BreakOp>(op))
-              lowerTerminator(op, exitBlock, rewriter);
-          });
-
-      // Extract region contents before erasing the switch op.
-      rewriter.inlineRegionBefore(region, exitBlock);
+    for (auto x : op.getCaseDestinations()) {
+      caseDestinations.push_back(x);
     }
 
-    // Last case is a fallthrough: branch it to exit.
-    if (fallthroughYieldOp) {
-      rewriteYieldOp(rewriter, fallthroughYieldOp, exitBlock);
-      fallthroughYieldOp = nullptr;
+    for (auto x : op.getCaseOperands()) {
+      caseOperands.push_back(x);
     }
-
+    
     // Set switch op to branch to the newly created blocks.
     rewriter.setInsertionPoint(op);
     rewriter.replaceOpWithNewOp<mlir::LLVM::SwitchOp>(
-        op, adaptor.getCondition(), defaultDestination, defaultOperands,
-        caseValues, caseDestinations, caseOperands);
+        op, adaptor.getCondition(), op.getDefaultDestination(), 
+        op.getDefaultOperands(), 
+        caseValues, 
+        caseDestinations,
+        caseOperands);
     return mlir::success();
   }
 };
@@ -2967,7 +2915,7 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRCastOpLowering, CIRGlobalOpLowering, CIRGetGlobalOpLowering,
       CIRVAStartLowering, CIRVAEndLowering, CIRVACopyLowering, CIRVAArgLowering,
       CIRBrOpLowering, CIRTernaryOpLowering, CIRGetMemberOpLowering,
-      CIRSwitchOpLowering, CIRPtrDiffOpLowering, CIRCopyOpLowering,
+      CIRFlatSwitchOpLowering, CIRPtrDiffOpLowering, CIRCopyOpLowering,
       CIRMemCpyOpLowering, CIRFAbsOpLowering, CIRExpectOpLowering,
       CIRVTableAddrPointOpLowering, CIRVectorCreateLowering,
       CIRVectorInsertLowering, CIRVectorExtractLowering, CIRVectorCmpOpLowering,

--- a/clang/test/CIR/CodeGen/switch.cir
+++ b/clang/test/CIR/CodeGen/switch.cir
@@ -1,0 +1,207 @@
+// RUN: cir-opt %s -cir-flatten-cfg -o - | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+module {
+  cir.func @shouldFlatSwitchWithDefault(%arg0: !s8i) {
+    cir.switch (%arg0 : !s8i) [
+    case (equal, 1) {
+      cir.break
+    },
+    case (default) {
+      cir.break
+    }
+    ]
+    cir.return
+  }
+// CHECK:  cir.func @shouldFlatSwitchWithDefault(%arg0: !s8i) {
+// CHECK:    cir.flat.switch %arg0 : !s8i, ^bb[[#DEFAULT:]] [
+// CHECK:      #cir.int<1> : !s8i: ^bb[[#CASE1:]]
+// CHECK:    ]
+// CHECK:  ^bb[[#CASE1]]:
+// CHECK:    cir.br ^bb3
+// CHECK:  ^bb[[#DEFAULT]]:
+// CHECK:    cir.br ^bb[[#EXIT:]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.return
+// CHECK:  }
+
+  cir.func @shouldFlatSwitchWithoutDefault(%arg0: !s32i) {
+    cir.switch (%arg0 : !s32i) [
+    case (equal, 1) {
+      cir.break
+    }
+    ]    
+    cir.return
+  }
+// CHECK:  cir.func @shouldFlatSwitchWithoutDefault(%arg0: !s32i) {
+// CHECK:    cir.flat.switch %arg0 : !s32i, ^bb[[#EXIT:]] [
+// CHECK:      #cir.int<1> : !s32i: ^bb[[#CASE1:]]
+// CHECK:    ]
+// CHECK:  ^bb[[#CASE1]]:
+// CHECK:    cir.br ^bb[[#EXIT]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.return
+// CHECK:  }
+
+
+  cir.func @shouldFlatSwitchWithImplicitFallthrough(%arg0: !s64i) {
+    cir.switch (%arg0 : !s64i) [
+    case (anyof, [1, 2] : !s64i) {
+      cir.break
+    }
+    ]    
+    cir.return
+  }
+// CHECK:  cir.func @shouldFlatSwitchWithImplicitFallthrough(%arg0: !s64i) {
+// CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
+// CHECK:      #cir.int<1> : !s64i: ^bb[[#CASE1N2:]],
+// CHECK:      #cir.int<2> : !s64i: ^bb[[#CASE1N2]]
+// CHECK:    ]
+// CHECK:  ^bb[[#CASE1N2]]:
+// CHECK:    cir.br ^bb[[#EXIT]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.return
+// CHECK:  }
+
+
+
+  cir.func @shouldFlatSwitchWithExplicitFallthrough(%arg0: !s64i) {
+      cir.switch (%arg0 : !s64i) [
+      case (equal, 1 : !s64i) { // case 1 has its own region
+        cir.yield // fallthrough to case 2
+      },      
+      case (equal, 2 : !s64i) {
+        cir.break
+      }      
+      ]      
+    cir.return
+  }
+// CHECK:  cir.func @shouldFlatSwitchWithExplicitFallthrough(%arg0: !s64i) {
+// CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
+// CHECK:      #cir.int<1> : !s64i: ^bb[[#CASE1:]],
+// CHECK:      #cir.int<2> : !s64i: ^bb[[#CASE2:]]
+// CHECK:    ]
+// CHECK:  ^bb[[#CASE1]]:
+// CHECK:    cir.br ^bb[[#CASE2]]
+// CHECK:  ^bb[[#CASE2]]:
+// CHECK:    cir.br ^bb[[#EXIT]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.return
+// CHECK:  }
+
+  cir.func @shouldFlatSwitchWithFallthroughToExit(%arg0: !s64i) {
+      cir.switch (%arg0 : !s64i) [
+      case (equal, 1 : !s64i) {
+        cir.yield // fallthrough to exit
+      }      
+      ]   
+    cir.return
+  }
+// CHECK:  cir.func @shouldFlatSwitchWithFallthroughToExit(%arg0: !s64i) {
+// CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
+// CHECK:      #cir.int<1> : !s64i: ^bb[[#CASE1:]]
+// CHECK:    ]
+// CHECK:  ^bb[[#CASE1]]:
+// CHECK:    cir.br ^bb[[#EXIT]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.return
+// CHECK:  }
+
+  cir.func @shouldDropEmptySwitch(%arg0: !s64i) {
+    cir.switch (%arg0 : !s64i) [
+    ]
+    // CHECK-NOT: llvm.switch
+    cir.return
+  }
+// CHECK:      cir.func @shouldDropEmptySwitch(%arg0: !s64i) 
+// CHECK-NOT:    cir.flat.switch
+
+
+  cir.func @shouldFlatMultiBlockCase(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+      cir.switch (%1 : !s32i) [
+      case (equal, 3) {
+        cir.return
+      ^bb1:  // no predecessors
+        cir.break
+      }
+      ] 
+    }
+    cir.return
+  }
+
+// CHECK:  cir.func @shouldFlatMultiBlockCase(%arg0: !s32i) {
+// CHECK:     %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["a", init] {alignment = 4 : i64}
+// CHECK:     cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+// CHECK:     cir.br ^bb1
+// CHECK:   ^bb1:  // pred: ^bb0
+// CHECK:     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
+// CHECK:     cir.flat.switch %1 : !s32i, ^bb4 [
+// CHECK:       #cir.int<3> : !s32i: ^bb2
+// CHECK:     ]
+// CHECK:   ^bb2:  // pred: ^bb1
+// CHECK:     cir.return
+// CHECK:   ^bb3:  // no predecessors
+// CHECK:     cir.br ^bb4
+// CHECK:   ^bb4:  // 2 preds: ^bb1, ^bb3
+// CHECK:     cir.br ^bb5
+// CHECK:   ^bb5:  // pred: ^bb4
+// CHECK:     cir.return
+// CHECK:   }
+
+
+   cir.func @shouldFlatNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+    %0 = cir.alloca !s32i, cir.ptr <!s32i>, ["x", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, cir.ptr <!s32i>, ["y", init] {alignment = 4 : i64}
+    %2 = cir.alloca !s32i, cir.ptr <!s32i>, ["__retval"] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, cir.ptr <!s32i>
+    cir.store %arg1, %1 : !s32i, cir.ptr <!s32i>
+    cir.scope {
+      %5 = cir.load %0 : cir.ptr <!s32i>, !s32i
+      cir.switch (%5 : !s32i) [
+      case (equal, 0) {
+        cir.scope {
+          %6 = cir.load %1 : cir.ptr <!s32i>, !s32i
+          %7 = cir.const(#cir.int<0> : !s32i) : !s32i
+          %8 = cir.cmp(ge, %6, %7) : !s32i, !s32i
+          %9 = cir.cast(int_to_bool, %8 : !s32i), !cir.bool
+          cir.if %9 {
+            cir.break
+          }
+        }
+        cir.break
+      }
+      ] 
+    } 
+    %3 = cir.const(#cir.int<3> : !s32i) : !s32i
+    cir.store %3, %2 : !s32i, cir.ptr <!s32i>
+    %4 = cir.load %2 : cir.ptr <!s32i>, !s32i
+    cir.return %4 : !s32i 
+  }
+// CHECK:  cir.func @shouldFlatNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+// CHECK:    cir.flat.switch %3 : !s32i, ^bb7 [
+// CHECK:      #cir.int<0> : !s32i: ^bb2
+// CHECK:    ]
+// CHECK:  ^bb2:  // pred: ^bb1
+// CHECK:    cir.br ^bb3
+// CHECK:  ^bb3:  // pred: ^bb2
+// CHECK:    cir.brcond {{%.*}} ^bb4, ^bb5
+// CHECK:  ^bb4:  // pred: ^bb3
+// CHECK:    cir.br ^bb7
+// CHECK:  ^bb5:  // pred: ^bb3
+// CHECK:    cir.br ^bb6
+// CHECK:  ^bb6:  // pred: ^bb5
+// CHECK:    cir.br ^bb7
+// CHECK:  ^bb7:  // 3 preds: ^bb1, ^bb4, ^bb6
+// CHECK:    cir.br ^bb8
+// CHECK:  ^bb8:  // pred: ^bb7    
+// CHECK:    cir.return %9 : !s32i
+// CHECK:  }
+
+}

--- a/clang/test/CIR/CodeGen/switch.cir
+++ b/clang/test/CIR/CodeGen/switch.cir
@@ -17,7 +17,7 @@ module {
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithDefault(%arg0: !s8i) {
-// CHECK:    cir.flat.switch %arg0 : !s8i, ^bb[[#DEFAULT:]] [
+// CHECK:    cir.switch.flat %arg0 : !s8i, ^bb[[#DEFAULT:]] [
 // CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1]]:
@@ -37,7 +37,7 @@ module {
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithoutDefault(%arg0: !s32i) {
-// CHECK:    cir.flat.switch %arg0 : !s32i, ^bb[[#EXIT:]] [
+// CHECK:    cir.switch.flat %arg0 : !s32i, ^bb[[#EXIT:]] [
 // CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1]]:
@@ -56,7 +56,7 @@ module {
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithImplicitFallthrough(%arg0: !s64i) {
-// CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
+// CHECK:    cir.switch.flat %arg0 : !s64i, ^bb[[#EXIT:]] [
 // CHECK:      1: ^bb[[#CASE1N2:]],
 // CHECK:      2: ^bb[[#CASE1N2]]
 // CHECK:    ]
@@ -80,7 +80,7 @@ module {
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithExplicitFallthrough(%arg0: !s64i) {
-// CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
+// CHECK:    cir.switch.flat %arg0 : !s64i, ^bb[[#EXIT:]] [
 // CHECK:      1: ^bb[[#CASE1:]],
 // CHECK:      2: ^bb[[#CASE2:]]
 // CHECK:    ]
@@ -101,7 +101,7 @@ module {
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithFallthroughToExit(%arg0: !s64i) {
-// CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
+// CHECK:    cir.switch.flat %arg0 : !s64i, ^bb[[#EXIT:]] [
 // CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1]]:
@@ -117,7 +117,7 @@ module {
     cir.return
   }
 // CHECK:      cir.func @shouldDropEmptySwitch(%arg0: !s64i) 
-// CHECK-NOT:    cir.flat.switch
+// CHECK-NOT:    cir.switch.flat
 
 
   cir.func @shouldFlatMultiBlockCase(%arg0: !s32i) {
@@ -142,7 +142,7 @@ module {
 // CHECK:     cir.br ^bb1
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
-// CHECK:     cir.flat.switch %1 : !s32i, ^bb4 [
+// CHECK:     cir.switch.flat %1 : !s32i, ^bb4 [
 // CHECK:       3: ^bb2
 // CHECK:     ]
 // CHECK:   ^bb2:  // pred: ^bb1
@@ -185,7 +185,7 @@ module {
     cir.return %4 : !s32i 
   }
 // CHECK:  cir.func @shouldFlatNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
-// CHECK:    cir.flat.switch %3 : !s32i, ^bb7 [
+// CHECK:    cir.switch.flat %3 : !s32i, ^bb7 [
 // CHECK:      0: ^bb2
 // CHECK:    ]
 // CHECK:  ^bb2:  // pred: ^bb1

--- a/clang/test/CIR/CodeGen/switch.cir
+++ b/clang/test/CIR/CodeGen/switch.cir
@@ -18,7 +18,7 @@ module {
   }
 // CHECK:  cir.func @shouldFlatSwitchWithDefault(%arg0: !s8i) {
 // CHECK:    cir.flat.switch %arg0 : !s8i, ^bb[[#DEFAULT:]] [
-// CHECK:      #cir.int<1> : !s8i: ^bb[[#CASE1:]]
+// CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1]]:
 // CHECK:    cir.br ^bb3
@@ -38,7 +38,7 @@ module {
   }
 // CHECK:  cir.func @shouldFlatSwitchWithoutDefault(%arg0: !s32i) {
 // CHECK:    cir.flat.switch %arg0 : !s32i, ^bb[[#EXIT:]] [
-// CHECK:      #cir.int<1> : !s32i: ^bb[[#CASE1:]]
+// CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1]]:
 // CHECK:    cir.br ^bb[[#EXIT]]
@@ -57,8 +57,8 @@ module {
   }
 // CHECK:  cir.func @shouldFlatSwitchWithImplicitFallthrough(%arg0: !s64i) {
 // CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
-// CHECK:      #cir.int<1> : !s64i: ^bb[[#CASE1N2:]],
-// CHECK:      #cir.int<2> : !s64i: ^bb[[#CASE1N2]]
+// CHECK:      1: ^bb[[#CASE1N2:]],
+// CHECK:      2: ^bb[[#CASE1N2]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1N2]]:
 // CHECK:    cir.br ^bb[[#EXIT]]
@@ -81,8 +81,8 @@ module {
   }
 // CHECK:  cir.func @shouldFlatSwitchWithExplicitFallthrough(%arg0: !s64i) {
 // CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
-// CHECK:      #cir.int<1> : !s64i: ^bb[[#CASE1:]],
-// CHECK:      #cir.int<2> : !s64i: ^bb[[#CASE2:]]
+// CHECK:      1: ^bb[[#CASE1:]],
+// CHECK:      2: ^bb[[#CASE2:]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1]]:
 // CHECK:    cir.br ^bb[[#CASE2]]
@@ -102,7 +102,7 @@ module {
   }
 // CHECK:  cir.func @shouldFlatSwitchWithFallthroughToExit(%arg0: !s64i) {
 // CHECK:    cir.flat.switch %arg0 : !s64i, ^bb[[#EXIT:]] [
-// CHECK:      #cir.int<1> : !s64i: ^bb[[#CASE1:]]
+// CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1]]:
 // CHECK:    cir.br ^bb[[#EXIT]]
@@ -143,7 +143,7 @@ module {
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     %1 = cir.load %0 : cir.ptr <!s32i>, !s32i
 // CHECK:     cir.flat.switch %1 : !s32i, ^bb4 [
-// CHECK:       #cir.int<3> : !s32i: ^bb2
+// CHECK:       3: ^bb2
 // CHECK:     ]
 // CHECK:   ^bb2:  // pred: ^bb1
 // CHECK:     cir.return
@@ -186,7 +186,7 @@ module {
   }
 // CHECK:  cir.func @shouldFlatNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
 // CHECK:    cir.flat.switch %3 : !s32i, ^bb7 [
-// CHECK:      #cir.int<0> : !s32i: ^bb2
+// CHECK:      0: ^bb2
 // CHECK:    ]
 // CHECK:  ^bb2:  // pred: ^bb1
 // CHECK:    cir.br ^bb3


### PR DESCRIPTION
This PR adds flattening for `SwitchOp`. Despite of the previous PRs, here we have to introduce an operation for the flattening, since later we'll need to create `llvm.switch` in the lowering.
So `cir.flat.switch`  is a  new operation, which barely copied from the dialect.  I added several tests as well. 
