### PR TITLE
[CIR][CIRGen] Add CIRGen for binary fp2fp builtin operations

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3324,6 +3324,26 @@ def SinOp : UnaryFPToFPBuiltinOp<"sin">;
 def SqrtOp : UnaryFPToFPBuiltinOp<"sqrt">;
 def TruncOp : UnaryFPToFPBuiltinOp<"trunc">;
 
+class BinaryFPToFPBuiltinOp<string mnemonic>
+    : CIR_Op<mnemonic, [Pure, SameOperandsAndResultType]> {
+  let summary = [{
+    libc builtin equivalent ignoring floating-point exceptions and errno.
+  }];
+
+  let arguments = (ins CIR_AnyFloat:$lhs, CIR_AnyFloat:$rhs);
+  let results = (outs CIR_AnyFloat:$result);
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs `:` qualified(type($lhs)) attr-dict
+  }];
+}
+
+def CopysignOp : BinaryFPToFPBuiltinOp<"copysign">;
+def FMaxOp : BinaryFPToFPBuiltinOp<"fmax">;
+def FMinOp : BinaryFPToFPBuiltinOp<"fmin">;
+def FModOp : BinaryFPToFPBuiltinOp<"fmod">;
+def PowOp : BinaryFPToFPBuiltinOp<"pow">;
+
 //===----------------------------------------------------------------------===//
 // Branch Probability Operations
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -320,10 +320,12 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BIcopysignl:
     case Builtin::BI__builtin_copysign:
     case Builtin::BI__builtin_copysignf:
-    case Builtin::BI__builtin_copysignf16:
     case Builtin::BI__builtin_copysignl:
-    case Builtin::BI__builtin_copysignf128:
       return buildBinaryFPBuiltin<mlir::cir::CopysignOp>(*this, *E);
+
+    case Builtin::BI__builtin_copysignf16:
+    case Builtin::BI__builtin_copysignf128:
+      llvm_unreachable("NYI");
 
     case Builtin::BIcos:
     case Builtin::BIcosf:
@@ -390,22 +392,26 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BIfmaxl:
     case Builtin::BI__builtin_fmax:
     case Builtin::BI__builtin_fmaxf:
-    case Builtin::BI__builtin_fmaxf16:
     case Builtin::BI__builtin_fmaxl:
-    case Builtin::BI__builtin_fmaxf128:
       return RValue::get(
           buildBinaryMaybeConstrainedFPBuiltin<mlir::cir::FMaxOp>(*this, *E));
+
+    case Builtin::BI__builtin_fmaxf16:
+    case Builtin::BI__builtin_fmaxf128:
+      llvm_unreachable("NYI");
 
     case Builtin::BIfmin:
     case Builtin::BIfminf:
     case Builtin::BIfminl:
     case Builtin::BI__builtin_fmin:
     case Builtin::BI__builtin_fminf:
-    case Builtin::BI__builtin_fminf16:
     case Builtin::BI__builtin_fminl:
-    case Builtin::BI__builtin_fminf128:
       return RValue::get(
           buildBinaryMaybeConstrainedFPBuiltin<mlir::cir::FMinOp>(*this, *E));
+
+    case Builtin::BI__builtin_fminf16:
+    case Builtin::BI__builtin_fminf128:
+      llvm_unreachable("NYI");
 
     // fmod() is a special-case. It maps to the frem instruction rather than an
     // LLVM intrinsic.
@@ -414,10 +420,12 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BIfmodl:
     case Builtin::BI__builtin_fmod:
     case Builtin::BI__builtin_fmodf:
-    case Builtin::BI__builtin_fmodf16:
     case Builtin::BI__builtin_fmodl:
-    case Builtin::BI__builtin_fmodf128:
       return buildBinaryFPBuiltin<mlir::cir::FModOp>(*this, *E);
