### PR TITLE
[CIR][CodeGen] Goto pass

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2506,8 +2506,6 @@ def FuncOp : CIR_Op<"func", [
     can also be specified `global_ctor(<prio>)`. Similarly, for global destructors
     both `global_dtor` and `global_dtor(<prio>)` are available.
 
-    The `has_labels` indicates whether labels and goto-s operations exists in a function.
-
     Example:
 
     ```mlir
@@ -2540,7 +2538,6 @@ def FuncOp : CIR_Op<"func", [
                        UnitAttr:$coroutine,
                        UnitAttr:$lambda,
                        UnitAttr:$no_proto,
-                       UnitAttr:$has_labels,
                        DefaultValuedAttr<GlobalLinkageKind,
                                          "GlobalLinkageKind::ExternalLinkage">:$linkage,
                        ExtraFuncAttr:$extra_attrs,
@@ -3646,14 +3643,42 @@ def SwitchFlatOp : CIR_Op<"switch.flat", [AttrSizedOperandSegments, Terminator]>
   ];
 }
 
+//===----------------------------------------------------------------------===//
+// GotoOp
+//===----------------------------------------------------------------------===//
+
 def GotoOp : CIR_Op<"goto", [Terminator]> {
-  let description = [{ Transfers control to the specified label }];
+  let description = [{ Transfers control to the specified label.
+
+  Example:
+  ```C++
+    void foo() {
+      goto exit;
+
+    exit:
+      return;
+    }
+    ```
+
+    ```mlir
+    cir.func @foo() {
+      cir.goto "exit"
+    ^bb1:
+      cir.label "exit"
+      cir.return
+    }
+    ```
+  }];
   let arguments = (ins StrAttr:$label);
   let assemblyFormat = [{ $label attr-dict }];
 }
 
+//===----------------------------------------------------------------------===//
+// LabelOp
+//===----------------------------------------------------------------------===//
+
 def LabelOp : CIR_Op<"label"> {
-  let description = [{ An identifier which may be referred by Goto operation }];
+  let description = [{ An identifier which may be referred by cir.goto operation }];
   let arguments = (ins StrAttr:$label);
   let assemblyFormat = [{ $label attr-dict }];
   let hasVerifier = 1;

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3643,6 +3643,25 @@ def SwitchFlatOp : CIR_Op<"switch.flat", [AttrSizedOperandSegments, Terminator]>
   ];
 }
 
+def GotoOp : CIR_Op<"goto", [Terminator]> {
+  let summary = "goto";
+  let description = [{ }];
+
+  let arguments = (ins StrAttr:$label);
+  let assemblyFormat = [{ $label attr-dict }];
+
+
+}
+
+def LabelOp : CIR_Op<"label"> {
+  let summary = "label";
+  let description = [{ }];
+
+  let arguments = (ins StrAttr:$label);
+  let assemblyFormat = [{ $label attr-dict }];
+
+}
+
 //===----------------------------------------------------------------------===//
 // Atomic operations
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2506,6 +2506,8 @@ def FuncOp : CIR_Op<"func", [
     can also be specified `global_ctor(<prio>)`. Similarly, for global destructors
     both `global_dtor` and `global_dtor(<prio>)` are available.
 
+    The `has_labels` indicates whether labels and goto-s operations exists in a function.
+
     Example:
 
     ```mlir
@@ -2538,6 +2540,7 @@ def FuncOp : CIR_Op<"func", [
                        UnitAttr:$coroutine,
                        UnitAttr:$lambda,
                        UnitAttr:$no_proto,
+                       UnitAttr:$has_labels,
                        DefaultValuedAttr<GlobalLinkageKind,
                                          "GlobalLinkageKind::ExternalLinkage">:$linkage,
                        ExtraFuncAttr:$extra_attrs,
@@ -3644,22 +3647,16 @@ def SwitchFlatOp : CIR_Op<"switch.flat", [AttrSizedOperandSegments, Terminator]>
 }
 
 def GotoOp : CIR_Op<"goto", [Terminator]> {
-  let summary = "goto";
-  let description = [{ }];
-
+  let description = [{ Transfers control to the specified label }];
   let arguments = (ins StrAttr:$label);
   let assemblyFormat = [{ $label attr-dict }];
-
-
 }
 
 def LabelOp : CIR_Op<"label"> {
-  let summary = "label";
-  let description = [{ }];
-
+  let description = [{ An identifier which may be referred by Goto operation }];
   let arguments = (ins StrAttr:$label);
   let assemblyFormat = [{ $label attr-dict }];
-
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3677,7 +3677,8 @@ def GotoOp : CIR_Op<"goto", [Terminator]> {
 // LabelOp
 //===----------------------------------------------------------------------===//
 
-def LabelOp : CIR_Op<"label"> {
+// The LabelOp has AlwaysSpeculatable trait in order to not to be swept by canonicalizer
+def LabelOp : CIR_Op<"label", [AlwaysSpeculatable]> {
   let description = [{ An identifier which may be referred by cir.goto operation }];
   let arguments = (ins StrAttr:$label);
   let assemblyFormat = [{ $label attr-dict }];

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -35,6 +35,7 @@ std::unique_ptr<Pass> createIdiomRecognizerPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createFlattenCFGPass();
+std::unique_ptr<Pass> createGotoSolverPass();
 
 void populateCIRPreLoweringPasses(mlir::OpPassManager &pm);
 

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -89,6 +89,13 @@ def FlattenCFG : Pass<"cir-flatten-cfg"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def GotoSolver : Pass<"cir-goto-solver"> {
+  let summary = "TODO";
+  let description = [{ TODO }];
+  let constructor = "mlir::createGotoSolverPass()";
+  let dependentDialects = ["cir::CIRDialect"];
+}
+
 def IdiomRecognizer : Pass<"cir-idiom-recognizer"> {
   let summary = "Raise calls to C/C++ libraries to CIR operations";
   let description = [{

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -90,8 +90,11 @@ def FlattenCFG : Pass<"cir-flatten-cfg"> {
 }
 
 def GotoSolver : Pass<"cir-goto-solver"> {
-  let summary = "TODO";
-  let description = [{ TODO }];
+  let summary = "Replaces goto operatations with branches";
+  let description = [{
+    This pass transforms CIR and replaces goto-s with branch
+    operations to the proper blocks.
+  }];
   let constructor = "mlir::createGotoSolverPass()";
   let dependentDialects = ["cir::CIRDialect"];
 }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -323,22 +323,6 @@ void CIRGenFunction::LexicalScope::cleanup() {
   auto &builder = CGF.builder;
   auto *localScope = CGF.currLexScope;
 
-  // Handle pending gotos and the solved labels in this scope.
-  while (!localScope->PendingGotos.empty()) {
-    auto gotoInfo = localScope->PendingGotos.back();
-    // FIXME: Currently only support resolving goto labels inside the
-    // same lexical ecope.
-    assert(localScope->SolvedLabels.count(gotoInfo.second) &&
-           "goto across scopes not yet supported");
-
-    // The goto in this lexical context actually maps to a basic
-    // block.
-    auto g = cast<mlir::cir::BrOp>(gotoInfo.first);
-    g.setSuccessor(CGF.LabelMap[gotoInfo.second].getBlock());
-    localScope->PendingGotos.pop_back();
-  }
-  localScope->SolvedLabels.clear();
-
   auto applyCleanup = [&]() {
     if (PerformCleanup) {
       // ApplyDebugLocation

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1952,13 +1952,6 @@ public:
       return CleanupBlock;
     }
 
-    // Goto's introduced in this scope but didn't get fixed.
-    llvm::SmallVector<std::pair<mlir::Operation *, const clang::LabelDecl *>, 4>
-        PendingGotos;
-
-    // Labels solved inside this scope.
-    llvm::SmallPtrSet<const clang::LabelDecl *, 4> SolvedLabels;
-
     // ---
     // Exception handling
     // ---

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -554,6 +554,14 @@ mlir::LogicalResult CIRGenFunction::buildGotoStmt(const GotoStmt &S) {
   // info support just yet, look at this again once we have it.
   assert(builder.getInsertionBlock() && "not yet implemented");
 
+  mlir::Block *currBlock = builder.getBlock();
+  mlir::Block *gotoBlock = currBlock;
+  if (!currBlock->empty() &&
+      currBlock->back().hasTrait<mlir::OpTrait::IsTerminator>()) {
+    gotoBlock = builder.createBlock(builder.getBlock()->getParent());
+    builder.setInsertionPointToEnd(gotoBlock);
+  }
+
   // A goto marks the end of a block, create a new one for codegen after
   // buildGotoStmt can resume building in that block.
 

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -325,6 +325,9 @@ mlir::LogicalResult CIRGenFunction::buildLabelStmt(const clang::LabelStmt &S) {
   if (buildLabel(S.getDecl()).failed())
     return mlir::failure();
 
+  auto fn = dyn_cast<mlir::cir::FuncOp>(CurFn);
+  fn.setHasLabels(true);
+
   // IsEHa: not implemented.
   assert(!(getContext().getLangOpts().EHAsynch && S.isSideEntry()));
 

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -325,9 +325,6 @@ mlir::LogicalResult CIRGenFunction::buildLabelStmt(const clang::LabelStmt &S) {
   if (buildLabel(S.getDecl()).failed())
     return mlir::failure();
 
-  auto fn = dyn_cast<mlir::cir::FuncOp>(CurFn);
-  fn.setHasLabels(true);
-
   // IsEHa: not implemented.
   assert(!(getContext().getLangOpts().EHAsynch && S.isSideEntry()));
 

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -82,7 +82,7 @@ namespace mlir {
 
 void populateCIRPreLoweringPasses(OpPassManager &pm) {
   pm.addPass(createFlattenCFGPass());
-  // add other passes here
+  pm.addPass(createGotoSolverPass());
 }
 
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1980,11 +1980,6 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
   }
   state.addAttribute(getExtraAttrsAttrName(state.name), extraAttrs);
 
-  auto hasLabelsNameAttr = getGlobalDtorAttrName(state.name);
-  if (::mlir::succeeded(
-          parser.parseOptionalKeyword(hasLabelsNameAttr.strref())))
-    state.addAttribute(hasLabelsNameAttr, parser.getBuilder().getUnitAttr());
-
   // Parse the optional function body.
   auto *body = state.addRegion();
   OptionalParseResult parseResult = parser.parseOptionalRegion(
@@ -2066,7 +2061,7 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
       {getSymVisibilityAttrName(), getAliaseeAttrName(),
        getFunctionTypeAttrName(), getLinkageAttrName(), getBuiltinAttrName(),
        getNoProtoAttrName(), getGlobalCtorAttrName(), getGlobalDtorAttrName(),
-       getExtraAttrsAttrName(), getHasLabelsAttrName()});
+       getExtraAttrsAttrName()});
 
   if (auto aliaseeName = getAliasee()) {
     p << " alias(";
@@ -2091,9 +2086,6 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
     p.printAttributeWithoutType(getExtraAttrs());
     p << ")";
   }
-
-  if (getHasLabels())
-    p << " has_labels";
 
   // Print the body if this is not an external function.
   Region &body = getOperation()->getRegion(0);
@@ -3079,7 +3071,7 @@ LogicalResult LabelOp::verify() {
   auto *op = getOperation();
   auto *blk = op->getBlock();
   if (&blk->front() != op)
-    return emitError() << "LabelOp must be the first operation in a block";
+    return emitError() << "must be the first operation in a block";
   return mlir::success();
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <numeric>
 #include <optional>
+#include <set>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -2173,6 +2174,25 @@ LogicalResult cir::FuncOp::verify() {
       return emitOpError() << "a function alias '" << *fn
                            << "' must have empty body";
   }
+
+  std::set<llvm::StringRef> labels;
+  std::set<llvm::StringRef> gotos;
+
+  getOperation()->walk([&](mlir::Operation *op) {
+    if (auto lab = dyn_cast<mlir::cir::LabelOp>(op)) {
+      labels.emplace(lab.getLabel());
+    } else if (auto goTo = dyn_cast<mlir::cir::GotoOp>(op)) {
+      gotos.emplace(goTo.getLabel());
+    }
+  });
+
+  std::vector<llvm::StringRef> mismatched;
+  std::set_difference(gotos.begin(), gotos.end(), 
+                      labels.begin(), labels.end(), 
+                      std::back_inserter(mismatched));
+
+  if (!mismatched.empty())    
+    return emitOpError() << "goto/label mismatch";
 
   return success();
 }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1981,7 +1981,8 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
   state.addAttribute(getExtraAttrsAttrName(state.name), extraAttrs);
 
   auto hasLabelsNameAttr = getGlobalDtorAttrName(state.name);
-  if (::mlir::succeeded(parser.parseOptionalKeyword(hasLabelsNameAttr.strref())))
+  if (::mlir::succeeded(
+          parser.parseOptionalKeyword(hasLabelsNameAttr.strref())))
     state.addAttribute(hasLabelsNameAttr, parser.getBuilder().getUnitAttr());
 
   // Parse the optional function body.
@@ -3075,8 +3076,8 @@ LogicalResult BinOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult LabelOp::verify() {
-  auto* op = getOperation();
-  auto* blk = op->getBlock();
+  auto *op = getOperation();
+  auto *blk = op->getBlock();
   if (&blk->front() != op)
     return emitError() << "LabelOp must be the first operation in a block";
   return mlir::success();

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2187,11 +2187,10 @@ LogicalResult cir::FuncOp::verify() {
   });
 
   std::vector<llvm::StringRef> mismatched;
-  std::set_difference(gotos.begin(), gotos.end(), 
-                      labels.begin(), labels.end(), 
+  std::set_difference(gotos.begin(), gotos.end(), labels.begin(), labels.end(),
                       std::back_inserter(mismatched));
 
-  if (!mismatched.empty())    
+  if (!mismatched.empty())
     return emitOpError() << "goto/label mismatch";
 
   return success();

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_clang_library(MLIRCIRTransforms
   LibOpt.cpp
   StdHelpers.cpp
   FlattenCFG.cpp
+  GotoSolver.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -224,7 +224,7 @@ public:
         });
 
     // Lower optional body region yield.
-    for (auto& blk : op.getBody().getBlocks()) {
+    for (auto &blk : op.getBody().getBlocks()) {
       auto bodyYield = dyn_cast<mlir::cir::YieldOp>(blk.getTerminator());
       if (bodyYield)
         lowerTerminator(bodyYield, (step ? step : cond), rewriter);

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -224,9 +224,11 @@ public:
         });
 
     // Lower optional body region yield.
-    auto bodyYield = dyn_cast<mlir::cir::YieldOp>(body->getTerminator());
-    if (bodyYield)
-      lowerTerminator(bodyYield, (step ? step : cond), rewriter);
+    for (auto& blk : op.getBody().getBlocks()) {
+      auto bodyYield = dyn_cast<mlir::cir::YieldOp>(blk.getTerminator());
+      if (bodyYield)
+        lowerTerminator(bodyYield, (step ? step : cond), rewriter);
+    }
 
     // Lower mandatory step region yield.
     if (step)

--- a/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
@@ -1,0 +1,58 @@
+#include "PassDetail.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+#include <iostream>
+
+using namespace mlir;
+using namespace mlir::cir;
+
+namespace {
+
+struct GotoSolverPass : public GotoSolverBase<GotoSolverPass> {
+
+  GotoSolverPass() = default;
+  void runOnOperation() override;
+};
+
+static void process(mlir::cir::FuncOp func) {
+  
+  mlir::OpBuilder rewriter(func.getContext());
+  std::map<std::string, Block*> labels;
+  std::vector<mlir::cir::GotoOp> gotos;
+
+  func.getBody().walk([&](mlir::Operation* op) {
+    if (auto lab = dyn_cast<mlir::cir::LabelOp>(op)) {
+      labels.emplace(lab.getLabel().str(), lab->getBlock());
+      lab.erase();
+    } else if (auto goTo = dyn_cast<mlir::cir::GotoOp>(op)) {
+      gotos.push_back(goTo);
+    }
+  });
+
+  for (auto goTo : gotos) {
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(goTo);
+    auto dest = labels[goTo.getLabel().str()];
+    rewriter.create<mlir::cir::BrOp>(goTo.getLoc(), dest);
+    goTo.erase();
+  }
+  
+}
+
+void GotoSolverPass::runOnOperation() {
+    SmallVector<Operation *, 16> ops;
+    getOperation()->walk([&](mlir::cir::FuncOp op) {
+      process(op);
+    });
+}
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createGotoSolverPass() {
+    return std::make_unique<GotoSolverPass>();
+}

--- a/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
@@ -19,12 +19,12 @@ struct GotoSolverPass : public GotoSolverBase<GotoSolverPass> {
 };
 
 static void process(mlir::cir::FuncOp func) {
-  
+
   mlir::OpBuilder rewriter(func.getContext());
-  std::map<std::string, Block*> labels;
+  std::map<std::string, Block *> labels;
   std::vector<mlir::cir::GotoOp> gotos;
 
-  func.getBody().walk([&](mlir::Operation* op) {
+  func.getBody().walk([&](mlir::Operation *op) {
     if (auto lab = dyn_cast<mlir::cir::LabelOp>(op)) {
       labels.emplace(lab.getLabel().str(), lab->getBlock());
       lab.erase();
@@ -40,19 +40,18 @@ static void process(mlir::cir::FuncOp func) {
     rewriter.create<mlir::cir::BrOp>(goTo.getLoc(), dest);
     goTo.erase();
   }
-  
 }
 
 void GotoSolverPass::runOnOperation() {
-    SmallVector<Operation *, 16> ops;
-    getOperation()->walk([&](mlir::cir::FuncOp op) {
-      if (op.getHasLabels())
-        process(op);
-    });
+  SmallVector<Operation *, 16> ops;
+  getOperation()->walk([&](mlir::cir::FuncOp op) {
+    if (op.getHasLabels())
+      process(op);
+  });
 }
 
 } // namespace
 
 std::unique_ptr<Pass> mlir::createGotoSolverPass() {
-    return std::make_unique<GotoSolverPass>();
+  return std::make_unique<GotoSolverPass>();
 }

--- a/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
@@ -6,7 +6,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
-#include <iostream>
 
 using namespace mlir;
 using namespace mlir::cir;
@@ -47,7 +46,8 @@ static void process(mlir::cir::FuncOp func) {
 void GotoSolverPass::runOnOperation() {
     SmallVector<Operation *, 16> ops;
     getOperation()->walk([&](mlir::cir::FuncOp op) {
-      process(op);
+      if (op.getHasLabels())
+        process(op);
     });
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
@@ -44,9 +44,7 @@ static void process(mlir::cir::FuncOp func) {
 
 void GotoSolverPass::runOnOperation() {
   SmallVector<Operation *, 16> ops;
-  getOperation()->walk([&](mlir::cir::FuncOp op) {
-    process(op);
-  });
+  getOperation()->walk([&](mlir::cir::FuncOp op) { process(op); });
 }
 
 } // namespace

--- a/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
@@ -45,8 +45,7 @@ static void process(mlir::cir::FuncOp func) {
 void GotoSolverPass::runOnOperation() {
   SmallVector<Operation *, 16> ops;
   getOperation()->walk([&](mlir::cir::FuncOp op) {
-    if (op.getHasLabels())
-      process(op);
+    process(op);
   });
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/MergeCleanups.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/MergeCleanups.cpp
@@ -42,6 +42,9 @@ struct RemoveRedudantBranches : public OpRewritePattern<BrOp> {
     Block *block = op.getOperation()->getBlock();
     Block *dest = op.getDest();
 
+    if (isa<mlir::cir::LabelOp>(dest->front()))
+      return failure();
+
     // Single edge between blocks: merge it.
     if (block->getNumSuccessors() == 1 &&
         dest->getSinglePredecessor() == block) {

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -203,3 +203,52 @@ err:
 // CHECK:  ^bb[[#RETURN2]]:
 // CHECK:    cir.return 
   
+
+void flatLoopWithNoTerminatorInFront(int* ptr) {
+  
+  if (ptr)
+    goto loop;
+
+  do {
+    if (!ptr)
+      goto end;
+  loop:
+      ptr++;
+  } while(ptr);
+
+  end:
+  ;
+}
+
+// CHECK:  cir.func @_Z31flatLoopWithNoTerminatorInFrontPi
+// CHECK:    cir.brcond {{.*}} ^bb[[#BLK2:]], ^bb[[#BLK3:]]
+// CHECK:  ^bb[[#BLK2]]:
+// CHECK:    cir.br ^bb[[#LABEL_LOOP:]]
+// CHECK:  ^bb[[#BLK3]]:
+// CHECK:    cir.br ^bb[[#BLK4:]] 
+// CHECK:  ^bb[[#BLK4]]:
+// CHECK:    cir.br ^bb[[#BLK5:]]
+// CHECK:  ^bb[[#BLK5]]:
+// CHECK:    cir.br ^bb[[#BODY:]]
+// CHECK:  ^bb[[#COND]]: 
+// CHECK:    cir.brcond {{.*}} ^bb[[#BODY]], ^bb[[#EXIT:]]
+// CHECK:  ^bb[[#BODY]]:
+// CHECK:    cir.br ^bb[[#BLK8:]]
+// CHECK:  ^bb[[#BLK8]]:
+// CHECK:    cir.brcond {{.*}} ^bb[[#BLK9:]], ^bb[[#BLK10:]]
+// CHECK:  ^bb[[#BLK9]]:
+// CHECK:    cir.br ^bb[[#RETURN:]]
+// CHECK:  ^bb[[#BLK10]]:
+// CHECK:    cir.br ^bb[[#BLK11:]]
+// CHECK:  ^bb[[#BLK11]]:
+// CHECK:    cir.br ^bb[[#LABEL_LOOP]]
+// CHECK:  ^bb[[#LABEL_LOOP]]:
+// CHECK:    cir.br ^bb[[#COND]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.br ^bb[[#BLK14:]]
+// CHECK:  ^bb[[#BLK14]]:
+// CHECK:    cir.br ^bb[[#RETURN]]
+// CHECK:  ^bb[[#RETURN]]:
+// CHECK:    cir.return
+// CHECK:  }
+// CHECK:}

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -151,6 +151,17 @@ end:
 // NOFLAT:  ^bb[[#BLK2:]]:
 // NOFLAT:    cir.label "end"
 
+
+void labelWithoutMatch() {
+end:
+  return;
+}
+// NOFLAT:  cir.func @_Z17labelWithoutMatchv()
+// NOFLAT:    cir.label "end"
+// NOFLAT:    cir.return
+// NOFLAT:  }
+
+
 int jumpIntoLoop(int* ar) {
 
   if (ar)

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -1,5 +1,8 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-flat %s -o %t1.cir
+// RUN: FileCheck --input-file=%t1.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t2.cir
+// RUN: FileCheck --input-file=%t2.cir %s -check-prefix=NOFLAT
+
 
 void g0(int a) {
   int b = a;
@@ -64,3 +67,139 @@ end:
 // CHECK:     [[R:%[0-9]+]] = cir.load %0 : !cir.ptr<!s32i>, !s32i
 // CHECK-NEXT:     [[R]] : !s32i
 // CHECK-NEXT:   }
+
+
+int shouldNotGenBranchRet(int x) {
+  if (x > 5)
+    goto err;
+  return 0;
+err:
+  return -1;
+}
+// NOFLAT:  cir.func @_Z21shouldNotGenBranchReti
+// NOFLAT:    cir.if %8 {
+// NOFLAT:      cir.goto "err"
+// NOFLAT:    }
+// NOFLAT:  ^bb1:
+// NOFLAT:    %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
+// NOFLAT:    cir.return %3 : !s32i
+// NOFLAT:  ^bb2:  // no predecessors
+// NOFLAT:    cir.label "err"
+
+int shouldGenBranch(int x) {
+  if (x > 5)
+    goto err;
+  x++;
+err:
+  return -1;
+}
+// NOFLAT:  cir.func @_Z15shouldGenBranchi
+// NOFLAT:    cir.if %9 {
+// NOFLAT:      cir.goto "err"
+// NOFLAT:    }
+// NOFLAT:    cir.br ^bb1
+// NOFLAT:  ^bb1:  
+// NOFLAT:    cir.label "err"
+
+int shouldCreateBlkForGoto(int a) {
+  switch (a) {
+    case(42):
+      break;
+      goto exit;
+    default:
+      return 0;
+  };
+
+exit:
+  return -1;
+
+}
+// NOFLAT: cir.func @_Z22shouldCreateBlkForGotoi
+// NOFLAT:   case (equal, 42) {
+// NOFLAT:     cir.break
+// NOFLAT:   ^bb1:  // no predecessors
+// NOFLAT:     cir.goto "exit"
+// NOFLAT:   }
+
+
+int jumpIntoLoop(int* ar) {
+
+  if (ar)
+    goto label;
+  return -1;
+  
+  while (ar) {
+  label:
+    ++ar;
+  }
+
+  return 0;
+}
+
+// CHECK:  cir.func @_Z12jumpIntoLoopPi
+// CHECK:    cir.brcond {{.*}} ^bb[[#BLK2:]], ^bb[[#BLK3:]]
+// CHECK:  ^bb[[#BLK2]]:
+// CHECK:    cir.br ^bb[[#BODY:]]
+// CHECK:  ^bb[[#BLK3]]:
+// CHECK:    cir.br ^bb[[#BLK4:]]
+// CHECK:  ^bb[[#BLK4]]:
+// CHECK:    cir.br ^bb[[#RETURN:]]
+// CHECK:  ^bb[[#RETURN]]:
+// CHECK:    cir.return
+// CHECK:  ^bb[[#BLK5:]]:
+// CHECK:    cir.br ^bb[[#BLK6:]]
+// CHECK:  ^bb[[#BLK6]]:
+// CHECK:    cir.br ^bb[[#COND:]]
+// CHECK:  ^bb[[#COND]]:
+// CHECK:    cir.brcond {{.*}} ^bb[[#BODY]], ^bb[[#EXIT:]]
+// CHECK:  ^bb[[#BODY]]: 
+// CHECK:    cir.br ^bb[[#COND]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.br ^bb[[#BLK7:]]
+// CHECK:  ^bb[[#BLK7]]:
+// CHECK:    cir.br ^bb[[#RETURN]]
+
+
+
+int jumpFromLoop(int* ar) {
+
+  if (!ar) {
+err:
+  return -1;
+}
+
+  while (ar) {
+    if (*ar == 42)
+      goto err;
+    ++ar;
+  }
+  
+  return 0;
+}
+// CHECK:  cir.func @_Z12jumpFromLoopPi
+// CHECK:    cir.brcond {{.*}} ^bb[[#RETURN1:]], ^bb[[#BLK3:]]
+// CHECK:  ^bb[[#RETURN1]]:
+// CHECK:    cir.return
+// CHECK:  ^bb[[#BLK3]]:
+// CHECK:    cir.br ^bb[[#BLK4:]]
+// CHECK:  ^bb[[#BLK4]]:
+// CHECK:    cir.br ^bb[[#BLK5:]]
+// CHECK:  ^bb[[#BLK5]]:
+// CHECK:    cir.br ^bb[[#COND:]]
+// CHECK:  ^bb[[#COND]]: 
+// CHECK:    cir.brcond {{.*}} ^bb[[#BODY:]], ^bb[[#EXIT:]]
+// CHECK:  ^bb[[#BODY]]:
+// CHECK:    cir.br ^bb[[#IF42:]]
+// CHECK:  ^bb[[#IF42]]:
+// CHECK:    cir.brcond {{.*}} ^bb[[#IF42TRUE:]], ^bb[[#IF42FALSE:]]
+// CHECK:  ^bb[[#IF42TRUE]]:
+// CHECK:    cir.br ^bb[[#RETURN1]]
+// CHECK:  ^bb[[#IF42FALSE]]:
+// CHECK:    cir.br ^bb[[#BLK11:]]
+// CHECK:  ^bb[[#BLK11]]:
+// CHECK:    cir.br ^bb[[#COND]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.br ^bb[[#RETURN2:]]
+// CHECK:  ^bb[[#RETURN2]]:
+// CHECK:    cir.return 
+  

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -121,6 +121,35 @@ exit:
 // NOFLAT:     cir.goto "exit"
 // NOFLAT:   }
 
+void severalLabelsInARow(int a) {
+  int b = a;
+  goto end1;
+  b = b + 1;
+  goto end2;
+end1:
+end2:
+  b = b + 2;
+}
+// NOFLAT:  cir.func @_Z19severalLabelsInARowi
+// NOFLAT:  ^bb[[#BLK1:]]:
+// NOFLAT:    cir.label "end1"
+// NOFLAT:    cir.br ^bb[[#BLK2:]]
+// NOFLAT:  ^bb[[#BLK2]]:
+// NOFLAT:    cir.label "end2"
+
+void severalGotosInARow(int a) {
+  int b = a;
+  goto end;
+  goto end;
+end:
+  b = b + 2;
+}
+// NOFLAT:  cir.func @_Z18severalGotosInARowi
+// NOFLAT:    cir.goto "end"
+// NOFLAT:  ^bb[[#BLK1:]]:
+// NOFLAT:    cir.goto "end"
+// NOFLAT:  ^bb[[#BLK2:]]:
+// NOFLAT:    cir.label "end"
 
 int jumpIntoLoop(int* ar) {
 
@@ -165,7 +194,7 @@ int jumpFromLoop(int* ar) {
 
   if (!ar) {
 err:
-  return -1;
+    return -1;
 }
 
   while (ar) {

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -81,7 +81,7 @@ err:
 // NOFLAT:      cir.goto "err"
 // NOFLAT:    }
 // NOFLAT:  ^bb1:
-// NOFLAT:    %3 = cir.load %1 : cir.ptr <!s32i>, !s32i
+// NOFLAT:    %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
 // NOFLAT:    cir.return %3 : !s32i
 // NOFLAT:  ^bb2:  // no predecessors
 // NOFLAT:    cir.label "err"

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1107,3 +1107,14 @@ module {
     %0 = cir.dyn_cast(ptr, %arg0 : !cir.ptr<!Base>, #cir.dyn_cast_info<#cir.global_view<@_ZTI4Base> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI7Derived> : !cir.ptr<!u32i>, @__dynamic_cast, @__cxa_bad_cast, #cir.int<0> : !s64i>) -> !cir.ptr<!Derived>
   }
 }
+
+
+// -----
+
+// expected-error@+1 {{goto/label mismatch}}
+cir.func @bad_goto() -> () {
+  cir.goto "somewhere"
+^bb1:
+  cir.label "label"
+  cir.return
+} 

--- a/clang/test/CIR/Lowering/goto.cir
+++ b/clang/test/CIR/Lowering/goto.cir
@@ -1,36 +1,53 @@
-// RUN: cir-opt %s -canonicalize -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-opt %s -canonicalize -o - | cir-translate -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s --pass-pipeline='builtin.module(cir-to-llvm,canonicalize{region-simplify=false})' -o - | FileCheck %s -check-prefix=MLIR
 
-!u32i = !cir.int<u, 32>
+!s32i = !cir.int<s, 32>
 
 module {
-  cir.func @foo() {
-    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["b", init] {alignment = 4 : i64}
-    %1 = cir.const(#cir.int<1> : !u32i) : !u32i
-    cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
-    cir.br ^bb2
-  ^bb1:  // no predecessors
-    %2 = cir.load %0 : !cir.ptr<!u32i>, !u32i
-    %3 = cir.const(#cir.int<1> : !u32i) : !u32i
-    %4 = cir.binop(add, %2, %3) : !u32i
-    cir.store %4, %0 : !u32i, !cir.ptr<!u32i>
-    cir.br ^bb2
-  ^bb2:  // 2 preds: ^bb0, ^bb1
-    %5 = cir.load %0 : !cir.ptr<!u32i>, !u32i
-    %6 = cir.const(#cir.int<2> : !u32i) : !u32i
-    %7 = cir.binop(add, %5, %6) : !u32i
-    cir.store %7, %0 : !u32i, !cir.ptr<!u32i>
-    cir.return
+  
+  cir.func @gotoFromIf(%arg0: !s32i) -> !s32i {
+    %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
+    cir.scope {
+      %6 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+      %7 = cir.const(#cir.int<5> : !s32i) : !s32i
+      %8 = cir.cmp(gt, %6, %7) : !s32i, !s32i
+      %9 = cir.cast(int_to_bool, %8 : !s32i), !cir.bool
+      cir.if %9 {
+        cir.goto "err"
+      }
+    }
+    %2 = cir.const(#cir.int<0> : !s32i) : !s32i
+    cir.store %2, %1 : !s32i, !cir.ptr<!s32i>
+    cir.br ^bb1
+  ^bb1:
+    %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+    cir.return %3 : !s32i
+  ^bb2:
+    cir.label "err"
+    %4 = cir.const(#cir.int<1> : !s32i) : !s32i
+    %5 = cir.unary(minus, %4) : !s32i, !s32i
+    cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+    cir.br ^bb1
   }
+
+// MLIR:  llvm.func @gotoFromIf
+// MLIR:    %[[#One:]] = llvm.mlir.constant(1 : i32) : i32
+// MLIR:    %[[#Zero:]] = llvm.mlir.constant(0 : i32) : i32
+// MLIR:    llvm.cond_br {{.*}}, ^bb[[#COND_YES:]], ^bb[[#COND_NO:]]
+// MLIR:  ^bb[[#COND_YES]]:
+// MLIR:    llvm.br ^bb[[#GOTO_BLK:]]
+// MLIR:   ^bb[[#COND_NO]]:
+// MLIR:    llvm.br ^bb[[#BLK:]]
+// MLIR:  ^bb[[#BLK]]:
+// MLIR:    llvm.store %[[#Zero]], %[[#Ret_val_addr:]] : i32, !llvm.ptr
+// MLIR:    llvm.br ^bb[[#RETURN:]]
+// MLIR:  ^bb[[#RETURN]]:
+// MLIR:    %[[#Ret_val:]] = llvm.load %[[#Ret_val_addr]] : !llvm.ptr -> i32
+// MLIR:    llvm.return %[[#Ret_val]] : i32
+// MLIR:  ^bb[[#GOTO_BLK]]:
+// MLIR:    %[[#Neg_one:]] = llvm.sub %[[#Zero]], %[[#One]]  : i32
+// MLIR:    llvm.store %[[#Neg_one]], %[[#Ret_val_addr]] : i32, !llvm.ptr
+// MLIR:    llvm.br ^bb[[#RETURN]]
+// MLIR: }
 }
-
-//      MLIR: module {
-// MLIR-NEXT: llvm.func @foo
-//      MLIR: llvm.br ^bb1
-//      MLIR: ^bb1:
-//      MLIR: return
-
-//      LLVM: br label %[[Value:[0-9]+]]
-// LLVM-EMPTY:
-// LLVM-NEXT: [[Value]]:              ; preds =
-//      LLVM: ret void

--- a/clang/test/CIR/Lowering/goto.cir
+++ b/clang/test/CIR/Lowering/goto.cir
@@ -10,14 +10,14 @@ module {
     cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
     cir.scope {
       %6 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-      %7 = cir.const(#cir.int<5> : !s32i) : !s32i
+      %7 = cir.const #cir.int<5> : !s32i
       %8 = cir.cmp(gt, %6, %7) : !s32i, !s32i
       %9 = cir.cast(int_to_bool, %8 : !s32i), !cir.bool
       cir.if %9 {
         cir.goto "err"
       }
     }
-    %2 = cir.const(#cir.int<0> : !s32i) : !s32i
+    %2 = cir.const #cir.int<0> : !s32i
     cir.store %2, %1 : !s32i, !cir.ptr<!s32i>
     cir.br ^bb1
   ^bb1:
@@ -25,7 +25,7 @@ module {
     cir.return %3 : !s32i
   ^bb2:
     cir.label "err"
-    %4 = cir.const(#cir.int<1> : !s32i) : !s32i
+    %4 = cir.const #cir.int<1> : !s32i
     %5 = cir.unary(minus, %4) : !s32i, !s32i
     cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
     cir.br ^bb1

--- a/clang/test/CIR/Lowering/region-simplify.cir
+++ b/clang/test/CIR/Lowering/region-simplify.cir
@@ -6,18 +6,18 @@
 module {
   cir.func @foo() {
     %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["b", init] {alignment = 4 : i64}
-    %1 = cir.const(#cir.int<1> : !u32i) : !u32i
+    %1 = cir.const #cir.int<1> : !u32i
     cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
     cir.br ^bb2
   ^bb1:  // no predecessors
     %2 = cir.load %0 : !cir.ptr<!u32i>, !u32i
-    %3 = cir.const(#cir.int<1> : !u32i) : !u32i
+    %3 = cir.const #cir.int<1> : !u32i
     %4 = cir.binop(add, %2, %3) : !u32i
     cir.store %4, %0 : !u32i, !cir.ptr<!u32i>
     cir.br ^bb2
   ^bb2:  // 2 preds: ^bb0, ^bb1
     %5 = cir.load %0 : !cir.ptr<!u32i>, !u32i
-    %6 = cir.const(#cir.int<2> : !u32i) : !u32i
+    %6 = cir.const #cir.int<2> : !u32i
     %7 = cir.binop(add, %5, %6) : !u32i
     cir.store %7, %0 : !u32i, !cir.ptr<!u32i>
     cir.return

--- a/clang/test/CIR/Lowering/region-simplify.cir
+++ b/clang/test/CIR/Lowering/region-simplify.cir
@@ -1,0 +1,38 @@
+// RUN: cir-opt %s -canonicalize -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-opt %s -canonicalize -o - | cir-translate -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+
+!u32i = !cir.int<u, 32>
+
+module {
+  cir.func @foo() {
+    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["b", init] {alignment = 4 : i64}
+    %1 = cir.const(#cir.int<1> : !u32i) : !u32i
+    cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
+    cir.br ^bb2
+  ^bb1:  // no predecessors
+    %2 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+    %3 = cir.const(#cir.int<1> : !u32i) : !u32i
+    %4 = cir.binop(add, %2, %3) : !u32i
+    cir.store %4, %0 : !u32i, !cir.ptr<!u32i>
+    cir.br ^bb2
+  ^bb2:  // 2 preds: ^bb0, ^bb1
+    %5 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+    %6 = cir.const(#cir.int<2> : !u32i) : !u32i
+    %7 = cir.binop(add, %5, %6) : !u32i
+    cir.store %7, %0 : !u32i, !cir.ptr<!u32i>
+    cir.return
+  }
+
+  //      MLIR: module {
+// MLIR-NEXT: llvm.func @foo
+//      MLIR: llvm.br ^bb1
+//      MLIR: ^bb1:
+//      MLIR: return
+
+//      LLVM: br label %[[Value:[0-9]+]]
+// LLVM-EMPTY:
+// LLVM-NEXT: [[Value]]:              ; preds =
+//      LLVM: ret void
+
+
+}


### PR DESCRIPTION
This PR:
1) adds new operations: `GotoOp` and `LabelOp` and inserts them in the codegen 
2) adds a pass that replaces `goto` operations with branches to the corresponded blocks (and erases `LabelOp` from CIR)
3) adds an attribute for `FuncOp` to track which functions should be processed by the pass
4) adds several tests for goto-s