### PR TITLE
[CIR][NFC] remove redundant test in CIR/IR/data-member-ptr.cir

### DIFF
--- a/clang/test/CIR/IR/data-member-ptr.cir
+++ b/clang/test/CIR/IR/data-member-ptr.cir
@@ -3,8 +3,6 @@
 !s32i = !cir.int<s, 32>
 !ty_22Foo22 = !cir.struct<struct "Foo" {!s32i}>
 
-#global_ptr = #cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>
-
 module {
   cir.func @null_member() {
     %0 = cir.const #cir.data_member<null> : !cir.data_member<!s32i in !ty_22Foo22>
@@ -13,12 +11,6 @@ module {
 
   cir.func @get_runtime_member(%arg0: !cir.ptr<!ty_22Foo22>) {
     %0 = cir.const #cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>
-    %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
-    cir.return
-  }
-
-  cir.func @get_global_member(%arg0: !cir.ptr<!ty_22Foo22>) {
-    %0 = cir.const #global_ptr
     %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
     cir.return
   }
@@ -35,12 +27,6 @@ module {
 // CHECK-NEXT:      %0 = cir.const #cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>
 // CHECK-NEXT:      %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
 // CHECK-NEXT:      cir.return
-// CHECK-NEXT:   }
-
-// CHECK-NEXT:   cir.func @get_global_member(%arg0: !cir.ptr<!ty_22Foo22>) {
-// CHECK-NEXT:     %0 = cir.const #cir.data_member<0> : !cir.data_member<!s32i in !ty_22Foo22>
-// CHECK-NEXT:     %1 = cir.get_runtime_member %arg0[%0 : !cir.data_member<!s32i in !ty_22Foo22>] : !cir.ptr<!ty_22Foo22> -> !cir.ptr<!s32i>
-// CHECK-NEXT:     cir.return
 // CHECK-NEXT:   }
 
 //      CHECK: }


### PR DESCRIPTION
As suggested in #401, this PR removes the `get_global_member` test in `CIR/IR/data-member-ptr.cir` as it is redundant.

The original comment: https://github.com/llvm/clangir/pull/401#discussion_r1589952990