### PR TITLE
[CIR][CodeGen][Bugfix] store fptr of a function with no args

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -787,14 +787,13 @@ static LValue buildFunctionDeclLValue(CIRGenFunction &CGF, const Expr *E,
   mlir::Value addr = CGF.getBuilder().create<mlir::cir::GetGlobalOp>(
       loc, ptrTy, funcOp.getSymName());
 
-  if (funcOp.getFunctionType() != CGF.CGM.getTypes().ConvertType(FD->getType())) {
+  if (funcOp.getFunctionType() !=
+      CGF.CGM.getTypes().ConvertType(FD->getType())) {
     fnTy = CGF.CGM.getTypes().ConvertType(FD->getType());
     ptrTy = mlir::cir::PointerType::get(CGF.getBuilder().getContext(), fnTy);
 
     addr = CGF.getBuilder().create<mlir::cir::CastOp>(
-              addr.getLoc(),
-              ptrTy,
-              mlir::cir::CastKind::bitcast, addr);
+        addr.getLoc(), ptrTy, mlir::cir::CastKind::bitcast, addr);
   }
 
   return CGF.makeAddrLValue(Address(addr, fnTy, align), E->getType(),

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -782,10 +782,21 @@ static LValue buildFunctionDeclLValue(CIRGenFunction &CGF, const Expr *E,
   auto loc = CGF.getLoc(E->getSourceRange());
   CharUnits align = CGF.getContext().getDeclAlign(FD);
 
-  auto fnTy = funcOp.getFunctionType();
+  mlir::Type fnTy = funcOp.getFunctionType();
   auto ptrTy = mlir::cir::PointerType::get(CGF.getBuilder().getContext(), fnTy);
-  auto addr = CGF.getBuilder().create<mlir::cir::GetGlobalOp>(
+  mlir::Value addr = CGF.getBuilder().create<mlir::cir::GetGlobalOp>(
       loc, ptrTy, funcOp.getSymName());
+
+  if (funcOp.getFunctionType() != CGF.CGM.getTypes().ConvertType(FD->getType())) {
+    fnTy = CGF.CGM.getTypes().ConvertType(FD->getType());
+    ptrTy = mlir::cir::PointerType::get(CGF.getBuilder().getContext(), fnTy);
+
+    addr = CGF.getBuilder().create<mlir::cir::CastOp>(
+              addr.getLoc(),
+              ptrTy,
+              mlir::cir::CastKind::bitcast, addr);
+  }
+
   return CGF.makeAddrLValue(Address(addr, fnTy, align), E->getType(),
                             AlignmentSource::Decl);
 }

--- a/clang/test/CIR/CodeGen/store.c
+++ b/clang/test/CIR/CodeGen/store.c
@@ -14,3 +14,17 @@ void foo(void) {
 // CHECK-NEXT:   cir.store %2, %0 : !s32i, !cir.ptr<!s32i>
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }
+
+typedef int (*fn_t)();
+int get42() { return 42; }
+
+void storeNoArgsFn() {
+  fn_t f = get42;
+}
+
+// CHECK:  cir.func {{.*@storeNoArgsFn}}
+// CHECK:    %0 = cir.alloca
+// CHECK:    %1 = cir.get_global @get42 : !cir.ptr<!cir.func<!s32i ()>>
+// CHECK:    %2 = cir.cast(bitcast, %1 : !cir.ptr<!cir.func<!s32i ()>>), !cir.ptr<!cir.func<!s32i (...)>>
+// CHECK:    cir.store %2, %0 : !cir.ptr<!cir.func<!s32i (...)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (...)>>>
+


### PR DESCRIPTION
This PR fixes the next bug showed in the example below:
```
typedef int (*fn_t)();
int get42() { return 42; }

void foo() {
  fn_t f = get42;
}
```

The function type `fn_t`  is generated as the variadic one due to no arg types listed, this is the `codegen` feature. And once we store the function pointer to a real function - a pointer to `get42` here has the expected `i32 ()*` type - we get a verification error, so `bitcast` is needed. The original `codegen` doesn't have it because of opaque pointers used, and had the `bitcast` earlier, long time ago:
```
%f = alloca i32 (...)*
store i32 (...)* bitcast (i32 ()* @get42 to i32 (...)*), i32 (...)** %f
```

