### PR TITLE
[CIR] Add FuncAttrs to cir.calls

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -415,6 +415,57 @@ public:
                                  mlir::ValueRange value = {}) {
     return create<mlir::cir::YieldOp>(loc, value);
   }
+
+  mlir::cir::CallOp
+  createCallOp(mlir::Location loc,
+               mlir::SymbolRefAttr callee = mlir::SymbolRefAttr(),
+               mlir::Type returnType = mlir::cir::VoidType(),
+               mlir::ValueRange operands = mlir::ValueRange(),
+               mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
+
+    mlir::cir::CallOp callOp =
+        create<mlir::cir::CallOp>(loc, callee, returnType, operands);
+
+    if (extraFnAttr) {
+      callOp->setAttr("extra_attrs", extraFnAttr);
+    } else {
+      mlir::NamedAttrList empty;
+      callOp->setAttr("extra_attrs",
+                      mlir::cir::ExtraFuncAttributesAttr::get(
+                          getContext(), empty.getDictionary(getContext())));
+    }
+    return callOp;
+  }
+
+  mlir::cir::CallOp
+  createCallOp(mlir::Location loc, mlir::cir::FuncOp callee,
+               mlir::ValueRange operands = mlir::ValueRange(),
+               mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
+    return createCallOp(loc, mlir::SymbolRefAttr::get(callee),
+                        callee.getFunctionType().getReturnType(), operands,
+                        extraFnAttr);
+  }
+
+  mlir::cir::CallOp
+  createIndirectCallOp(mlir::Location loc, mlir::Value ind_target,
+                       mlir::cir::FuncType fn_type,
+                       mlir::ValueRange operands = mlir::ValueRange(),
+                       mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
+
+    llvm::SmallVector<mlir::Value, 4> resOperands({ind_target});
+    resOperands.append(operands.begin(), operands.end());
+
+    return createCallOp(loc, mlir::SymbolRefAttr(), fn_type.getReturnType(),
+                        resOperands, extraFnAttr);
+  }
+
+  mlir::cir::CallOp
+  createCallOp(mlir::Location loc, mlir::SymbolRefAttr callee,
+               mlir::ValueRange operands = mlir::ValueRange(),
+               mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
+    return createCallOp(loc, callee, mlir::cir::VoidType(), operands,
+                        extraFnAttr);
+  }
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2785,6 +2785,7 @@ class CIR_CallOp<string mnemonic, list<Trait> extra_traits = []> :
   dag commonArgs = (ins
     OptionalAttr<FlatSymbolRefAttr>:$callee,
     Variadic<CIR_AnyType>:$arg_ops,
+    ExtraFuncAttr:$extra_attrs,
     OptionalAttr<ASTCallExprInterface>:$ast
   );
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2821,12 +2821,16 @@ def CallOp : CIR_CallOp<"call"> {
   let arguments = commonArgs;
   let results = (outs Optional<CIR_AnyType>:$result);
 
+  let skipDefaultBuilders = 1;
+
   let builders = [
-    OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
+    OpBuilder<(ins "SymbolRefAttr":$callee, "mlir::Type":$resType,
+              CArg<"ValueRange", "{}">:$operands), [{
       $_state.addOperands(operands);
-      $_state.addAttribute("callee", SymbolRefAttr::get(callee));
-      if (!callee.getFunctionType().isVoid())
-        $_state.addTypes(callee.getFunctionType().getReturnType());
+      if (callee)
+        $_state.addAttribute("callee", callee);
+      if (resType && !resType.isa<VoidType>())
+        $_state.addTypes(resType);
     }]>,
     OpBuilder<(ins "Value":$ind_target,
                "FuncType":$fn_type,
@@ -2835,18 +2839,6 @@ def CallOp : CIR_CallOp<"call"> {
       $_state.addOperands(operands);
       if (!fn_type.isVoid())
         $_state.addTypes(fn_type.getReturnType());
-    }]>,
-    OpBuilder<(ins "SymbolRefAttr":$callee, "mlir::Type":$resType,
-              CArg<"ValueRange", "{}">:$operands), [{
-      $_state.addOperands(operands);
-      $_state.addAttribute("callee", callee);
-      if (resType && !resType.isa<VoidType>())
-        $_state.addTypes(resType);
-    }]>,
-    OpBuilder<(ins "SymbolRefAttr":$callee,
-              CArg<"ValueRange", "{}">:$operands), [{
-      $_state.addOperands(operands);
-      $_state.addAttribute("callee", callee);
     }]>
   ];
 }

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -179,10 +179,9 @@ mlir::cir::CallOp CIRGenFunction::buildCoroIDBuiltinCall(mlir::Location loc,
   } else
     fnOp = cast<mlir::cir::FuncOp>(builtin);
 