+
+    case Builtin::BI__builtin_fmodf16:
+    case Builtin::BI__builtin_fmodf128:
+      llvm_unreachable("NYI");
 
     case Builtin::BIlog:
     case Builtin::BIlogf:
@@ -463,11 +471,13 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BIpowl:
     case Builtin::BI__builtin_pow:
     case Builtin::BI__builtin_powf:
-    case Builtin::BI__builtin_powf16:
     case Builtin::BI__builtin_powl:
-    case Builtin::BI__builtin_powf128:
       return RValue::get(
           buildBinaryMaybeConstrainedFPBuiltin<mlir::cir::PowOp>(*this, *E));
+
+    case Builtin::BI__builtin_powf16:
+    case Builtin::BI__builtin_powf128:
+      llvm_unreachable("NYI");
 
     case Builtin::BIrint:
     case Builtin::BIrintf:

--- a/clang/test/CIR/CodeGen/builtin-floating-point.c
+++ b/clang/test/CIR/CodeGen/builtin-floating-point.c
@@ -616,3 +616,223 @@ long double call_truncl(long double f) {
   // CHECK: {{.+}} = cir.trunc {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.trunc {{.+}} : !cir.long_double<!cir.double>
 }
+
+// copysign
+
+float my_copysignf(float x, float y) {
+  return __builtin_copysignf(x, y);
+  // CHECK: cir.func @my_copysignf
+  // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.float
+}
+
+double my_copysign(double x, double y) {
+  return __builtin_copysign(x, y);
+  // CHECK: cir.func @my_copysign
+  // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double my_copysignl(long double x, long double y) {
+  return __builtin_copysignl(x, y);
+  // CHECK: cir.func @my_copysignl
+  // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+float copysignf(float, float);
+double copysign(double, double);
+long double copysignl(long double, long double);
+
+float call_copysignf(float x, float y) {
+  return copysignf(x, y);
+  // CHECK: cir.func @call_copysignf
+  // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.float
+}
+
+double call_copysign(double x, double y) {
+  return copysign(x, y);
+  // CHECK: cir.func @call_copysign
+  // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double call_copysignl(long double x, long double y) {
+  return copysignl(x, y);
+  // CHECK: cir.func @call_copysignl
+  // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+// fmax
+
+float my_fmaxf(float x, float y) {
+  return __builtin_fmaxf(x, y);
+  // CHECK: cir.func @my_fmaxf
+  // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.float
+}
+
+double my_fmax(double x, double y) {
+  return __builtin_fmax(x, y);
+  // CHECK: cir.func @my_fmax
+  // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double my_fmaxl(long double x, long double y) {
+  return __builtin_fmaxl(x, y);
+  // CHECK: cir.func @my_fmaxl
+  // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+float fmaxf(float, float);
+double fmax(double, double);
+long double fmaxl(long double, long double);
+
+float call_fmaxf(float x, float y) {
+  return fmaxf(x, y);
+  // CHECK: cir.func @call_fmaxf
+  // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.float
+}
+
+double call_fmax(double x, double y) {
+  return fmax(x, y);
+  // CHECK: cir.func @call_fmax
+  // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double call_fmaxl(long double x, long double y) {
+  return fmaxl(x, y);
+  // CHECK: cir.func @call_fmaxl
+  // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+// fmin
+
+float my_fminf(float x, float y) {
+  return __builtin_fminf(x, y);
+  // CHECK: cir.func @my_fminf
+  // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.float
+}
+
+double my_fmin(double x, double y) {
+  return __builtin_fmin(x, y);
+  // CHECK: cir.func @my_fmin
+  // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double my_fminl(long double x, long double y) {
+  return __builtin_fminl(x, y);
+  // CHECK: cir.func @my_fminl
+  // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+float fminf(float, float);
+double fmin(double, double);
+long double fminl(long double, long double);
+
+float call_fminf(float x, float y) {
+  return fminf(x, y);
+  // CHECK: cir.func @call_fminf
+  // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.float
+}
+
+double call_fmin(double x, double y) {
+  return fmin(x, y);
+  // CHECK: cir.func @call_fmin
+  // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double call_fminl(long double x, long double y) {
+  return fminl(x, y);
+  // CHECK: cir.func @call_fminl
+  // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+// fmod
+
+float my_fmodf(float x, float y) {
+  return __builtin_fmodf(x, y);
+  // CHECK: cir.func @my_fmodf
+  // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.float
+}
+
+double my_fmod(double x, double y) {
+  return __builtin_fmod(x, y);
+  // CHECK: cir.func @my_fmod
+  // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double my_fmodl(long double x, long double y) {
+  return __builtin_fmodl(x, y);
+  // CHECK: cir.func @my_fmodl
+  // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+float fmodf(float, float);
+double fmod(double, double);
+long double fmodl(long double, long double);
+
+float call_fmodf(float x, float y) {
+  return fmodf(x, y);
+  // CHECK: cir.func @call_fmodf
+  // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.float
+}
+
+double call_fmod(double x, double y) {
+  return fmod(x, y);
+  // CHECK: cir.func @call_fmod
+  // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double call_fmodl(long double x, long double y) {
+  return fmodl(x, y);
+  // CHECK: cir.func @call_fmodl
+  // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+// pow
+
+float my_powf(float x, float y) {
+  return __builtin_powf(x, y);
+  // CHECK: cir.func @my_powf
+  // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.float
+}
+
+double my_pow(double x, double y) {
+  return __builtin_pow(x, y);
+  // CHECK: cir.func @my_pow
+  // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double my_powl(long double x, long double y) {
+  return __builtin_powl(x, y);
+  // CHECK: cir.func @my_powl
+  // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}
+
+float powf(float, float);
+double pow(double, double);
+long double powl(long double, long double);
+
+float call_powf(float x, float y) {
+  return powf(x, y);
+  // CHECK: cir.func @call_powf
+  // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.float
+}
+
+double call_pow(double x, double y) {
+  return pow(x, y);
+  // CHECK: cir.func @call_pow
+  // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.double
+}
+
+long double call_powl(long double x, long double y) {
+  return powl(x, y);
+  // CHECK: cir.func @call_powl
+  // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
+  // AARCH64: %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+}

--- a/clang/test/CIR/CodeGen/builtin-floating-point.c
+++ b/clang/test/CIR/CodeGen/builtin-floating-point.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -ffast-math -fclangir -emit-cir %s -o - | FileCheck %s
-// RUN: %clang_cc1 -triple aarch64-apple-darwin-macho -ffast-math -fclangir -emit-cir %s -o - | FileCheck %s --check-prefix=AARCH64
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -ffast-math -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t1.cir 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -triple aarch64-apple-darwin-macho -ffast-math -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t1.cir 2>&1 | FileCheck %s --check-prefix=AARCH64
 
 // ceil
 

--- a/clang/test/CIR/Lowering/builtin-binary-fp2fp.c
+++ b/clang/test/CIR/Lowering/builtin-binary-fp2fp.c
@@ -1,0 +1,132 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+// copysign
+
+float my_copysignf(float x, float y) {
+  return __builtin_copysignf(x, y);
+}
+
+// LLVM: define float @my_copysignf
+// LLVM:   %{{.+}} = call float @llvm.copysign.f32(float %{{.+}}, float %{{.+}})
+// LLVM: }
+
+double my_copysign(double x, double y) {
+  return __builtin_copysign(x, y);
+}
+
+// LLVM: define double @my_copysign
+// LLVM:   %{{.+}} = call double @llvm.copysign.f64(double %{{.+}}, double %{{.+}})
+// LLVM: }
+
+long double my_copysignl(long double x, long double y) {
+  return __builtin_copysignl(x, y);
+}
+
+// LLVM: define x86_fp80 @my_copysignl
+// LLVM:   %{{.+}} = call x86_fp80 @llvm.copysign.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+// LLVM: }
+
+// fmax
+
+float my_fmaxf(float x, float y) {
+  return __builtin_fmaxf(x, y);
+}
+
+// LLVM: define float @my_fmaxf
+// LLVM:   %{{.+}} = call float @llvm.maxnum.f32(float %{{.+}}, float %{{.+}})
+// LLVM: }
+
+double my_fmax(double x, double y) {
+  return __builtin_fmax(x, y);
+}
+
+// LLVM: define double @my_fmax
+// LLVM:   %{{.+}} = call double @llvm.maxnum.f64(double %{{.+}}, double %{{.+}})
+// LLVM: }
+
+long double my_fmaxl(long double x, long double y) {
+  return __builtin_fmaxl(x, y);
+}
+
+// LLVM: define x86_fp80 @my_fmaxl
+// LLVM:   %{{.+}} = call x86_fp80 @llvm.maxnum.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+// LLVM: }
+
+// fmin
+
+float my_fminf(float x, float y) {
+  return __builtin_fminf(x, y);
+}
+
+// LLVM: define float @my_fminf
+// LLVM:   %{{.+}} = call float @llvm.minnum.f32(float %{{.+}}, float %{{.+}})
+// LLVM: }
+
+double my_fmin(double x, double y) {
+  return __builtin_fmin(x, y);
+}
+
+// LLVM: define double @my_fmin
+// LLVM:   %{{.+}} = call double @llvm.minnum.f64(double %{{.+}}, double %{{.+}})
+// LLVM: }
+
+long double my_fminl(long double x, long double y) {
+  return __builtin_fminl(x, y);
+}
+
+// LLVM: define x86_fp80 @my_fminl
+// LLVM:   %{{.+}} = call x86_fp80 @llvm.minnum.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+// LLVM: }
+
+// fmod
+
+float my_fmodf(float x, float y) {
+  return __builtin_fmodf(x, y);
+}
+
+// LLVM: define float @my_fmodf
+// LLVM:   %{{.+}} = call float @fmodf(float %{{.+}}, float %{{.+}})
+// LLVM: }
+
+double my_fmod(double x, double y) {
+  return __builtin_fmod(x, y);
+}
+
+// LLVM: define double @my_fmod
+// LLVM:   %{{.+}} = call double @fmod(double %{{.+}}, double %{{.+}})
+// LLVM: }
+
+long double my_fmodl(long double x, long double y) {
+  return __builtin_fmodl(x, y);
+}
+
+// LLVM: define x86_fp80 @my_fmodl
+// LLVM:   %{{.+}} = call x86_fp80 @fmodl(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+// LLVM: }
+
+// pow
+
+float my_powf(float x, float y) {
+  return __builtin_powf(x, y);
+}
+
+// LLVM: define float @my_powf
+// LLVM:   %{{.+}} = call float @powf(float %{{.+}}, float %{{.+}})
+// LLVM: }
+
+double my_pow(double x, double y) {
+  return __builtin_pow(x, y);
+}
+
+// LLVM: define double @my_pow
+// LLVM:   %{{.+}} = call double @pow(double %{{.+}}, double %{{.+}})
+// LLVM: }
+
+long double my_powl(long double x, long double y) {
+  return __builtin_powl(x, y);
+}
+
+// LLVM: define x86_fp80 @my_powl
+// LLVM:   %{{.+}} = call x86_fp80 @powl(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+// LLVM: }


### PR DESCRIPTION
This PR adds the following operations for the builtin binary fp2fp functions:

  - `cir.copysign` for `__builtin_copysign`;
  - `cir.fmax` for `__builtin_fmax`;
  - `cir.fmin` for `__builtin_fmin`;
  - `cir.fmod` for `__builtin_fmod`;
  - `cir.pow` for `__builtin_pow`.

This PR also includes CIRGen support for these new operations.