### PR TITLE
[CIR][NFC] Create LLVM intrinsic calls through `createCallLLVMIntrinsicOp`

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1997,6 +1997,16 @@ createCallLLVMIntrinsicOp(mlir::ConversionPatternRewriter &rewriter,
       loc, resultTy, intrinsicNameAttr, operands);
 }
 
+static mlir::LLVM::CallIntrinsicOp replaceOpWithCallLLVMIntrinsicOp(
+    mlir::ConversionPatternRewriter &rewriter, mlir::Operation *op,
+    const llvm::Twine &intrinsicName, mlir::Type resultTy,
+    mlir::ValueRange operands) {
+  auto callIntrinOp = createCallLLVMIntrinsicOp(
+      rewriter, op->getLoc(), intrinsicName, resultTy, operands);
+  rewriter.replaceOp(op, callIntrinOp.getOperation());
+  return callIntrinOp;
+}
+
 static mlir::Value createLLVMBitOp(mlir::Location loc,
                                    const llvm::Twine &llvmIntrinBaseName,
                                    mlir::Type resultTy, mlir::Value operand,
@@ -2081,16 +2091,14 @@ public:
     auto llvmResTy = getTypeConverter()->convertType(op.getType());
     auto loc = op->getLoc();
 
-    auto llvmIntrinNameAttr =
-        mlir::StringAttr::get(rewriter.getContext(), "llvm.objectsize");
     mlir::cir::SizeInfoType kindInfo = op.getKind();
     auto falseValue = rewriter.create<mlir::LLVM::ConstantOp>(
         loc, rewriter.getI1Type(), false);
     auto trueValue = rewriter.create<mlir::LLVM::ConstantOp>(
         loc, rewriter.getI1Type(), true);
 
-    rewriter.replaceOpWithNewOp<mlir::LLVM::CallIntrinsicOp>(
-        op, llvmResTy, llvmIntrinNameAttr,
+    replaceOpWithCallLLVMIntrinsicOp(
+        rewriter, op, "llvm.objectsize", llvmResTy,
         mlir::ValueRange{adaptor.getPtr(),
                          kindInfo == mlir::cir::SizeInfoType::max ? falseValue
                                                                   : trueValue,
@@ -2417,11 +2425,8 @@ public:
 
     std::string llvmIntrinName = "llvm.bswap.i";
     llvmIntrinName.append(std::to_string(resTy.getWidth()));
-    auto llvmIntrinNameAttr =
-        mlir::StringAttr::get(rewriter.getContext(), llvmIntrinName);
 
-    rewriter.replaceOpWithNewOp<mlir::LLVM::CallIntrinsicOp>(
-        op, resTy, llvmIntrinNameAttr, adaptor.getInput());
+    rewriter.replaceOpWithNewOp<mlir::LLVM::ByteSwapOp>(op, adaptor.getInput());
 
     return mlir::LogicalResult::success();
   }
@@ -2632,10 +2637,7 @@ public:
     auto loc = op->getLoc();
     rewriter.eraseOp(op);
 
-    auto llvmTrapIntrinsicType =
-        mlir::LLVM::LLVMVoidType::get(op->getContext());
-    rewriter.create<mlir::LLVM::CallIntrinsicOp>(
-        loc, llvmTrapIntrinsicType, "llvm.trap", mlir::ValueRange{});
+    rewriter.create<mlir::LLVM::Trap>(loc);
 
     // Note that the call to llvm.trap is not a terminator in LLVM dialect.
     // So we must emit an additional llvm.unreachable to terminate the current

--- a/clang/test/CIR/Lowering/bswap.cir
+++ b/clang/test/CIR/Lowering/bswap.cir
@@ -9,7 +9,7 @@ cir.func @test(%arg0: !u32i) -> !u32i {
 }
 
 //      MLIR: llvm.func @test(%arg0: i32) -> i32
-// MLIR-NEXT:   %0 = llvm.call_intrinsic "llvm.bswap.i32"(%arg0) : (i32) -> i32
+// MLIR-NEXT:   %0 = llvm.intr.bswap(%arg0) : (i32) -> i32
 // MLIR-NEXT:   llvm.return %0 : i32
 // MLIR-NEXT: }
 

--- a/clang/test/CIR/Lowering/intrinsics.cir
+++ b/clang/test/CIR/Lowering/intrinsics.cir
@@ -14,7 +14,7 @@ module {
   }
 
   //      MLIR: llvm.func @test_trap()
-  // MLIR-NEXT:   llvm.call_intrinsic "llvm.trap"() : () -> !llvm.void
+  // MLIR-NEXT:   "llvm.intr.trap"() : () -> ()
   // MLIR-NEXT:   llvm.unreachable
 
   //      LLVM: define void @test_trap()


### PR DESCRIPTION
This PR does not introduce any functional changes. It cleans up code in `LowerToLLVM.cpp` and creates all LLVM intrinsic calls through the unified `createCallLLVMIntrinsicOp` function, as suggested by [this comment](https://github.com/llvm/clangir/pull/556#discussion_r1575198259) in #556 .

Some LLVM intrinsics already have specialized LLVMIR operations. CIR operations that depend on these intrinsics are lowered to those specialized operations rather than `llvm.call_intrinsic` operation.