### PR TITLE
[CIR] Fix TargetLowering library depencies

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -32,36 +32,12 @@ public:
   }
 
   /// Parse a data layout string (with fallback to default values).
-  void reset(llvm::StringRef dataLayout) { clear(); };
+  void reset(llvm::StringRef dataLayout);
 
   // Free all internal data structures.
-  void clear() {};
+  void clear();
 
-  CIRDataLayout(mlir::ModuleOp modOp) {
-    auto dlSpec = modOp->getAttr(mlir::DLTIDialect::kDataLayoutAttrName)
-                      .dyn_cast<mlir::DataLayoutSpecAttr>();
-    assert(dlSpec && "expected dl_spec in the module");
-    auto entries = dlSpec.getEntries();
-
-    for (auto entry : entries) {
-      auto entryKey = entry.getKey();
-      auto strKey = entryKey.dyn_cast<mlir::StringAttr>();
-      if (!strKey)
-        continue;
-      auto entryName = strKey.strref();
-      if (entryName == mlir::DLTIDialect::kDataLayoutEndiannessKey) {
-        auto value = entry.getValue().dyn_cast<mlir::StringAttr>();
-        assert(value && "expected string attribute");
-        auto endian = value.getValue();
-        if (endian == mlir::DLTIDialect::kDataLayoutEndiannessBig)
-          bigEndian = true;
-        else if (endian == mlir::DLTIDialect::kDataLayoutEndiannessLittle)
-          bigEndian = false;
-        else
-          llvm_unreachable("unknown endianess");
-      }
-    }
-  };
+  CIRDataLayout(mlir::ModuleOp modOp);
 
   bool isBigEndian() const { return bigEndian; }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -32,12 +32,37 @@ public:
   }
 
   /// Parse a data layout string (with fallback to default values).
-  void reset(llvm::StringRef dataLayout);
+  void reset(llvm::StringRef dataLayout) { clear(); };
 
   // Free all internal data structures.
-  void clear();
+  void clear() {};
 
-  CIRDataLayout(mlir::ModuleOp modOp);
+  CIRDataLayout(mlir::ModuleOp modOp) {
+    auto dlSpec = modOp->getAttr(mlir::DLTIDialect::kDataLayoutAttrName)
+                      .dyn_cast<mlir::DataLayoutSpecAttr>();
+    assert(dlSpec && "expected dl_spec in the module");
+    auto entries = dlSpec.getEntries();
+
+    for (auto entry : entries) {
+      auto entryKey = entry.getKey();
+      auto strKey = entryKey.dyn_cast<mlir::StringAttr>();
+      if (!strKey)
+        continue;
+      auto entryName = strKey.strref();
+      if (entryName == mlir::DLTIDialect::kDataLayoutEndiannessKey) {
+        auto value = entry.getValue().dyn_cast<mlir::StringAttr>();
+        assert(value && "expected string attribute");
+        auto endian = value.getValue();
+        if (endian == mlir::DLTIDialect::kDataLayoutEndiannessBig)
+          bigEndian = true;
+        else if (endian == mlir::DLTIDialect::kDataLayoutEndiannessLittle)
+          bigEndian = false;
+        else
+          llvm_unreachable("unknown endianess");
+      }
+    }
+  };
+
   bool isBigEndian() const { return bigEndian; }
 
   // `useABI` is `true` if not using prefered alignment.

