### PR TITLE
[CIR][Asm] Remove duplicated lambda & coroutine attributes

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2025,6 +2025,9 @@ bool cir::FuncOp::isDeclaration() {
 void cir::FuncOp::print(OpAsmPrinter &p) {
   p << ' ';
 
+  // When adding a specific keyword here, do not forget to omit it in
+  // printFunctionAttributes below or there will be a syntax error when
+  // parsing
   if (getBuiltin())
     p << "builtin ";
 
@@ -2058,10 +2061,19 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
   function_interface_impl::printFunctionAttributes(
       p, *this,
       // These are all omitted since they are custom printed already.
-      {getSymVisibilityAttrName(), getAliaseeAttrName(),
-       getFunctionTypeAttrName(), getLinkageAttrName(), getBuiltinAttrName(),
-       getNoProtoAttrName(), getGlobalCtorAttrName(), getGlobalDtorAttrName(),
-       getExtraAttrsAttrName()});
+      {
+          getAliaseeAttrName(),
+          getBuiltinAttrName(),
+          getCoroutineAttrName(),
+          getExtraAttrsAttrName(),
+          getFunctionTypeAttrName(),
+          getGlobalCtorAttrName(),
+          getGlobalDtorAttrName(),
+          getLambdaAttrName(),
+          getLinkageAttrName(),
+          getNoProtoAttrName(),
+          getSymVisibilityAttrName(),
+      });
 
   if (auto aliaseeName = getAliasee()) {
     p << " alias(";

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -148,7 +148,7 @@ VoidTask silly_task() {
   co_await std::suspend_always();
 }
 
-// CHECK: cir.func coroutine @_Z10silly_taskv() -> ![[VoidTask]] {{.*}} {
+// CHECK: cir.func coroutine @_Z10silly_taskv() -> ![[VoidTask]] extra{{.*}}{
 
 // Allocate promise.
 
@@ -274,7 +274,7 @@ folly::coro::Task<int> byRef(const std::string& s) {
 }
 
 // FIXME: this could be less redundant than two allocas + reloads
-// CHECK: cir.func coroutine @_Z5byRefRKSt6string(%arg0: !cir.ptr<![[StdString]]>
+// CHECK: cir.func coroutine @_Z5byRefRKSt6string(%arg0: !cir.ptr<![[StdString]]> {{.*}}22 extra{{.*}}{
 // CHECK: %[[#AllocaParam:]] = cir.alloca !cir.ptr<![[StdString]]>, {{.*}} ["s", init]
 // CHECK: %[[#AllocaFnUse:]] = cir.alloca !cir.ptr<![[StdString]]>, {{.*}} ["s", init]
 
@@ -291,7 +291,7 @@ folly::coro::Task<void> silly_coro() {
 // Make sure we properly handle OnFallthrough coro body sub stmt and
 // check there are not multiple co_returns emitted.
 
-// CHECK: cir.func coroutine @_Z10silly_corov()
+// CHECK: cir.func coroutine @_Z10silly_corov() {{.*}}22 extra{{.*}}{
 // CHECK: cir.await(init, ready : {
 // CHECK: cir.call @_ZN5folly4coro4TaskIvE12promise_type11return_voidEv
 // CHECK-NOT: cir.call @_ZN5folly4coro4TaskIvE12promise_type11return_voidEv
@@ -303,7 +303,7 @@ folly::coro::Task<int> go1() {
   co_return co_await task;
 }
 
-// CHECK: cir.func coroutine @_Z3go1v()
+// CHECK: cir.func coroutine @_Z3go1v() {{.*}}22 extra{{.*}}{
 // CHECK: %[[#IntTaskAddr:]] = cir.alloca ![[IntTask]], !cir.ptr<![[IntTask]]>, ["task", init]
 
 // CHECK:   cir.await(init, ready : {
@@ -338,8 +338,8 @@ folly::coro::Task<int> go1_lambda() {
   co_return co_await task;
 }
 
-// CHECK: cir.func coroutine lambda internal private @_ZZ10go1_lambdavENK3$_0clEv
-// CHECK: cir.func coroutine @_Z10go1_lambdav()
+// CHECK: cir.func coroutine lambda internal private @_ZZ10go1_lambdavENK3$_0clEv{{.*}}22 extra{{.*}}{
+// CHECK: cir.func coroutine @_Z10go1_lambdav() {{.*}}22 extra{{.*}}{
 
 folly::coro::Task<int> go4() {
   auto* fn = +[](int const& i) -> folly::coro::Task<int> { co_return i; };
@@ -347,7 +347,7 @@ folly::coro::Task<int> go4() {
   co_return co_await std::move(task);
 }
 
-// CHECK: cir.func coroutine @_Z3go4v()
+// CHECK: cir.func coroutine @_Z3go4v() {{.*}}22 extra{{.*}}{
 
 // CHECK:   cir.await(init, ready : {
 // CHECK:   }, suspend : {

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -9,7 +9,7 @@ void fn() {
 //      CHECK: !ty_22anon2E222 = !cir.struct<class "anon.2" {!cir.int<u, 8>}>
 //  CHECK-DAG: module
 
-//      CHECK: cir.func lambda internal private @_ZZ2fnvENK3$_0clEv
+//      CHECK: cir.func lambda internal private @_ZZ2fnvENK3$_0clEv{{.*}}) extra
 
 //      CHECK:   cir.func @_Z2fnv()
 // CHECK-NEXT:     %0 = cir.alloca !ty_22anon2E222, !cir.ptr<!ty_22anon2E222>, ["a"]
@@ -21,7 +21,7 @@ void l0() {
   a();
 }
 
-// CHECK: cir.func lambda internal private @_ZZ2l0vENK3$_0clEv(
+// CHECK: cir.func lambda internal private @_ZZ2l0vENK3$_0clEv({{.*}}) extra
 
 // CHECK: %0 = cir.alloca !cir.ptr<!ty_22anon2E422>, !cir.ptr<!cir.ptr<!ty_22anon2E422>>, ["this", init] {alignment = 8 : i64}
 // CHECK: cir.store %arg0, %0 : !cir.ptr<!ty_22anon2E422>, !cir.ptr<!cir.ptr<!ty_22anon2E422>>
@@ -99,7 +99,7 @@ int g3() {
 }
 
 // lambda operator()
-// CHECK: cir.func lambda internal private @_ZZ2g3vENK3$_0clERKi
+// CHECK: cir.func lambda internal private @_ZZ2g3vENK3$_0clERKi{{.*}}!s32i extra
 
 // lambda __invoke()
 // CHECK:   cir.func internal private @_ZZ2g3vEN3$_08__invokeERKi


### PR DESCRIPTION
Do not print in cir.func definition the 'attr { ... }' with coroutine or lambda attributes since they are already printed before the function name. Otherwise redundancy breaks a future parsing. Sort the attributes to be skipped so it is more obvious to see the list of attributes.
Improve the tests to check there are no spurious attributes anymore.