### PR TITLE
[CIR][CIRGen] Support for signed #cir.ptr

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -327,7 +327,7 @@ public:
     return create<mlir::cir::ForOp>(loc, condBuilder, bodyBuilder, stepBuilder);
   }
 
-  mlir::TypedAttr getConstPtrAttr(mlir::Type t, uint64_t v) {
+  mlir::TypedAttr getConstPtrAttr(mlir::Type t, int64_t v) {
     assert(t.isa<mlir::cir::PointerType>() && "expected cir.ptr");
     return mlir::cir::ConstPtrAttr::get(getContext(), t, v);
   }

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -248,13 +248,13 @@ def FPAttr : CIR_Attr<"FP", "fp", [TypedAttrInterface]> {
 
 def ConstPtrAttr : CIR_Attr<"ConstPtr", "ptr", [TypedAttrInterface]> {
   let summary = "Holds a constant pointer value";
-  let parameters = (ins AttributeSelfTypeParameter<"">:$type, "uint64_t":$value);
+  let parameters = (ins AttributeSelfTypeParameter<"">:$type, "int64_t":$value);
   let description = [{
     A pointer attribute is a literal attribute that represents an integral
     value of a pointer type.
   }];
   let builders = [
-    AttrBuilderWithInferredContext<(ins "Type":$type, "uint64_t":$value), [{
+    AttrBuilderWithInferredContext<(ins "Type":$type, "int64_t":$value), [{
       return $_get(type.getContext(), type, value);
     }]>,
   ];

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -253,7 +253,7 @@ public:
     if (auto arrTy = ty.dyn_cast<mlir::cir::ArrayType>())
       return getZeroAttr(arrTy);
     if (auto ptrTy = ty.dyn_cast<mlir::cir::PointerType>())
-      return getConstPtrAttr(ptrTy, 0);
+      return getConstNullPtrAttr(ptrTy);
     if (auto structTy = ty.dyn_cast<mlir::cir::StructType>())
       return getZeroAttr(structTy);
     if (ty.isa<mlir::cir::BoolType>()) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1491,9 +1491,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     // Note that DestTy is used as the MLIR type instead of a custom
     // nullptr type.
     mlir::Type Ty = CGF.getCIRType(DestTy);
-    return Builder.create<mlir::cir::ConstantOp>(
-        CGF.getLoc(E->getExprLoc()), Ty,
-        mlir::cir::ConstPtrAttr::get(Builder.getContext(), Ty, 0));
+    return Builder.getNullPtr(Ty, CGF.getLoc(E->getExprLoc()));
   }
 
   case CK_NullToMemberPointer: {

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -213,7 +213,7 @@ void LangAttr::print(AsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 
 Attribute ConstPtrAttr::parse(AsmParser &parser, Type odsType) {
-  uint64_t value;
+  int64_t value;
 
   if (!odsType.isa<cir::PointerType>())
     return {};

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -203,8 +203,7 @@ void LibOptPass::xformStdFindIntoMemchr(StdFindOp findOp) {
   //   return result;
   // else
   // return last;
-  auto NullPtr = builder.create<ConstantOp>(
-      findOp.getLoc(), first.getType(), ConstPtrAttr::get(first.getType(), 0));
+  auto NullPtr = builder.getNullPtr(first.getType(), findOp.getLoc());
   auto CmpResult = builder.create<CmpOp>(
       findOp.getLoc(), BoolType::get(builder.getContext()), CmpOpKind::eq,
       NullPtr.getRes(), MemChrResult);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -188,8 +188,10 @@ lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::cir::ConstPtrAttr ptrAttr,
     return rewriter.create<mlir::LLVM::ZeroOp>(
         loc, converter->convertType(ptrAttr.getType()));
   }
+  mlir::DataLayout layout(parentOp->getParentOfType<mlir::ModuleOp>());
   mlir::Value ptrVal = rewriter.create<mlir::LLVM::ConstantOp>(
-      loc, rewriter.getI64Type(), ptrAttr.getValue());
+      loc, rewriter.getIntegerType(layout.getTypeSizeInBits(ptrAttr.getType())),
+      ptrAttr.getValue());
   return rewriter.create<mlir::LLVM::IntToPtrOp>(
       loc, converter->convertType(ptrAttr.getType()), ptrVal);
 }

--- a/clang/test/CIR/IR/constptrattr.cir
+++ b/clang/test/CIR/IR/constptrattr.cir
@@ -4,5 +4,7 @@
 
 cir.global external @const_ptr = #cir.ptr<4660> : !cir.ptr<!s32i>
 // CHECK: cir.global external @const_ptr = #cir.ptr<4660> : !cir.ptr<!s32i>
+cir.global external @signed_ptr = #cir.ptr<-1> : !cir.ptr<!s32i>
+// CHECK: cir.global external @signed_ptr = #cir.ptr<-1> : !cir.ptr<!s32i>
 cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>
 // CHECK: cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>

--- a/clang/test/CIR/Lowering/types.cir
+++ b/clang/test/CIR/Lowering/types.cir
@@ -2,7 +2,11 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 !void = !cir.void
+!u8i = !cir.int<u, 8>
 module {
+  cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<-8> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
+  // CHECK: llvm.mlir.constant(-8 : i64) : i64
+  // CHECK:  llvm.inttoptr %{{[0-9]+}} : i64 to !llvm.ptr
   cir.func @testTypeLowering() {
     // Should lower void pointers as opaque pointers.
     %0 = cir.const(#cir.ptr<null> : !cir.ptr<!void>) : !cir.ptr<!void>


### PR DESCRIPTION
The constant initialization isn't related to the pointee. We should be able to write #cir.ptr<-1> : !cir.ptr<whatever>