-  return builder.create<mlir::cir::CallOp>(
-      loc, fnOp,
-      mlir::ValueRange{builder.getUInt32(NewAlign, loc), nullPtr, nullPtr,
-                       nullPtr});
+  return builder.createCallOp(loc, fnOp,
+                              mlir::ValueRange{builder.getUInt32(NewAlign, loc),
+                                               nullPtr, nullPtr, nullPtr});
 }
 
 mlir::cir::CallOp
@@ -202,7 +201,7 @@ CIRGenFunction::buildCoroAllocBuiltinCall(mlir::Location loc) {
   } else
     fnOp = cast<mlir::cir::FuncOp>(builtin);
 
-  return builder.create<mlir::cir::CallOp>(
+  return builder.createCallOp(
       loc, fnOp, mlir::ValueRange{CurCoro.Data->CoroId.getResult()});
 }
 
@@ -223,7 +222,7 @@ CIRGenFunction::buildCoroBeginBuiltinCall(mlir::Location loc,
   } else
     fnOp = cast<mlir::cir::FuncOp>(builtin);
 
-  return builder.create<mlir::cir::CallOp>(
+  return builder.createCallOp(
       loc, fnOp,
       mlir::ValueRange{CurCoro.Data->CoroId.getResult(), coroframeAddr});
 }
@@ -244,7 +243,7 @@ mlir::cir::CallOp CIRGenFunction::buildCoroEndBuiltinCall(mlir::Location loc,
   } else
     fnOp = cast<mlir::cir::FuncOp>(builtin);
 
