### PR TITLE
[CIR][ABI][NFC] Prime AArch64 CC lowering

### DIFF
--- a/clang/include/clang/CIR/Target/AArch64.h
+++ b/clang/include/clang/CIR/Target/AArch64.h
@@ -1,0 +1,17 @@
+
+#ifndef CIR_AAARCH64_H
+#define CIR_AAARCH64_H
+
+namespace cir {
+
+/// The ABI kind for AArch64 targets.
+enum class AArch64ABIKind {
+  AAPCS = 0,
+  DarwinPCS,
+  Win64,
+  AAPCSSoft,
+};
+
+} // namespace cir
+
+#endif // CIR_AAARCH64_H

--- a/clang/include/clang/CIR/Target/x86.h
+++ b/clang/include/clang/CIR/Target/x86.h
@@ -15,6 +15,13 @@
 
 namespace cir {
 
+/// The AVX ABI level for X86 targets.
+enum class X86AVXABILevel {
+  None,
+  AVX,
+  AVX512,
+};
+
 // Possible argument classifications according to the x86 ABI documentation.
 enum X86ArgClass {
   Integer = 0,

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -3,7 +3,6 @@
 #include "CIRGenCXXABI.h"
 #include "CIRGenFunctionInfo.h"
 #include "CIRGenTypes.h"
-#include "CallingConv.h"
 
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/Target/x86.h"
@@ -136,10 +135,14 @@ public:
 
 } // namespace
 
+//===----------------------------------------------------------------------===//
+// X86 ABI Implementation
+//===----------------------------------------------------------------------===//
+
 namespace {
 
 /// The AVX ABI leel for X86 targets.
-enum class X86AVXABILevel { None, AVX, AVX512 };
+using X86AVXABILevel = ::cir::X86AVXABILevel;
 
 class X86_64ABIInfo : public ABIInfo {
   using Class = X86ArgClass;

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -8,7 +8,6 @@
 
 #include "LoweringPrepareCXXABI.h"
 #include "PassDetail.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Region.h"
 #include "clang/AST/ASTContext.h"

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareCXXABI.h
@@ -20,21 +20,14 @@
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Target/AArch64.h"
 
 namespace cir {
-// TODO: This is a temporary solution to know AArch64 ABI Kind
-//       This should be removed once we have a proper ABI info query
-enum class AArch64ABIKind {
-  AAPCS = 0,
-  DarwinPCS,
-  Win64,
-  AAPCSSoft,
-};
 
 class LoweringPrepareCXXABI {
 public:
   static LoweringPrepareCXXABI *createItaniumABI();
-  static LoweringPrepareCXXABI *createAArch64ABI(AArch64ABIKind k);
+  static LoweringPrepareCXXABI *createAArch64ABI(::cir::AArch64ABIKind k);
 
   virtual mlir::Value lowerVAArg(CIRBaseBuilderTy &builder,
                                  mlir::cir::VAArgOp op,

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -18,6 +18,7 @@
 #include "mlir/IR/Value.h"
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
+#include "clang/CIR/Target/AArch64.h"
 
 namespace mlir {
 namespace cir {
@@ -51,17 +52,10 @@ CIRCXXABI *CreateItaniumCXXABI(LowerModule &CGM);
 // should be updated to follow some level of codegen parity.
 namespace cir {
 
-enum class AArch64ABIKind {
-  AAPCS = 0,
-  DarwinPCS,
-  Win64,
-  AAPCSSoft,
-};
-
 class LoweringPrepareCXXABI {
 public:
   static LoweringPrepareCXXABI *createItaniumABI();
-  static LoweringPrepareCXXABI *createAArch64ABI(AArch64ABIKind k);
+  static LoweringPrepareCXXABI *createAArch64ABI(::cir::AArch64ABIKind k);
 
   virtual mlir::Value lowerVAArg(CIRBaseBuilderTy &builder,
                                  mlir::cir::VAArgOp op,

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -12,6 +12,7 @@ add_clang_library(TargetLowering
   RecordLayoutBuilder.cpp
   TargetInfo.cpp
   TargetLoweringInfo.cpp
+  Targets/AArch64.cpp
   Targets/X86.cpp
   Targets/LoweringPrepareAArch64CXXABI.cpp
   Targets/LoweringPrepareItaniumCXXABI.cpp

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -22,6 +22,7 @@
 
 #include "CIRCXXABI.h"
 #include "LowerModule.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace mlir {
 namespace cir {
@@ -30,8 +31,16 @@ namespace {
 
 class ItaniumCXXABI : public CIRCXXABI {
 
+protected:
+  bool UseARMMethodPtrABI;
+  bool UseARMGuardVarABI;
+  bool Use32BitVTableOffsetABI;
+
 public:
-  ItaniumCXXABI(LowerModule &LM) : CIRCXXABI(LM) {}
+  ItaniumCXXABI(LowerModule &LM, bool UseARMMethodPtrABI = false,
+                bool UseARMGuardVarABI = false)
+      : CIRCXXABI(LM), UseARMMethodPtrABI(UseARMMethodPtrABI),
+        UseARMGuardVarABI(UseARMGuardVarABI), Use32BitVTableOffsetABI(false) {}
 
   bool classifyReturnType(LowerFunctionInfo &FI) const override;
 };
@@ -52,6 +61,13 @@ bool ItaniumCXXABI::classifyReturnType(LowerFunctionInfo &FI) const {
 
 CIRCXXABI *CreateItaniumCXXABI(LowerModule &LM) {
   switch (LM.getCXXABIKind()) {
+  // Note that AArch64 uses the generic ItaniumCXXABI class since it doesn't
+  // include the other 32-bit ARM oddities: constructor/destructor return values
+  // and array cookies.
+  case clang::TargetCXXABI::GenericAArch64:
+    return new ItaniumCXXABI(LM, /*UseARMMethodPtrABI=*/true,
+                             /*UseARMGuardVarABI=*/true);
+
   case clang::TargetCXXABI::GenericItanium:
     if (LM.getTargetInfo().getTriple().getArch() == llvm::Triple::le32) {
       llvm_unreachable("NYI");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -19,9 +19,12 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
+#include "clang/CIR/Target/AArch64.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using MissingFeatures = ::cir::MissingFeatures;
+using AArch64ABIKind = ::cir::AArch64ABIKind;
+using X86AVXABILevel = ::cir::X86AVXABILevel;
 
 namespace mlir {
 namespace cir {

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -52,6 +52,17 @@ createTargetLoweringInfo(LowerModule &LM) {
   const llvm::Triple &Triple = Target.getTriple();
 
   switch (Triple.getArch()) {
+  case llvm::Triple::aarch64: {
+    AArch64ABIKind Kind = AArch64ABIKind::AAPCS;
+    if (Target.getABI() == "darwinpcs")
+      llvm_unreachable("DarwinPCS ABI NYI");
+    else if (Triple.isOSWindows())
+      llvm_unreachable("Windows ABI NYI");
+    else if (Target.getABI() == "aapcs-soft")
+      llvm_unreachable("AAPCS-soft ABI NYI");
+
+    return createAArch64TargetLoweringInfo(LM, Kind);
+  }
   case llvm::Triple::x86_64: {
     switch (Triple.getOS()) {
     case llvm::Triple::Win32:

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
@@ -27,8 +27,19 @@ enum class X86AVXABILevel {
   AVX512,
 };
 
+/// The ABI kind for AArch64 targets.
+enum class AArch64ABIKind {
+  AAPCS = 0,
+  DarwinPCS,
+  Win64,
+  AAPCSSoft,
+};
+
 std::unique_ptr<TargetLoweringInfo>
 createX86_64TargetLoweringInfo(LowerModule &CGM, X86AVXABILevel AVXLevel);
+
+std::unique_ptr<TargetLoweringInfo>
+createAArch64TargetLoweringInfo(LowerModule &CGM, AArch64ABIKind AVXLevel);
 
 } // namespace cir
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
@@ -16,30 +16,17 @@
 
 #include "LowerModule.h"
 #include "TargetLoweringInfo.h"
+#include "clang/CIR/Target/AArch64.h"
+#include "clang/CIR/Target/x86.h"
 
 namespace mlir {
 namespace cir {
 
-/// The AVX ABI level for X86 targets.
-enum class X86AVXABILevel {
-  None,
-  AVX,
-  AVX512,
-};
-
-/// The ABI kind for AArch64 targets.
-enum class AArch64ABIKind {
-  AAPCS = 0,
-  DarwinPCS,
-  Win64,
-  AAPCSSoft,
-};
+std::unique_ptr<TargetLoweringInfo>
+createX86_64TargetLoweringInfo(LowerModule &CGM, ::cir::X86AVXABILevel AVXLevel);
 
 std::unique_ptr<TargetLoweringInfo>
-createX86_64TargetLoweringInfo(LowerModule &CGM, X86AVXABILevel AVXLevel);
-
-std::unique_ptr<TargetLoweringInfo>
-createAArch64TargetLoweringInfo(LowerModule &CGM, AArch64ABIKind AVXLevel);
+createAArch64TargetLoweringInfo(LowerModule &CGM, ::cir::AArch64ABIKind AVXLevel);
 
 } // namespace cir
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
@@ -19,16 +19,16 @@
 #include "clang/CIR/Target/AArch64.h"
 #include "clang/CIR/Target/x86.h"
 
-using namespace ::cir;
-
 namespace mlir {
 namespace cir {
 
 std::unique_ptr<TargetLoweringInfo>
-createX86_64TargetLoweringInfo(LowerModule &CGM, X86AVXABILevel AVXLevel);
+createX86_64TargetLoweringInfo(LowerModule &CGM,
+                               ::cir::X86AVXABILevel AVXLevel);
 
 std::unique_ptr<TargetLoweringInfo>
-createAArch64TargetLoweringInfo(LowerModule &CGM, AArch64ABIKind AVXLevel);
+createAArch64TargetLoweringInfo(LowerModule &CGM,
+                                ::cir::AArch64ABIKind AVXLevel);
 
 } // namespace cir
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
@@ -19,14 +19,16 @@
 #include "clang/CIR/Target/AArch64.h"
 #include "clang/CIR/Target/x86.h"
 
+using namespace ::cir;
+
 namespace mlir {
 namespace cir {
 
 std::unique_ptr<TargetLoweringInfo>
-createX86_64TargetLoweringInfo(LowerModule &CGM, ::cir::X86AVXABILevel AVXLevel);
+createX86_64TargetLoweringInfo(LowerModule &CGM, X86AVXABILevel AVXLevel);
 
 std::unique_ptr<TargetLoweringInfo>
-createAArch64TargetLoweringInfo(LowerModule &CGM, ::cir::AArch64ABIKind AVXLevel);
+createAArch64TargetLoweringInfo(LowerModule &CGM, AArch64ABIKind AVXLevel);
 
 } // namespace cir
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/CIR/Target/AArch64.h"
 #include "ABIInfoImpl.h"
 #include "LowerFunctionInfo.h"
 #include "LowerTypes.h"
@@ -16,6 +17,7 @@
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/Support/ErrorHandling.h"
 
+using AArch64ABIKind = ::cir::AArch64ABIKind;
 using ABIArgInfo = ::cir::ABIArgInfo;
 using MissingFeature = ::cir::MissingFeatures;
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -1,0 +1,77 @@
+//===- AArch64.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ABIInfoImpl.h"
+#include "LowerFunctionInfo.h"
+#include "LowerTypes.h"
+#include "TargetInfo.h"
+#include "TargetLoweringInfo.h"
+#include "clang/CIR/ABIArgInfo.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "clang/CIR/MissingFeatures.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using ABIArgInfo = ::cir::ABIArgInfo;
+using MissingFeature = ::cir::MissingFeatures;
+
+namespace mlir {
+namespace cir {
+
+//===----------------------------------------------------------------------===//
+// AArch64 ABI Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class AArch64ABIInfo : public ABIInfo {
+  AArch64ABIKind Kind;
+
+public:
+  AArch64ABIInfo(LowerTypes &CGT, AArch64ABIKind Kind)
+      : ABIInfo(CGT), Kind(Kind) {}
+
+private:
+  AArch64ABIKind getABIKind() const { return Kind; }
+
+  ABIArgInfo classifyReturnType(Type RetTy, bool IsVariadic) const;
+
+  void computeInfo(LowerFunctionInfo &FI) const override {
+    if (!::mlir::cir::classifyReturnType(getCXXABI(), FI, *this))
+      FI.getReturnInfo() =
+          classifyReturnType(FI.getReturnType(), FI.isVariadic());
+
+    for (auto &_ : FI.arguments())
+      llvm_unreachable("NYI");
+  }
+};
+
+class AArch64TargetLoweringInfo : public TargetLoweringInfo {
+public:
+  AArch64TargetLoweringInfo(LowerTypes &LT, AArch64ABIKind Kind)
+      : TargetLoweringInfo(std::make_unique<AArch64ABIInfo>(LT, Kind)) {
+    assert(!MissingFeature::swift());
+  }
+};
+
+} // namespace
+
+ABIArgInfo AArch64ABIInfo::classifyReturnType(Type RetTy,
+                                              bool IsVariadic) const {
+  if (RetTy.isa<VoidType>())
+    return ABIArgInfo::getIgnore();
+
+  llvm_unreachable("NYI");
+}
+
+std::unique_ptr<TargetLoweringInfo>
+createAArch64TargetLoweringInfo(LowerModule &CGM, AArch64ABIKind Kind) {
+  return std::make_unique<AArch64TargetLoweringInfo>(CGM.getTypes(), Kind);
+}
+
+} // namespace cir
+} // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -10,6 +10,8 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <memory>
 
+using X86AVXABILevel = ::cir::X86AVXABILevel;
+
 namespace mlir {
 namespace cir {
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -30,6 +30,7 @@ add_clang_library(clangCIRLoweringDirectToLLVM
   MLIRCIR
   MLIRAnalysis
   MLIRBuiltinToLLVMIRTranslation
+  MLIRLLVMToLLVMIRTranslation
   MLIRCIRTransforms
   MLIRIR
   MLIRParser

--- a/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
@@ -31,6 +31,7 @@ add_clang_library(clangCIRLoweringThroughMLIR
   MLIRCIR
   MLIRAnalysis
   MLIRBuiltinToLLVMIRTranslation
+  MLIRLLVMToLLVMIRTranslation
   MLIRIR
   MLIRParser
   MLIRSideEffectInterfaces

--- a/clang/test/CIR/Transforms/Target/aarch64/aarch64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/aarch64/aarch64-call-conv-lowering-pass.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-after=cir-call-conv-lowering %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// CHECK: @_Z4Voidv()
+void Void(void) {
+// CHECK:   cir.call @_Z4Voidv() : () -> ()
+  Void();
+}


### PR DESCRIPTION
This patch is a preparation for the AArch64 calling convention lowering. It adds the basic infrastructure to initialize the AArch64 ABI details and validates it against a trivial void return and argument call conv lowering.