### PR TITLE
[CIR] Add -cir-mlir-scf-prepare to simplify lowering to SCF

### DIFF
--- a/clang/include/clang/CIR/CIRToCIRPasses.h
+++ b/clang/include/clang/CIR/CIRToCIRPasses.h
@@ -28,14 +28,13 @@ class ModuleOp;
 namespace cir {
 
 // Run set of cleanup/prepare/etc passes CIR <-> CIR.
-mlir::LogicalResult
-runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
-                  clang::ASTContext &astCtx, bool enableVerifier,
-                  bool enableLifetime, llvm::StringRef lifetimeOpts,
-                  bool enableIdiomRecognizer,
-                  llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
-                  llvm::StringRef libOptOpts,
-                  std::string &passOptParsingFailure, bool flattenCIR);
+mlir::LogicalResult runCIRToCIRPasses(
+    mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
+    clang::ASTContext &astCtx, bool enableVerifier, bool enableLifetime,
+    llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
+    llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
+    llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
+    bool flattenCIR, bool emitMLIR);
 
 } // namespace cir
 

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -28,6 +28,7 @@ std::unique_ptr<Pass> createLifetimeCheckPass(ArrayRef<StringRef> remark,
                                               clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createMergeCleanupsPass();
 std::unique_ptr<Pass> createDropASTPass();
+std::unique_ptr<Pass> createSCFPreparePass();
 std::unique_ptr<Pass> createLoweringPreparePass();
 std::unique_ptr<Pass> createLoweringPreparePass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createIdiomRecognizerPass();

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -75,6 +75,16 @@ def LoweringPrepare : Pass<"cir-lowering-prepare"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def SCFPrepare : Pass<"cir-mlir-scf-prepare"> {
+  let summary = "Preparation work before lowering to SCF dialect";
+  let description = [{
+    This pass does preparation work for SCF lowering. For example, it may
+    hoist the loop invariant or canonicalize the loop comparison.
+  }];
+  let constructor = "mlir::createSCFPreparePass()";
+  let dependentDialects = ["cir::CIRDialect"];
+}
+
 def FlattenCFG : Pass<"cir-flatten-cfg"> {
   let summary = "Produces flatten cfg";
   let description = [{ 

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -79,7 +79,8 @@ def SCFPrepare : Pass<"cir-mlir-scf-prepare"> {
   let summary = "Preparation work before lowering to SCF dialect";
   let description = [{
     This pass does preparation work for SCF lowering. For example, it may
-    hoist the loop invariant or canonicalize the loop comparison.
+    hoist the loop invariant or canonicalize the loop comparison. Currently,
+    the pass only be enabled for through MLIR pipeline.
   }];
   let constructor = "mlir::createSCFPreparePass()";
   let dependentDialects = ["cir::CIRDialect"];

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -19,14 +19,13 @@
 #include "mlir/Support/LogicalResult.h"
 
 namespace cir {
-mlir::LogicalResult
-runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
-                  clang::ASTContext &astCtx, bool enableVerifier,
-                  bool enableLifetime, llvm::StringRef lifetimeOpts,
-                  bool enableIdiomRecognizer,
-                  llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
-                  llvm::StringRef libOptOpts,
-                  std::string &passOptParsingFailure, bool flattenCIR) {
+mlir::LogicalResult runCIRToCIRPasses(
+    mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
+    clang::ASTContext &astCtx, bool enableVerifier, bool enableLifetime,
+    llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
+    llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
+    llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
+    bool flattenCIR, bool emitMLIR) {
   mlir::PassManager pm(mlirCtx);
   pm.addPass(mlir::createMergeCleanupsPass());
 
@@ -67,6 +66,9 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext *mlirCtx,
   pm.addPass(mlir::createLoweringPreparePass(&astCtx));
   if (flattenCIR)
     mlir::populateCIRPreLoweringPasses(pm);
+
+  if (emitMLIR)
+    pm.addPass(mlir::createSCFPreparePass());
 
   // FIXME: once CIRCodenAction fixes emission other than CIR we
   // need to run this right before dialect emission.

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@ add_clang_library(MLIRCIRTransforms
   StdHelpers.cpp
   FlattenCFG.cpp
   GotoSolver.cpp
+  SCFPrepare.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/SCFPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/SCFPrepare.cpp
@@ -1,0 +1,226 @@
+//===- SCFPrepare.cpp - pareparation work for SCF lowering ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+
+using namespace mlir;
+using namespace cir;
+
+//===----------------------------------------------------------------------===//
+// Rewrite patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+static Value findIVAddr(Block *step) {
+  Value IVAddr = nullptr;
+  for (Operation &op : *step) {
+    if (auto loadOp = dyn_cast<LoadOp>(op))
+      IVAddr = loadOp.getAddr();
+    else if (auto storeOp = dyn_cast<StoreOp>(op))
+      if (IVAddr != storeOp.getAddr())
+        return nullptr;
+  }
+  return IVAddr;
+}
+
+static CmpOp findLoopCmpAndIV(Block *cond, Value IVAddr, Value &IV) {
+  Operation *IVLoadOp = nullptr;
+  for (Operation &op : *cond) {
+    if (auto loadOp = dyn_cast<LoadOp>(op))
+      if (loadOp.getAddr() == IVAddr) {
+        IVLoadOp = &op;
+        break;
+      }
+  }
+  if (!IVLoadOp)
+    return nullptr;
+  if (!IVLoadOp->hasOneUse())
+    return nullptr;
+  IV = IVLoadOp->getResult(0);
+  return dyn_cast<CmpOp>(*IVLoadOp->user_begin());
+}
+
+// Canonicalize IV to LHS of loop comparison
+// For example, transfer cir.cmp(gt, %bound, %IV) to cir.cmp(lt, %IV, %bound).
+// So we could use RHS as boundary and use lt to determine it's an upper bound.
+struct canonicalizeIVtoCmpLHS : public OpRewritePattern<ForOp> {
+  using OpRewritePattern<ForOp>::OpRewritePattern;
+
+  CmpOpKind swapCmpKind(CmpOpKind kind) const {
+    switch (kind) {
+    case CmpOpKind::gt:
+      return CmpOpKind::lt;
+    case CmpOpKind::ge:
+      return CmpOpKind::le;
+    case CmpOpKind::lt:
+      return CmpOpKind::gt;
+    case CmpOpKind::le:
+      return CmpOpKind::ge;
+    default:
+      break;
+    }
+    return kind;
+  }
+
+  void replaceWithNewCmpOp(CmpOp oldCmp, CmpOpKind newKind, Value lhs,
+                           Value rhs, PatternRewriter &rewriter) const {
+    rewriter.setInsertionPointAfter(oldCmp.getOperation());
+    auto newCmp = rewriter.create<mlir::cir::CmpOp>(
+        oldCmp.getLoc(), oldCmp.getType(), newKind, lhs, rhs);
+    oldCmp->replaceAllUsesWith(newCmp);
+    oldCmp->erase();
+  }
+
+  LogicalResult matchAndRewrite(ForOp op,
+                                PatternRewriter &rewriter) const final {
+    auto *cond = &op.getCond().front();
+    auto *step = (op.maybeGetStep() ? &op.maybeGetStep()->front() : nullptr);
+    if (!step)
+      return failure();
+    Value IVAddr = findIVAddr(step);
+    if (!IVAddr)
+      return failure();
+    Value IV = nullptr;
+    auto loopCmp = findLoopCmpAndIV(cond, IVAddr, IV);
+    if (!loopCmp || !IV)
+      return failure();
+
+    CmpOpKind cmpKind = loopCmp.getKind();
+    Value cmpRhs = loopCmp.getRhs();
+    // Canonicalize IV to LHS of loop Cmp.
+    if (loopCmp.getLhs() != IV) {
+      cmpKind = swapCmpKind(cmpKind);
+      cmpRhs = loopCmp.getLhs();
+      replaceWithNewCmpOp(loopCmp, cmpKind, IV, cmpRhs, rewriter);
+      return success();
+    }
+
+    return failure();
+  }
+};
+
+// Hoist loop invariant operations in condition block out of loop
+// The condition block may be generated as following which contains the
+// operations produced upper bound.
+// SCF for loop required loop boundary as input operands. So we need to
+// hoist the boundary operations out of loop.
+//
+//   cir.for : cond {
+//     %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
+//     %5 = cir.const #cir.int<100> : !s32i       <- upper bound
+//     %6 = cir.cmp(lt, %4, %5) : !s32i, !s32i
+//     %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+//     cir.condition(%7
+//  } body {
+struct hoistLoopInvariantInCondBlock : public OpRewritePattern<ForOp> {
+  using OpRewritePattern<ForOp>::OpRewritePattern;
+
+  bool isLoopInvariantLoad(Operation *op, ForOp forOp) const {
+    auto load = dyn_cast<LoadOp>(op);
+    if (!load)
+      return false;
+
+    auto loadAddr = load.getAddr();
+    auto result =
+        forOp->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+          if (auto store = dyn_cast<StoreOp>(op)) {
+            if (store.getAddr() == loadAddr)
+              return mlir::WalkResult::interrupt();
+          }
+          return mlir::WalkResult::advance();
+        });
+
+    if (result.wasInterrupted())
+      return false;
+
+    return true;
+  }
+
+  LogicalResult matchAndRewrite(ForOp forOp,
+                                PatternRewriter &rewriter) const final {
+    auto *cond = &forOp.getCond().front();
+    auto *step =
+        (forOp.maybeGetStep() ? &forOp.maybeGetStep()->front() : nullptr);
+    if (!step)
+      return failure();
+    Value IVAddr = findIVAddr(step);
+    if (!IVAddr)
+      return failure();
+    Value IV = nullptr;
+    auto loopCmp = findLoopCmpAndIV(cond, IVAddr, IV);
+    if (!loopCmp || !IV)
+      return failure();
+
+    Value cmpRhs = loopCmp.getRhs();
+    auto defOp = cmpRhs.getDefiningOp();
+    SmallVector<Operation *> ops;
+    // Go through the cast if exist.
+    if (defOp && isa<mlir::cir::CastOp>(defOp)) {
+      ops.push_back(defOp);
+      defOp = defOp->getOperand(0).getDefiningOp();
+    }
+    if (defOp &&
+        (isa<ConstantOp>(defOp) || isLoopInvariantLoad(defOp, forOp))) {
+      ops.push_back(defOp);
+      for (auto op : reverse(ops))
+        op->moveBefore(forOp);
+      return success();
+    }
+
+    return failure();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// SCFPreparePass
+//===----------------------------------------------------------------------===//
+
+struct SCFPreparePass : public SCFPrepareBase<SCFPreparePass> {
+  using SCFPrepareBase::SCFPrepareBase;
+  void runOnOperation() override;
+};
+
+void populateSCFPreparePatterns(RewritePatternSet &patterns) {
+  // clang-format off
+  patterns.add<
+    canonicalizeIVtoCmpLHS,
+    hoistLoopInvariantInCondBlock
+  >(patterns.getContext());
+  // clang-format on
+}
+
+void SCFPreparePass::runOnOperation() {
+  // Collect rewrite patterns.
+  RewritePatternSet patterns(&getContext());
+  populateSCFPreparePatterns(patterns);
+
+  // Collect operations to apply patterns.
+  SmallVector<Operation *, 16> ops;
+  getOperation()->walk([&](Operation *op) {
+    // CastOp here is to perform a manual `fold` in
+    // applyOpPatternsAndFold
+    if (isa<ForOp>(op))
+      ops.push_back(op);
+  });
+
+  // Apply patterns.
+  if (applyOpPatternsAndFold(ops, std::move(patterns)).failed())
+    signalPassFailure();
+}
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createSCFPreparePass() {
+  return std::make_unique<SCFPreparePass>();
+}

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -186,7 +186,8 @@ public:
               feOptions.ClangIRLifetimeCheck, lifetimeOpts,
               feOptions.ClangIRIdiomRecognizer, idiomRecognizerOpts,
               feOptions.ClangIRLibOpt, libOptOpts, passOptParsingFailure,
-              action == CIRGenAction::OutputType::EmitCIRFlat)
+              action == CIRGenAction::OutputType::EmitCIRFlat,
+              action == CIRGenAction::OutputType::EmitMLIR)
               .failed()) {
         if (!passOptParsingFailure.empty())
           diagnosticsEngine.Report(diag::err_drv_cir_pass_opt_parsing)

--- a/clang/test/CIR/Transforms/scf-prepare.cir
+++ b/clang/test/CIR/Transforms/scf-prepare.cir
@@ -1,0 +1,140 @@
+// RUN: cir-opt %s -cir-mlir-scf-prepare -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.global "private" external @a : !cir.array<!s32i x 100>
+
+  // for (int i = l; u > i; ++i)
+  //   a[i] = 3;
+  //
+  // Check that the loop boundary been hoisted out of loop and the comparison
+  // been transferred from gt to lt.
+  cir.func @variableLoopBound(%arg0: !s32i, %arg1: !s32i) {
+    // CHECK: %[[BOUND:.*]] = cir.load %[[BOUND_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
+    // CHECK: cir.for : cond {
+    // CHECK:   %[[IV:.*]] = cir.load %[[IV_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
+    // CHECK:   %[[COND:.*]] = cir.cmp(lt, %[[IV]], %4) : !s32i, !s32i
+
+    %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["l", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["u", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
+    cir.store %arg1, %1 : !s32i, !cir.ptr<!s32i>
+    cir.scope {
+      %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
+      %3 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+      cir.store %3, %2 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load %2 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp(gt, %4, %5) : !s32i, !s32i
+        %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+        cir.condition(%7)
+      } body {
+        %4 = cir.const #cir.int<3> : !s32i
+        %5 = cir.get_global @a : !cir.ptr<!cir.array<!s32i x 100>>
+        %6 = cir.load %2 : !cir.ptr<!s32i>, !s32i
+        %7 = cir.cast(array_to_ptrdecay, %5 : !cir.ptr<!cir.array<!s32i x 100>>), !cir.ptr<!s32i>
+        %8 = cir.ptr_stride(%7 : !cir.ptr<!s32i>, %6 : !s32i), !cir.ptr<!s32i>
+        cir.store %4, %8 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      } step {
+        %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.unary(inc, %4) : !s32i, !s32i
+        cir.store %5, %2 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // for (int i = 0; 50 >= i; ++i)
+  //   a[i] = 3;
+  //
+  // Check that the loop boundary been hoisted out of loop and the comparison
+  // been transferred from ge to le.
+  cir.func @constantLoopBound() {
+    // CHECK: %[[BOUND:.*]] = cir.const #cir.int<50> : !s32i
+    // CHECK: cir.for : cond {
+    // CHECK:   %[[IV:.*]] = cir.load %[[IV_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
+    // CHECK:   %[[COND:.*]] = cir.cmp(le, %[[IV]], %[[BOUND]]) : !s32i, !s32i
+ 
+    cir.scope {
+      %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
+      %1 = cir.const #cir.int<0> : !s32i
+      cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %2 = cir.const #cir.int<50> : !s32i
+        %3 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+        %4 = cir.cmp(ge, %2, %3) : !s32i, !s32i
+        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
+        cir.condition(%5)
+      } body {
+        %2 = cir.const #cir.int<3> : !s32i
+        %3 = cir.get_global @a : !cir.ptr<!cir.array<!s32i x 100>>
+        %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.cast(array_to_ptrdecay, %3 : !cir.ptr<!cir.array<!s32i x 100>>), !cir.ptr<!s32i>
+        %6 = cir.ptr_stride(%5 : !cir.ptr<!s32i>, %4 : !s32i), !cir.ptr<!s32i>
+        cir.store %2, %6 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      } step {
+        %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+        %3 = cir.unary(inc, %2) : !s32i, !s32i
+        cir.store %3, %0 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+
+  // for (int i = l; u > i; ++i) {
+  //   --u;
+  //   a[i] = 3;
+  // }
+  //
+  // Check that the loop boundary not been hoisted because it's not loop
+  // invariant and the loop comparison been transferred from gt to lt.
+  cir.func @variableLoopBoundNotLoopInvariant(%arg0: !s32i, %arg1: !s32i) {
+    // CHECK: cir.store %[[IV_INIT:.*]], %[[IV_ADDR:.*]] : !s32i, !cir.ptr<!s32i>
+    // CHECK: cir.for : cond {
+    // CHECK:   %[[BOUND:.*]] = cir.load %[[BOUND_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
+    // CHECK:   %[[IV:.*]] = cir.load %[[IV_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
+    // CHECK:   %[[COND:.*]] = cir.cmp(lt, %[[IV]], %[[BOUND]]) : !s32i, !s32i
+
+    %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["l", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["u", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
+    cir.store %arg1, %1 : !s32i, !cir.ptr<!s32i>
+    cir.scope {
+      %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
+      %3 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+      cir.store %3, %2 : !s32i, !cir.ptr<!s32i>
+      cir.for : cond {
+        %4 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.load %2 : !cir.ptr<!s32i>, !s32i
+        %6 = cir.cmp(gt, %4, %5) : !s32i, !s32i
+        %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
+        cir.condition(%7)
+      } body {
+        cir.scope {
+          %4 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+          %5 = cir.unary(dec, %4) : !s32i, !s32i
+          cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+          %6 = cir.const #cir.int<3> : !s32i
+          %7 = cir.get_global @a : !cir.ptr<!cir.array<!s32i x 100>>
+          %8 = cir.load %2 : !cir.ptr<!s32i>, !s32i
+          %9 = cir.cast(array_to_ptrdecay, %7 : !cir.ptr<!cir.array<!s32i x 100>>), !cir.ptr<!s32i>
+          %10 = cir.ptr_stride(%9 : !cir.ptr<!s32i>, %8 : !s32i), !cir.ptr<!s32i>
+          cir.store %6, %10 : !s32i, !cir.ptr<!s32i>
+        }
+        cir.yield
+      } step {
+        %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
+        %5 = cir.unary(inc, %4) : !s32i, !s32i
+        cir.store %5, %2 : !s32i, !cir.ptr<!s32i>
+        cir.yield
+      }
+    }
+    cir.return
+  }
+}

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-flat -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRFLAT
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRMLIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -mmlir --mlir-print-ir-after-all -mllvm -print-after-all  %s -o %t.ll 2>&1 | FileCheck %s -check-prefix=CIR -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-drop-ast %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRPASS
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-flat -mmlir --mlir-print-ir-before=cir-flatten-cfg %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CFGPASS
@@ -15,6 +16,7 @@ int foo(void) {
 // CIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
 // CIR:  cir.func @foo() -> !s32i
 // CIR-NOT: IR Dump After FlattenCFG
+// CIR-NOT: IR Dump After SCFPrepare
 // CIR:  IR Dump After DropAST (cir-drop-ast)
 // CIR:  cir.func @foo() -> !s32i
 // CIRFLAT:  IR Dump After MergeCleanups (cir-merge-cleanups)
@@ -24,6 +26,10 @@ int foo(void) {
 // CIRFLAT:  IR Dump After FlattenCFG (cir-flatten-cfg)
 // CIRFLAT:  IR Dump After DropAST (cir-drop-ast)
 // CIRFLAT:  cir.func @foo() -> !s32i
+// CIRMLIR:  IR Dump After MergeCleanups (cir-merge-cleanups)
+// CIRMLIR:  IR Dump After LoweringPrepare (cir-lowering-prepare)
+// CIRMLIR:  IR Dump After SCFPrepare (cir-mlir-scf-prepare
+// CIRMLIR:  IR Dump After DropAST (cir-drop-ast)
 // LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-flat-to-llvm)
 // LLVM: llvm.func @foo() -> i32
 // LLVM: IR Dump After

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -43,6 +43,9 @@ int main(int argc, char **argv) {
   });
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createSCFPreparePass();
+  });
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return cir::createConvertCIRToMLIRPass();
   });
 


### PR DESCRIPTION
This commit introduces SCFPreparePass to
1) Canonicalize IV to LHS of loop comparison
    For example, transfer  `cir.cmp(gt, %bound, %IV)` to `cir.cmp(lt, %IV, %bound)`. So we could use RHS as boundary and use `lt` to determine it's an upper bound.
2) Hoist loop invariant operations in condition block out of loop.
    The condition block may be generated as following which contains the operations produced upper bound.
    SCF for loop required loop boundary as input operands. So we might need to hoist the boundary operations out of loop.
```
      cir.for : cond {
        %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
        %5 = cir.const #cir.int<100> : !s32i       <- upper bound
        %6 = cir.cmp(lt, %4, %5) : !s32i, !s32i
        %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.boo
        cir.condition(%7
       } body {
```
     