### PR TITLE
[CIR][CIRGen][LowerToLLVM] Add address space attribute for pointer type

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -194,9 +194,22 @@ def CIR_PointerType : CIR_Type<"Pointer", "ptr",
     `CIR.ptr` is a type returned by any op generating a pointer in C++.
   }];
 
-  let parameters = (ins "mlir::Type":$pointee);
+  let parameters = (ins "mlir::Type":$pointee, DefaultValuedParameter<"unsigned", "0">:$addrSpace);
 
-  let assemblyFormat = "`<` $pointee `>`";
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "mlir::Type":$pointee, CArg<"unsigned", "0">:$addrSpace), [{
+      return Base::get(pointee.getContext(), pointee, addrSpace);
+    }]>,
+    TypeBuilder<(ins "mlir::Type":$pointee, CArg<"unsigned", "0">:$addrSpace), [{
+      return Base::get($_ctxt, pointee, addrSpace);
+    }]>,
+  ];
+
+  let assemblyFormat = [{
+    `<` $pointee ( `,` `addrspace` `(` $addrSpace^ `)` )? `>`
+  }];
+
+  let skipDefaultBuilders = 1;
 
   let extraClassDeclaration = [{
     bool isVoidPtr() const {

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -194,13 +194,16 @@ def CIR_PointerType : CIR_Type<"Pointer", "ptr",
     `CIR.ptr` is a type returned by any op generating a pointer in C++.
   }];
 
-  let parameters = (ins "mlir::Type":$pointee, DefaultValuedParameter<"unsigned", "0">:$addrSpace);
+  let parameters = (ins "mlir::Type":$pointee,
+                        DefaultValuedParameter<"unsigned", "0">:$addrSpace);
 
   let builders = [
-    TypeBuilderWithInferredContext<(ins "mlir::Type":$pointee, CArg<"unsigned", "0">:$addrSpace), [{
+    TypeBuilderWithInferredContext<(ins
+      "mlir::Type":$pointee, CArg<"unsigned", "0">:$addrSpace), [{
       return Base::get(pointee.getContext(), pointee, addrSpace);
     }]>,
-    TypeBuilder<(ins "mlir::Type":$pointee, CArg<"unsigned", "0">:$addrSpace), [{
+    TypeBuilder<(ins
+      "mlir::Type":$pointee, CArg<"unsigned", "0">:$addrSpace), [{
       return Base::get($_ctxt, pointee, addrSpace);
     }]>,
   ];

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -598,9 +598,9 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
     const ReferenceType *RTy = cast<ReferenceType>(Ty);
     QualType ETy = RTy->getPointeeType();
     auto PointeeType = convertTypeForMem(ETy);
-    // TODO(cir): use Context.getTargetAddressSpace(ETy) on pointer
-    ResultType =
-        ::mlir::cir::PointerType::get(Builder.getContext(), PointeeType);
+    ResultType = ::mlir::cir::PointerType::get(
+        Builder.getContext(), PointeeType,
+        Context.getTargetAddressSpace(ETy.getAddressSpace()));
     assert(ResultType && "Cannot get pointer type?");
     break;
   }
@@ -615,9 +615,9 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
     // if (PointeeType->isVoidTy())
     //  PointeeType = Builder.getI8Type();
 
-    // FIXME: add address specifier to cir::PointerType?
-    ResultType =
-        ::mlir::cir::PointerType::get(Builder.getContext(), PointeeType);
+    ResultType = ::mlir::cir::PointerType::get(
+        Builder.getContext(), PointeeType,
+        Context.getTargetAddressSpace(ETy.getAddressSpace()));
     assert(ResultType && "Cannot get pointer type?");
     break;
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3178,7 +3178,8 @@ void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
                           mlir::DataLayout &dataLayout) {
   converter.addConversion([&](mlir::cir::PointerType type) -> mlir::Type {
     // Drop pointee type since LLVM dialect only allows opaque pointers.
-    return mlir::LLVM::LLVMPointerType::get(type.getContext());
+    return mlir::LLVM::LLVMPointerType::get(type.getContext(),
+                                            type.getAddrSpace());
   });
   converter.addConversion([&](mlir::cir::ArrayType type) -> mlir::Type {
     auto ty = converter.convertType(type.getEltType());

--- a/clang/test/CIR/CodeGen/address-space.c
+++ b/clang/test/CIR/CodeGen/address-space.c
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// CHECK: cir.func {{@.*foo.*}}(%arg0: !cir.ptr<!s32i>
+void foo(int __attribute__((address_space(0))) *arg) {
+  return;
+}
+
+// CHECK: cir.func {{@.*bar.*}}(%arg0: !cir.ptr<!s32i, addrspace(1)>
+void bar(int __attribute__((address_space(1))) *arg) {
+  return;
+}

--- a/clang/test/CIR/CodeGen/address-space.c
+++ b/clang/test/CIR/CodeGen/address-space.c
@@ -3,14 +3,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -S -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
-// CIR: cir.func {{@.*foo.*}}(%arg0: !cir.ptr<!s32i>
-// LLVM: define void @foo(ptr %0)
-void foo(int __attribute__((address_space(0))) *arg) {
-  return;
-}
-
-// CIR: cir.func {{@.*bar.*}}(%arg0: !cir.ptr<!s32i, addrspace(1)>
-// LLVM: define void @bar(ptr addrspace(1) %0)
-void bar(int __attribute__((address_space(1))) *arg) {
+// CIR: cir.func {{@.*foo.*}}(%arg0: !cir.ptr<!s32i, addrspace(1)>
+// LLVM: define void @foo(ptr addrspace(1) %0)
+void foo(int __attribute__((address_space(1))) *arg) {
   return;
 }

--- a/clang/test/CIR/CodeGen/address-space.c
+++ b/clang/test/CIR/CodeGen/address-space.c
@@ -1,12 +1,16 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -S -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
-// CHECK: cir.func {{@.*foo.*}}(%arg0: !cir.ptr<!s32i>
+// CIR: cir.func {{@.*foo.*}}(%arg0: !cir.ptr<!s32i>
+// LLVM: define void @foo(ptr %0)
 void foo(int __attribute__((address_space(0))) *arg) {
   return;
 }
 
-// CHECK: cir.func {{@.*bar.*}}(%arg0: !cir.ptr<!s32i, addrspace(1)>
+// CIR: cir.func {{@.*bar.*}}(%arg0: !cir.ptr<!s32i, addrspace(1)>
+// LLVM: define void @bar(ptr addrspace(1) %0)
 void bar(int __attribute__((address_space(1))) *arg) {
   return;
 }

--- a/clang/test/CIR/IR/address-space.cir
+++ b/clang/test/CIR/IR/address-space.cir
@@ -1,0 +1,11 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+!s32i = !cir.int<s, 32>
+
+module {
+  // CHECK: @test_addrspace_assembly_format(%arg0: !cir.ptr<!s32i>)
+  cir.func @test_addrspace_assembly_format(%arg0: !cir.ptr<!s32i, addrspace(0)>) {
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/address-space.cir
+++ b/clang/test/CIR/Lowering/address-space.cir
@@ -1,0 +1,20 @@
+// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+!s32i = !cir.int<s, 32>
+
+module  {
+  // LLVM: define void @foo(ptr %0)
+  cir.func @foo(%arg0: !cir.ptr<!s32i>) {
+    // LLVM-NEXT: alloca ptr,
+    %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg", init] {alignment = 8 : i64}
+    cir.return
+  }
+
+  // LLVM: define void @bar(ptr addrspace(1) %0)
+  cir.func @bar(%arg0: !cir.ptr<!s32i, addrspace(1)>) {
+    // LLVM-NEXT: alloca ptr addrspace(1)
+    %0 = cir.alloca !cir.ptr<!s32i, addrspace(1)>, !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, ["arg", init] {alignment = 8 : i64}
+    cir.return
+  }
+}


### PR DESCRIPTION
This is the prelude of address space support. Linked issue: #418 .

I want to solve it by these steps:

1. This PR, add the attribute and implement asm format & type conversion.
2. Enable the feature flag of address space, but break it into several other flags. And re-categorize / fix occurrences in the codebase. There is already [a draft commit for this part](https://github.com/seven-mile/clangir/commit/d6752161b23f7872a7999219137a9dd241fe8fa5). PR coming soon.
    * The proposed new feature flags are: `addressSpaceCasting` and (existing) `addressSpaceInGlobalVar`
3. Implement `clang::CK_AddressSpaceConversion` as a new kind of `cir.cast`. Also fix the corresponding occurrences.
4. Make ops like `cir.global` and `cir.get_global` aware of address space, and solve the latter flag.
5. Relax the restriction of default alloca address space. Then we can use correct address spaces for languages like OpenCL in future.

---

Revert to this PR itself, which includes:

* custom assembly format ~`cir.ptr<T[, $addrspace]>`~ `cir.ptr<T[, addrspace($addrspace)]>`
* two build functions with optional argument `addrspace = 0` extended
    * I set `skipDefaultBuilders = 1`, tell me if it's not a good practice😉
* CIRGen / Lowering support for the two type converter from `AST -> CIR -> LLVM` pipeline
* two corresponding test cases
