### PR TITLE
[CIR][CIRDataLayout]moving CIRDataLayout to MLIRCIR

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -722,29 +722,3 @@ CIRGenBitFieldInfo CIRGenBitFieldInfo::MakeInfo(CIRGenTypes &Types,
                                                 CharUnits StorageOffset) {
   llvm_unreachable("NYI");
 }
-
-CIRDataLayout::CIRDataLayout(mlir::ModuleOp modOp) : layout{modOp} {
-  auto dlSpec = modOp->getAttr(mlir::DLTIDialect::kDataLayoutAttrName)
-                    .dyn_cast<mlir::DataLayoutSpecAttr>();
-  assert(dlSpec && "expected dl_spec in the module");
-  auto entries = dlSpec.getEntries();
-
-  for (auto entry : entries) {
-    auto entryKey = entry.getKey();
-    auto strKey = entryKey.dyn_cast<mlir::StringAttr>();
-    if (!strKey)
-      continue;
-    auto entryName = strKey.strref();
-    if (entryName == mlir::DLTIDialect::kDataLayoutEndiannessKey) {
-      auto value = entry.getValue().dyn_cast<mlir::StringAttr>();
-      assert(value && "expected string attribute");
-      auto endian = value.getValue();
-      if (endian == mlir::DLTIDialect::kDataLayoutEndiannessBig)
-        bigEndian = true;
-      else if (endian == mlir::DLTIDialect::kDataLayoutEndiannessLittle)
-        bigEndian = false;
-      else
-        llvm_unreachable("unknown endianess");
-    }
-  }
-}

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -1,0 +1,43 @@
+//===- CIRDialect.cpp - MLIR CIR ops implementation -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the CIR DataLayout class and its functions.
+//
+//===----------------------------------------------------------------------===//a
+//
+
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
+
+namespace cir {
+CIRDataLayout::CIRDataLayout(mlir::ModuleOp modOp) : layout{modOp} {
+  auto dlSpec = modOp->getAttr(mlir::DLTIDialect::kDataLayoutAttrName)
+                    .dyn_cast<mlir::DataLayoutSpecAttr>();
+  assert(dlSpec && "expected dl_spec in the module");
+  auto entries = dlSpec.getEntries();
+
+  for (auto entry : entries) {
+    auto entryKey = entry.getKey();
+    auto strKey = entryKey.dyn_cast<mlir::StringAttr>();
+    if (!strKey)
+      continue;
+    auto entryName = strKey.strref();
+    if (entryName == mlir::DLTIDialect::kDataLayoutEndiannessKey) {
+      auto value = entry.getValue().dyn_cast<mlir::StringAttr>();
+      assert(value && "expected string attribute");
+      auto endian = value.getValue();
+      if (endian == mlir::DLTIDialect::kDataLayoutEndiannessBig)
+        bigEndian = true;
+      else if (endian == mlir::DLTIDialect::kDataLayoutEndiannessLittle)
+        bigEndian = false;
+      else
+        llvm_unreachable("unknown endianess");
+    }
+  }
+}
+
+} // namespace cir

--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_clang_library(MLIRCIR
   CIRAttrs.cpp
+  CIRDataLayout.cpp
   CIRDialect.cpp
   CIRTypes.cpp
   FPEnv.cpp


### PR DESCRIPTION
fix build failure 
undefined reference to `cir::CIRDataLayout::CIRDataLayout(mlir::ModuleOp)'
by breaking circular dependency caused by the fact CIRDataLayout was in CIR Codegen 
