### PR TITLE
[CIR][LLVMLowering] Add LLVM lowering for unary fp2fp builtins

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3162,6 +3162,38 @@ private:
 };
 
 template <typename CIROp, typename LLVMOp>
+class CIRUnaryFPToFPBuiltinOpLowering
+    : public mlir::OpConversionPattern<CIROp> {
+public:
+  using mlir::OpConversionPattern<CIROp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(CIROp op,
+                  typename mlir::OpConversionPattern<CIROp>::OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto resTy = this->getTypeConverter()->convertType(op.getType());
+    rewriter.replaceOpWithNewOp<LLVMOp>(op, resTy, adaptor.getSrc());
+    return mlir::success();
+  }
+};
+
+using CIRCeilOpLowering =
+    CIRUnaryFPToFPBuiltinOpLowering<mlir::cir::CeilOp, mlir::LLVM::FCeilOp>;
+using CIRFloorOpLowering =
+    CIRUnaryFPToFPBuiltinOpLowering<mlir::cir::FloorOp, mlir::LLVM::FFloorOp>;
+using CIRFabsOpLowering =
+    CIRUnaryFPToFPBuiltinOpLowering<mlir::cir::FAbsOp, mlir::LLVM::FAbsOp>;
+using CIRNearbyintOpLowering =
+    CIRUnaryFPToFPBuiltinOpLowering<mlir::cir::NearbyintOp,
+                                    mlir::LLVM::NearbyintOp>;
+using CIRRintOpLowering =
+    CIRUnaryFPToFPBuiltinOpLowering<mlir::cir::RintOp, mlir::LLVM::RintOp>;
+using CIRRoundOpLowering =
+    CIRUnaryFPToFPBuiltinOpLowering<mlir::cir::RoundOp, mlir::LLVM::RoundOp>;
+using CIRTruncOpLowering =
+    CIRUnaryFPToFPBuiltinOpLowering<mlir::cir::TruncOp, mlir::LLVM::FTruncOp>;
+
+template <typename CIROp, typename LLVMOp>
 class CIRBinaryFPToFPBuiltinOpLowering
     : public mlir::OpConversionPattern<CIROp> {
 public:
@@ -3210,8 +3242,10 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRStackRestoreLowering, CIRUnreachableLowering, CIRTrapLowering,
       CIRInlineAsmOpLowering, CIRSetBitfieldLowering, CIRGetBitfieldLowering,
       CIRPrefetchLowering, CIRObjSizeOpLowering, CIRIsConstantOpLowering,
-      CIRCmpThreeWayOpLowering, CIRCopysignOpLowering, CIRFMaxOpLowering,
-      CIRFMinOpLowering>(converter, patterns.getContext());
+      CIRCmpThreeWayOpLowering, CIRCeilOpLowering, CIRFloorOpLowering,
+      CIRFAbsOpLowering, CIRNearbyintOpLowering, CIRRintOpLowering,
+      CIRRoundOpLowering, CIRTruncOpLowering, CIRCopysignOpLowering,
+      CIRFMaxOpLowering, CIRFMinOpLowering>(converter, patterns.getContext());
 }
 
 namespace {

--- a/clang/test/CIR/CodeGen/builtin-floating-point.c
+++ b/clang/test/CIR/CodeGen/builtin-floating-point.c
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -ffast-math -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t1.cir 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -triple aarch64-apple-darwin-macho -ffast-math -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t1.cir 2>&1 | FileCheck %s --check-prefix=AARCH64
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -ffast-math -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 // ceil
 
@@ -7,12 +9,20 @@ float my_ceilf(float f) {
   return __builtin_ceilf(f);
   // CHECK: cir.func @my_ceilf
   // CHECK: {{.+}} = cir.ceil {{.+}} : !cir.float
+
+  // LLVM: define float @my_ceilf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.ceil.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double my_ceil(double f) {
   return __builtin_ceil(f);
   // CHECK: cir.func @my_ceil
   // CHECK: {{.+}} = cir.ceil {{.+}} : !cir.double
+
+  // LLVM: define double @my_ceil(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.ceil.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_ceill(long double f) {
@@ -20,6 +30,10 @@ long double my_ceill(long double f) {
   // CHECK: cir.func @my_ceill
   // CHECK: {{.+}} = cir.ceil {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.ceil {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_ceill(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.ceil.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float ceilf(float);
@@ -30,12 +44,20 @@ float call_ceilf(float f) {
   return ceilf(f);
   // CHECK: cir.func @call_ceilf
   // CHECK: {{.+}} = cir.ceil {{.+}} : !cir.float
+
+  // LLVM: define float @call_ceilf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.ceil.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double call_ceil(double f) {
   return ceil(f);
   // CHECK: cir.func @call_ceil
   // CHECK: {{.+}} = cir.ceil {{.+}} : !cir.double
+
+  // LLVM: define double @call_ceil(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.ceil.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_ceill(long double f) {
@@ -43,6 +65,10 @@ long double call_ceill(long double f) {
   // CHECK: cir.func @call_ceill
   // CHECK: {{.+}} = cir.ceil {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.ceil {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_ceill(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.ceil.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // cos
@@ -51,12 +77,20 @@ float my_cosf(float f) {
   return __builtin_cosf(f);
   // CHECK: cir.func @my_cosf
   // CHECK: {{.+}} = cir.cos {{.+}} : !cir.float
+
+  // LLVM: define float @my_cosf(float %0)
+  // LLVM:   %{{.+}} = call float @cosf(float %{{.+}})
+  // LLVM: }
 }
 
 double my_cos(double f) {
   return __builtin_cos(f);
   // CHECK: cir.func @my_cos
   // CHECK: {{.+}} = cir.cos {{.+}} : !cir.double
+
+  // LLVM: define double @my_cos(double %0)
+  // LLVM:   %{{.+}} = call double @cos(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_cosl(long double f) {
@@ -64,6 +98,10 @@ long double my_cosl(long double f) {
   // CHECK: cir.func @my_cosl
   // CHECK: {{.+}} = cir.cos {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.cos {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_cosl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @cosl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float cosf(float);
@@ -74,12 +112,20 @@ float call_cosf(float f) {
   return cosf(f);
   // CHECK: cir.func @call_cosf
   // CHECK: {{.+}} = cir.cos {{.+}} : !cir.float
+
+  // LLVM: define float @call_cosf(float %0)
+  // LLVM:   %{{.+}} = call float @cosf(float %{{.+}})
+  // LLVM: }
 }
 
 double call_cos(double f) {
   return cos(f);
   // CHECK: cir.func @call_cos
   // CHECK: {{.+}} = cir.cos {{.+}} : !cir.double
+
+  // LLVM: define double @call_cos(double %0)
+  // LLVM:   %{{.+}} = call double @cos(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_cosl(long double f) {
@@ -87,6 +133,10 @@ long double call_cosl(long double f) {
   // CHECK: cir.func @call_cosl
   // CHECK: {{.+}} = cir.cos {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.cos {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_cosl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @cosl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // exp
@@ -95,12 +145,20 @@ float my_expf(float f) {
   return __builtin_expf(f);
   // CHECK: cir.func @my_expf
   // CHECK: {{.+}} = cir.exp {{.+}} : !cir.float
+
+  // LLVM: define float @my_expf(float %0)
+  // LLVM:   %{{.+}} = call float @expf(float %{{.+}})
+  // LLVM: }
 }
 
 double my_exp(double f) {
   return __builtin_exp(f);
   // CHECK: cir.func @my_exp
   // CHECK: {{.+}} = cir.exp {{.+}} : !cir.double
+
+  // LLVM: define double @my_exp(double %0)
+  // LLVM:   %{{.+}} = call double @exp(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_expl(long double f) {
@@ -108,6 +166,10 @@ long double my_expl(long double f) {
   // CHECK: cir.func @my_expl
   // CHECK: {{.+}} = cir.exp {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.exp {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_expl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @expl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float expf(float);
@@ -118,12 +180,20 @@ float call_expf(float f) {
   return expf(f);
   // CHECK: cir.func @call_expf
   // CHECK: {{.+}} = cir.exp {{.+}} : !cir.float
+
+  // LLVM: define float @call_expf(float %0)
+  // LLVM:   %{{.+}} = call float @expf(float %{{.+}})
+  // LLVM: }
 }
 
 double call_exp(double f) {
   return exp(f);
   // CHECK: cir.func @call_exp
   // CHECK: {{.+}} = cir.exp {{.+}} : !cir.double
+
+  // LLVM: define double @call_exp(double %0)
+  // LLVM:   %{{.+}} = call double @exp(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_expl(long double f) {
@@ -131,6 +201,10 @@ long double call_expl(long double f) {
   // CHECK: cir.func @call_expl
   // CHECK: {{.+}} = cir.exp {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.exp {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_expl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @expl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // exp2
@@ -139,12 +213,20 @@ float my_exp2f(float f) {
   return __builtin_exp2f(f);
   // CHECK: cir.func @my_exp2f
   // CHECK: {{.+}} = cir.exp2 {{.+}} : !cir.float
+
+  // LLVM: define float @my_exp2f(float %0)
+  // LLVM:   %{{.+}} = call float @exp2f(float %{{.+}})
+  // LLVM: }
 }
 
 double my_exp2(double f) {
   return __builtin_exp2(f);
   // CHECK: cir.func @my_exp2
   // CHECK: {{.+}} = cir.exp2 {{.+}} : !cir.double
+
+  // LLVM: define double @my_exp2(double %0)
+  // LLVM:   %{{.+}} = call double @exp2(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_exp2l(long double f) {
@@ -152,6 +234,10 @@ long double my_exp2l(long double f) {
   // CHECK: cir.func @my_exp2l
   // CHECK: {{.+}} = cir.exp2 {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.exp2 {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_exp2l(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @exp2l(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float exp2f(float);
@@ -162,12 +248,20 @@ float call_exp2f(float f) {
   return exp2f(f);
   // CHECK: cir.func @call_exp2f
   // CHECK: {{.+}} = cir.exp2 {{.+}} : !cir.float
+
+  // LLVM: define float @call_exp2f(float %0)
+  // LLVM:   %{{.+}} = call float @exp2f(float %{{.+}})
+  // LLVM: }
 }
 
 double call_exp2(double f) {
   return exp2(f);
   // CHECK: cir.func @call_exp2
   // CHECK: {{.+}} = cir.exp2 {{.+}} : !cir.double
+
+  // LLVM: define double @call_exp2(double %0)
+  // LLVM:   %{{.+}} = call double @exp2(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_exp2l(long double f) {
@@ -175,6 +269,10 @@ long double call_exp2l(long double f) {
   // CHECK: cir.func @call_exp2l
   // CHECK: {{.+}} = cir.exp2 {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.exp2 {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_exp2l(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @exp2l(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // floor
@@ -183,12 +281,20 @@ float my_floorf(float f) {
   return __builtin_floorf(f);
   // CHECK: cir.func @my_floorf
   // CHECK: {{.+}} = cir.floor {{.+}} : !cir.float
+
+  // LLVM: define float @my_floorf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.floor.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double my_floor(double f) {
   return __builtin_floor(f);
   // CHECK: cir.func @my_floor
   // CHECK: {{.+}} = cir.floor {{.+}} : !cir.double
+
+  // LLVM: define double @my_floor(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.floor.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_floorl(long double f) {
@@ -196,6 +302,10 @@ long double my_floorl(long double f) {
   // CHECK: cir.func @my_floorl
   // CHECK: {{.+}} = cir.floor {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.floor {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_floorl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.floor.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float floorf(float);
@@ -206,12 +316,20 @@ float call_floorf(float f) {
   return floorf(f);
   // CHECK: cir.func @call_floorf
   // CHECK: {{.+}} = cir.floor {{.+}} : !cir.float
+
+  // LLVM: define float @call_floorf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.floor.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double call_floor(double f) {
   return floor(f);
   // CHECK: cir.func @call_floor
   // CHECK: {{.+}} = cir.floor {{.+}} : !cir.double
+
+  // LLVM: define double @call_floor(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.floor.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_floorl(long double f) {
@@ -219,6 +337,10 @@ long double call_floorl(long double f) {
   // CHECK: cir.func @call_floorl
   // CHECK: {{.+}} = cir.floor {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.floor {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_floorl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.floor.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // log
@@ -227,12 +349,20 @@ float my_logf(float f) {
   return __builtin_logf(f);
   // CHECK: cir.func @my_logf
   // CHECK: {{.+}} = cir.log {{.+}} : !cir.float
+
+  // LLVM: define float @my_logf(float %0)
+  // LLVM:   %{{.+}} = call float @logf(float %{{.+}})
+  // LLVM: }
 }
 
 double my_log(double f) {
   return __builtin_log(f);
   // CHECK: cir.func @my_log
   // CHECK: {{.+}} = cir.log {{.+}} : !cir.double
+
+  // LLVM: define double @my_log(double %0)
+  // LLVM:   %{{.+}} = call double @log(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_logl(long double f) {
@@ -240,6 +370,10 @@ long double my_logl(long double f) {
   // CHECK: cir.func @my_logl
   // CHECK: {{.+}} = cir.log {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.log {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_logl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @logl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float logf(float);
@@ -250,12 +384,20 @@ float call_logf(float f) {
   return logf(f);
   // CHECK: cir.func @call_logf
   // CHECK: {{.+}} = cir.log {{.+}} : !cir.float
+
+  // LLVM: define float @call_logf(float %0)
+  // LLVM:   %{{.+}} = call float @logf(float %{{.+}})
+  // LLVM: }
 }
 
 double call_log(double f) {
   return log(f);
   // CHECK: cir.func @call_log
   // CHECK: {{.+}} = cir.log {{.+}} : !cir.double
+
+  // LLVM: define double @call_log(double %0)
+  // LLVM:   %{{.+}} = call double @log(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_logl(long double f) {
@@ -263,6 +405,10 @@ long double call_logl(long double f) {
   // CHECK: cir.func @call_logl
   // CHECK: {{.+}} = cir.log {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.log {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_logl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @logl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // log10
@@ -271,12 +417,20 @@ float my_log10f(float f) {
   return __builtin_log10f(f);
   // CHECK: cir.func @my_log10f
   // CHECK: {{.+}} = cir.log10 {{.+}} : !cir.float
+
+  // LLVM: define float @my_log10f(float %0)
+  // LLVM:   %{{.+}} = call float @log10f(float %{{.+}})
+  // LLVM: }
 }
 
 double my_log10(double f) {
   return __builtin_log10(f);
   // CHECK: cir.func @my_log10
   // CHECK: {{.+}} = cir.log10 {{.+}} : !cir.double
+
+  // LLVM: define double @my_log10(double %0)
+  // LLVM:   %{{.+}} = call double @log10(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_log10l(long double f) {
@@ -284,6 +438,10 @@ long double my_log10l(long double f) {
   // CHECK: cir.func @my_log10l
   // CHECK: {{.+}} = cir.log10 {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.log10 {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_log10l(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @log10l(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float log10f(float);
@@ -294,12 +452,20 @@ float call_log10f(float f) {
   return log10f(f);
   // CHECK: cir.func @call_log10f
   // CHECK: {{.+}} = cir.log10 {{.+}} : !cir.float
+
+  // LLVM: define float @call_log10f(float %0)
+  // LLVM:   %{{.+}} = call float @log10f(float %{{.+}})
+  // LLVM: }
 }
 
 double call_log10(double f) {
   return log10(f);
   // CHECK: cir.func @call_log10
   // CHECK: {{.+}} = cir.log10 {{.+}} : !cir.double
+
+  // LLVM: define double @call_log10(double %0)
+  // LLVM:   %{{.+}} = call double @log10(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_log10l(long double f) {
@@ -307,6 +473,10 @@ long double call_log10l(long double f) {
   // CHECK: cir.func @call_log10l
   // CHECK: {{.+}} = cir.log10 {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.log10 {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_log10l(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @log10l(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // log2
@@ -315,12 +485,20 @@ float my_log2f(float f) {
   return __builtin_log2f(f);
   // CHECK: cir.func @my_log2f
   // CHECK: {{.+}} = cir.log2 {{.+}} : !cir.float
+
+  // LLVM: define float @my_log2f(float %0)
+  // LLVM:   %{{.+}} = call float @log2f(float %{{.+}})
+  // LLVM: }
 }
 
 double my_log2(double f) {
   return __builtin_log2(f);
   // CHECK: cir.func @my_log2
   // CHECK: {{.+}} = cir.log2 {{.+}} : !cir.double
+
+  // LLVM: define double @my_log2(double %0)
+  // LLVM:   %{{.+}} = call double @log2(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_log2l(long double f) {
@@ -328,6 +506,10 @@ long double my_log2l(long double f) {
   // CHECK: cir.func @my_log2l
   // CHECK: {{.+}} = cir.log2 {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.log2 {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_log2l(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @log2l(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float log2f(float);
@@ -338,12 +520,20 @@ float call_log2f(float f) {
   return log2f(f);
   // CHECK: cir.func @call_log2f
   // CHECK: {{.+}} = cir.log2 {{.+}} : !cir.float
+
+  // LLVM: define float @call_log2f(float %0)
+  // LLVM:   %{{.+}} = call float @log2f(float %{{.+}})
+  // LLVM: }
 }
 
 double call_log2(double f) {
   return log2(f);
   // CHECK: cir.func @call_log2
   // CHECK: {{.+}} = cir.log2 {{.+}} : !cir.double
+
+  // LLVM: define double @call_log2(double %0)
+  // LLVM:   %{{.+}} = call double @log2(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_log2l(long double f) {
@@ -351,6 +541,10 @@ long double call_log2l(long double f) {
   // CHECK: cir.func @call_log2l
   // CHECK: {{.+}} = cir.log2 {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.log2 {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_log2l(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @log2l(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // nearbyint
@@ -359,12 +553,20 @@ float my_nearbyintf(float f) {
   return __builtin_nearbyintf(f);
   // CHECK: cir.func @my_nearbyintf
   // CHECK: {{.+}} = cir.nearbyint {{.+}} : !cir.float
+
+  // LLVM: define float @my_nearbyintf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.nearbyint.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double my_nearbyint(double f) {
   return __builtin_nearbyint(f);
   // CHECK: cir.func @my_nearbyint
   // CHECK: {{.+}} = cir.nearbyint {{.+}} : !cir.double
+
+  // LLVM: define double @my_nearbyint(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.nearbyint.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_nearbyintl(long double f) {
@@ -372,6 +574,10 @@ long double my_nearbyintl(long double f) {
   // CHECK: cir.func @my_nearbyintl
   // CHECK: {{.+}} = cir.nearbyint {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.nearbyint {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_nearbyintl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.nearbyint.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float nearbyintf(float);
@@ -382,12 +588,20 @@ float call_nearbyintf(float f) {
   return nearbyintf(f);
   // CHECK: cir.func @call_nearbyintf
   // CHECK: {{.+}} = cir.nearbyint {{.+}} : !cir.float
+
+  // LLVM: define float @call_nearbyintf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.nearbyint.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double call_nearbyint(double f) {
   return nearbyint(f);
   // CHECK: cir.func @call_nearbyint
   // CHECK: {{.+}} = cir.nearbyint {{.+}} : !cir.double
+
+  // LLVM: define double @call_nearbyint(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.nearbyint.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_nearbyintl(long double f) {
@@ -395,6 +609,10 @@ long double call_nearbyintl(long double f) {
   // CHECK: cir.func @call_nearbyintl
   // CHECK: {{.+}} = cir.nearbyint {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.nearbyint {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_nearbyintl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.nearbyint.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // rint
@@ -403,12 +621,20 @@ float my_rintf(float f) {
   return __builtin_rintf(f);
   // CHECK: cir.func @my_rintf
   // CHECK: {{.+}} = cir.rint {{.+}} : !cir.float
+
+  // LLVM: define float @my_rintf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.rint.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double my_rint(double f) {
   return __builtin_rint(f);
   // CHECK: cir.func @my_rint
   // CHECK: {{.+}} = cir.rint {{.+}} : !cir.double
+
+  // LLVM: define double @my_rint(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.rint.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_rintl(long double f) {
@@ -416,6 +642,10 @@ long double my_rintl(long double f) {
   // CHECK: cir.func @my_rintl
   // CHECK: {{.+}} = cir.rint {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.rint {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_rintl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.rint.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float rintf(float);
@@ -426,12 +656,20 @@ float call_rintf(float f) {
   return rintf(f);
   // CHECK: cir.func @call_rintf
   // CHECK: {{.+}} = cir.rint {{.+}} : !cir.float
+
+  // LLVM: define float @call_rintf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.rint.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double call_rint(double f) {
   return rint(f);
   // CHECK: cir.func @call_rint
   // CHECK: {{.+}} = cir.rint {{.+}} : !cir.double
+
+  // LLVM: define double @call_rint(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.rint.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_rintl(long double f) {
@@ -439,6 +677,10 @@ long double call_rintl(long double f) {
   // CHECK: cir.func @call_rintl
   // CHECK: {{.+}} = cir.rint {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.rint {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_rintl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.rint.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // round
@@ -447,12 +689,20 @@ float my_roundf(float f) {
   return __builtin_roundf(f);
   // CHECK: cir.func @my_roundf
   // CHECK: {{.+}} = cir.round {{.+}} : !cir.float
+
+  // LLVM: define float @my_roundf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.round.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double my_round(double f) {
   return __builtin_round(f);
   // CHECK: cir.func @my_round
   // CHECK: {{.+}} = cir.round {{.+}} : !cir.double
+
+  // LLVM: define double @my_round(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.round.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_roundl(long double f) {
@@ -460,6 +710,10 @@ long double my_roundl(long double f) {
   // CHECK: cir.func @my_roundl
   // CHECK: {{.+}} = cir.round {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.round {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_roundl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.round.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float roundf(float);
@@ -470,12 +724,20 @@ float call_roundf(float f) {
   return roundf(f);
   // CHECK: cir.func @call_roundf
   // CHECK: {{.+}} = cir.round {{.+}} : !cir.float
+
+  // LLVM: define float @call_roundf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.round.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double call_round(double f) {
   return round(f);
   // CHECK: cir.func @call_round
   // CHECK: {{.+}} = cir.round {{.+}} : !cir.double
+
+  // LLVM: define double @call_round(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.round.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_roundl(long double f) {
@@ -483,6 +745,10 @@ long double call_roundl(long double f) {
   // CHECK: cir.func @call_roundl
   // CHECK: {{.+}} = cir.round {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.round {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_roundl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.round.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // sin
@@ -491,12 +757,20 @@ float my_sinf(float f) {
   return __builtin_sinf(f);
   // CHECK: cir.func @my_sinf
   // CHECK: {{.+}} = cir.sin {{.+}} : !cir.float
+
+  // LLVM: define float @my_sinf(float %0)
+  // LLVM:   %{{.+}} = call float @sinf(float %{{.+}})
+  // LLVM: }
 }
 
 double my_sin(double f) {
   return __builtin_sin(f);
   // CHECK: cir.func @my_sin
   // CHECK: {{.+}} = cir.sin {{.+}} : !cir.double
+
+  // LLVM: define double @my_sin(double %0)
+  // LLVM:   %{{.+}} = call double @sin(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_sinl(long double f) {
@@ -504,6 +778,10 @@ long double my_sinl(long double f) {
   // CHECK: cir.func @my_sinl
   // CHECK: {{.+}} = cir.sin {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.sin {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_sinl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @sinl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float sinf(float);
@@ -514,12 +792,20 @@ float call_sinf(float f) {
   return sinf(f);
   // CHECK: cir.func @call_sinf
   // CHECK: {{.+}} = cir.sin {{.+}} : !cir.float
+
+  // LLVM: define float @call_sinf(float %0)
+  // LLVM:   %{{.+}} = call float @sinf(float %{{.+}})
+  // LLVM: }
 }
 
 double call_sin(double f) {
   return sin(f);
   // CHECK: cir.func @call_sin
   // CHECK: {{.+}} = cir.sin {{.+}} : !cir.double
+
+  // LLVM: define double @call_sin(double %0)
+  // LLVM:   %{{.+}} = call double @sin(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_sinl(long double f) {
@@ -527,6 +813,10 @@ long double call_sinl(long double f) {
   // CHECK: cir.func @call_sinl
   // CHECK: {{.+}} = cir.sin {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.sin {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_sinl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @sinl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // sqrt
@@ -535,12 +825,20 @@ float my_sqrtf(float f) {
   return __builtin_sqrtf(f);
   // CHECK: cir.func @my_sqrtf
   // CHECK: {{.+}} = cir.sqrt {{.+}} : !cir.float
+
+  // LLVM: define float @my_sqrtf(float %0)
+  // LLVM:   %{{.+}} = call float @sqrtf(float %{{.+}})
+  // LLVM: }
 }
 
 double my_sqrt(double f) {
   return __builtin_sqrt(f);
   // CHECK: cir.func @my_sqrt
   // CHECK: {{.+}} = cir.sqrt {{.+}} : !cir.double
+
+  // LLVM: define double @my_sqrt(double %0)
+  // LLVM:   %{{.+}} = call double @sqrt(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_sqrtl(long double f) {
@@ -548,6 +846,10 @@ long double my_sqrtl(long double f) {
   // CHECK: cir.func @my_sqrtl
   // CHECK: {{.+}} = cir.sqrt {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.sqrt {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_sqrtl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @sqrtl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float sqrtf(float);
@@ -558,12 +860,20 @@ float call_sqrtf(float f) {
   return sqrtf(f);
   // CHECK: cir.func @call_sqrtf
   // CHECK: {{.+}} = cir.sqrt {{.+}} : !cir.float
+
+  // LLVM: define float @call_sqrtf(float %0)
+  // LLVM:   %{{.+}} = call float @sqrtf(float %{{.+}})
+  // LLVM: }
 }
 
 double call_sqrt(double f) {
   return sqrt(f);
   // CHECK: cir.func @call_sqrt
   // CHECK: {{.+}} = cir.sqrt {{.+}} : !cir.double
+
+  // LLVM: define double @call_sqrt(double %0)
+  // LLVM:   %{{.+}} = call double @sqrt(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_sqrtl(long double f) {
@@ -571,6 +881,10 @@ long double call_sqrtl(long double f) {
   // CHECK: cir.func @call_sqrtl
   // CHECK: {{.+}} = cir.sqrt {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.sqrt {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_sqrtl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @sqrtl(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // trunc
@@ -579,12 +893,20 @@ float my_truncf(float f) {
   return __builtin_truncf(f);
   // CHECK: cir.func @my_truncf
   // CHECK: {{.+}} = cir.trunc {{.+}} : !cir.float
+
+  // LLVM: define float @my_truncf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.trunc.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double my_trunc(double f) {
   return __builtin_trunc(f);
   // CHECK: cir.func @my_trunc
   // CHECK: {{.+}} = cir.trunc {{.+}} : !cir.double
+
+  // LLVM: define double @my_trunc(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.trunc.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double my_truncl(long double f) {
@@ -592,6 +914,10 @@ long double my_truncl(long double f) {
   // CHECK: cir.func @my_truncl
   // CHECK: {{.+}} = cir.trunc {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.trunc {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_truncl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.trunc.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float truncf(float);
@@ -602,12 +928,20 @@ float call_truncf(float f) {
   return truncf(f);
   // CHECK: cir.func @call_truncf
   // CHECK: {{.+}} = cir.trunc {{.+}} : !cir.float
+
+  // LLVM: define float @call_truncf(float %0)
+  // LLVM:   %{{.+}} = call float @llvm.trunc.f32(float %{{.+}})
+  // LLVM: }
 }
 
 double call_trunc(double f) {
   return trunc(f);
   // CHECK: cir.func @call_trunc
   // CHECK: {{.+}} = cir.trunc {{.+}} : !cir.double
+
+  // LLVM: define double @call_trunc(double %0)
+  // LLVM:   %{{.+}} = call double @llvm.trunc.f64(double %{{.+}})
+  // LLVM: }
 }
 
 long double call_truncl(long double f) {
@@ -615,6 +949,10 @@ long double call_truncl(long double f) {
   // CHECK: cir.func @call_truncl
   // CHECK: {{.+}} = cir.trunc {{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: {{.+}} = cir.trunc {{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_truncl(x86_fp80 %0)
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.trunc.f80(x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // copysign
@@ -623,12 +961,20 @@ float my_copysignf(float x, float y) {
   return __builtin_copysignf(x, y);
   // CHECK: cir.func @my_copysignf
   // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @my_copysignf
+  // LLVM:   %{{.+}} = call float @llvm.copysign.f32(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double my_copysign(double x, double y) {
   return __builtin_copysign(x, y);
   // CHECK: cir.func @my_copysign
   // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @my_copysign
+  // LLVM:   %{{.+}} = call double @llvm.copysign.f64(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double my_copysignl(long double x, long double y) {
@@ -636,6 +982,10 @@ long double my_copysignl(long double x, long double y) {
   // CHECK: cir.func @my_copysignl
   // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_copysignl
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.copysign.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float copysignf(float, float);
@@ -646,12 +996,20 @@ float call_copysignf(float x, float y) {
   return copysignf(x, y);
   // CHECK: cir.func @call_copysignf
   // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @call_copysignf
+  // LLVM:   %{{.+}} = call float @llvm.copysign.f32(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double call_copysign(double x, double y) {
   return copysign(x, y);
   // CHECK: cir.func @call_copysign
   // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @call_copysign
+  // LLVM:   %{{.+}} = call double @llvm.copysign.f64(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double call_copysignl(long double x, long double y) {
@@ -659,6 +1017,10 @@ long double call_copysignl(long double x, long double y) {
   // CHECK: cir.func @call_copysignl
   // CHECK:   %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.copysign %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_copysignl
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.copysign.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // fmax
@@ -667,12 +1029,20 @@ float my_fmaxf(float x, float y) {
   return __builtin_fmaxf(x, y);
   // CHECK: cir.func @my_fmaxf
   // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @my_fmaxf
+  // LLVM:   %{{.+}} = call float @llvm.maxnum.f32(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double my_fmax(double x, double y) {
   return __builtin_fmax(x, y);
   // CHECK: cir.func @my_fmax
   // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @my_fmax
+  // LLVM:   %{{.+}} = call double @llvm.maxnum.f64(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double my_fmaxl(long double x, long double y) {
@@ -680,6 +1050,10 @@ long double my_fmaxl(long double x, long double y) {
   // CHECK: cir.func @my_fmaxl
   // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_fmaxl
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.maxnum.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float fmaxf(float, float);
@@ -690,12 +1064,20 @@ float call_fmaxf(float x, float y) {
   return fmaxf(x, y);
   // CHECK: cir.func @call_fmaxf
   // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @call_fmaxf
+  // LLVM:   %{{.+}} = call float @llvm.maxnum.f32(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double call_fmax(double x, double y) {
   return fmax(x, y);
   // CHECK: cir.func @call_fmax
   // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @call_fmax
+  // LLVM:   %{{.+}} = call double @llvm.maxnum.f64(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double call_fmaxl(long double x, long double y) {
@@ -703,6 +1085,10 @@ long double call_fmaxl(long double x, long double y) {
   // CHECK: cir.func @call_fmaxl
   // CHECK:   %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.fmax %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_fmaxl
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.maxnum.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // fmin
@@ -711,12 +1097,20 @@ float my_fminf(float x, float y) {
   return __builtin_fminf(x, y);
   // CHECK: cir.func @my_fminf
   // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @my_fminf
+  // LLVM:   %{{.+}} = call float @llvm.minnum.f32(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double my_fmin(double x, double y) {
   return __builtin_fmin(x, y);
   // CHECK: cir.func @my_fmin
   // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @my_fmin
+  // LLVM:   %{{.+}} = call double @llvm.minnum.f64(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double my_fminl(long double x, long double y) {
@@ -724,6 +1118,10 @@ long double my_fminl(long double x, long double y) {
   // CHECK: cir.func @my_fminl
   // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_fminl
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.minnum.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float fminf(float, float);
@@ -734,12 +1132,20 @@ float call_fminf(float x, float y) {
   return fminf(x, y);
   // CHECK: cir.func @call_fminf
   // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @call_fminf
+  // LLVM:   %{{.+}} = call float @llvm.minnum.f32(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double call_fmin(double x, double y) {
   return fmin(x, y);
   // CHECK: cir.func @call_fmin
   // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @call_fmin
+  // LLVM:   %{{.+}} = call double @llvm.minnum.f64(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double call_fminl(long double x, long double y) {
@@ -747,6 +1153,10 @@ long double call_fminl(long double x, long double y) {
   // CHECK: cir.func @call_fminl
   // CHECK:   %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.fmin %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_fminl
+  // LLVM:   %{{.+}} = call x86_fp80 @llvm.minnum.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // fmod
@@ -755,12 +1165,20 @@ float my_fmodf(float x, float y) {
   return __builtin_fmodf(x, y);
   // CHECK: cir.func @my_fmodf
   // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @my_fmodf
+  // LLVM:   %{{.+}} = call float @fmodf(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double my_fmod(double x, double y) {
   return __builtin_fmod(x, y);
   // CHECK: cir.func @my_fmod
   // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @my_fmod
+  // LLVM:   %{{.+}} = call double @fmod(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double my_fmodl(long double x, long double y) {
@@ -768,6 +1186,10 @@ long double my_fmodl(long double x, long double y) {
   // CHECK: cir.func @my_fmodl
   // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_fmodl
+  // LLVM:   %{{.+}} = call x86_fp80 @fmodl(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float fmodf(float, float);
@@ -778,12 +1200,20 @@ float call_fmodf(float x, float y) {
   return fmodf(x, y);
   // CHECK: cir.func @call_fmodf
   // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @call_fmodf
+  // LLVM:   %{{.+}} = call float @fmodf(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double call_fmod(double x, double y) {
   return fmod(x, y);
   // CHECK: cir.func @call_fmod
   // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @call_fmod
+  // LLVM:   %{{.+}} = call double @fmod(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double call_fmodl(long double x, long double y) {
@@ -791,6 +1221,10 @@ long double call_fmodl(long double x, long double y) {
   // CHECK: cir.func @call_fmodl
   // CHECK:   %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.fmod %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_fmodl
+  // LLVM:   %{{.+}} = call x86_fp80 @fmodl(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 // pow
@@ -799,12 +1233,20 @@ float my_powf(float x, float y) {
   return __builtin_powf(x, y);
   // CHECK: cir.func @my_powf
   // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @my_powf
+  // LLVM:   %{{.+}} = call float @powf(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double my_pow(double x, double y) {
   return __builtin_pow(x, y);
   // CHECK: cir.func @my_pow
   // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @my_pow
+  // LLVM:   %{{.+}} = call double @pow(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double my_powl(long double x, long double y) {
@@ -812,6 +1254,10 @@ long double my_powl(long double x, long double y) {
   // CHECK: cir.func @my_powl
   // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @my_powl
+  // LLVM:   %{{.+}} = call x86_fp80 @powl(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }
 
 float powf(float, float);
@@ -822,12 +1268,20 @@ float call_powf(float x, float y) {
   return powf(x, y);
   // CHECK: cir.func @call_powf
   // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.float
+
+  // LLVM: define float @call_powf
+  // LLVM:   %{{.+}} = call float @powf(float %{{.+}}, float %{{.+}})
+  // LLVM: }
 }
 
 double call_pow(double x, double y) {
   return pow(x, y);
   // CHECK: cir.func @call_pow
   // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.double
+
+  // LLVM: define double @call_pow
+  // LLVM:   %{{.+}} = call double @pow(double %{{.+}}, double %{{.+}})
+  // LLVM: }
 }
 
 long double call_powl(long double x, long double y) {
@@ -835,4 +1289,8 @@ long double call_powl(long double x, long double y) {
   // CHECK: cir.func @call_powl
   // CHECK:   %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.long_double<!cir.f80>
   // AARCH64: %{{.+}} = cir.pow %{{.+}}, %{{.+}} : !cir.long_double<!cir.double>
+
+  // LLVM: define x86_fp80 @call_powl
+  // LLVM:   %{{.+}} = call x86_fp80 @powl(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
+  // LLVM: }
 }


### PR DESCRIPTION
This patch adds LLVM lowering support for unary fp2fp builtins.

Those builtins that should be lowered to runtime function calls are lowered to such calls during lowering prepare. Other builtins are lowered to LLVM intrinsic calls during LLVM lowering.