### PR TITLE
[CIR][Passes] Add CallConvLowering pass skeleton

### DIFF
--- a/clang/include/clang/CIR/CIRToCIRPasses.h
+++ b/clang/include/clang/CIR/CIRToCIRPasses.h
@@ -34,7 +34,7 @@ mlir::LogicalResult runCIRToCIRPasses(
     llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
     llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
     llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
-    bool flattenCIR, bool emitMLIR);
+    bool flattenCIR, bool emitMLIR, bool enableCallConvLowering);
 
 } // namespace cir
 

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -38,6 +38,9 @@ std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createFlattenCFGPass();
 std::unique_ptr<Pass> createGotoSolverPass();
 
+/// Create a pass to lower ABI-independent function definitions/calls.
+std::unique_ptr<Pass> createCallConvLoweringPass();
+
 void populateCIRPreLoweringPasses(mlir::OpPassManager &pm);
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -149,4 +149,15 @@ def LibOpt : Pass<"cir-lib-opt"> {
   ];
 }
 
+def CallConvLowering : Pass<"cir-call-conv-lowering"> {
+  let summary = "Handle calling conventions for CIR functions";
+  let description = [{
+    This pass lowers CIR function definitions and calls according to the
+    calling conventions for the target architecture. This pass is necessary
+    to properly lower CIR functions to LLVM IR.
+  }];
+  let constructor = "mlir::createCallConvLoweringPass()";
+  let dependentDialects = ["mlir::cir::CIRDialect"];
+}
+
 #endif // MLIR_DIALECT_CIR_PASSES

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2934,6 +2934,10 @@ def fclangir_lib_opt : Flag<["-"], "fclangir-lib-opt">,
   Visibility<[ClangOption, CC1Option]>, Group<f_Group>,
   Alias<fclangir_lib_opt_EQ>,
   HelpText<"Enable C/C++ library based optimizations">;
+def fclangir_call_conv_lowering : Flag<["-"], "fclangir-call-conv-lowering">,
+  Visibility<[ClangOption, CC1Option]>, Group<f_Group>,
+  HelpText<"Enable ClangIR calling convention lowering">,
+  MarshallingInfoFlag<FrontendOpts<"ClangIREnableCallConvLowering">>;
 
 def clangir_disable_passes : Flag<["-"], "clangir-disable-passes">,
   Visibility<[ClangOption, CC1Option]>,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -444,6 +444,9 @@ public:
   // Enable Clang IR library optimizations
   unsigned ClangIRLibOpt : 1;
 
