### PR TITLE
[CIR][CIRGen] Introduce initial support for ASTAllocaAddressSpace

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2659,7 +2659,9 @@ Address CIRGenFunction::CreateTempAlloca(mlir::Type Ty, CharUnits Align,
   // be different from the type defined by the language. For example,
   // in C++ the auto variables are in the default address space. Therefore
   // cast alloca to the default address space when necessary.
-  assert(!UnimplementedFeature::getASTAllocaAddressSpace());
+  if (getASTAllocaAddressSpace() != LangAS::Default) {
+    llvm_unreachable("Requires address space cast which is NYI");
+  }
   return Address(V, Ty, Align);
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -160,7 +160,7 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
   AllocaInt8PtrTy = UInt8PtrTy;
   // TODO: GlobalsInt8PtrTy
   // TODO: ConstGlobalsPtrTy
-  // TODO: ASTAllocaAddressSpace
+  ASTAllocaAddressSpace = getTargetCIRGenInfo().getASTAllocaAddressSpace();
 
   PtrDiffTy = ::mlir::cir::IntType::get(
       builder.getContext(), astCtx.getTargetInfo().getMaxPointerWidth(),

--- a/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CLANG_LIB_CIR_CODEGENTYPECACHE_H
 #define LLVM_CLANG_LIB_CIR_CODEGENTYPECACHE_H
 
+#include "UnimplementedFeatureGuarding.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 #include "clang/AST/CharUnits.h"
@@ -107,7 +108,7 @@ struct CIRGenTypeCache {
   //     unsigned char SizeAlignInBytes;
   //   };
 
-  //   clang::LangAS ASTAllocaAddressSpace;
+  clang::LangAS ASTAllocaAddressSpace;
 
   //   clang::CharUnits getSizeSize() const {
   //     return clang::CharUnits::fromQuantity(SizeSizeInBytes);
@@ -122,9 +123,14 @@ struct CIRGenTypeCache {
     return clang::CharUnits::fromQuantity(PointerAlignInBytes);
   }
 
-  //   clang::LangAS getASTAllocaAddressSpace() const {
-  //     return ASTAllocaAddressSpace;
-  //   }
+  clang::LangAS getASTAllocaAddressSpace() const {
+    // Address spaces are not yet fully supported, but the usage of the default
+    // alloca address space can be used for now only for comparison with the
+    // default address space.
+    assert(!UnimplementedFeature::addressSpace());
+    assert(ASTAllocaAddressSpace == clang::LangAS::Default);
+    return ASTAllocaAddressSpace;
+  }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -60,6 +60,11 @@ public:
                            std::vector<LValue> &ResultRegDests,
                            std::string &AsmString, unsigned NumOutputs) const {}
 
+  /// Get the AST address space for alloca.
+  virtual clang::LangAS getASTAllocaAddressSpace() const {
+    return clang::LangAS::Default;
+  }
+
   virtual ~TargetCIRGenInfo() {}
 };
 

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -30,7 +30,6 @@ struct UnimplementedFeature {
   // Address space related
   static bool addressSpace() { return false; }
   static bool addressSpaceInGlobalVar() { return false; }
-  static bool getASTAllocaAddressSpace() { return false; }
 
   // Clang codegen options
   static bool strictVTablePointers() { return false; }


### PR DESCRIPTION
ASTAllocaAddressSpace is a target-specific definition specificed by the codegen target info.
In this commit, initial support is introduced which asserts that only the default (no qualifier) address space is supported.