--- a/clang/lib/Basic/Targets.h
+++ b/clang/lib/Basic/Targets.h
@@ -23,7 +23,6 @@
 namespace clang {
 namespace targets {
 
-LLVM_LIBRARY_VISIBILITY
 std::unique_ptr<clang::TargetInfo>
 AllocateTarget(const llvm::Triple &Triple, const clang::TargetOptions &Opts);
 

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -722,33 +722,3 @@ CIRGenBitFieldInfo CIRGenBitFieldInfo::MakeInfo(CIRGenTypes &Types,
                                                 CharUnits StorageOffset) {
   llvm_unreachable("NYI");
 }
-
-CIRDataLayout::CIRDataLayout(mlir::ModuleOp modOp) : layout{modOp} {
-  auto dlSpec = modOp->getAttr(mlir::DLTIDialect::kDataLayoutAttrName)
-                    .dyn_cast<mlir::DataLayoutSpecAttr>();
-  assert(dlSpec && "expected dl_spec in the module");
-  auto entries = dlSpec.getEntries();
-
-  for (auto entry : entries) {
-    auto entryKey = entry.getKey();
-    auto strKey = entryKey.dyn_cast<mlir::StringAttr>();
-    if (!strKey)
-      continue;
-    auto entryName = strKey.strref();
-    if (entryName == mlir::DLTIDialect::kDataLayoutEndiannessKey) {
-      auto value = entry.getValue().dyn_cast<mlir::StringAttr>();
-      assert(value && "expected string attribute");
-      auto endian = value.getValue();
-      if (endian == mlir::DLTIDialect::kDataLayoutEndiannessBig)
-        bigEndian = true;
-      else if (endian == mlir::DLTIDialect::kDataLayoutEndiannessLittle)
-        bigEndian = false;
-      else
-        llvm_unreachable("unknown endianess");
-    }
-  }
-}
-
-void CIRDataLayout::reset(StringRef Desc) { clear(); }
-
-void CIRDataLayout::clear() {}

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -33,4 +33,4 @@ void CIRDataLayout::reset(llvm::StringRef Desc) { clear(); }
 
 void CIRDataLayout::clear() {}
 
-}
+} // namespace cir

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -1,0 +1,36 @@
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace cir {
+
+CIRDataLayout::CIRDataLayout(mlir::ModuleOp modOp) : layout{modOp} {
+  auto dlSpec = modOp->getAttr(mlir::DLTIDialect::kDataLayoutAttrName)
+                    .dyn_cast<mlir::DataLayoutSpecAttr>();
+  assert(dlSpec && "expected dl_spec in the module");
+  auto entries = dlSpec.getEntries();
+
+  for (auto entry : entries) {
+    auto entryKey = entry.getKey();
+    auto strKey = entryKey.dyn_cast<mlir::StringAttr>();
+    if (!strKey)
+      continue;
+    auto entryName = strKey.strref();
+    if (entryName == mlir::DLTIDialect::kDataLayoutEndiannessKey) {
+      auto value = entry.getValue().dyn_cast<mlir::StringAttr>();
+      assert(value && "expected string attribute");
+      auto endian = value.getValue();
+      if (endian == mlir::DLTIDialect::kDataLayoutEndiannessBig)
+        bigEndian = true;
+      else if (endian == mlir::DLTIDialect::kDataLayoutEndiannessLittle)
+        bigEndian = false;
+      else
+        llvm_unreachable("unknown endianess");
+    }
+  }
+}
+
+void CIRDataLayout::reset(llvm::StringRef Desc) { clear(); }
+
+void CIRDataLayout::clear() {}
+
+}

--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_clang_library(MLIRCIR
   CIRAttrs.cpp
+  CIRDataLayout.cpp
   CIRDialect.cpp
   CIRTypes.cpp
   FPEnv.cpp

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -17,12 +17,15 @@ add_clang_library(TargetLowering
   Targets/LoweringPrepareItaniumCXXABI.cpp
 
   DEPENDS
+  clangBasic
 
   LINK_LIBS PUBLIC
 
+  clangBasic
+  LLVMTargetParser
   MLIRIR
   MLIRPass
-
+  MLIRDLTIDialect
   MLIRCIR
   MLIRCIRInterfaces
 )


### PR DESCRIPTION
This patch fixes the library dependencies of the CIRTargetLowering library. It would fail to build with `BUILD_SHARED_LIBS=ON``.