+  // Enable Clang IR call conv lowering pass.
+  unsigned ClangIREnableCallConvLowering : 1;
+
   CodeCompleteOptions CodeCompleteOpts;
 
   /// Specifies the output format of the AST.

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -25,7 +25,7 @@ mlir::LogicalResult runCIRToCIRPasses(
     llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
     llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
     llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
-    bool flattenCIR, bool emitMLIR) {
+    bool flattenCIR, bool emitMLIR, bool enableCallConvLowering) {
   mlir::PassManager pm(mlirCtx);
   pm.addPass(mlir::createMergeCleanupsPass());
 
@@ -64,6 +64,12 @@ mlir::LogicalResult runCIRToCIRPasses(
   }
 
   pm.addPass(mlir::createLoweringPreparePass(&astCtx));
+
+  // FIXME(cir): This pass should run by default, but it is lacking support for
+  // several code bits. Once it's more mature, we should fix this.
+  if (enableCallConvLowering)
+    pm.addPass(mlir::createCallConvLoweringPass());
+
   if (flattenCIR)
     mlir::populateCIRPreLoweringPasses(pm);
 

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_clang_library(MLIRCIRTransforms
   FlattenCFG.cpp
   GotoSolver.cpp
   SCFPrepare.cpp
+  CallConvLowering.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -1,0 +1,76 @@
+//===- CallConvLowering.cpp - Rewrites functions according to call convs --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+
+#define GEN_PASS_DEF_CALLCONVLOWERING
+#include "clang/CIR/Dialect/Passes.h.inc"
+
+namespace mlir {
+namespace cir {
+
+//===----------------------------------------------------------------------===//
+// Rewrite Patterns
+//===----------------------------------------------------------------------===//
+
+struct CallConvLoweringPattern : public OpRewritePattern<FuncOp> {
+  using OpRewritePattern<FuncOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(FuncOp op,
+                                PatternRewriter &rewriter) const final {
+    if (!op.getAst())
+      return op.emitError("function has no AST information");
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+struct CallConvLoweringPass
+    : ::impl::CallConvLoweringBase<CallConvLoweringPass> {
+  using CallConvLoweringBase::CallConvLoweringBase;
+
+  void runOnOperation() override;
+  StringRef getArgument() const override { return "cir-call-conv-lowering"; };
+};
+
+void populateCallConvLoweringPassPatterns(RewritePatternSet &patterns) {
+  patterns.add<CallConvLoweringPattern>(patterns.getContext());
+}
+
+void CallConvLoweringPass::runOnOperation() {
+
+  // Collect rewrite patterns.
+  RewritePatternSet patterns(&getContext());
+  populateCallConvLoweringPassPatterns(patterns);
+
+  // Collect operations to be considered by the pass.
+  SmallVector<Operation *, 16> ops;
+  getOperation()->walk([&](FuncOp op) { ops.push_back(op); });
+
+  // Configure rewrite to ignore new ops created during the pass.
+  GreedyRewriteConfig config;
+  config.strictMode = GreedyRewriteStrictness::ExistingOps;
+
+  // Apply patterns.
+  if (failed(applyOpPatternsAndFold(ops, std::move(patterns), config)))
+    signalPassFailure();
+}
+
+} // namespace cir
+
+std::unique_ptr<Pass> createCallConvLoweringPass() {
+  return std::make_unique<cir::CallConvLoweringPass>();
+}
+
+} // namespace mlir

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -187,7 +187,8 @@ public:
               feOptions.ClangIRIdiomRecognizer, idiomRecognizerOpts,
               feOptions.ClangIRLibOpt, libOptOpts, passOptParsingFailure,
               action == CIRGenAction::OutputType::EmitCIRFlat,
-              action == CIRGenAction::OutputType::EmitMLIR)
+              action == CIRGenAction::OutputType::EmitMLIR,
+              feOptions.ClangIREnableCallConvLowering)
               .failed()) {
         if (!passOptParsingFailure.empty())
           diagnosticsEngine.Report(diag::err_drv_cir_pass_opt_parsing)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4971,6 +4971,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_clangir_disable_passes))
     CmdArgs.push_back("-clangir-disable-passes");
 
+  if (Args.hasArg(options::OPT_fclangir_call_conv_lowering))
+    CmdArgs.push_back("-fclangir-call-conv-lowering");
+
   // ClangIR lib opt requires idiom recognizer.
   if (Args.hasArg(options::OPT_fclangir_lib_opt,
                   options::OPT_fclangir_lib_opt_EQ)) {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2932,6 +2932,9 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_clangir_verify_diagnostics))
     Opts.ClangIRVerifyDiags = true;
 
+  if (Args.hasArg(OPT_fclangir_call_conv_lowering))
+    Opts.ClangIREnableCallConvLowering = true;
+
   if (const Arg *A = Args.getLastArg(OPT_fclangir_lifetime_check,
                                      OPT_fclangir_lifetime_check_EQ)) {
     Opts.ClangIRLifetimeCheck = true;

--- a/clang/test/CIR/Transforms/Target/x86/x86-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/x86/x86-call-conv-lowering-pass.cpp
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-after=cir-call-conv-lowering %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// Just check if the pass is called for now.
+// CHECK: module


### PR DESCRIPTION
This patch adds a new CallConvLowering pass that aims to lower the calling conventions of the functions in the module. It also includes a new Clang command line option to enable it. Also, it is considered a part of the lowering prepare set of passes, as it is unlikely to be used elsewhere in the pipeline.

Since this will be dealing with ABI/Target-specific information, it requires AST info. For this reason, it can only be executed through the clang driver or cc1 tool for now as CIR does not encode AST info.

This pass is disabled by default and can be enabled by passing the flag `-fclangir-call-conv-lowering`. Once this pass is more mature, it should be enabled by default as a required step to lower to LLVM Dialect.