-  return builder.create<mlir::cir::CallOp>(
+  return builder.createCallOp(
       loc, fnOp, mlir::ValueRange{nullPtr, builder.getBool(false, loc)});
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1717,8 +1717,8 @@ void CIRGenModule::ReplaceUsesOfNonProtoTypeWithRealFunction(
       builder.setInsertionPoint(noProtoCallOp);
 
       // Patch call type with the real function type.
-      auto realCallOp = builder.create<mlir::cir::CallOp>(
-          noProtoCallOp.getLoc(), NewFn, noProtoCallOp.getOperands());
+      auto realCallOp = builder.createCallOp(noProtoCallOp.getLoc(), NewFn,
+                                             noProtoCallOp.getOperands());
 
       // Replace old no proto call with fixed call.
       noProtoCallOp.replaceAllUsesWith(realCallOp);

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2310,6 +2310,7 @@ verifyCallCommInSymbolUses(Operation *op, SymbolTableCollection &symbolTable) {
 
 static ::mlir::ParseResult parseCallCommon(
     ::mlir::OpAsmParser &parser, ::mlir::OperationState &result,
+    llvm::StringRef extraAttrsAttrName,
     llvm::function_ref<::mlir::ParseResult(::mlir::OpAsmParser &,
                                            ::mlir::OperationState &)>
         customOpHandler =
@@ -2344,6 +2345,23 @@ static ::mlir::ParseResult parseCallCommon(
     return ::mlir::failure();
   if (parser.parseRParen())
     return ::mlir::failure();
+
+  auto &builder = parser.getBuilder();
+  Attribute extraAttrs;
+  if (::mlir::succeeded(parser.parseOptionalKeyword("extra"))) {
+    if (parser.parseLParen().failed())
+      return failure();
+    if (parser.parseAttribute(extraAttrs).failed())
+      return failure();
+    if (parser.parseRParen().failed())
+      return failure();
+  } else {
+    NamedAttrList empty;
+    extraAttrs = mlir::cir::ExtraFuncAttributesAttr::get(
+        builder.getContext(), empty.getDictionary(builder.getContext()));
+  }
+  result.addAttribute(extraAttrsAttrName, extraAttrs);
+
   if (parser.parseOptionalAttrDict(result.attributes))
     return ::mlir::failure();
   if (parser.parseColon())
@@ -2364,6 +2382,7 @@ static ::mlir::ParseResult parseCallCommon(
 void printCallCommon(
     Operation *op, mlir::Value indirectCallee, mlir::FlatSymbolRefAttr flatSym,
     ::mlir::OpAsmPrinter &state,
+    ::mlir::cir::ExtraFuncAttributesAttr extraAttrs,
     llvm::function_ref<void()> customOpHandler = []() {}) {
   state << ' ';
 
@@ -2379,13 +2398,20 @@ void printCallCommon(
   state << "(";
   state << ops;
   state << ")";
-  llvm::SmallVector<::llvm::StringRef, 2> elidedAttrs;
+
+  llvm::SmallVector<::llvm::StringRef, 4> elidedAttrs;
   elidedAttrs.push_back("callee");
   elidedAttrs.push_back("ast");
+  elidedAttrs.push_back("extra_attrs");
   state.printOptionalAttrDict(op->getAttrs(), elidedAttrs);
   state << ' ' << ":";
   state << ' ';
   state.printFunctionalType(op->getOperands().getTypes(), op->getResultTypes());
+  if (!extraAttrs.getElements().empty()) {
+    state << " extra(";
+    state.printAttributeWithoutType(extraAttrs);
+    state << ")";
+  }
 }
 
 LogicalResult
@@ -2395,12 +2421,14 @@ cir::CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
 ::mlir::ParseResult CallOp::parse(::mlir::OpAsmParser &parser,
                                   ::mlir::OperationState &result) {
-  return parseCallCommon(parser, result);
+
+  return parseCallCommon(parser, result, getExtraAttrsAttrName(result.name));
 }
 
 void CallOp::print(::mlir::OpAsmPrinter &state) {
   mlir::Value indirectCallee = isIndirect() ? getIndirectCall() : nullptr;
-  printCallCommon(*this, indirectCallee, getCalleeAttr(), state);
+  printCallCommon(*this, indirectCallee, getCalleeAttr(), state,
+                  getExtraAttrs());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2457,7 +2485,7 @@ LogicalResult cir::TryCallOp::verify() { return mlir::success(); }
 ::mlir::ParseResult TryCallOp::parse(::mlir::OpAsmParser &parser,
                                      ::mlir::OperationState &result) {
   return parseCallCommon(
-      parser, result,
+      parser, result, getExtraAttrsAttrName(result.name),
       [](::mlir::OpAsmParser &parser,
          ::mlir::OperationState &result) -> ::mlir::ParseResult {
         ::mlir::OpAsmParser::UnresolvedOperand exceptionRawOperands[1];
@@ -2499,7 +2527,8 @@ void TryCallOp::print(::mlir::OpAsmPrinter &state) {
   state << getExceptionInfo();
   state << ")";
   mlir::Value indirectCallee = isIndirect() ? getIndirectCall() : nullptr;
-  printCallCommon(*this, indirectCallee, getCalleeAttr(), state);
+  printCallCommon(*this, indirectCallee, getCalleeAttr(), state,
+                  getExtraAttrs());
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -317,8 +317,9 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
   // NOTE(cir): We don't know if the callee was already lowered, so we only
   // fetch the name from the callee, while the return type is fetch from the
   // lowering types manager.
-  CallOp _ = rewriter.create<CallOp>(loc, Caller.getCalleeAttr(),
-                                     IRFuncTy.getReturnType(), IRCallArgs);
+  CallOp callOp = rewriter.create<CallOp>(loc, Caller.getCalleeAttr(),
+                                          IRFuncTy.getReturnType(), IRCallArgs);
+  callOp.setExtraAttrsAttr(Caller.getExtraAttrs());
 
   assert(!::cir::MissingFeatures::vectorType());
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
@@ -36,7 +36,7 @@ static void buildBadCastCall(CIRBaseBuilderTy &builder, mlir::Location loc,
   // TODO(cir): set the calling convention to __cxa_bad_cast.
   assert(!MissingFeatures::setCallingConv());
 
-  builder.create<mlir::cir::CallOp>(loc, badCastFuncRef, mlir::ValueRange{});
+  builder.createCallOp(loc, badCastFuncRef, mlir::ValueRange{});
   builder.create<mlir::cir::UnreachableOp>(loc);
   builder.clearInsertionPoint();
 }
@@ -62,8 +62,8 @@ static mlir::Value buildDynamicCastAfterNullCheck(CIRBaseBuilderTy &builder,
   assert(!MissingFeatures::setCallingConv());
   mlir::Value castedPtr =
       builder
-          .create<mlir::cir::CallOp>(loc, dynCastFuncRef,
-                                     builder.getVoidPtrTy(), dynCastFuncArgs)
+          .createCallOp(loc, dynCastFuncRef, builder.getVoidPtrTy(),
+                        dynCastFuncArgs)
           .getResult();
 
   assert(castedPtr.getType().isa<mlir::cir::PointerType>() &&

--- a/clang/test/CIR/CodeGen/call-extra-attrs.cpp
+++ b/clang/test/CIR/CodeGen/call-extra-attrs.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+__attribute__((nothrow))
+int s0(int a, int b) {
+  int x = a + b;
+  return x;
+}
+
+__attribute__((noinline))
+int s1(int a, int b) {
+  return s0(a,b);
+}
+
+int s2(int a, int b) {
+  return s1(a, b);
+}
+
+// CIR: #fn_attr = #cir<extra({inline = #cir.inline<no>, nothrow = #cir.nothrow, optnone = #cir.optnone})>
+// CIR: #fn_attr1 = #cir<extra({nothrow = #cir.nothrow})>
+
+// CIR: cir.func @_Z2s0ii(%{{.*}}, %{{.*}}) -> {{.*}} extra(#fn_attr)
+// CIR: cir.func @_Z2s1ii(%{{.*}}, %{{.*}}) -> {{.*}} extra(#fn_attr)
+// CIR: cir.call @_Z2s0ii(%{{.*}}, %{{.*}}) : ({{.*}}, {{.*}}) -> {{.*}} extra(#fn_attr1)
+// CIR: cir.func @_Z2s2ii(%{{.*}}, %{{.*}}) -> {{.*}} extra(#fn_attr)
+// CHECK-NOT: cir.call @_Z2s1ii(%{{.*}}, %{{.*}}) : ({{.*}}, {{.*}}) -> {{.*}} extra(#fn_attr{{.*}}) 
+
+// LLVM: define i32 @_Z2s0ii(i32 %0, i32 %1) #[[#ATTR1:]]
+// LLVM: define i32 @_Z2s1ii(i32 %0, i32 %1) #[[#ATTR1:]]
+// LLVM: define i32 @_Z2s2ii(i32 %0, i32 %1) #[[#ATTR1:]]
+
+// LLVM: attributes #[[#ATTR1]] = {{.*}} noinline nounwind optnone


### PR DESCRIPTION
Some function attributes are also callsite attributes, for instance, nothrow. This means they are going to show up in both. We don't support that just yet, hence the PR.

CIR has an attribute `ExtraFuncAttr` that we current use as part of `FuncOp`, see CIROps.td. This attribute also needs to be added to `CallOp` and `TryCalOp`.

Right now, In `CIRGenCall.cpp: AddAttributesFromFunctionProtoType` fills in `FuncAttrs`, but doesn't use it for anything. We should use the `FuncAttrs` result to populate constructing a `ExtraFuncAttr` and add it to the aforementioned call operations.