### PR TITLE
[CIR][CodeGen][Bugfix] fixes volatile structs copy

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3100,7 +3100,8 @@ def CatchParamOp : CIR_Op<"catch_param"> {
 
 def CopyOp : CIR_Op<"copy", [SameTypeOperands]> {
   let arguments = (ins Arg<CIR_PointerType, "", [MemWrite]>:$dst,
-                       Arg<CIR_PointerType, "", [MemRead]>:$src);
+                       Arg<CIR_PointerType, "", [MemRead]>:$src,
+                       UnitAttr:$is_volatile);
   let summary = "Copies contents from a CIR pointer to another";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.copy` will copy the memory
@@ -3118,7 +3119,8 @@ def CopyOp : CIR_Op<"copy", [SameTypeOperands]> {
     ```
   }];
 
-  let assemblyFormat = "$src `to` $dst attr-dict `:` qualified(type($dst))";
+  let assemblyFormat = [{$src `to` $dst (`volatile` $is_volatile^)?
+                        attr-dict `:` qualified(type($dst)) }];
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -584,8 +584,9 @@ public:
   //
 
   /// Create a copy with inferred length.
-  mlir::cir::CopyOp createCopy(mlir::Value dst, mlir::Value src) {
-    return create<mlir::cir::CopyOp>(dst.getLoc(), dst, src);
+  mlir::cir::CopyOp createCopy(mlir::Value dst, mlir::Value src,
+                               bool isVolatile=false) {
+    return create<mlir::cir::CopyOp>(dst.getLoc(), dst, src, isVolatile);
   }
 
   /// Create a break operation.

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -585,7 +585,7 @@ public:
 
   /// Create a copy with inferred length.
   mlir::cir::CopyOp createCopy(mlir::Value dst, mlir::Value src,
-                               bool isVolatile=false) {
+                               bool isVolatile = false) {
     return create<mlir::cir::CopyOp>(dst.getLoc(), dst, src, isVolatile);
   }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -437,7 +437,7 @@ public:
     const mlir::Value length = rewriter.create<mlir::LLVM::ConstantOp>(
         op.getLoc(), rewriter.getI32Type(), op.getLength());
     rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyOp>(
-        op, adaptor.getDst(), adaptor.getSrc(), length, /*isVolatile=*/false);
+        op, adaptor.getDst(), adaptor.getSrc(), length, op.getIsVolatile());
     return mlir::success();
   }
 };

--- a/clang/test/CIR/CodeGen/agg-copy.c
+++ b/clang/test/CIR/CodeGen/agg-copy.c
@@ -83,3 +83,12 @@ void foo6(A* a1) {
 // CHECK:   [[TMP2:%.*]] = cir.load deref [[TMP0]] : !cir.ptr<!cir.ptr<!ty_22A22>>, !cir.ptr<!ty_22A22>
 // CHECK:   cir.copy [[TMP2]] to [[TMP1]] : !cir.ptr<!ty_22A22>
 }
+
+volatile A vol_a;
+A foo7() {
+  return vol_a;
+}
+// CHECK: cir.func {{.*@foo7}}
+// CHECK:   %0 = cir.alloca
+// CHECK:   %1 = cir.get_global @vol_a
+// CHECK:   cir.copy %1 to %0 volatile


### PR DESCRIPTION
This PR fixes a fail on `llvm_unreachable`  for the next case:
``` 
volatile A vol_a;
A foo7() {
  return vol_a;
}
```
Basically, it's just a copy-pasta from the original `code-gen`. 
Also, I added the `isVolatile` attribute for the `cit.copy` operation