### PR TITLE
[CIR][LLVMLowering] Add LLVM lowering for data member pointers

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -345,12 +345,12 @@ def DataMemberAttr : CIR_Attr<"DataMember", "data_member",
   let parameters = (ins AttributeSelfTypeParameter<
                             "", "mlir::cir::DataMemberType">:$type,
                         OptionalParameter<
-                            "std::optional<size_t>">:$memberIndex);
+                            "std::optional<unsigned>">:$member_index);
   let description = [{
     A data member attribute is a literal attribute that represents a constant
     pointer-to-data-member value.
 
-    The `memberIndex` parameter represents the index of the pointed-to member
+    The `member_index` parameter represents the index of the pointed-to member
     within its containing struct. It is an optional parameter; lack of this
     parameter indicates a null pointer-to-data-member value.
 
@@ -365,7 +365,13 @@ def DataMemberAttr : CIR_Attr<"DataMember", "data_member",
   let genVerifyDecl = 1;
 
   let assemblyFormat = [{
-    `<` ($memberIndex^):(`null`)? `>`
+    `<` ($member_index^):(`null`)? `>`
+  }];
+
+  let extraClassDeclaration = [{
+    bool isNullPtr() const {
+      return !getMemberIndex().has_value();
+    }
   }];
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -245,7 +245,7 @@ public:
   }
 
   mlir::cir::DataMemberAttr getDataMemberAttr(mlir::cir::DataMemberType ty,
-                                              size_t memberIndex) {
+                                              unsigned memberIndex) {
     return mlir::cir::DataMemberAttr::get(getContext(), ty, memberIndex);
   }
 

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -420,7 +420,7 @@ CmpThreeWayInfoAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 LogicalResult
 DataMemberAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                        mlir::cir::DataMemberType ty,
-                       std::optional<size_t> memberIndex) {
+                       std::optional<unsigned> memberIndex) {
   if (!memberIndex.has_value()) {
     // DataMemberAttr without a given index represents a null value.
     return success();

--- a/clang/test/CIR/Lowering/data-member.cir
+++ b/clang/test/CIR/Lowering/data-member.cir
@@ -1,0 +1,52 @@
+// RUN: cir-opt -cir-to-llvm -o - %s | FileCheck -check-prefix=MLIR %s
+// RUN: cir-translate -cir-to-llvmir -o - %s  | FileCheck -check-prefix=LLVM %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!structT = !cir.struct<struct "Point" {!cir.int<s, 32>, !cir.int<s, 32>, !cir.int<s, 32>}>
+
+module @test {
+  cir.global external @pt_member = #cir.data_member<1> : !cir.data_member<!s32i in !structT>
+  // MLIR: llvm.mlir.global external @pt_member(4 : i64) {addr_space = 0 : i32} : i64
+  // LLVM: @pt_member = global i64 4
+
+  cir.func @constant() -> !cir.data_member<!s32i in !structT> {
+    %0 = cir.const #cir.data_member<1> : !cir.data_member<!s32i in !structT>
+    cir.return %0 : !cir.data_member<!s32i in !structT>
+  }
+  //      MLIR: llvm.func @constant() -> i64
+  // MLIR-NEXT:   %0 = llvm.mlir.constant(4 : i64) : i64
+  // MLIR-NEXT:   llvm.return %0 : i64
+  // MLIR-NEXT: }
+
+  //      LLVM: define i64 @constant()
+  // LLVM-NEXT:   ret i64 4
+  // LLVM-NEXT: }
+
+  cir.func @null_constant() -> !cir.data_member<!s32i in !structT> {
+    %0 = cir.const #cir.data_member<null> : !cir.data_member<!s32i in !structT>
+    cir.return %0 : !cir.data_member<!s32i in !structT>
+  }
+  //      MLIR: llvm.func @null_constant() -> i64
+  // MLIR-NEXT:   %0 = llvm.mlir.constant(-1 : i64) : i64
+  // MLIR-NEXT:   llvm.return %0 : i64
+  // MLIR-NEXT: }
+
+  //      LLVM: define i64 @null_constant() !dbg !7 {
+  // LLVM-NEXT:   ret i64 -1
+  // LLVM-NEXT: }
+
+  cir.func @get_runtime_member(%arg0: !cir.ptr<!structT>, %arg1: !cir.data_member<!s32i in !structT>) -> !cir.ptr<!s32i> {
+    %0 = cir.get_runtime_member %arg0[%arg1 : !cir.data_member<!s32i in !structT>] : !cir.ptr<!structT> -> !cir.ptr<!s32i>
+    cir.return %0 : !cir.ptr<!s32i>
+  }
+  //      MLIR: llvm.func @get_runtime_member(%arg0: !llvm.ptr, %arg1: i64) -> !llvm.ptr
+  // MLIR-NEXT:   %0 = llvm.getelementptr %arg0[%arg1] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+  // MLIR-NEXT:   llvm.return %0 : !llvm.ptr
+  // MLIR-NEXT: }
+
+  //      LLVM: define ptr @get_runtime_member(ptr %0, i64 %1)
+  // LLVM-NEXT:   %3 = getelementptr i8, ptr %0, i64 %1
+  // LLVM-NEXT:   ret ptr %3
+  // LLVM-NEXT: }
+}


### PR DESCRIPTION
This PR adds LLVM lowering support for data member pointers. It includes the following changes:

- ~~The `#cir.data_member` attribute now has a new parameter named `memberOffset`. When the data member pointer is not null, this parameter gives the offset of the pointed-to member within its containing object. This offset is calculated by target ABI.~~
- ~~A new attribute `#cir.data_member_ptr_layout` is added. It contains ABI-specific layout information about a data member pointer that is required to lower it to LLVM IR. This attribute is attached to the module op, and it is queried during LLVMIR lowering to obtain the lowering information in it.~~
- Some CIRGen of the data member pointers is refactored to follow the upstream CodeGen skeleton.