### PR TITLE
[CIR][LowerToLLVM][CXXABI] Lower cir.va.arg

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -269,6 +269,19 @@ public:
     return createCast(mlir::cir::CastKind::int_to_ptr, src, newTy);
   }
 
+  mlir::Value createGetMemberOp(mlir::Location &loc, mlir::Value structPtr,
+                                const char *fldName, unsigned idx) {
+
+    assert(structPtr.getType().isa<mlir::cir::PointerType>());
+    auto structBaseTy =
+        structPtr.getType().cast<mlir::cir::PointerType>().getPointee();
+    assert(structBaseTy.isa<mlir::cir::StructType>());
+    auto fldTy = structBaseTy.cast<mlir::cir::StructType>().getMembers()[idx];
+    auto fldPtrTy = ::mlir::cir::PointerType::get(getContext(), fldTy);
+    return create<mlir::cir::GetMemberOp>(loc, fldPtrTy, structPtr, fldName,
+                                          idx);
+  }
+
   mlir::Value createPtrToInt(mlir::Value src, mlir::Type newTy) {
     return createCast(mlir::cir::CastKind::ptr_to_int, src, newTy);
   }

--- a/clang/lib/CIR/Dialect/IR/MissingFeatures.h
+++ b/clang/lib/CIR/Dialect/IR/MissingFeatures.h
@@ -28,6 +28,8 @@ struct MissingFeatures {
   static bool supportTySizeQueryForAArch64() { return false; }
   static bool supportTyAlignQueryForAArch64() { return false; }
   static bool supportisHomogeneousAggregateQueryForAArch64() { return false; }
+  static bool supportisEndianQueryForAArch64() { return false; }
+  static bool supportisAggregateTypeForABIAArch64() { return false; }
 
   // Address space related
   static bool addressSpace() { return false; }

--- a/clang/lib/CIR/Dialect/IR/MissingFeatures.h
+++ b/clang/lib/CIR/Dialect/IR/MissingFeatures.h
@@ -21,6 +21,13 @@ struct MissingFeatures {
   // C++ ABI support
   static bool cxxABI() { return false; }
   static bool setCallingConv() { return false; }
+  static bool handleBigEndian() { return false; }
+  static bool handleAArch64Indirect() { return false; }
+  static bool classifyArgumentTypeForAArch64() { return false; }
+  static bool supportgetCoerceToTypeForAArch64() { return false; }
+  static bool supportTySizeQueryForAArch64() { return false; }
+  static bool supportTyAlignQueryForAArch64() { return false; }
+  static bool supportisHomogeneousAggregateQueryForAArch64() { return false; }
 
   // Address space related
   static bool addressSpace() { return false; }

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_clang_library(MLIRCIRTransforms
   LifetimeCheck.cpp
   LoweringPrepare.cpp
   LoweringPrepareItaniumCXXABI.cpp
+  LoweringPrepareAArch64CXXABI.cpp
   MergeCleanups.cpp
   DropAST.cpp
   IdiomRecognizer.cpp

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -17,6 +17,7 @@
 #include "clang/Basic/Module.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/Interfaces/ASTAttrInterfaces.h"
@@ -334,8 +335,9 @@ static void canonicalizeIntrinsicThreeWayCmp(CIRBaseBuilderTy &builder,
 void LoweringPreparePass::lowerVAArgOp(VAArgOp op) {
   CIRBaseBuilderTy builder(getContext());
   builder.setInsertionPoint(op);
+  ::cir::CIRDataLayout datalayout(theModule);
 
-  auto res = cxxABI->lowerVAArg(builder, op);
+  auto res = cxxABI->lowerVAArg(builder, op, datalayout);
   if (res) {
     op.replaceAllUsesWith(res);
     op.erase();

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareAArch64CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareAArch64CXXABI.cpp
@@ -1,0 +1,258 @@
+//====- LoweringPrepareArm64CXXABI.cpp - Arm64 ABI specific code -----====//
+//
+// Part of the LLVM Project,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+//
+// This file provides ARM64 C++ ABI specific code that is used during LLVMIR
+// lowering prepare.
+//
+//===------------------------------------------------------------------===//
+
+#include "../IR/MissingFeatures.h"
+#include "LoweringPrepareItaniumCXXABI.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
+
+#include <assert.h>
+
+using cir::AArch64ABIKind;
+
+namespace {
+class LoweringPrepareAArch64CXXABI : public LoweringPrepareItaniumCXXABI {
+public:
+  LoweringPrepareAArch64CXXABI(AArch64ABIKind k) : Kind(k) {}
+  mlir::Value lowerVAArg(cir::CIRBaseBuilderTy &builder,
+                         mlir::cir::VAArgOp op) override;
+
+private:
+  AArch64ABIKind Kind;
+  mlir::Value lowerAAPCSVAArg(cir::CIRBaseBuilderTy &builder,
+                              mlir::cir::VAArgOp op);
+  bool isDarwinPCS() const { return Kind == AArch64ABIKind::DarwinPCS; }
+  mlir::Value lowerMSVAArg(cir::CIRBaseBuilderTy &builder,
+                           mlir::cir::VAArgOp op) {
+    llvm_unreachable("MSVC ABI not supported yet");
+  }
+  mlir::Value lowerDarwinVAArg(cir::CIRBaseBuilderTy &builder,
+                               mlir::cir::VAArgOp op) {
+    llvm_unreachable("Darwin ABI not supported yet");
+  }
+};
+} // namespace
+
+cir::LoweringPrepareCXXABI *
+cir::LoweringPrepareCXXABI::createAArch64ABI(AArch64ABIKind k) {
+  return new LoweringPrepareAArch64CXXABI(k);
+}
+
+mlir::Value
+LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(cir::CIRBaseBuilderTy &builder,
+                                              mlir::cir::VAArgOp op) {
+  auto loc = op->getLoc();
+  auto valist = op->getOperand(0);
+  auto opResTy = op.getType();
+  // front end should not produce non-scalar type of VAArgOp
+  bool isSupportedType =
+      opResTy.isa<mlir::cir::IntType, mlir::cir::SingleType,
+                  mlir::cir::PointerType, mlir::cir::BoolType,
+                  mlir::cir::DoubleType, mlir::cir::ArrayType>();
+
+  // Homogenous Aggregate type not supported and indirect arg
+  // passing not supported yet. And for these supported types,
+  // we should not have alignment greater than 8 problem.
+  assert(isSupportedType);
+  assert(!cir::MissingFeatures::classifyArgumentTypeForAArch64());
+  // indirect arg passing would expect one more level of pointer dereference.
+  assert(!cir::MissingFeatures::handleAArch64Indirect());
+  assert(!cir::MissingFeatures::supportgetCoerceToTypeForAArch64());
+  // we don't convert to LLVM Type here as we are lowering to CIR here.
+  // so baseTy is the just type of the result of va_arg.
+  // but it depends on arg type indirectness and coercion defined by ABI.
+  auto baseTy = opResTy;
+
+  if (baseTy.isa<mlir::cir::ArrayType>()) {
+    llvm_unreachable("ArrayType VAArg loweing NYI");
+  }
+  // numRegs may not be 1 if ArrayType is supported.
+  unsigned numRegs = 1;
+
+  if (Kind == AArch64ABIKind::AAPCSSoft) {
+    llvm_unreachable("AAPCSSoft cir.var_arg lowering NYI");
+  }
+  bool IsFPR = mlir::cir::isAnyFloatingPointType(opResTy);
+
+  // The AArch64 va_list type and handling is specified in the Procedure Call
+  // Standard, section B.4:
+  //
+  // struct {
+  //   void *__stack;
+  //   void *__gr_top;
+  //   void *__vr_top;
+  //   int __gr_offs;
+  //   int __vr_offs;
+  // };
+  auto curInsertionP = builder.saveInsertionPoint();
+  auto currentBlock = builder.getInsertionBlock();
+  auto boolTy = builder.getBoolTy();
+
+  auto maybeRegBlock = builder.createBlock(builder.getBlock()->getParent());
+  auto inRegBlock = builder.createBlock(builder.getBlock()->getParent());
+  auto onStackBlock = builder.createBlock(builder.getBlock()->getParent());
+
+  //=======================================
+  // Find out where argument was passed
+  //=======================================
+
+  // If v/gr_offs >= 0 we're already using the stack for this type of
+  // argument. We don't want to keep updating regOffs (in case it overflows,
+  // though anyone passing 2GB of arguments, each at most 16 bytes, deserves
+  // whatever they get).
+
+  assert(!cir::MissingFeatures::handleAArch64Indirect());
+  assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
+  assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+  // indirectness, type size and type alignment all
+  // decide regSize, but they are all ABI defined
+  // thus need ABI lowering query system.
+  int regSize = 8;
+  int regTopIndex;
+  mlir::Value regOffsP;
+  mlir::cir::LoadOp regOffs;
+
+  builder.restoreInsertionPoint(curInsertionP);
+  // 3 is the field number of __gr_offs, 4 is the field number of __vr_offs
+  if (!IsFPR) {
+    regOffsP = builder.createGetMemberOp(loc, valist, "gr_offs", 3);
+    regOffs = builder.create<mlir::cir::LoadOp>(loc, regOffsP);
+    regTopIndex = 1;
+    regSize = llvm::alignTo(regSize, 8);
+  } else {
+    regOffsP = builder.createGetMemberOp(loc, valist, "vr_offs", 4);
+    regOffs = builder.create<mlir::cir::LoadOp>(loc, regOffsP);
+    regTopIndex = 2;
+    regSize = 16 * numRegs;
+  }
+
+  //=======================================
+  // Find out where argument was passed
+  //=======================================
+
+  // If regOffs >= 0 we're already using the stack for this type of
+  // argument. We don't want to keep updating regOffs (in case it overflows,
+  // though anyone passing 2GB of arguments, each at most 16 bytes, deserves
+  // whatever they get).
+  auto zeroValue = builder.create<mlir::cir::ConstantOp>(
+      loc, regOffs.getType(), mlir::cir::IntAttr::get(regOffs.getType(), 0));
+  auto usingStack = builder.create<mlir::cir::CmpOp>(
+      loc, boolTy, mlir::cir::CmpOpKind::ge, regOffs, zeroValue);
+  builder.create<mlir::cir::BrCondOp>(loc, usingStack, onStackBlock,
+                                      maybeRegBlock);
+
+  auto contBlock = currentBlock->splitBlock(op);
+
+  // Otherwise, at least some kind of argument could go in these registers, the
+  // question is whether this particular type is too big.
+  builder.setInsertionPointToEnd(maybeRegBlock);
+
+  // Integer arguments may need to correct register alignment (for example a
+  // "struct { __int128 a; };" gets passed in x_2N, x_{2N+1}). In this case we
+  // align __gr_offs to calculate the potential address.
+  if (!IsFPR) {
+    assert(!cir::MissingFeatures::handleAArch64Indirect());
+    assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+  }
+
+  // Update the gr_offs/vr_offs pointer for next call to va_arg on this va_list.
+  // The fact that this is done unconditionally reflects the fact that
+  // allocating an argument to the stack also uses up all the remaining
+  // registers of the appropriate kind.
+  auto regSizeValue = builder.create<mlir::cir::ConstantOp>(
+      loc, regOffs.getType(),
+      mlir::cir::IntAttr::get(regOffs.getType(), regSize));
+  auto newOffset = builder.create<mlir::cir::BinOp>(
+      loc, regOffs.getType(), mlir::cir::BinOpKind::Add, regOffs, regSizeValue);
+  builder.createStore(loc, newOffset, regOffsP);
+  // Now we're in a position to decide whether this argument really was in
+  // registers or not.
+  auto inRegs = builder.create<mlir::cir::CmpOp>(
+      loc, boolTy, mlir::cir::CmpOpKind::le, newOffset, zeroValue);
+  builder.create<mlir::cir::BrCondOp>(loc, inRegs, inRegBlock, onStackBlock);
+
+  //=======================================
+  // Argument was in registers
+  //=======================================
+  // Now we emit the code for if the argument was originally passed in
+  // registers. First start the appropriate block:
+  builder.setInsertionPointToEnd(inRegBlock);
+  auto regTopP = builder.createGetMemberOp(
+      loc, valist, IsFPR ? "vr_top" : "gr_top", regTopIndex);
+  auto regTop = builder.create<mlir::cir::LoadOp>(loc, regTopP);
+  auto i8Ty = mlir::IntegerType::get(builder.getContext(), 8);
+  auto i8PtrTy = mlir::cir::PointerType::get(builder.getContext(), i8Ty);
+  auto castRegTop = builder.createBitcast(regTop, i8PtrTy);
+  // On big-endian platforms, the value will be right-aligned in its stack slot.
+  // and we also need to think about other ABI lowering concerns listed below.
+  assert(!cir::MissingFeatures::handleBigEndian());
+  assert(!cir::MissingFeatures::handleAArch64Indirect());
+  assert(!cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
+  assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
+  assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+
+  auto resAsInt8P = builder.create<mlir::cir::PtrStrideOp>(
+      loc, castRegTop.getType(), castRegTop, regOffs);
+  auto resAsVoidP = builder.createBitcast(resAsInt8P, regTop.getType());
+  builder.create<mlir::cir::BrOp>(loc, mlir::ValueRange{resAsVoidP}, contBlock);
+
+  //=======================================
+  // Argument was on the stack
+  //=======================================
+  builder.setInsertionPointToEnd(onStackBlock);
+  auto stackP = builder.createGetMemberOp(loc, valist, "stack", 0);
+
+  auto onStackPtr = builder.create<mlir::cir::LoadOp>(loc, stackP);
+  auto ptrDiffTy =
+      mlir::cir::IntType::get(builder.getContext(), 64, /*signed=*/false);
+
+  // On big-endian platforms, the value will be right-aligned in its stack slot
+  // Also, the consideration involves type size and alignment, arg indirectness
+  // which are all ABI defined thus need ABI lowering query system.
+  // The implementation we have now supports most common cases which assumes
+  // no indirectness, no alignment greater than 8, and little endian.
+  assert(!cir::MissingFeatures::handleBigEndian());
+  assert(!cir::MissingFeatures::handleAArch64Indirect());
+  assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+  assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
+
+  auto eight = builder.create<mlir::cir::ConstantOp>(
+      loc, ptrDiffTy, mlir::cir::IntAttr::get(ptrDiffTy, 8));
+  auto castStack = builder.createBitcast(onStackPtr, i8PtrTy);
+  // Write the new value of __stack for the next call to va_arg
+  auto newStackAsi8Ptr = builder.create<mlir::cir::PtrStrideOp>(
+      loc, castStack.getType(), castStack, eight);
+  auto newStack = builder.createBitcast(newStackAsi8Ptr, onStackPtr.getType());
+  builder.createStore(loc, newStack, stackP);
+  builder.create<mlir::cir::BrOp>(loc, mlir::ValueRange{onStackPtr}, contBlock);
+
+  // generate additional instructions for end block
+  builder.setInsertionPoint(op);
+  contBlock->addArgument(onStackPtr.getType(), loc);
+  auto resP = contBlock->getArgument(0);
+  assert(resP.getType().isa<mlir::cir::PointerType>());
+  auto opResPTy = mlir::cir::PointerType::get(builder.getContext(), opResTy);
+  auto castResP = builder.createBitcast(resP, opResPTy);
+  auto res = builder.create<mlir::cir::LoadOp>(loc, castResP);
+  // there would be another level of ptr dereference if indirect arg passing
+  assert(!cir::MissingFeatures::handleAArch64Indirect());
+  return res.getResult();
+}
+
+mlir::Value
+LoweringPrepareAArch64CXXABI::lowerVAArg(cir::CIRBaseBuilderTy &builder,
+                                         mlir::cir::VAArgOp op) {
+  return Kind == AArch64ABIKind::Win64 ? lowerMSVAArg(builder, op)
+         : isDarwinPCS()               ? lowerDarwinVAArg(builder, op)
+                                       : lowerAAPCSVAArg(builder, op);
+}

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareCXXABI.h
@@ -21,11 +21,22 @@
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 
 namespace cir {
+// TODO: This is a temporary solution to know AArch64 ABI Kind
+//       This should be removed once we have a proper ABI info query
+enum class AArch64ABIKind {
+  AAPCS = 0,
+  DarwinPCS,
+  Win64,
+  AAPCSSoft,
+};
 
 class LoweringPrepareCXXABI {
 public:
   static LoweringPrepareCXXABI *createItaniumABI();
+  static LoweringPrepareCXXABI *createAArch64ABI(AArch64ABIKind k);
 
+  virtual mlir::Value lowerVAArg(CIRBaseBuilderTy &builder,
+                                 mlir::cir::VAArgOp op) = 0;
   virtual ~LoweringPrepareCXXABI() {}
 
   virtual mlir::Value lowerDynamicCast(CIRBaseBuilderTy &builder,

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareCXXABI.h
@@ -18,6 +18,7 @@
 #include "mlir/IR/Value.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 
 namespace cir {
@@ -36,7 +37,8 @@ public:
   static LoweringPrepareCXXABI *createAArch64ABI(AArch64ABIKind k);
 
   virtual mlir::Value lowerVAArg(CIRBaseBuilderTy &builder,
-                                 mlir::cir::VAArgOp op) = 0;
+                                 mlir::cir::VAArgOp op,
+                                 const cir::CIRDataLayout &datalayout) = 0;
   virtual ~LoweringPrepareCXXABI() {}
 
   virtual mlir::Value lowerDynamicCast(CIRBaseBuilderTy &builder,

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
@@ -20,6 +20,7 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 
 using namespace cir;
@@ -160,8 +161,9 @@ LoweringPrepareItaniumCXXABI::lowerDynamicCast(CIRBaseBuilderTy &builder,
       .getResult();
 }
 
-mlir::Value LoweringPrepareItaniumCXXABI::lowerVAArg(CIRBaseBuilderTy &builder,
-                                                     mlir::cir::VAArgOp op) {
+mlir::Value LoweringPrepareItaniumCXXABI::lowerVAArg(
+    CIRBaseBuilderTy &builder, mlir::cir::VAArgOp op,
+    const ::cir::CIRDataLayout &datalayout) {
   // There is no generic cir lowering for var_arg, here we fail
   // so to prevent attempt of calling lowerVAArg for ItaniumCXXABI
   llvm_unreachable("NYI");

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
@@ -1,18 +1,19 @@
-//====- LoweringPrepareItaniumCXXABI.h - Itanium ABI specific code --------===//
+//====- LoweringPrepareItaniumCXXABI.cpp - Itanium ABI specific code-----===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Part of the LLVM Project, under the Apache License v2.0 with
+// LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===--------------------------------------------------------------------===//
 //
-// This file provides Itanium C++ ABI specific code that is used during LLVMIR
-// lowering prepare.
+// This file provides Itanium C++ ABI specific code
+// that is used during LLVMIR lowering prepare.
 //
-//===----------------------------------------------------------------------===//
+//===--------------------------------------------------------------------===//
 
+#include "LoweringPrepareItaniumCXXABI.h"
 #include "../IR/MissingFeatures.h"
-#include "LoweringPrepareCXXABI.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
@@ -23,18 +24,7 @@
 
 using namespace cir;
 
-namespace {
-
-class LoweringPrepareItaniumCXXABI : public LoweringPrepareCXXABI {
-public:
-  mlir::Value lowerDynamicCast(CIRBaseBuilderTy &builder,
-                               clang::ASTContext &astCtx,
-                               mlir::cir::DynamicCastOp op) override;
-};
-
-} // namespace
-
-LoweringPrepareCXXABI *LoweringPrepareCXXABI::createItaniumABI() {
+cir::LoweringPrepareCXXABI *cir::LoweringPrepareCXXABI::createItaniumABI() {
   return new LoweringPrepareItaniumCXXABI();
 }
 
@@ -168,4 +158,11 @@ LoweringPrepareItaniumCXXABI::lowerDynamicCast(CIRBaseBuilderTy &builder,
                 loc, builder.getNullPtr(op.getType(), loc).getResult());
           })
       .getResult();
+}
+
+mlir::Value LoweringPrepareItaniumCXXABI::lowerVAArg(CIRBaseBuilderTy &builder,
+                                                     mlir::cir::VAArgOp op) {
+  // There is no generic cir lowering for var_arg, here we fail
+  // so to prevent attempt of calling lowerVAArg for ItaniumCXXABI
+  llvm_unreachable("NYI");
 }

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.h
@@ -12,12 +12,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "LoweringPrepareCXXABI.h"
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 
 class LoweringPrepareItaniumCXXABI : public cir::LoweringPrepareCXXABI {
 public:
   mlir::Value lowerDynamicCast(cir::CIRBaseBuilderTy &builder,
                                clang::ASTContext &astCtx,
                                mlir::cir::DynamicCastOp op) override;
-  mlir::Value lowerVAArg(cir::CIRBaseBuilderTy &builder,
-                         mlir::cir::VAArgOp op) override;
+  mlir::Value lowerVAArg(cir::CIRBaseBuilderTy &builder, mlir::cir::VAArgOp op,
+                         const cir::CIRDataLayout &datalayout) override;
 };

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.h
@@ -1,0 +1,23 @@
+//====- LoweringPrepareItaniumCXXABI.h - Itanium ABI specific code --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides Itanium C++ ABI specific code that is used during LLVMIR
+// lowering prepare.
+//
+//===----------------------------------------------------------------------===//
+
+#include "LoweringPrepareCXXABI.h"
+
+class LoweringPrepareItaniumCXXABI : public cir::LoweringPrepareCXXABI {
+public:
+  mlir::Value lowerDynamicCast(cir::CIRBaseBuilderTy &builder,
+                               clang::ASTContext &astCtx,
+                               mlir::cir::DynamicCastOp op) override;
+  mlir::Value lowerVAArg(cir::CIRBaseBuilderTy &builder,
+                         mlir::cir::VAArgOp op) override;
+};

--- a/clang/test/CIR/CodeGen/var-arg-float.c
+++ b/clang/test/CIR/CodeGen/var-arg-float.c
@@ -1,0 +1,119 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=BEFORE
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+#include <stdarg.h>
+
+double f1(int n, ...) {
+  va_list valist;
+  va_start(valist, n);
+  double res = va_arg(valist, double);
+  va_end(valist);
+  return res;
+}
+
+// BEFORE: !ty_22__va_list22 = !cir.struct<struct "__va_list" {!cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.int<s, 32>, !cir.int<s, 32>}
+// BEFORE:  cir.func @f1(%arg0: !s32i, ...) -> !cir.double
+// BEFORE:  [[RETP:%.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["__retval"]
+// BEFORE:  [[RESP:%.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["res", init]
+// BEFORE:  cir.va.start [[VARLIST:%.*]] : !cir.ptr<!ty_22__va_list22>
+// BEFORE:  [[TMP0:%.*]] = cir.va.arg [[VARLIST]] : (!cir.ptr<!ty_22__va_list22>) -> !cir.double
+// BEFORE:  cir.store [[TMP0]], [[RESP]] : !cir.double, !cir.ptr<!cir.double>
+// BEFORE:  cir.va.end [[VARLIST]] : !cir.ptr<!ty_22__va_list22>
+// BEFORE:  [[RES:%.*]] = cir.load [[RESP]] : !cir.ptr<!cir.double>, !cir.double
+// BEFORE:   cir.store [[RES]], [[RETP]] : !cir.double, !cir.ptr<!cir.double>
+// BEFORE:  [[RETV:%.*]] = cir.load [[RETP]] : !cir.ptr<!cir.double>, !cir.double
+// BEFORE:   cir.return [[RETV]] : !cir.double
+
+// beginning block cir code
+// AFTER: !ty_22__va_list22 = !cir.struct<struct "__va_list" {!cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.int<s, 32>, !cir.int<s, 32>}
+// AFTER:  cir.func @f1(%arg0: !s32i, ...) -> !cir.double
+// AFTER:  [[RETP:%.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["__retval"]
+// AFTER:  [[RESP:%.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["res", init]
+// AFTER:  cir.va.start [[VARLIST:%.*]] : !cir.ptr<!ty_22__va_list22>
+// AFTER:  [[VR_OFFS_P:%.*]] = cir.get_member [[VARLIST]][4] {name = "vr_offs"} : !cir.ptr<!ty_22__va_list22> -> !cir.ptr<!s32i>
+// AFTER:  [[VR_OFFS:%.*]] = cir.load [[VR_OFFS_P]] : !cir.ptr<!s32i>, !s32i
+// AFTER:  [[ZERO:%.*]] = cir.const #cir.int<0> : !s32i
+// AFTER:  [[CMP0:%.*]] = cir.cmp(ge, [[VR_OFFS]], [[ZERO]]) : !s32i, !cir.bool
+// AFTER-NEXT:  cir.brcond [[CMP0]] [[BB_ON_STACK:\^bb.*]], [[BB_MAY_REG:\^bb.*]]
+
+
+// AFTER-NEXT: [[BB_END:\^bb.*]]([[BLK_ARG:%.*]]: !cir.ptr<!void>):  // 2 preds: [[BB_IN_REG:\^bb.*]], [[BB_ON_STACK]]
+// AFTER-NEXT:  [[TMP0:%.*]] = cir.cast(bitcast, [[BLK_ARG]] : !cir.ptr<!void>), !cir.ptr<!cir.double>
+// AFTER-NEXT:  [[TMP1:%.*]] = cir.load [[TMP0]] : !cir.ptr<!cir.double>, !cir.double
+// AFTER:   cir.store [[TMP1]], [[RESP]] : !cir.double, !cir.ptr<!cir.double>
+// AFTER:   cir.va.end [[VARLIST]] : !cir.ptr<!ty_22__va_list22>
+// AFTER:   [[RES:%.*]] = cir.load [[RESP]] : !cir.ptr<!cir.double>, !cir.double
+// AFTER:   cir.store [[RES]], [[RETP]] : !cir.double, !cir.ptr<!cir.double>
+// AFTER:  [[RETV:%.*]] = cir.load [[RETP]] : !cir.ptr<!cir.double>, !cir.double
+// AFTER:   cir.return [[RETV]] : !cir.double
+
+
+// AFTER: [[BB_MAY_REG]]:
+// AFTER-NEXT: [[SIXTEEN:%.*]] = cir.const #cir.int<16> : !s32i
+// AFTER-NEXT: [[NEW_REG_OFFS:%.*]] = cir.binop(add, [[VR_OFFS]], [[SIXTEEN]]) : !s32i
+// AFTER-NEXT: cir.store [[NEW_REG_OFFS]], [[VR_OFFS_P]] : !s32i, !cir.ptr<!s32i>
+// AFTER-NEXT: [[CMP1:%.*]] = cir.cmp(le, [[NEW_REG_OFFS]], [[ZERO]]) : !s32i, !cir.bool
+// AFTER-NEXT: cir.brcond [[CMP1]] [[BB_IN_REG]], [[BB_ON_STACK]]
+
+
+// AFTER: [[BB_IN_REG]]:
+// AFTER-NEXT: [[VR_TOP_P:%.*]] = cir.get_member [[VARLIST]][2] {name = "vr_top"} : !cir.ptr<!ty_22__va_list22> -> !cir.ptr<!cir.ptr<!void>>
+// AFTER-NEXT: [[VR_TOP:%.*]] = cir.load [[VR_TOP_P]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// AFTER-NEXT: [[TMP2:%.*]] = cir.cast(bitcast, [[VR_TOP]] : !cir.ptr<!void>), !cir.ptr<i8>
+// AFTER-NEXT: [[TMP3:%.*]] = cir.ptr_stride([[TMP2]] : !cir.ptr<i8>, [[VR_OFFS]] : !s32i), !cir.ptr<i8>
+// AFTER-NEXT: [[IN_REG_OUTPUT:%.*]] = cir.cast(bitcast, [[TMP3]] : !cir.ptr<i8>), !cir.ptr<!void>
+// AFTER-NEXT: cir.br [[BB_END]]([[IN_REG_OUTPUT]] : !cir.ptr<!void>)
+
+
+// AFTER: [[BB_ON_STACK]]:
+// AFTER-NEXT: [[STACK_P:%.*]] = cir.get_member [[VARLIST]][0] {name = "stack"} : !cir.ptr<!ty_22__va_list22> -> !cir.ptr<!cir.ptr<!void>>
+// AFTER-NEXT: [[STACK_V:%.*]] = cir.load [[STACK_P]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// AFTER-NEXT: [[EIGHT_IN_PTR_ARITH:%.*]]  = cir.const #cir.int<8> : !u64i
+// AFTER-NEXT: [[TMP4:%.*]] = cir.cast(bitcast, [[STACK_V]] : !cir.ptr<!void>), !cir.ptr<i8>
+// AFTER-NEXT: [[TMP5:%.*]] = cir.ptr_stride([[TMP4]] : !cir.ptr<i8>, [[EIGHT_IN_PTR_ARITH]] : !u64i), !cir.ptr<i8>
+// AFTER-NEXT: [[NEW_STACK_V:%.*]] = cir.cast(bitcast, [[TMP5]] : !cir.ptr<i8>), !cir.ptr<!void>
+// AFTER-NEXT: cir.store [[NEW_STACK_V]], [[STACK_P]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
+// AFTER-NEXT: cir.br [[BB_END]]([[STACK_V]] : !cir.ptr<!void>)
+
+// beginning block llvm code
+// LLVM: %struct.__va_list = type { ptr, ptr, ptr, i32, i32 }
+// LLVM: define double @f1(i32 %0, ...)
+// LLVM: [[ARGN:%.*]] = alloca i32, i64 1, align 4,
+// LLVM: [[RETP:%.*]] = alloca double, i64 1, align 8,
+// LLVM: [[RESP:%.*]] = alloca double, i64 1, align 8,
+// LLVM: call void @llvm.va_start.p0(ptr [[VARLIST:%.*]]),
+// LLVM: [[VR_OFFS_P:%.*]] = getelementptr %struct.__va_list, ptr [[VARLIST]], i32 0, i32 4
+// LLVM: [[VR_OFFS:%.*]] = load i32, ptr [[VR_OFFS_P]], align 4,
+// LLVM-NEXT: [[CMP0:%.*]] = icmp sge i32 [[VR_OFFS]], 0,
+// LLVM-NEXT: br i1 [[CMP0]], label %[[BB_ON_STACK:.*]], label %[[BB_MAY_REG:.*]],
+
+// LLVM: [[BB_END:.*]]: ; preds = %[[BB_ON_STACK]], %[[BB_IN_REG:.*]]
+// LLVM-NEXT: [[PHIP:%.*]] = phi ptr [ [[IN_REG_OUTPUT:%.*]], %[[BB_IN_REG]] ], [ [[STACK_V:%.*]], %[[BB_ON_STACK]] ]
+// LLVM-NEXT: [[PHIV:%.*]] = load double, ptr [[PHIP]], align 8,
+// LLVM-NEXT: store double [[PHIV]], ptr [[RESP]], align 8,
+// LLVM: call void @llvm.va_end.p0(ptr [[VARLIST]]),
+// LLVM: [[RES:%.*]] = load double, ptr [[RESP]], align 8,
+// LLVM: store double [[RES]], ptr [[RETP]], align 8,
+// LLVM: [[RETV:%.*]] = load double, ptr [[RETP]], align 8,
+// LLVM-NEXT: ret double [[RETV]],
+
+// LLVM:  [[BB_MAY_REG]]: ;
+// LLVM-NEXT: [[NEW_REG_OFFS:%.*]] = add i32 [[VR_OFFS]], 16,
+// LLVM-NEXT: store i32 [[NEW_REG_OFFS]], ptr [[VR_OFFS_P]], align 4,
+// LLVM-NEXT: [[CMP1:%.*]] = icmp sle i32 [[NEW_REG_OFFS]], 0,
+// LLVM-NEXT: br i1 [[CMP1]], label %[[BB_IN_REG]], label %[[BB_ON_STACK]],
+
+// LLVM:  [[BB_IN_REG]]: ;
+// LLVM-NEXT: [[VR_TOP_P:%.*]] = getelementptr %struct.__va_list, ptr [[VARLIST]], i32 0, i32 2,
+// LLVM-NEXT: [[VR_TOP:%.*]] = load ptr, ptr [[VR_TOP_P]], align 8,
+// LLVM-NEXT: [[EXT64_VR_OFFS:%.*]] = sext i32 [[VR_OFFS]] to i64,
+// LLVM-NEXT: [[IN_REG_OUTPUT]] = getelementptr i8, ptr [[VR_TOP]], i64 [[EXT64_VR_OFFS]],
+// LLVM-NEXT: br label %[[BB_END]],
+
+// LLVM:  [[BB_ON_STACK]]: ;
+// LLVM-NEXT: [[STACK_P:%.*]] = getelementptr %struct.__va_list, ptr [[VARLIST]], i32 0, i32 0,
+// LLVM-NEXT: [[STACK_V]] = load ptr, ptr [[STACK_P]], align 8,
+// LLVM-NEXT: [[NEW_STACK_V:%.*]] = getelementptr i8, ptr [[STACK_V]], i32 8,
+// LLVM-NEXT: store ptr [[NEW_STACK_V]], ptr [[STACK_P]], align 8,
+// LLVM-NEXT: br label %[[BB_END]],

--- a/clang/test/CIR/CodeGen/var-arg.c
+++ b/clang/test/CIR/CodeGen/var-arg.c
@@ -1,0 +1,120 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=BEFORE
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+#include <stdarg.h>
+
+int f1(int n, ...) {
+  va_list valist;
+  va_start(valist, n);
+  int res = va_arg(valist, int);
+  va_end(valist);
+  return res;
+}
+
+// BEFORE: !ty_22__va_list22 = !cir.struct<struct "__va_list" {!cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.int<s, 32>, !cir.int<s, 32>}
+// BEFORE:  cir.func @f1(%arg0: !s32i, ...) -> !s32i
+// BEFORE:  [[RETP:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// BEFORE:  [[RESP:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["res", init]
+// BEFORE:  cir.va.start [[VARLIST:%.*]] : !cir.ptr<!ty_22__va_list22>
+// BEFORE:  [[TMP0:%.*]] = cir.va.arg [[VARLIST]] : (!cir.ptr<!ty_22__va_list22>) -> !s32i
+// BEFORE:  cir.store [[TMP0]], [[RESP]] : !s32i, !cir.ptr<!s32i>
+// BEFORE:  cir.va.end [[VARLIST]] : !cir.ptr<!ty_22__va_list22>
+// BEFORE:  [[RES:%.*]] = cir.load [[RESP]] : !cir.ptr<!s32i>, !s32i
+// BEFORE:   cir.store [[RES]], [[RETP]] : !s32i, !cir.ptr<!s32i>
+// BEFORE:  [[RETV:%.*]] = cir.load [[RETP]] : !cir.ptr<!s32i>, !s32i
+// BEFORE:   cir.return [[RETV]] : !s32i
+
+// AFTER: !ty_22__va_list22 = !cir.struct<struct "__va_list" {!cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.ptr<!cir.void>, !cir.int<s, 32>, !cir.int<s, 32>}
+// AFTER:  cir.func @f1(%arg0: !s32i, ...) -> !s32i
+// AFTER:  [[RETP:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// AFTER:  [[RESP:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["res", init]
+// AFTER:  cir.va.start [[VARLIST:%.*]] : !cir.ptr<!ty_22__va_list22>
+// AFTER:  [[GR_OFFS_P:%.*]] = cir.get_member [[VARLIST]][3] {name = "gr_offs"} : !cir.ptr<!ty_22__va_list22> -> !cir.ptr<!s32i>
+// AFTER:  [[GR_OFFS:%.*]] = cir.load [[GR_OFFS_P]] : !cir.ptr<!s32i>, !s32i
+// AFTER:  [[ZERO:%.*]] = cir.const #cir.int<0> : !s32i
+// AFTER:  [[CMP0:%.*]] = cir.cmp(ge, [[GR_OFFS]], [[ZERO]]) : !s32i, !cir.bool
+// AFTER-NEXT:  cir.brcond [[CMP0]] [[BB_ON_STACK:\^bb.*]], [[BB_MAY_REG:\^bb.*]]
+
+// This BB is where different path converges. BLK_ARG is the arg addr which
+// could come from IN_REG block where arg is passed in register, and saved in callee
+// stack's argument saving area.
+// Or from ON_STACK block which means arg is passed in from caller's stack area.
+// AFTER-NEXT: [[BB_END:\^bb.*]]([[BLK_ARG:%.*]]: !cir.ptr<!void>):  // 2 preds: [[BB_IN_REG:\^bb.*]], [[BB_ON_STACK]]
+// AFTER-NEXT:  [[TMP0:%.*]] = cir.cast(bitcast, [[BLK_ARG]] : !cir.ptr<!void>), !cir.ptr<!s32i>
+// AFTER-NEXT:  [[TMP1:%.*]] = cir.load [[TMP0]] : !cir.ptr<!s32i>, !s32i
+// AFTER:   cir.store [[TMP1]], [[RESP]] : !s32i, !cir.ptr<!s32i>
+// AFTER:   cir.va.end [[VARLIST]] : !cir.ptr<!ty_22__va_list22>
+// AFTER:   [[RES:%.*]] = cir.load [[RESP]] : !cir.ptr<!s32i>, !s32i
+// AFTER:   cir.store [[RES]], [[RETP]] : !s32i, !cir.ptr<!s32i>
+// AFTER:  [[RETV:%.*]] = cir.load [[RETP]] : !cir.ptr<!s32i>, !s32i
+// AFTER:   cir.return [[RETV]] : !s32i
+
+// This BB calculates to see if it is possible to pass arg in register.
+// AFTER: [[BB_MAY_REG]]:
+// AFTER-NEXT: [[EIGHT:%.*]] = cir.const #cir.int<8> : !s32i
+// AFTER-NEXT: [[NEW_REG_OFFS:%.*]] = cir.binop(add, [[GR_OFFS]], [[EIGHT]]) : !s32i
+// AFTER-NEXT: cir.store [[NEW_REG_OFFS]], [[GR_OFFS_P]] : !s32i, !cir.ptr<!s32i>
+// AFTER-NEXT: [[CMP1:%.*]] = cir.cmp(le, [[NEW_REG_OFFS]], [[ZERO]]) : !s32i, !cir.bool
+// AFTER-NEXT: cir.brcond [[CMP1]] [[BB_IN_REG]], [[BB_ON_STACK]]
+
+// arg is passed in register.
+// AFTER: [[BB_IN_REG]]:
+// AFTER-NEXT: [[GR_TOP_P:%.*]] = cir.get_member [[VARLIST]][1] {name = "gr_top"} : !cir.ptr<!ty_22__va_list22> -> !cir.ptr<!cir.ptr<!void>>
+// AFTER-NEXT: [[GR_TOP:%.*]] = cir.load [[GR_TOP_P]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// AFTER-NEXT: [[TMP2:%.*]] = cir.cast(bitcast, [[GR_TOP]] : !cir.ptr<!void>), !cir.ptr<i8>
+// AFTER-NEXT: [[TMP3:%.*]] = cir.ptr_stride([[TMP2]] : !cir.ptr<i8>, [[GR_OFFS]] : !s32i), !cir.ptr<i8>
+// AFTER-NEXT: [[IN_REG_OUTPUT:%.*]] = cir.cast(bitcast, [[TMP3]] : !cir.ptr<i8>), !cir.ptr<!void>
+// AFTER-NEXT: cir.br [[BB_END]]([[IN_REG_OUTPUT]] : !cir.ptr<!void>)
+
+// arg is passed in stack.
+// AFTER: [[BB_ON_STACK]]:
+// AFTER-NEXT: [[STACK_P:%.*]] = cir.get_member [[VARLIST]][0] {name = "stack"} : !cir.ptr<!ty_22__va_list22> -> !cir.ptr<!cir.ptr<!void>>
+// AFTER-NEXT: [[STACK_V:%.*]] = cir.load [[STACK_P]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// AFTER-NEXT: [[EIGHT_IN_PTR_ARITH:%.*]]  = cir.const #cir.int<8> : !u64i
+// AFTER-NEXT: [[TMP4:%.*]] = cir.cast(bitcast, [[STACK_V]] : !cir.ptr<!void>), !cir.ptr<i8>
+// AFTER-NEXT: [[TMP5:%.*]] = cir.ptr_stride([[TMP4]] : !cir.ptr<i8>, [[EIGHT_IN_PTR_ARITH]] : !u64i), !cir.ptr<i8>
+// AFTER-NEXT: [[NEW_STACK_V:%.*]] = cir.cast(bitcast, [[TMP5]] : !cir.ptr<i8>), !cir.ptr<!void>
+// AFTER-NEXT: cir.store [[NEW_STACK_V]], [[STACK_P]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
+// AFTER-NEXT: cir.br [[BB_END]]([[STACK_V]] : !cir.ptr<!void>)
+
+// LLVM: %struct.__va_list = type { ptr, ptr, ptr, i32, i32 }
+// LLVM: define i32 @f1(i32 %0, ...)
+// LLVM: [[ARGN:%.*]] = alloca i32, i64 1, align 4,
+// LLVM: [[RETP:%.*]] = alloca i32, i64 1, align 4,
+// LLVM: [[RESP:%.*]] = alloca i32, i64 1, align 4,
+// LLVM: call void @llvm.va_start.p0(ptr [[VARLIST:%.*]]),
+// LLVM: [[GR_OFFS_P:%.*]] = getelementptr %struct.__va_list, ptr [[VARLIST]], i32 0, i32 3
+// LLVM: [[GR_OFFS:%.*]] = load i32, ptr [[GR_OFFS_P]], align 4,
+// LLVM-NEXT: [[CMP0:%.*]] = icmp sge i32 [[GR_OFFS]], 0,
+// LLVM-NEXT: br i1 [[CMP0]], label %[[BB_ON_STACK:.*]], label %[[BB_MAY_REG:.*]],
+
+// LLVM: [[BB_END:.*]]: ; preds = %[[BB_ON_STACK]], %[[BB_IN_REG:.*]]
+// LLVM-NEXT: [[PHIP:%.*]] = phi ptr [ [[IN_REG_OUTPUT:%.*]], %[[BB_IN_REG]] ], [ [[STACK_V:%.*]], %[[BB_ON_STACK]] ]
+// LLVM-NEXT: [[PHIV:%.*]] = load i32, ptr [[PHIP]], align 4,
+// LLVM-NEXT: store i32 [[PHIV]], ptr [[RESP]], align 4,
+// LLVM: call void @llvm.va_end.p0(ptr [[VARLIST]]),
+// LLVM: [[RES:%.*]] = load i32, ptr [[RESP]], align 4,
+// LLVM: store i32 [[RES]], ptr [[RETP]], align 4,
+// LLVM: [[RETV:%.*]] = load i32, ptr [[RETP]], align 4,
+// LLVM-NEXT: ret i32 [[RETV]],
+
+// LLVM:  [[BB_MAY_REG]]: ;
+// LLVM: [[NEW_REG_OFFS:%.*]] = add i32 [[GR_OFFS]], 8,
+// LLVM: store i32 [[NEW_REG_OFFS]], ptr [[GR_OFFS_P]], align 4,
+// LLVM-NEXT: [[CMP1:%.*]] = icmp sle i32 [[NEW_REG_OFFS]], 0,
+// LLVM-NEXT: br i1 [[CMP1]], label %[[BB_IN_REG]], label %[[BB_ON_STACK]],
+
+// LLVM:  [[BB_IN_REG]]: ;
+// LLVM-NEXT: [[GR_TOP_P:%.*]] = getelementptr %struct.__va_list, ptr [[VARLIST]], i32 0, i32 1,
+// LLVM-NEXT: [[GR_TOP:%.*]] = load ptr, ptr [[GR_TOP_P]], align 8,
+// LLVM-NEXT: [[EXT64_GR_OFFS:%.*]] = sext i32 [[GR_OFFS]] to i64,
+// LLVM-NEXT: [[IN_REG_OUTPUT]] = getelementptr i8, ptr [[GR_TOP]], i64 [[EXT64_GR_OFFS]],
+// LLVM-NEXT: br label %[[BB_END]],
+
+// LLVM:  [[BB_ON_STACK]]: ;
+// LLVM-NEXT: [[STACK_P:%.*]] = getelementptr %struct.__va_list, ptr [[VARLIST]], i32 0, i32 0,
+// LLVM-NEXT: [[STACK_V]] = load ptr, ptr [[STACK_P]], align 8,
+// LLVM-NEXT: [[NEW_STACK_V:%.*]] = getelementptr i8, ptr [[STACK_V]], i32 8,
+// LLVM-NEXT: store ptr [[NEW_STACK_V]], ptr [[STACK_P]], align 8,
+// LLVM-NEXT: br label %[[BB_END]],

--- a/clang/test/CIR/CodeGen/variadics.c
+++ b/clang/test/CIR/CodeGen/variadics.c
@@ -1,9 +1,5 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
-// RUN: %clang_cc1 -x c++ -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
-// RUN: %clang_cc1 -x c++ -std=c++20 -triple aarch64-none-linux-android24 -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple aarch64-none-linux-android24  -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -x c++ -std=c++20 -triple aarch64-none-linux-android24  -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s
 
 typedef __builtin_va_list va_list;
 
@@ -15,7 +11,8 @@ typedef __builtin_va_list va_list;
 // CHECK: [[VALISTTYPE:!.+va_list.*]] = !cir.struct<struct "{{.*}}__va_list
 
 int average(int count, ...) {
-// CHECK: cir.func @{{.*}}average{{.*}}(%arg0: !s32i loc({{.+}}), ...) -> !s32i
+// CHECK: cir.func @{{.*}}average{{.*}}(%arg0: !s32i, ...) -> !s32i
+// AMR64_CHECK: cir.func @{{.*}}average{{.*}}(%arg0: !s32i loc({{.+}}), ...) -> !s32i
     va_list args, args_copy;
     va_start(args, count);
     // CHECK: cir.va.start %{{[0-9]+}} : !cir.ptr<[[VALISTTYPE]]>


### PR DESCRIPTION
lowering var_arg op for ARM64 architecture. This is CIR lowering.

This PR modified LoweringPrepare CXXABI code to make LoweringPrepareArm64CXXABI class inherit more generic LoweringPrepareItaniumCXXABI, this way lowering var_arg would be only meaningful for arm64 targets and for other arch its no op for now.

The ABI doc and detailed algorithm description can be found in this official doc.
[](https://github.com/ARM-software/abi-aa/blob/617079d8a0d45bec83d351974849483cf0cc66d5/aapcs64/aapcs64.rst#appendix-variable-argument-lists)

The following pic is a easier-to-understand and close to lowered code explanation

<img width="738" alt="Screenshot 2024-04-29 at 4 02 17 PM" src="https://github.com/llvm/clangir/assets/166402688/bd3666f0-9f91-4ad4-a837-2c39d601b580">


