### PR TITLE
[CIR][CIRGen][LowerToLLVM] Support address space casting

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -328,6 +328,15 @@ public:
     return createBitcast(src, getPointerTo(newPointeeTy));
   }
 
+  mlir::Value createAddrSpaceCast(mlir::Location loc, mlir::Value src,
+                                  mlir::Type newTy) {
+    return createCast(loc, mlir::cir::CastKind::addrspace_cast, src, newTy);
+  }
+
+  mlir::Value createAddrSpaceCast(mlir::Value src, mlir::Type newTy) {
+    return createCast(mlir::cir::CastKind::addrspace_cast, src, newTy);
+  }
+
   mlir::Value createPtrIsNull(mlir::Value ptr) {
     return createNot(createPtrToBoolCast(ptr));
   }

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -16,6 +16,7 @@
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Dialect/IR/FPEnv.h"
+#include "clang/CIR/MissingFeatures.h"
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -334,7 +334,7 @@ public:
   }
 
   mlir::Value createAddrSpaceCast(mlir::Value src, mlir::Type newTy) {
-    return createCast(mlir::cir::CastKind::address_space, src, newTy);
+    return createAddrSpaceCast(src.getLoc(), src, newTy);
   }
 
   mlir::Value createPtrIsNull(mlir::Value ptr) {

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -330,11 +330,11 @@ public:
 
   mlir::Value createAddrSpaceCast(mlir::Location loc, mlir::Value src,
                                   mlir::Type newTy) {
-    return createCast(loc, mlir::cir::CastKind::addrspace_cast, src, newTy);
+    return createCast(loc, mlir::cir::CastKind::address_space, src, newTy);
   }
 
   mlir::Value createAddrSpaceCast(mlir::Value src, mlir::Type newTy) {
-    return createCast(mlir::cir::CastKind::addrspace_cast, src, newTy);
+    return createCast(mlir::cir::CastKind::address_space, src, newTy);
   }
 
   mlir::Value createPtrIsNull(mlir::Value ptr) {

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -400,6 +400,7 @@ public:
 
   // Creates constant nullptr for pointer type ty.
   mlir::cir::ConstantOp getNullPtr(mlir::Type ty, mlir::Location loc) {
+    assert(!MissingFeatures::targetCodeGenInfoGetNullPointer());
     return create<mlir::cir::ConstantOp>(loc, ty, getConstPtrAttr(ty, 0));
   }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -69,6 +69,7 @@ def CK_FloatToBoolean : I32EnumAttrCase<"float_to_bool", 10>;
 def CK_BooleanToIntegral : I32EnumAttrCase<"bool_to_int", 11>;
 def CK_IntegralToFloat : I32EnumAttrCase<"int_to_float", 12>;
 def CK_BooleanToFloat : I32EnumAttrCase<"bool_to_float", 13>;
+def CK_AddressSpaceConversion : I32EnumAttrCase<"addrspace_cast", 14>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
@@ -76,7 +77,8 @@ def CastKind : I32EnumAttr<
     [CK_IntegralToBoolean, CK_ArrayToPointerDecay, CK_IntegralCast,
      CK_BitCast, CK_FloatingCast, CK_PtrToBoolean, CK_FloatToIntegral,
      CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean,
-     CK_BooleanToIntegral, CK_IntegralToFloat, CK_BooleanToFloat]> {
+     CK_BooleanToIntegral, CK_IntegralToFloat, CK_BooleanToFloat,
+     CK_AddressSpaceConversion]> {
   let cppNamespace = "::mlir::cir";
 }
 
@@ -98,6 +100,7 @@ def CastOp : CIR_Op<"cast", [Pure]> {
     - `ptr_to_bool`
     - `bool_to_int`
     - `bool_to_float`
+    - `addrspace_cast`
 
     This is effectively a subset of the rules from
     `llvm-project/clang/include/clang/AST/OperationKinds.def`; but note that some

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -69,7 +69,7 @@ def CK_FloatToBoolean : I32EnumAttrCase<"float_to_bool", 10>;
 def CK_BooleanToIntegral : I32EnumAttrCase<"bool_to_int", 11>;
 def CK_IntegralToFloat : I32EnumAttrCase<"int_to_float", 12>;
 def CK_BooleanToFloat : I32EnumAttrCase<"bool_to_float", 13>;
-def CK_AddressSpaceConversion : I32EnumAttrCase<"addrspace_cast", 14>;
+def CK_AddressSpaceConversion : I32EnumAttrCase<"address_space", 14>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
@@ -100,7 +100,7 @@ def CastOp : CIR_Op<"cast", [Pure]> {
     - `ptr_to_bool`
     - `bool_to_int`
     - `bool_to_float`
-    - `addrspace_cast`
+    - `address_space`
 
     This is effectively a subset of the rules from
     `llvm-project/clang/include/clang/AST/OperationKinds.def`; but note that some

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -155,6 +155,7 @@ struct MissingFeatures {
   static bool checkFunctionCallABI() { return false; }
   static bool zeroInitializer() { return false; }
   static bool targetCodeGenInfoIsProtoCallVariadic() { return false; }
+  static bool targetCodeGenInfoGetNullPointer() { return false; }
   static bool chainCalls() { return false; }
   static bool operandBundles() { return false; }
   static bool exceptions() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1770,7 +1770,7 @@ LValue CIRGenFunction::buildCastLValue(const CastExpr *E) {
     mlir::Value V = getTargetHooks().performAddrSpaceCast(
         *this, LV.getPointer(), E->getSubExpr()->getType().getAddressSpace(),
         E->getType().getAddressSpace(), ConvertType(DestTy));
-    assert(!UnimplementedFeature::tbaa());
+    assert(!MissingFeatures::tbaa());
     return makeAddrLValue(Address(V, getTypes().convertTypeForMem(E->getType()),
                                   LV.getAddress().getAlignment()),
                           E->getType(), LV.getBaseInfo());

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -14,6 +14,7 @@
 #include "CIRGenFunction.h"
 #include "CIRGenModule.h"
 #include "CIRGenOpenMPRuntime.h"
+#include "TargetInfo.h"
 #include "clang/CIR/MissingFeatures.h"
 
 #include "clang/AST/StmtVisitor.h"
@@ -1510,8 +1511,24 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     return CGF.getBuilder().createBitcast(CGF.getLoc(E->getSourceRange()), Src,
                                           DstTy);
   }
-  case CK_AddressSpaceConversion:
-    llvm_unreachable("NYI");
+  case CK_AddressSpaceConversion: {
+    Expr::EvalResult Result;
+    if (E->EvaluateAsRValue(Result, CGF.getContext()) &&
+        Result.Val.isNullPointer()) {
+      // If E has side effect, it is emitted even if its final result is a
+      // null pointer. In that case, a DCE pass should be able to
+      // eliminate the useless instructions emitted during translating E.
+      if (Result.HasSideEffects) {
+        llvm_unreachable("NYI");
+      }
+      return CGF.CGM.buildNullConstant(DestTy, CGF.getLoc(E->getExprLoc()));
+    }
+    // Since target may map different address spaces in AST to the same address
+    // space, an address space conversion may end up as a bitcast.
+    return CGF.CGM.getTargetCIRGenInfo().performAddrSpaceCast(
+        CGF, Visit(E), E->getType()->getPointeeType().getAddressSpace(),
+        DestTy->getPointeeType().getAddressSpace(), ConvertType(DestTy));
+  }
   case CK_AtomicToNonAtomic:
     llvm_unreachable("NYI");
   case CK_NonAtomicToAtomic:

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1521,7 +1521,6 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
       if (Result.HasSideEffects) {
         llvm_unreachable("NYI");
       }
-      assert(!MissingFeatures::targetCodeGenInfoGetNullPointer());
       return CGF.CGM.buildNullConstant(DestTy, CGF.getLoc(E->getExprLoc()));
     }
     // Since target may map different address spaces in AST to the same address

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1521,6 +1521,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
       if (Result.HasSideEffects) {
         llvm_unreachable("NYI");
       }
+      assert(!MissingFeatures::targetCodeGenInfoGetNullPointer());
       return CGF.CGM.buildNullConstant(DestTy, CGF.getLoc(E->getExprLoc()));
     }
     // Since target may map different address spaces in AST to the same address

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -419,6 +419,17 @@ ABIArgInfo X86_64ABIInfo::classifyReturnType(QualType RetTy) const {
   return ABIArgInfo::getDirect(ResType);
 }
 
+mlir::Value TargetCIRGenInfo::performAddrSpaceCast(
+    CIRGenFunction &CGF, mlir::Value Src, clang::LangAS SrcAddr,
+    clang::LangAS DestAddr, mlir::Type DestTy, bool IsNonNull) const {
+  // Since target may map different address spaces in AST to the same address
+  // space, an address space conversion may end up as a bitcast.
+  if (auto globalOp = Src.getDefiningOp<mlir::cir::GlobalOp>())
+    llvm_unreachable("Global ops addrspace cast NYI");
+  // Try to preserve the source's name to make IR more readable.
+  return CGF.getBuilder().createAddrSpaceCast(Src, DestTy);
+}
+
 const TargetCIRGenInfo &CIRGenModule::getTargetCIRGenInfo() {
   if (TheTargetCIRGenInfo)
     return *TheTargetCIRGenInfo;

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -23,6 +23,7 @@
 namespace cir {
 
 class CIRGenFunction;
+class CIRGenModule;
 
 /// This class organizes various target-specific codegeneration issues, like
 /// target-specific attributes, builtins and so on.
@@ -64,6 +65,18 @@ public:
   virtual clang::LangAS getASTAllocaAddressSpace() const {
     return clang::LangAS::Default;
   }
+
+  /// Perform address space cast of an expression of pointer type.
+  /// \param V is the value to be casted to another address space.
+  /// \param SrcAddr is the language address space of \p V.
+  /// \param DestAddr is the targeted language address space.
+  /// \param DestTy is the destination pointer type.
+  /// \param IsNonNull is the flag indicating \p V is known to be non null.
+  virtual mlir::Value performAddrSpaceCast(CIRGenFunction &CGF, mlir::Value V,
+                                           clang::LangAS SrcAddr,
+                                           clang::LangAS DestAddr,
+                                           mlir::Type DestTy,
+                                           bool IsNonNull = false) const;
 
   virtual ~TargetCIRGenInfo() {}
 };

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -496,6 +496,15 @@ LogicalResult CastOp::verify() {
       return emitOpError() << "requires !cir.float type for result";
     return success();
   }
+  case cir::CastKind::addrspace_cast: {
+    auto srcPtrTy = srcType.dyn_cast<mlir::cir::PointerType>();
+    auto resPtrTy = resType.dyn_cast<mlir::cir::PointerType>();
+    if (!srcPtrTy || !resPtrTy)
+      return emitOpError() << "requires !cir.ptr type for source and result";
+    if (srcPtrTy.getPointee() != resPtrTy.getPointee())
+      return emitOpError() << "requires two types differ in addrspace only";
+    return success();
+  }
   }
 
   llvm_unreachable("Unknown CastOp kind?");

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -523,7 +523,8 @@ OpFoldResult CastOp::fold(FoldAdaptor adaptor) {
       return foldResults[0].get<mlir::Attribute>();
     return {};
   }
-  case mlir::cir::CastKind::bitcast: {
+  case mlir::cir::CastKind::bitcast:
+  case mlir::cir::CastKind::address_space: {
     return getSrc();
   }
   default:

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -496,7 +496,7 @@ LogicalResult CastOp::verify() {
       return emitOpError() << "requires !cir.float type for result";
     return success();
   }
-  case cir::CastKind::addrspace_cast: {
+  case cir::CastKind::address_space: {
     auto srcPtrTy = srcType.dyn_cast<mlir::cir::PointerType>();
     auto resPtrTy = resType.dyn_cast<mlir::cir::PointerType>();
     if (!srcPtrTy || !resPtrTy)

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -753,6 +753,14 @@ public:
           mlir::cir::CmpOpKind::ne, castOp.getSrc(), null);
       break;
     }
+    case mlir::cir::CastKind::addrspace_cast: {
+      auto dstTy = castOp.getType();
+      auto llvmSrcVal = adaptor.getOperands().front();
+      auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::AddrSpaceCastOp>(
+          castOp, llvmDstTy, llvmSrcVal);
+      break;
+    }
     }
 
     return mlir::success();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -753,7 +753,7 @@ public:
           mlir::cir::CmpOpKind::ne, castOp.getSrc(), null);
       break;
     }
-    case mlir::cir::CastKind::addrspace_cast: {
+    case mlir::cir::CastKind::address_space: {
       auto dstTy = castOp.getType();
       auto llvmSrcVal = adaptor.getOperands().front();
       auto llvmDstTy = getTypeConverter()->convertType(dstTy);

--- a/clang/test/CIR/CodeGen/address-space-conversion.cpp
+++ b/clang/test/CIR/CodeGen/address-space-conversion.cpp
@@ -15,7 +15,7 @@ void test_ptr() {
   pi1_t ptr1;
   pi2_t ptr2 = (pi2_t)ptr1;
   // CIR:      %[[#PTR1:]] = cir.load %{{[0-9]+}} : !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, !cir.ptr<!s32i, addrspace(1)>
-  // CIR-NEXT: %[[#CAST:]] = cir.cast(addrspace_cast, %[[#PTR1]] : !cir.ptr<!s32i, addrspace(1)>), !cir.ptr<!s32i, addrspace(2)>
+  // CIR-NEXT: %[[#CAST:]] = cir.cast(address_space, %[[#PTR1]] : !cir.ptr<!s32i, addrspace(1)>), !cir.ptr<!s32i, addrspace(2)>
   // CIR-NEXT: cir.store %[[#CAST]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
 
   // LLVM:      %[[#PTR1:]] = load ptr addrspace(1), ptr %{{[0-9]+}}, align 8
@@ -32,7 +32,7 @@ void test_ref() {
   // CIR:      %[[#DEREF:]] = cir.load deref %{{[0-9]+}} : !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, !cir.ptr<!s32i, addrspace(1)>
   // CIR-NEXT: cir.store %[[#DEREF]], %[[#ALLOCAREF1:]] : !cir.ptr<!s32i, addrspace(1)>, !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>
   // CIR-NEXT: %[[#REF1:]] = cir.load %[[#ALLOCAREF1]] : !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, !cir.ptr<!s32i, addrspace(1)>
-  // CIR-NEXT: %[[#CAST:]] = cir.cast(addrspace_cast, %[[#REF1]] : !cir.ptr<!s32i, addrspace(1)>), !cir.ptr<!s32i, addrspace(2)>
+  // CIR-NEXT: %[[#CAST:]] = cir.cast(address_space, %[[#REF1]] : !cir.ptr<!s32i, addrspace(1)>), !cir.ptr<!s32i, addrspace(2)>
   // CIR-NEXT: cir.store %[[#CAST]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
 
   // LLVM:      %[[#DEREF:]] = load ptr addrspace(1), ptr %{{[0-9]+}}, align 8

--- a/clang/test/CIR/CodeGen/address-space-conversion.cpp
+++ b/clang/test/CIR/CodeGen/address-space-conversion.cpp
@@ -17,6 +17,10 @@ void test_ptr() {
   // CIR:      %[[#PTR1:]] = cir.load %{{[0-9]+}} : !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, !cir.ptr<!s32i, addrspace(1)>
   // CIR-NEXT: %[[#CAST:]] = cir.cast(addrspace_cast, %[[#PTR1]] : !cir.ptr<!s32i, addrspace(1)>), !cir.ptr<!s32i, addrspace(2)>
   // CIR-NEXT: cir.store %[[#CAST]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
+
+  // LLVM:      %[[#PTR1:]] = load ptr addrspace(1), ptr %{{[0-9]+}}, align 8
+  // LLVM-NEXT: %[[#CAST:]] = addrspacecast ptr addrspace(1) %[[#PTR1]] to ptr addrspace(2)
+  // LLVM-NEXT: store ptr addrspace(2) %[[#CAST]], ptr %{{[0-9]+}}, align 8
 }
 
 // CIR: cir.func @{{.*test_ref.*}}
@@ -30,6 +34,12 @@ void test_ref() {
   // CIR-NEXT: %[[#REF1:]] = cir.load %[[#ALLOCAREF1]] : !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, !cir.ptr<!s32i, addrspace(1)>
   // CIR-NEXT: %[[#CAST:]] = cir.cast(addrspace_cast, %[[#REF1]] : !cir.ptr<!s32i, addrspace(1)>), !cir.ptr<!s32i, addrspace(2)>
   // CIR-NEXT: cir.store %[[#CAST]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
+
+  // LLVM:      %[[#DEREF:]] = load ptr addrspace(1), ptr %{{[0-9]+}}, align 8
+  // LLVM-NEXT: store ptr addrspace(1) %[[#DEREF]], ptr %[[#ALLOCAREF1:]], align 8
+  // LLVM-NEXT: %[[#REF1:]] = load ptr addrspace(1), ptr %[[#ALLOCAREF1]], align 8
+  // LLVM-NEXT: %[[#CAST:]] = addrspacecast ptr addrspace(1) %[[#REF1]] to ptr addrspace(2)
+  // LLVM-NEXT: store ptr addrspace(2) %[[#CAST]], ptr %{{[0-9]+}}, align 8
 }
 
 // CIR: cir.func @{{.*test_nullptr.*}}
@@ -38,7 +48,10 @@ void test_nullptr() {
   constexpr pi1_t null1 = nullptr;
   pi2_t ptr = (pi2_t)null1;
   // CIR:      %[[#NULL1:]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i, addrspace(1)>
-  // CIR-NEXT: cir.store %[[#NULL1]], %[[#ALLOCAPTR:]] : !cir.ptr<!s32i, addrspace(1)>, !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>
+  // CIR-NEXT: cir.store %[[#NULL1]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(1)>, !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>
   // CIR-NEXT: %[[#NULL2:]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i, addrspace(2)>
   // CIR-NEXT: cir.store %[[#NULL2]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
+
+  // LLVM:      store ptr addrspace(1) null, ptr %{{[0-9]+}}, align 8
+  // LLVM-NEXT: store ptr addrspace(2) null, ptr %{{[0-9]+}}, align 8
 }

--- a/clang/test/CIR/CodeGen/address-space-conversion.cpp
+++ b/clang/test/CIR/CodeGen/address-space-conversion.cpp
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -S -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+using pi1_t = int __attribute__((address_space(1))) *;
+using pi2_t = int __attribute__((address_space(2))) *;
+
+using ri1_t = int __attribute__((address_space(1))) &;
+using ri2_t = int __attribute__((address_space(2))) &;
+
+// CIR: cir.func @{{.*test_ptr.*}}
+// LLVM: define void @{{.*test_ptr.*}}
+void test_ptr() {
+  pi1_t ptr1;
+  pi2_t ptr2 = (pi2_t)ptr1;
+  // CIR:      %[[#PTR1:]] = cir.load %{{[0-9]+}} : !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, !cir.ptr<!s32i, addrspace(1)>
+  // CIR-NEXT: %[[#CAST:]] = cir.cast(addrspace_cast, %[[#PTR1]] : !cir.ptr<!s32i, addrspace(1)>), !cir.ptr<!s32i, addrspace(2)>
+  // CIR-NEXT: cir.store %[[#CAST]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
+}
+
+// CIR: cir.func @{{.*test_ref.*}}
+// LLVM: define void @{{.*test_ref.*}}
+void test_ref() {
+  pi1_t ptr;
+  ri1_t ref1 = *ptr;
+  ri2_t ref2 = (ri2_t)ref1;
+  // CIR:      %[[#DEREF:]] = cir.load deref %{{[0-9]+}} : !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, !cir.ptr<!s32i, addrspace(1)>
+  // CIR-NEXT: cir.store %[[#DEREF]], %[[#ALLOCAREF1:]] : !cir.ptr<!s32i, addrspace(1)>, !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>
+  // CIR-NEXT: %[[#REF1:]] = cir.load %[[#ALLOCAREF1]] : !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>, !cir.ptr<!s32i, addrspace(1)>
+  // CIR-NEXT: %[[#CAST:]] = cir.cast(addrspace_cast, %[[#REF1]] : !cir.ptr<!s32i, addrspace(1)>), !cir.ptr<!s32i, addrspace(2)>
+  // CIR-NEXT: cir.store %[[#CAST]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
+}
+
+// CIR: cir.func @{{.*test_nullptr.*}}
+// LLVM: define void @{{.*test_nullptr.*}}
+void test_nullptr() {
+  constexpr pi1_t null1 = nullptr;
+  pi2_t ptr = (pi2_t)null1;
+  // CIR:      %[[#NULL1:]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i, addrspace(1)>
+  // CIR-NEXT: cir.store %[[#NULL1]], %[[#ALLOCAPTR:]] : !cir.ptr<!s32i, addrspace(1)>, !cir.ptr<!cir.ptr<!s32i, addrspace(1)>>
+  // CIR-NEXT: %[[#NULL2:]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i, addrspace(2)>
+  // CIR-NEXT: cir.store %[[#NULL2]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
+}

--- a/clang/test/CIR/IR/cast.cir
+++ b/clang/test/CIR/IR/cast.cir
@@ -15,10 +15,19 @@ module  {
     %2 = cir.cast(bitcast, %p : !cir.ptr<!s32i>), !cir.ptr<f32>
     cir.return
   }
+
+  cir.func @addrspace_cast(%arg0: !cir.ptr<!s32i>) {
+    %0 = cir.cast(addrspace_cast, %arg0 : !cir.ptr<!s32i>), !cir.ptr<!s32i, addrspace(2)>
+    cir.return
+  }
 }
 
 // CHECK: cir.func @yolo(%arg0: !s32i)
 // CHECK: %1 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
 // CHECK: %2 = cir.cast(array_to_ptrdecay, %0 : !cir.ptr<!cir.array<!s32i x 10>>), !cir.ptr<!s32i>
+
 // CHECK: cir.func @bitcast
 // CHECK: %0 = cir.cast(bitcast, %arg0 : !cir.ptr<!s32i>), !cir.ptr<f32>
+
+// CHECK: cir.func @addrspace_cast
+// CHECK: %0 = cir.cast(addrspace_cast, %arg0 : !cir.ptr<!s32i>), !cir.ptr<!s32i, addrspace(2)>

--- a/clang/test/CIR/IR/cast.cir
+++ b/clang/test/CIR/IR/cast.cir
@@ -17,7 +17,7 @@ module  {
   }
 
   cir.func @addrspace_cast(%arg0: !cir.ptr<!s32i>) {
-    %0 = cir.cast(addrspace_cast, %arg0 : !cir.ptr<!s32i>), !cir.ptr<!s32i, addrspace(2)>
+    %0 = cir.cast(address_space, %arg0 : !cir.ptr<!s32i>), !cir.ptr<!s32i, addrspace(2)>
     cir.return
   }
 }
@@ -30,4 +30,4 @@ module  {
 // CHECK: %0 = cir.cast(bitcast, %arg0 : !cir.ptr<!s32i>), !cir.ptr<f32>
 
 // CHECK: cir.func @addrspace_cast
-// CHECK: %0 = cir.cast(addrspace_cast, %arg0 : !cir.ptr<!s32i>), !cir.ptr<!s32i, addrspace(2)>
+// CHECK: %0 = cir.cast(address_space, %arg0 : !cir.ptr<!s32i>), !cir.ptr<!s32i, addrspace(2)>

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -301,6 +301,31 @@ cir.func @cast24(%p : !u32i) {
 // -----
 
 !u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
+cir.func @cast25(%p : !cir.ptr<!u32i, addrspace(1)>) {
+  %0 = cir.cast(address_space, %p : !cir.ptr<!u32i, addrspace(1)>), !cir.ptr<!u64i, addrspace(2)> // expected-error {{requires two types differ in addrspace only}}
+  cir.return
+}
+
+// -----
+
+!u64i = !cir.int<u, 64>
+cir.func @cast26(%p : !cir.ptr<!u64i, addrspace(1)>) {
+  %0 = cir.cast(address_space, %p : !cir.ptr<!u64i, addrspace(1)>), !u64i // expected-error {{requires !cir.ptr type for source and result}}
+  cir.return
+}
+
+// -----
+
+!u64i = !cir.int<u, 64>
+cir.func @cast27(%p : !u64i) {
+  %0 = cir.cast(address_space, %p : !u64i), !cir.ptr<!u64i, addrspace(1)> // expected-error {{requires !cir.ptr type for source and result}}
+  cir.return
+}
+
+// -----
+
+!u32i = !cir.int<u, 32>
 !u8i = !cir.int<u, 8>
 module {
   // expected-error@+1 {{constant array element should match array element type}}

--- a/clang/test/CIR/Transforms/merge-cleanups.cir
+++ b/clang/test/CIR/Transforms/merge-cleanups.cir
@@ -126,4 +126,13 @@ module  {
     cir.return %0 : !cir.ptr<!s32i>
   }
 
+  // Should remove redundant address space casts.
+  // CHECK-LABEL: @addrspacecastfold
+  //       CHECK:  %[[ARG0:.+]]: !cir.ptr<!s32i, addrspace(2)>
+  //       CHECK:  cir.return %[[ARG0]] : !cir.ptr<!s32i, addrspace(2)>
+  cir.func @addrspacecastfold(%arg0: !cir.ptr<!s32i, addrspace(2)>) -> !cir.ptr<!s32i, addrspace(2)> {
+    %0 = cir.cast(address_space, %arg0: !cir.ptr<!s32i, addrspace(2)>), !cir.ptr<!s32i, addrspace(2)>
+    cir.return %0 : !cir.ptr<!s32i, addrspace(2)>
+  }
+
 }


### PR DESCRIPTION
* New `CastKind::addrspace_cast` for `cir.cast`
* `TargetCIRGenInfo::performAddrSpaceCast` helper for non-constant values only
* CIRGen for address space casting of pointers and references
* Lowering to LLVM