### PR TITLE
[CIR][CodeGen] Support trailing_zeros for constant string literals

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -153,15 +153,24 @@ public:
                             unsigned size = 0) {
     unsigned finalSize = size ? size : str.size();
 
+    size_t lastNonZeroPos = str.find_last_not_of('\0');
     // If the string is full of null bytes, emit a #cir.zero rather than
     // a #cir.const_array.
-    if (str.count('\0') == str.size()) {
+    if (lastNonZeroPos == llvm::StringRef::npos) {
       auto arrayTy = mlir::cir::ArrayType::get(getContext(), eltTy, finalSize);
       return getZeroAttr(arrayTy);
     }
-
-    auto arrayTy = mlir::cir::ArrayType::get(getContext(), eltTy, finalSize);
-    return getConstArray(mlir::StringAttr::get(str, arrayTy), arrayTy);
+    int trailingZerosNum =
+        finalSize > lastNonZeroPos ? finalSize - lastNonZeroPos - 1 : 0;
+    auto truncatedArrayTy = mlir::cir::ArrayType::get(
+        getContext(), eltTy, finalSize - trailingZerosNum);
+    auto fullArrayTy =
+        mlir::cir::ArrayType::get(getContext(), eltTy, finalSize);
+    return mlir::cir::ConstArrayAttr::get(
+        getContext(), fullArrayTy,
+        mlir::StringAttr::get(str.drop_back(trailingZerosNum),
+                              truncatedArrayTy),
+        trailingZerosNum);
   }
 
   mlir::cir::ConstArrayAttr getConstArray(mlir::Attribute attrs,

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -40,7 +40,7 @@ void local_stringlit() {
   const char *s = "whatnow";
 }
 
-// CHECK: cir.global "private" constant internal @".str" = #cir.const_array<"whatnow\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
+// CHECK: cir.global "private" constant internal @".str" = #cir.const_array<"whatnow" : !cir.array<!s8i x 7>, trailing_zeros> : !cir.array<!s8i x 8> {alignment = 1 : i64}
 // CHECK: cir.func @_Z15local_stringlitv()
 // CHECK-NEXT:  %0 = cir.alloca !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>, ["s", init] {alignment = 8 : i64}
 // CHECK-NEXT:  %1 = cir.get_global @".str" : !cir.ptr<!cir.array<!s8i x 8>>

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -7,7 +7,9 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 char string[] = "whatnow";
-// CHECK: cir.global external @string = #cir.const_array<"whatnow\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8>
+// CHECK: cir.global external @string = #cir.const_array<"whatnow" : !cir.array<!s8i x 7>, trailing_zeros> : !cir.array<!s8i x 8>
+char big_string[100000] = "123";
+// CHECK: cir.global external @big_string = #cir.const_array<"123" : !cir.array<!s8i x 3>, trailing_zeros> : !cir.array<!s8i x 100000>
 int sint[] = {123, 456, 789};
 // CHECK: cir.global external @sint = #cir.const_array<[#cir.int<123> : !s32i, #cir.int<456> : !s32i, #cir.int<789> : !s32i]> : !cir.array<!s32i x 3>
 int filler_sint[4] = {1, 2}; // Ensure missing elements are zero-initialized.
@@ -41,7 +43,7 @@ struct {
   char y[3];
   char z[3];
 } nestedString = {"1", "", "\0"};
-// CHECK: cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>}>
+// CHECK: cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1" : !cir.array<!s8i x 1>, trailing_zeros> : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>}>
 
 struct {
   char *name;

--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -47,12 +47,12 @@ int use_func() { return func<int>(); }
 // CHECK-NEXT: cir.global external @w = #cir.fp<4.300000e+00> : !cir.double
 // CHECK-NEXT: cir.global external @x = #cir.int<51> : !s8i
 // CHECK-NEXT: cir.global external @rgb = #cir.const_array<[#cir.int<0> : !u8i, #cir.int<233> : !u8i, #cir.int<33> : !u8i]> : !cir.array<!u8i x 3>
-// CHECK-NEXT: cir.global external @alpha = #cir.const_array<"abc\00" : !cir.array<!s8i x 4>> : !cir.array<!s8i x 4>
+// CHECK-NEXT: cir.global external @alpha = #cir.const_array<"abc" : !cir.array<!s8i x 3>, trailing_zeros> : !cir.array<!s8i x 4>
 
-// CHECK-NEXT: cir.global "private" constant internal @".str" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
+// CHECK-NEXT: cir.global "private" constant internal @".str" = #cir.const_array<"example" : !cir.array<!s8i x 7>, trailing_zeros> : !cir.array<!s8i x 8> {alignment = 1 : i64}
 // CHECK-NEXT: cir.global external @s = #cir.global_view<@".str"> : !cir.ptr<!s8i>
 
-// CHECK-NEXT: cir.global "private" constant internal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
+// CHECK-NEXT: cir.global "private" constant internal @".str1" = #cir.const_array<"example1" : !cir.array<!s8i x 8>, trailing_zeros> : !cir.array<!s8i x 9> {alignment = 1 : i64}
 // CHECK-NEXT: cir.global external @s1 = #cir.global_view<@".str1"> : !cir.ptr<!s8i>
 
 // CHECK-NEXT: cir.global external @s2 = #cir.global_view<@".str"> : !cir.ptr<!s8i>
@@ -91,7 +91,7 @@ int use_func() { return func<int>(); }
 
 
 char string[] = "whatnow";
-// CHECK: cir.global external @string = #cir.const_array<"whatnow\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8>
+// CHECK: cir.global external @string = #cir.const_array<"whatnow" : !cir.array<!s8i x 7>, trailing_zeros> : !cir.array<!s8i x 8>
 unsigned uint[] = {255};
 // CHECK: cir.global external @uint = #cir.const_array<[#cir.int<255> : !u32i]> : !cir.array<!u32i x 1>
 short sshort[] = {11111, 22222};

--- a/clang/test/CIR/CodeGen/hello.c
+++ b/clang/test/CIR/CodeGen/hello.c
@@ -8,7 +8,7 @@ int main (void) {
 }
 
 // CHECK: cir.func private @printf(!cir.ptr<!s8i>, ...) -> !s32i
-// CHECK: cir.global "private" constant internal @".str" = #cir.const_array<"Hello, world!\0A\00" : !cir.array<!s8i x 15>> : !cir.array<!s8i x 15> {alignment = 1 : i64}
+// CHECK: cir.global "private" constant internal @".str" = #cir.const_array<"Hello, world!\0A" : !cir.array<!s8i x 14>, trailing_zeros> : !cir.array<!s8i x 15> {alignment = 1 : i64}
 // CHECK: cir.func @main() -> !s32i
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.get_global @printf : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s8i>, ...)>>

--- a/clang/test/CIR/CodeGen/static-vars.c
+++ b/clang/test/CIR/CodeGen/static-vars.c
@@ -46,5 +46,5 @@ void func3(void) {
 // Should match type size in bytes between var and initializer.
 void func4(void) {
   static char string[] = "Hello";
-  // CHECK-DAG: cir.global "private" internal @func4.string = #cir.const_array<"Hello\00" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6>
+  // CHECK-DAG: cir.global "private" internal @func4.string = #cir.const_array<"Hello" : !cir.array<!s8i x 5>, trailing_zeros> : !cir.array<!s8i x 6> {alignment = 1 : i64}
 }


### PR DESCRIPTION
The patch resolves [issue #248](https://github.com/llvm/clangir/issues/248). It can be considered a subsequent patch to [#373](https://github.com/llvm/clangir/pull/373), where the case of empty strings was processed.

The new patch adds processing for non-empty strings that may contain trailing zeros, such as:
```
char big_string[100000] = "123";
```
That is converted to
```
@big_string = #cir.const_array<"123" : !cir.array<!s8i x 3>, trailing_zeros> : !cir.array<!s8i x 100000>
```

It's worth noting that ordinary strings that are terminated with a single zero also get the trailing zeros, for instance
```
char string[] = "whatnow";
```
Is converted to
```
@string = #cir.const_array<"whatnow" : !cir.array<!s8i x 7>, trailing_zeros> : !cir.array<!s8i x 8>
```