### PR TITLE
[CIR][CIRGen] Support for signed #cir.ptr

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -361,7 +361,8 @@ public:
   }
 
   mlir::TypedAttr getConstPtrAttr(mlir::Type t, int64_t v) {
-    auto val = mlir::IntegerAttr::get(mlir::IntegerType::get(t.getContext(), 64), v);
+    auto val =
+        mlir::IntegerAttr::get(mlir::IntegerType::get(t.getContext(), 64), v);
     return mlir::cir::ConstPtrAttr::get(getContext(),
                                         t.cast<mlir::cir::PointerType>(), val);
   }

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -360,7 +360,7 @@ public:
     return create<mlir::cir::ForOp>(loc, condBuilder, bodyBuilder, stepBuilder);
   }
 
-  mlir::TypedAttr getConstPtrAttr(mlir::Type t, uint64_t v) {
+  mlir::TypedAttr getConstPtrAttr(mlir::Type t, int64_t v) {
     return mlir::cir::ConstPtrAttr::get(getContext(),
                                         t.cast<mlir::cir::PointerType>(), v);
   }

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -361,8 +361,9 @@ public:
   }
 
   mlir::TypedAttr getConstPtrAttr(mlir::Type t, int64_t v) {
+    auto val = mlir::IntegerAttr::get(mlir::IntegerType::get(t.getContext(), 64), v);
     return mlir::cir::ConstPtrAttr::get(getContext(),
-                                        t.cast<mlir::cir::PointerType>(), v);
+                                        t.cast<mlir::cir::PointerType>(), val);
   }
 
   // Creates constant nullptr for pointer type ty.

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -250,22 +250,24 @@ def ConstPtrAttr : CIR_Attr<"ConstPtr", "ptr", [TypedAttrInterface]> {
   let summary = "Holds a constant pointer value";
   let parameters = (ins
     AttributeSelfTypeParameter<"", "::mlir::cir::PointerType">:$type,
-    "uint64_t":$value);
+    "mlir::IntegerAttr":$value);
   let description = [{
     A pointer attribute is a literal attribute that represents an integral
     value of a pointer type.
   }];
   let builders = [
-    AttrBuilderWithInferredContext<(ins "Type":$type, "uint64_t":$value), [{
-      return $_get(type.getContext(), type.cast<mlir::cir::PointerType>(), value);
+    AttrBuilderWithInferredContext<(ins "Type":$type, "int64_t":$value), [{
+      auto val = mlir::IntegerAttr::get(mlir::IntegerType::get(type.getContext(), 64), value);
+      return $_get(type.getContext(), type.cast<mlir::cir::PointerType>(), val);
     }]>,
     AttrBuilder<(ins "Type":$type,
-                     "uint64_t":$value), [{
-      return $_get($_ctxt, type.cast<mlir::cir::PointerType>(), value);
+                     "int64_t":$value), [{
+      auto val = mlir::IntegerAttr::get(mlir::IntegerType::get(type.getContext(), 64), value);
+      return $_get($_ctxt, type.cast<mlir::cir::PointerType>(), val);
     }]>,
   ];
   let extraClassDeclaration = [{
-    bool isNullValue() const { return getValue() == 0; }
+    bool isNullValue() const { return getValue().getInt() == 0; }
   }];
 
   let assemblyFormat = [{

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -256,14 +256,12 @@ def ConstPtrAttr : CIR_Attr<"ConstPtr", "ptr", [TypedAttrInterface]> {
     value of a pointer type.
   }];
   let builders = [
-    AttrBuilderWithInferredContext<(ins "Type":$type, "int64_t":$value), [{
-      auto val = mlir::IntegerAttr::get(mlir::IntegerType::get(type.getContext(), 64), value);
-      return $_get(type.getContext(), type.cast<mlir::cir::PointerType>(), val);
+    AttrBuilderWithInferredContext<(ins "Type":$type, "mlir::IntegerAttr":$value), [{
+      return $_get(type.getContext(), type.cast<mlir::cir::PointerType>(), value);
     }]>,
     AttrBuilder<(ins "Type":$type,
-                     "int64_t":$value), [{
-      auto val = mlir::IntegerAttr::get(mlir::IntegerType::get(type.getContext(), 64), value);
-      return $_get($_ctxt, type.cast<mlir::cir::PointerType>(), val);
+                     "mlir::IntegerAttr":$value), [{
+      return $_get($_ctxt, type.cast<mlir::cir::PointerType>(), value);
     }]>,
   ];
   let extraClassDeclaration = [{

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -253,7 +253,7 @@ public:
     if (auto arrTy = ty.dyn_cast<mlir::cir::ArrayType>())
       return getZeroAttr(arrTy);
     if (auto ptrTy = ty.dyn_cast<mlir::cir::PointerType>())
-      return getConstPtrAttr(ptrTy, 0);
+      return getConstNullPtrAttr(ptrTy);
     if (auto structTy = ty.dyn_cast<mlir::cir::StructType>())
       return getZeroAttr(structTy);
     if (ty.isa<mlir::cir::BoolType>()) {

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -146,7 +146,7 @@ public:
 
   mlir::TypedAttr getConstNullPtrAttr(mlir::Type t) {
     assert(t.isa<mlir::cir::PointerType>() && "expected cir.ptr");
-    return mlir::cir::ConstPtrAttr::get(getContext(), t, 0);
+    return getConstPtrAttr(t, 0);
   }
 
   mlir::Attribute getString(llvm::StringRef str, mlir::Type eltTy,

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1490,9 +1490,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     // Note that DestTy is used as the MLIR type instead of a custom
     // nullptr type.
     mlir::Type Ty = CGF.getCIRType(DestTy);
-    return Builder.create<mlir::cir::ConstantOp>(
-        CGF.getLoc(E->getExprLoc()), Ty,
-        mlir::cir::ConstPtrAttr::get(Builder.getContext(), Ty, 0));
+    return Builder.getNullPtr(Ty, CGF.getLoc(E->getExprLoc()));
   }
 
   case CK_NullToMemberPointer: {

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -162,9 +162,8 @@ void CIRGenVTables::GenerateClassData(const CXXRecordDecl *RD) {
 static void AddPointerLayoutOffset(CIRGenModule &CGM,
                                    ConstantArrayBuilder &builder,
                                    CharUnits offset) {
-  builder.add(mlir::cir::ConstPtrAttr::get(CGM.getBuilder().getContext(),
-                                           CGM.getBuilder().getUInt8PtrTy(),
-                                           offset.getQuantity()));
+  builder.add(CGM.getBuilder().getConstPtrAttr(CGM.getBuilder().getUInt8PtrTy(),
+                                               offset.getQuantity()));
 }
 
 static void AddRelativeLayoutOffset(CIRGenModule &CGM,

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
@@ -197,7 +197,8 @@ public:
 
   /// Add a pointer of a specific type.
   void addPointer(mlir::cir::PointerType ptrTy, uint64_t value) {
-    add(mlir::cir::ConstPtrAttr::get(ptrTy.getContext(), ptrTy, value));
+    auto val = mlir::IntegerAttr::get(mlir::IntegerType::get(ptrTy.getContext(), 64), value);
+    add(mlir::cir::ConstPtrAttr::get(ptrTy.getContext(), ptrTy, val));
   }
 
   /// Add a bitcast of a value to a specific type.

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
@@ -197,7 +197,8 @@ public:
 
   /// Add a pointer of a specific type.
   void addPointer(mlir::cir::PointerType ptrTy, uint64_t value) {
-    auto val = mlir::IntegerAttr::get(mlir::IntegerType::get(ptrTy.getContext(), 64), value);
+    auto val = mlir::IntegerAttr::get(
+        mlir::IntegerType::get(ptrTy.getContext(), 64), value);
     add(mlir::cir::ConstPtrAttr::get(ptrTy.getContext(), ptrTy, val));
   }
 

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -44,9 +44,9 @@ parseFloatLiteral(mlir::AsmParser &parser,
                   mlir::FailureOr<llvm::APFloat> &value, mlir::Type ty);
 
 static mlir::ParseResult parseConstPtr(mlir::AsmParser &parser,
-                                       uint64_t &value);
+                                       mlir::IntegerAttr &value);
 
-static void printConstPtr(mlir::AsmPrinter &p, uint64_t value);
+static void printConstPtr(mlir::AsmPrinter &p, mlir::IntegerAttr value);
 
 #define GET_ATTRDEF_CLASSES
 #include "clang/CIR/Dialect/IR/CIROpsAttributes.cpp.inc"
@@ -219,18 +219,19 @@ void LangAttr::print(AsmPrinter &printer) const {
 
 // TODO: Consider encoding the null value differently and use conditional
 // assembly format instead of custom parsing/printing.
-static ParseResult parseConstPtr(AsmParser &parser, uint64_t &value) {
+static ParseResult parseConstPtr(AsmParser &parser, mlir::IntegerAttr &value) {
 
   if (parser.parseOptionalKeyword("null").succeeded()) {
-    value = 0;
+    value = mlir::IntegerAttr::get(
+        mlir::IntegerType::get(parser.getContext(), 64), 0);
     return success();
   }
 
-  return parser.parseInteger(value);
+  return parser.parseAttribute(value);
 }
 
-static void printConstPtr(AsmPrinter &p, uint64_t value) {
-  if (!value)
+static void printConstPtr(AsmPrinter &p, mlir::IntegerAttr value) {
+  if (!value.getInt())
     p << "null";
   else
     p << value;

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -203,8 +203,7 @@ void LibOptPass::xformStdFindIntoMemchr(StdFindOp findOp) {
   //   return result;
   // else
   // return last;
-  auto NullPtr = builder.create<ConstantOp>(
-      findOp.getLoc(), first.getType(), ConstPtrAttr::get(first.getType(), 0));
+  auto NullPtr = builder.getNullPtr(first.getType(), findOp.getLoc());
   auto CmpResult = builder.create<CmpOp>(
       findOp.getLoc(), BoolType::get(builder.getContext()), CmpOpKind::eq,
       NullPtr.getRes(), MemChrResult);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -742,10 +742,12 @@ public:
       return mlir::success();
     }
     case mlir::cir::CastKind::ptr_to_bool: {
+      auto zero =
+          mlir::IntegerAttr::get(mlir::IntegerType::get(getContext(), 64), 0);
       auto null = rewriter.create<mlir::cir::ConstantOp>(
           src.getLoc(), castOp.getSrc().getType(),
           mlir::cir::ConstPtrAttr::get(getContext(), castOp.getSrc().getType(),
-                                       0));
+                                       zero));
       rewriter.replaceOpWithNewOp<mlir::cir::CmpOp>(
           castOp, mlir::cir::BoolType::get(getContext()),
           mlir::cir::CmpOpKind::ne, castOp.getSrc(), null);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -188,8 +188,10 @@ lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::cir::ConstPtrAttr ptrAttr,
     return rewriter.create<mlir::LLVM::ZeroOp>(
         loc, converter->convertType(ptrAttr.getType()));
   }
+  mlir::DataLayout layout(parentOp->getParentOfType<mlir::ModuleOp>());
   mlir::Value ptrVal = rewriter.create<mlir::LLVM::ConstantOp>(
-      loc, rewriter.getI64Type(), ptrAttr.getValue());
+      loc, rewriter.getIntegerType(layout.getTypeSizeInBits(ptrAttr.getType())),
+      ptrAttr.getValue().getInt());
   return rewriter.create<mlir::LLVM::IntToPtrOp>(
       loc, converter->convertType(ptrAttr.getType()), ptrVal);
 }

--- a/clang/test/CIR/CodeGen/constptr.c
+++ b/clang/test/CIR/CodeGen/constptr.c
@@ -4,5 +4,5 @@
 int *p = (int*)0x1234;
 
 
-// CIR:  cir.global external @p = #cir.ptr<4660> : !cir.ptr<!s32i>
+// CIR:  cir.global external @p = #cir.ptr<4660 : i64> : !cir.ptr<!s32i>
 // LLVM: @p = global ptr inttoptr (i64 4660 to ptr)

--- a/clang/test/CIR/CodeGen/vbase.cpp
+++ b/clang/test/CIR/CodeGen/vbase.cpp
@@ -15,7 +15,7 @@ void ppp() { B b; }
 
 
 // Vtable definition for B
-// CIR:  cir.global linkonce_odr @_ZTV1B = #cir.vtable<{#cir.const_array<[#cir.ptr<12> : !cir.ptr<!u8i>, #cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1B> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}>
+// CIR:  cir.global linkonce_odr @_ZTV1B = #cir.vtable<{#cir.const_array<[#cir.ptr<12 : i64> : !cir.ptr<!u8i>, #cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1B> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}>
 
 // VTT for B.
 // CIR:  cir.global linkonce_odr @_ZTT1B = #cir.const_array<[#cir.global_view<@_ZTV1B, [0 : i32, 0 : i32, 3 : i32]> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>

--- a/clang/test/CIR/IR/constptrattr.cir
+++ b/clang/test/CIR/IR/constptrattr.cir
@@ -2,7 +2,9 @@
 
 !s32i = !cir.int<s, 32>
 
-cir.global external @const_ptr = #cir.ptr<4660> : !cir.ptr<!s32i>
-// CHECK: cir.global external @const_ptr = #cir.ptr<4660> : !cir.ptr<!s32i>
+cir.global external @const_ptr = #cir.ptr<4660 : i64> : !cir.ptr<!s32i>
+// CHECK: cir.global external @const_ptr = #cir.ptr<4660 : i64> : !cir.ptr<!s32i>
+cir.global external @signed_ptr = #cir.ptr<-1> : !cir.ptr<!s32i>
+// CHECK: cir.global external @signed_ptr = #cir.ptr<-1 : i64> : !cir.ptr<!s32i>
 cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>
 // CHECK: cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>

--- a/clang/test/CIR/Lowering/types.cir
+++ b/clang/test/CIR/Lowering/types.cir
@@ -2,7 +2,11 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 !void = !cir.void
+!u8i = !cir.int<u, 8>
 module {
+  cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<-8> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
+  // CHECK: llvm.mlir.constant(-8 : i64) : i64
+  // CHECK:  llvm.inttoptr %{{[0-9]+}} : i64 to !llvm.ptr
   cir.func @testTypeLowering() {
     // Should lower void pointers as opaque pointers.
     %0 = cir.const #cir.ptr<null> : !cir.ptr<!void>


### PR DESCRIPTION
The constant initialization isn't related to the pointee. We should be able to write #cir.ptr<-1 ： i64> : !cir.ptr<whatever>