### PR TITLE
[CIR][ThroughMLIR] Fix FuncOp for functions with pointer arguments.

### DIFF
--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -558,10 +558,10 @@ public:
                                  resultType ? mlir::TypeRange(resultType)
                                             : mlir::TypeRange()));
 
-    rewriter.inlineRegionBefore(op.getBody(), fn.getBody(), fn.end());
-    if (failed(rewriter.convertRegionTypes(&fn.getBody(), *typeConverter,
+    if (failed(rewriter.convertRegionTypes(&op.getBody(), *typeConverter,
                                            &signatureConversion)))
       return mlir::failure();
+    rewriter.inlineRegionBefore(op.getBody(), fn.getBody(), fn.end());
 
     rewriter.eraseOp(op);
     return mlir::LogicalResult::success();

--- a/clang/test/CIR/Lowering/ThroughMLIR/dot.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/dot.cir
@@ -1,6 +1,5 @@
 // RUN: cir-opt %s -cir-to-mlir -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
-// XFAIL: *
 
 !s32i = !cir.int<s, 32>
 module {


### PR DESCRIPTION
This PR is to fix the issue #658 .
Now we can get the correct result using the following command.
```
echo "void test(int *){}" |  ./build/Debug/bin/clang -cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir -o -
```
result:
```
module attributes {cir.lang = #cir.lang<c>, cir.sob = #cir.signed_overflow_behavior<undefined>, cir.triple = "x86_64-unknown-linux-gnu", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>, #dlti.dl_entry<"dlti.endianness", "little">>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} {
  func.func @test(%arg0: memref<i32> loc(fused[#loc3, #loc4])) {
    %alloca = memref.alloca() {alignment = 8 : i64} : memref<memref<i32>> loc(#loc7)
    memref.store %arg0, %alloca[] : memref<memref<i32>> loc(#loc5)
    return loc(#loc2)
  } loc(#loc6)
} loc(#loc)
```
And the test/CIR/Lowering/ThroughMLIR/dot.cir now passes the test, so I have removed the XFAIL flag.