### PR TITLE
[CIR][CIRGen] Fix compound assignment for vector types

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -646,6 +646,13 @@ RValue CIRGenFunction::buildLoadOfLValue(LValue LV, SourceLocation Loc) {
 
   if (LV.isSimple())
     return RValue::get(buildLoadOfScalar(LV, Loc));
+
+  if (LV.isVectorElt()) {
+    auto load = builder.createLoad(getLoc(Loc), LV.getVectorAddress());
+    return RValue::get(builder.create<mlir::cir::VecExtractOp>(
+        getLoc(Loc), load, LV.getVectorIdx()));
+  }
+
   llvm_unreachable("NYI");
 }
 

--- a/clang/test/CIR/CodeGen/vectype.cpp
+++ b/clang/test/CIR/CodeGen/vectype.cpp
@@ -42,6 +42,18 @@ void vector_int_test(int x) {
   // CHECK: %[[#UPDATEDVI:]] = cir.vec.insert %{{[0-9]+}}, %[[#LOADEDVI]][%{{[0-9]+}} : !s32i] : !cir.vector<!s32i x 4>
   // CHECK: cir.store %[[#UPDATEDVI]], %[[#STORAGEVI]] : !cir.vector<!s32i x 4>, !cir.ptr<!cir.vector<!s32i x 4>>
 
+  // Compound assignment
+  a[x] += a[0];
+  // CHECK: %[[#LOADCA1:]] = cir.load %{{[0-9]+}} : !cir.ptr<!cir.vector<!s32i x 4>>, !cir.vector<!s32i x 4>
+  // CHECK: %[[#RHSCA:]] = cir.vec.extract %[[#LOADCA1]][%{{[0-9]+}} : !s32i] : !cir.vector<!s32i x 4>
+  // CHECK: %[[#LOADCAIDX2:]] = cir.load %{{[0-9]+}} : !cir.ptr<!s32i>, !s32i
+  // CHECK: %[[#LOADCAVEC3:]] = cir.load %{{[0-9]+}} : !cir.ptr<!cir.vector<!s32i x 4>>, !cir.vector<!s32i x 4>
+  // CHECK: %[[#LHSCA:]] = cir.vec.extract %[[#LOADCAVEC3]][%[[#LOADCAIDX2]] : !s32i] : !cir.vector<!s32i x 4>
+  // CHECK: %[[#SUMCA:]] = cir.binop(add, %[[#LHSCA]], %[[#RHSCA]]) : !s32i
+  // CHECK: %[[#LOADCAVEC4:]] = cir.load %{{[0-9]+}} : !cir.ptr<!cir.vector<!s32i x 4>>, !cir.vector<!s32i x 4>
+  // CHECK: %[[#RESULTCAVEC:]] = cir.vec.insert %[[#SUMCA]], %[[#LOADCAVEC4]][%[[#LOADCAIDX2]] : !s32i] : !cir.vector<!s32i x 4>
+  // CHECK: cir.store %[[#RESULTCAVEC]], %{{[0-9]+}} : !cir.vector<!s32i x 4>, !cir.ptr<!cir.vector<!s32i x 4>>
+
   // Binary arithmetic operations
   vi4 d = a + b;
   // CHECK: %{{[0-9]+}} = cir.binop(add, %{{[0-9]+}}, %{{[0-9]+}}) : !cir.vector<!s32i x 4>

--- a/clang/test/CIR/Lowering/vectype.cpp
+++ b/clang/test/CIR/Lowering/vectype.cpp
@@ -74,6 +74,18 @@ void vector_int_test(int x) {
   // CHECK: %[[#T64:]] = llvm.insertelement %[[#T61]], %[[#T63]][%[[#T62]] : i32] : vector<4xi32>
   // CHECK: llvm.store %[[#T64]], %[[#T3]] : vector<4xi32>, !llvm.ptr
 
+  // Compound assignment
+  a[x] += a[0];
+  // CHECK: %[[#LOADCA1:]] = llvm.load %{{[0-9]+}} : !llvm.ptr -> vector<4xi32>
+  // CHECK: %[[#RHSCA:]] = llvm.extractelement %[[#LOADCA1:]][%{{[0-9]+}} : i32] : vector<4xi32>
+  // CHECK: %[[#LOADCAIDX2:]] = llvm.load %{{[0-9]+}} : !llvm.ptr -> i32
+  // CHECK: %[[#LOADCAVEC3:]] = llvm.load %{{[0-9]+}} : !llvm.ptr -> vector<4xi32>
+  // CHECK: %[[#LHSCA:]] = llvm.extractelement %[[#LOADCAVEC3:]][%[[#LOADCAIDX2:]] : i32] : vector<4xi32>
+  // CHECK: %[[#SUMCA:]] = llvm.add %[[#LHSCA:]], %[[#RHSCA:]] : i32
+  // CHECK: %[[#LOADCAVEC4:]] = llvm.load %{{[0-9]+}} : !llvm.ptr -> vector<4xi32>
+  // CHECK: %[[#RESULTCAVEC:]] = llvm.insertelement %[[#SUMCA:]], %[[#LOADCAVEC4:]][%[[#LOADCAIDX2:]] : i32] : vector<4xi32>
+  // CHECK: llvm.store %[[#RESULTCAVEC:]], %{{[0-9]+}} : vector<4xi32>, !llvm.ptr
+
   // Binary arithmetic operators.
   vi4 d = a + b;
   // CHECK: %[[#T65:]] = llvm.load %[[#T3]] : !llvm.ptr -> vector<4xi32>


### PR DESCRIPTION
There is [a code path](https://github.com/llvm/clangir/blob/3da10fafac66ff125fb59c602e41ad4b4f5cb382/clang/lib/CodeGen/CGExpr.cpp#L2190) missing the counterpart in CIRGen of vector types. When using compound assignments like `a[0] += a[1]`, this code path is activated and end up with NYI.