### PR TITLE
[CIR][IR][NFC] Fix CallOp builder with void return

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2816,7 +2816,7 @@ def CallOp : CIR_CallOp<"call"> {
   }];
 
   let arguments = commonArgs;
-  let results = (outs Variadic<CIR_AnyType>);
+  let results = (outs Optional<CIR_AnyType>:$result);
 
   let builders = [
     OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
@@ -2837,13 +2837,15 @@ def CallOp : CIR_CallOp<"call"> {
               CArg<"ValueRange", "{}">:$operands), [{
       $_state.addOperands(operands);
       $_state.addAttribute("callee", callee);
-      $_state.addTypes(resType);
+      if (resType && !resType.isa<VoidType>())
+        $_state.addTypes(resType);
     }]>,
     OpBuilder<(ins "SymbolRefAttr":$callee,
               CArg<"ValueRange", "{}">:$operands), [{
       $_state.addOperands(operands);
       $_state.addAttribute("callee", callee);
-    }]>];
+    }]>
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -203,7 +203,7 @@ CIRGenFunction::buildCoroAllocBuiltinCall(mlir::Location loc) {
     fnOp = cast<mlir::cir::FuncOp>(builtin);
 
   return builder.create<mlir::cir::CallOp>(
-      loc, fnOp, mlir::ValueRange{CurCoro.Data->CoroId.getResult(0)});
+      loc, fnOp, mlir::ValueRange{CurCoro.Data->CoroId.getResult()});
 }
 
 mlir::cir::CallOp
@@ -225,7 +225,7 @@ CIRGenFunction::buildCoroBeginBuiltinCall(mlir::Location loc,
 
   return builder.create<mlir::cir::CallOp>(
       loc, fnOp,
-      mlir::ValueRange{CurCoro.Data->CoroId.getResult(0), coroframeAddr});
+      mlir::ValueRange{CurCoro.Data->CoroId.getResult(), coroframeAddr});
 }
 
 mlir::cir::CallOp CIRGenFunction::buildCoroEndBuiltinCall(mlir::Location loc,
@@ -273,7 +273,7 @@ CIRGenFunction::buildCoroutineBody(const CoroutineBodyStmt &S) {
 
   auto storeAddr = coroFrame.getPointer();
   builder.CIRBaseBuilderTy::createStore(openCurlyLoc, nullPtrCst, storeAddr);
-  builder.create<mlir::cir::IfOp>(openCurlyLoc, coroAlloc.getResult(0),
+  builder.create<mlir::cir::IfOp>(openCurlyLoc, coroAlloc.getResult(),
                                   /*withElseRegion=*/false,
                                   /*thenBuilder=*/
                                   [&](mlir::OpBuilder &b, mlir::Location loc) {
@@ -287,7 +287,7 @@ CIRGenFunction::buildCoroutineBody(const CoroutineBodyStmt &S) {
       buildCoroBeginBuiltinCall(
           openCurlyLoc,
           builder.create<mlir::cir::LoadOp>(openCurlyLoc, allocaTy, storeAddr))
-          .getResult(0);
+          .getResult();
 
   // Handle allocation failure if 'ReturnStmtOnAllocFailure' was provided.
   if (auto *RetOnAllocFailure = S.getReturnStmtOnAllocFailure())

--- a/clang/lib/CIR/Dialect/Transforms/IdiomRecognizer.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/IdiomRecognizer.cpp
@@ -104,7 +104,7 @@ bool IdiomRecognizerPass::raiseStdFind(CallOp call) {
   CIRBaseBuilderTy builder(getContext());
   builder.setInsertionPointAfter(call.getOperation());
   auto findOp = builder.create<mlir::cir::StdFindOp>(
-      call.getLoc(), call.getResult(0).getType(), call.getCalleeAttr(),
+      call.getLoc(), call.getResult().getType(), call.getCalleeAttr(),
       call.getOperand(0), call.getOperand(1), call.getOperand(2));
 
   call.replaceAllUsesWith(findOp);
@@ -140,7 +140,7 @@ bool IdiomRecognizerPass::raiseIteratorBeginEnd(CallOp call) {
   if (!callExprAttr)
     return false;
 
-  if (!isIteratorLikeType(call.getResult(0).getType()))
+  if (!isIteratorLikeType(call.getResult().getType()))
     return false;
 
   // First argument is the container "this" pointer.
@@ -154,13 +154,13 @@ bool IdiomRecognizerPass::raiseIteratorBeginEnd(CallOp call) {
     if (opts.emitRemarkFoundCalls())
       emitRemark(call.getLoc()) << "found call to begin() iterator";
     iterOp = builder.create<mlir::cir::IterBeginOp>(
-        call.getLoc(), call.getResult(0).getType(), call.getCalleeAttr(),
+        call.getLoc(), call.getResult().getType(), call.getCalleeAttr(),
         call.getOperand(0));
   } else if (callExprAttr.isIteratorEndCall()) {
     if (opts.emitRemarkFoundCalls())
       emitRemark(call.getLoc()) << "found call to end() iterator";
     iterOp = builder.create<mlir::cir::IterEndOp>(
-        call.getLoc(), call.getResult(0).getType(), call.getCalleeAttr(),
+        call.getLoc(), call.getResult().getType(), call.getCalleeAttr(),
         call.getOperand(0));
   } else {
     return false;

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -1265,7 +1265,7 @@ void LifetimeCheckPass::updatePointsTo(mlir::Value addr, mlir::Value data,
   if (auto callOp = dyn_cast<CallOp>(dataSrcOp)) {
     // iter = vector<T>::begin()
     getPmap()[addr].clear();
-    getPmap()[addr].insert(State::getLocalValue(callOp.getResult(0)));
+    getPmap()[addr].insert(State::getLocalValue(callOp.getResult()));
   }
 
   if (auto loadOp = dyn_cast<LoadOp>(dataSrcOp)) {

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
@@ -71,7 +71,7 @@ static mlir::Value buildDynamicCastAfterNullCheck(CIRBaseBuilderTy &builder,
       builder
           .create<mlir::cir::CallOp>(loc, dynCastFuncRef,
                                      builder.getVoidPtrTy(), dynCastFuncArgs)
-          .getResult(0);
+          .getResult();
 
   assert(castedPtr.getType().isa<mlir::cir::PointerType>() &&
          "the return value of __dynamic_cast should be a ptr");


### PR DESCRIPTION
One of the builders was adding a retun value to the CallOp when given a void return type. The expected behavior is to not add a return value. Two other minor fixes were added to the return value: its constraint was replaced from variadic to optional and it was assigned a name. This prevents function calls with multiple returns and facilitates access to the single return value, respectively.