### PR TITLE
[CIR][CIRGen] Enable address space flags and re-categorize / fix usages

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -194,9 +194,22 @@ def CIR_PointerType : CIR_Type<"Pointer", "ptr",
     `CIR.ptr` is a type returned by any op generating a pointer in C++.
   }];
 
-  let parameters = (ins "mlir::Type":$pointee);
+  let parameters = (ins "mlir::Type":$pointee, DefaultValuedParameter<"unsigned", "0">:$addrSpace);
 
-  let assemblyFormat = "`<` $pointee `>`";
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "mlir::Type":$pointee, CArg<"unsigned", "0">:$addrSpace), [{
+      return Base::get(pointee.getContext(), pointee, addrSpace);
+    }]>,
+    TypeBuilder<(ins "mlir::Type":$pointee, CArg<"unsigned", "0">:$addrSpace), [{
+      return Base::get($_ctxt, pointee, addrSpace);
+    }]>,
+  ];
+
+  let assemblyFormat = [{
+    `<` $pointee ( `,` `addrspace` `(` $addrSpace^ `)` )? `>`
+  }];
+
+  let skipDefaultBuilders = 1;
 
   let extraClassDeclaration = [{
     bool isVoidPtr() const {

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -643,9 +643,8 @@ public:
 
   mlir::Value createDynCastToVoid(mlir::Location loc, mlir::Value src,
                                   bool vtableUseRelativeLayout) {
-    // TODO(cir): consider address space here.
-    assert(!UnimplementedFeature::addressSpace());
-    auto destTy = getVoidPtrTy();
+    auto srcTy = src.getType().cast<mlir::cir::PointerType>();
+    auto destTy = getVoidPtrTy(srcTy.getAddrSpace());
     return create<mlir::cir::DynamicCastOp>(
         loc, destTy, mlir::cir::DynamicCastKind::ptr, src,
         mlir::cir::DynamicCastInfoAttr{}, vtableUseRelativeLayout);
@@ -875,11 +874,11 @@ public:
   mlir::cir::GetRuntimeMemberOp createGetIndirectMember(mlir::Location loc,
                                                         mlir::Value objectPtr,
                                                         mlir::Value memberPtr) {
+    auto objectPtrTy = objectPtr.getType().cast<mlir::cir::PointerType>();
     auto memberPtrTy = memberPtr.getType().cast<mlir::cir::DataMemberType>();
 
-    // TODO(cir): consider address space.
-    assert(!UnimplementedFeature::addressSpace());
-    auto resultTy = getPointerTo(memberPtrTy.getMemberTy());
+    auto resultTy =
+        getPointerTo(memberPtrTy.getMemberTy(), objectPtrTy.getAddrSpace());
 
     return create<mlir::cir::GetRuntimeMemberOp>(loc, resultTy, objectPtr,
                                                  memberPtr);

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -694,8 +694,8 @@ void CIRGenFunction::initializeVTablePointer(mlir::Location loc,
   // Finally, store the address point. Use the same CIR types as the field.
   //
   // vtable field is derived from `this` pointer, therefore they should be in
-  // the same addr space.
-  assert(!UnimplementedFeature::addressSpace());
+  // the same addr space. while vtable APs should use addr space for globals,
+  // which we should ensure when creating these ops in CXX ABI.
   VTableField = builder.createElementBitCast(loc, VTableField,
                                              VTableAddressPoint.getType());
   builder.createStore(loc, VTableAddressPoint, VTableField);
@@ -1384,7 +1384,7 @@ CIRGenFunction::getAddressOfBaseClass(Address Value,
 
   // Get the base pointer type.
   auto BaseValueTy = convertType((PathEnd[-1])->getType());
-  assert(!UnimplementedFeature::addressSpace());
+  // TODO(cir): specify addr space in base ptr ty
   // auto BasePtrTy = builder.getPointerTo(BaseValueTy);
   // QualType DerivedTy = getContext().getRecordType(Derived);
   // CharUnits DerivedAlign = CGM.getClassPointerAlignment(Derived);

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -464,7 +464,7 @@ CIRGenModule::getOrCreateStaticVarDecl(const VarDecl &D,
     Name = getStaticDeclName(*this, D);
 
   mlir::Type LTy = getTypes().convertTypeForMem(Ty);
-  assert(!UnimplementedFeature::addressSpace());
+  assert(!UnimplementedFeature::addressSpaceInGlobalVar());
 
   // OpenCL variables in local address space and CUDA shared
   // variables cannot have an initializer.
@@ -491,7 +491,7 @@ CIRGenModule::getOrCreateStaticVarDecl(const VarDecl &D,
   setGVProperties(GV, &D);
 
   // Make sure the result is of the correct type.
-  assert(!UnimplementedFeature::addressSpace());
+  assert(!UnimplementedFeature::addressSpaceCasting());
 
   // Ensure that the static local gets initialized by making sure the parent
   // function gets emitted eventually.

--- a/clang/lib/CIR/CodeGen/CIRGenDeclCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDeclCXX.cpp
@@ -70,7 +70,7 @@ void CIRGenModule::buildGlobalVarDeclInit(const VarDecl *D,
     // For example, in the above CUDA code, the static local variable s has a
     // "shared" address space qualifier, but the constructor of StructWithCtor
     // expects "this" in the "generic" address space.
-    assert(!UnimplementedFeature::addressSpace());
+    assert(!UnimplementedFeature::addressSpaceCasting());
 
     if (!T->isReferenceType()) {
       bool NeedsDtor =

--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -439,7 +439,7 @@ static void buildCatchDispatchBlock(CIRGenFunction &CGF,
     assert(typeValue && "fell into catch-all case!");
     // Check for address space mismatch: if (typeValue->getType() !=
     // argTy)
-    assert(!UnimplementedFeature::addressSpace());
+    assert(!UnimplementedFeature::addressSpaceCasting());
 
     bool nextIsEnd = false;
     // If this is the last handler, we're at the end, and the next

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -721,7 +721,8 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef MangledName, mlir::Type Ty,
       return Entry;
   }
 
-  // TODO(cir): auto DAddrSpace = GetGlobalVarAddressSpace(D);
+  // TODO(cir): auto DAddrSpace = getGlobalVarAddressSpace(D);
+  assert(!UnimplementedFeature::addressSpaceInGlobalVar());
   // TODO(cir): do we need to strip pointer casts for Entry?
 
   auto loc = getLoc(D->getSourceRange());
@@ -809,6 +810,7 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef MangledName, mlir::Type Ty,
   }
 
   // TODO(cir): address space cast when needed for DAddrSpace.
+  assert(!UnimplementedFeature::addressSpaceCasting());
   return GV;
 }
 
@@ -2378,8 +2380,8 @@ mlir::cir::FuncOp CIRGenModule::GetOrCreateCIRFunction(
     return F;
   }
 
-  // TODO(cir): Might need bitcast to different address space.
-  assert(!UnimplementedFeature::addressSpace());
+  // TODO(cir): Might need address-space cast to different address space.
+  assert(!UnimplementedFeature::addressSpaceCasting());
   return F;
 }
 
@@ -2803,9 +2805,10 @@ mlir::cir::GlobalOp CIRGenModule::getOrInsertGlobal(
   // If the variable exists but has the wrong type, return a bitcast to the
   // right type.
   auto GVTy = GV.getSymType();
-  assert(!UnimplementedFeature::addressSpace());
+  assert(!UnimplementedFeature::addressSpaceInGlobalVar());
   auto PTy = builder.getPointerTo(Ty);
 
+  assert(!UnimplementedFeature::addressSpaceCasting());
   if (GVTy != PTy)
     llvm_unreachable("NYI");
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
@@ -128,7 +128,6 @@ struct CIRGenTypeCache {
     // Address spaces are not yet fully supported, but the usage of the default
     // alloca address space can be used for now only for comparison with the
     // default address space.
-    assert(!UnimplementedFeature::addressSpace());
     assert(ASTAllocaAddressSpace == clang::LangAS::Default);
     return ASTAllocaAddressSpace;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -598,9 +598,9 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
     const ReferenceType *RTy = cast<ReferenceType>(Ty);
     QualType ETy = RTy->getPointeeType();
     auto PointeeType = convertTypeForMem(ETy);
-    // TODO(cir): use Context.getTargetAddressSpace(ETy) on pointer
-    ResultType =
-        ::mlir::cir::PointerType::get(Builder.getContext(), PointeeType);
+    ResultType = ::mlir::cir::PointerType::get(
+        Builder.getContext(), PointeeType,
+        Context.getTargetAddressSpace(ETy.getAddressSpace()));
     assert(ResultType && "Cannot get pointer type?");
     break;
   }
@@ -615,9 +615,9 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
     // if (PointeeType->isVoidTy())
     //  PointeeType = Builder.getI8Type();
 
-    // FIXME: add address specifier to cir::PointerType?
-    ResultType =
-        ::mlir::cir::PointerType::get(Builder.getContext(), PointeeType);
+    ResultType = ::mlir::cir::PointerType::get(
+        Builder.getContext(), PointeeType,
+        Context.getTargetAddressSpace(ETy.getAddressSpace()));
     assert(ResultType && "Cannot get pointer type?");
     break;
   }

--- a/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
+++ b/clang/lib/CIR/CodeGen/UnimplementedFeatureGuarding.h
@@ -29,8 +29,9 @@ struct UnimplementedFeature {
   static bool vectorConstants() { return false; }
 
   // Address space related
-  static bool addressSpace() { return false; }
+  static bool addressSpace() { return true; }
   static bool addressSpaceInGlobalVar() { return false; }
+  static bool addressSpaceCasting() { return false; }
 
   // Clang codegen options
   static bool strictVTablePointers() { return false; }

--- a/clang/lib/CIR/Dialect/IR/MissingFeatures.h
+++ b/clang/lib/CIR/Dialect/IR/MissingFeatures.h
@@ -23,7 +23,8 @@ struct MissingFeatures {
   static bool setCallingConv() { return false; }
 
   // Address space related
-  static bool addressSpace() { return false; }
+  static bool addressSpace() { return true; }
+  static bool addressSpaceCasting() { return false; }
 
   // Sanitizers
   static bool buildTypeCheck() { return false; }

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
@@ -55,7 +55,7 @@ static mlir::Value buildDynamicCastAfterNullCheck(CIRBaseBuilderTy &builder,
   auto castInfo = op.getInfo().value();
 
   // TODO(cir): consider address space
-  assert(!MissingFeatures::addressSpace());
+  assert(!MissingFeatures::addressSpaceCasting());
 
   auto srcPtr = builder.createBitcast(srcValue, builder.getVoidPtrTy());
   auto srcRtti = builder.getConstant(loc, castInfo.getSrcRtti());
@@ -100,7 +100,7 @@ buildDynamicCastToVoidAfterNullCheck(CIRBaseBuilderTy &builder,
   bool vtableUsesRelativeLayout = op.getRelativeLayout();
 
   // TODO(cir): consider address space in this function.
-  assert(!MissingFeatures::addressSpace());
+  assert(!MissingFeatures::addressSpaceCasting());
 
   mlir::Type vtableElemTy;
   uint64_t vtableElemAlign;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3178,7 +3178,8 @@ void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
                           mlir::DataLayout &dataLayout) {
   converter.addConversion([&](mlir::cir::PointerType type) -> mlir::Type {
     // Drop pointee type since LLVM dialect only allows opaque pointers.
-    return mlir::LLVM::LLVMPointerType::get(type.getContext());
+    return mlir::LLVM::LLVMPointerType::get(type.getContext(),
+                                            type.getAddrSpace());
   });
   converter.addConversion([&](mlir::cir::ArrayType type) -> mlir::Type {
     auto ty = converter.convertType(type.getEltType());

--- a/clang/test/CIR/CodeGen/address-space.c
+++ b/clang/test/CIR/CodeGen/address-space.c
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// CHECK: cir.func {{@.*foo.*}}(%arg0: !cir.ptr<!s32i>
+void foo(int __attribute__((address_space(0))) *arg) {
+  return;
+}
+
+// CHECK: cir.func {{@.*bar.*}}(%arg0: !cir.ptr<!s32i, addrspace(1)>
+void bar(int __attribute__((address_space(1))) *arg) {
+  return;
+}

--- a/clang/test/CIR/Lowering/address-space.cir
+++ b/clang/test/CIR/Lowering/address-space.cir
@@ -1,0 +1,20 @@
+// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+!s32i = !cir.int<s, 32>
+
+module  {
+  // LLVM: define void @foo(ptr %0)
+  cir.func @foo(%arg0: !cir.ptr<!s32i>) {
+    // LLVM-NEXT: alloca ptr,
+    %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg", init] {alignment = 8 : i64}
+    cir.return
+  }
+
+  // LLVM: define void @bar(ptr addrspace(1) %0)
+  cir.func @bar(%arg0: !cir.ptr<!s32i, addrspace(1)>) {
+    // LLVM-NEXT: alloca ptr addrspace(1)
+    %0 = cir.alloca !cir.ptr<!s32i, addrspace(1)>, !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, ["arg", init] {alignment = 8 : i64}
+    cir.return
+  }
+}


### PR DESCRIPTION
Depend on #606 , will rebase after its merging.

This PR fixes simple cases and re-categorize other cases to `addressSpaceInGlobalVar` or `addressSpaceCasting`. Maybe the changes are hard to review😂. But I will solve them in months, so no need to be strict with the precise categorization.