### PR TITLE
[CIR][Lowering] Add MLIR lowering support for CIR cos operations

### DIFF
--- a/clang/test/CIR/Lowering/ThroughMLIR/cos.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/cos.cir
@@ -3,11 +3,10 @@
 
 module {
   cir.func @foo() {
-
     %1 = cir.const(#cir.fp<1.0> : !cir.float) : !cir.float
     %2 = cir.const(#cir.fp<1.0> : !cir.double) : !cir.double
-    %4 = cir.cos %1 : !cir.float
-    %5 = cir.cos %2 : !cir.double
+    %3 = cir.cos %1 : !cir.float
+    %4 = cir.cos %2 : !cir.double
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/ThroughMLIR/cos.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/cos.cir
@@ -1,0 +1,23 @@
+// RUN: cir-opt %s -cir-to-mlir -o %t.mlir
+// RUN: FileCheck %s --input-file %t.mlir
+
+module {
+  cir.func @foo() {
+
+    %1 = cir.const(#cir.fp<1.0> : !cir.float) : !cir.float
+    %2 = cir.const(#cir.fp<1.0> : !cir.double) : !cir.double
+    %4 = cir.cos %1 : !cir.float
+    %5 = cir.cos %2 : !cir.double
+    cir.return
+  }
+}
+
+//CHECK: module {
+//CHECK:   func.func @foo() {
+//CHECK:     %cst = arith.constant 1.000000e+00 : f32
+//CHECK:     %cst_0 = arith.constant 1.000000e+00 : f64
+//CHECK:     %0 = math.cos %cst : f32
+//CHECK:     %1 = math.cos %cst_0 : f64
+//CHECK:     return
+//CHECK:   }
+//CHECK: }


### PR DESCRIPTION
#563 This PR add cir.cos lowering to MLIR math dialect, now it only surpport single and double float types, I add an assertation for the long double and other unimplemented types 