### PR TITLE
[CIR][CodeGen] Support side effects in address space casting

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1523,7 +1523,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
       // null pointer. In that case, a DCE pass should be able to
       // eliminate the useless instructions emitted during translating E.
       if (Result.HasSideEffects) {
-        llvm_unreachable("NYI");
+        Visit(E);
       }
       return CGF.CGM.buildNullConstant(DestTy, CGF.getLoc(E->getExprLoc()));
     }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1522,9 +1522,8 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
       // If E has side effect, it is emitted even if its final result is a
       // null pointer. In that case, a DCE pass should be able to
       // eliminate the useless instructions emitted during translating E.
-      if (Result.HasSideEffects) {
+      if (Result.HasSideEffects)
         Visit(E);
-      }
       return CGF.CGM.buildNullConstant(DestTy, CGF.getLoc(E->getExprLoc()));
     }
     // Since target may map different address spaces in AST to the same address

--- a/clang/test/CIR/CodeGen/address-space-conversion.cpp
+++ b/clang/test/CIR/CodeGen/address-space-conversion.cpp
@@ -55,3 +55,14 @@ void test_nullptr() {
   // LLVM:      store ptr addrspace(1) null, ptr %{{[0-9]+}}, align 8
   // LLVM-NEXT: store ptr addrspace(2) null, ptr %{{[0-9]+}}, align 8
 }
+
+void test_side_effect(pi1_t b) {
+  pi2_t p = (pi2_t)(*b++, (int*)0);
+  // CIR:      %{{[0-9]+}} = cir.ptr_stride(%{{[0-9]+}} : !cir.ptr<!s32i, addrspace(1)>, %{{[0-9]+}} : !s32i), !cir.ptr<!s32i, addrspace(1)>
+  // CIR:      %[[#CASTED:]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i, addrspace(2)>
+  // CIR-NEXT: cir.store %[[#CASTED]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
+
+
+  // LLVM:      %{{[0-9]+}} = getelementptr i32, ptr addrspace(1) %{{[0-9]+}}, i64 1
+  // LLVM:      store ptr addrspace(2) null, ptr %{{[0-9]+}}, align 8
+}

--- a/clang/test/CIR/CodeGen/address-space-conversion.cpp
+++ b/clang/test/CIR/CodeGen/address-space-conversion.cpp
@@ -59,10 +59,10 @@ void test_nullptr() {
 void test_side_effect(pi1_t b) {
   pi2_t p = (pi2_t)(*b++, (int*)0);
   // CIR:      %{{[0-9]+}} = cir.ptr_stride(%{{[0-9]+}} : !cir.ptr<!s32i, addrspace(1)>, %{{[0-9]+}} : !s32i), !cir.ptr<!s32i, addrspace(1)>
-  // CIR:      %[[#CASTED:]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i, addrspace(2)>
-  // CIR-NEXT: cir.store %[[#CASTED]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
-
+  // CIR:      %[[#CAST:]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i, addrspace(2)>
+  // CIR-NEXT: cir.store %[[#CAST]], %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(2)>, !cir.ptr<!cir.ptr<!s32i, addrspace(2)>>
 
   // LLVM:      %{{[0-9]+}} = getelementptr i32, ptr addrspace(1) %{{[0-9]+}}, i64 1
   // LLVM:      store ptr addrspace(2) null, ptr %{{[0-9]+}}, align 8
+
 }


### PR DESCRIPTION
Continue the work of #652 . Test the branch of null pointer expressions with side effects.