### PR TITLE
[CIR][ABI] Add unsigned int CC lowering for x86_64

### DIFF
--- a/clang/include/clang/CIR/ABIArgInfo.h
+++ b/clang/include/clang/CIR/ABIArgInfo.h
@@ -100,8 +100,8 @@ private:
     unsigned AllocaFieldIndex;     // isInAlloca()
   };
   Kind TheKind;
-  bool CanBeFlattened : 1; // isDirect()
   bool InReg : 1;          // isDirect() || isExtend() || isIndirect()
+  bool CanBeFlattened : 1; // isDirect()
   bool SignExt : 1;        // isExtend()
 
   bool canHavePaddingType() const {
@@ -117,7 +117,7 @@ private:
 public:
   ABIArgInfo(Kind K = Direct)
       : TypeData(nullptr), PaddingType(nullptr), DirectAttr{0, 0}, TheKind(K),
-        CanBeFlattened(false) {}
+        InReg(false), CanBeFlattened(false), SignExt(false) {}
 
   static ABIArgInfo getDirect(mlir::Type T = nullptr, unsigned Offset = 0,
                               mlir::Type Padding = nullptr,

--- a/clang/include/clang/CIR/ABIArgInfo.h
+++ b/clang/include/clang/CIR/ABIArgInfo.h
@@ -164,7 +164,8 @@ public:
   }
   static ABIArgInfo getZeroExtend(mlir::Type Ty, mlir::Type T = nullptr) {
     // NOTE(cir): Enumerations are IntTypes in CIR.
-    assert(Ty.isa<mlir::cir::IntType>() || Ty.isa<mlir::cir::BoolType>());
+    assert(mlir::isa<mlir::cir::IntType>(Ty) ||
+           mlir::isa<mlir::cir::BoolType>(Ty));
     auto AI = ABIArgInfo(Extend);
     AI.setCoerceToType(T);
     AI.setPaddingType(nullptr);
@@ -185,9 +186,9 @@ public:
   static ABIArgInfo getExtend(mlir::Type Ty, mlir::Type T = nullptr) {
     // NOTE(cir): The original can apply this method on both integers and
     // enumerations, but in CIR, these two types are one and the same.
-    if (Ty.isa<mlir::cir::IntType>() &&
-        Ty.cast<mlir::cir::IntType>().isSigned())
-      return getSignExtend(Ty.cast<mlir::cir::IntType>(), T);
+    if (mlir::isa<mlir::cir::IntType>(Ty) &&
+        mlir::cast<mlir::cir::IntType>(Ty).isSigned())
+      return getSignExtend(mlir::cast<mlir::cir::IntType>(Ty), T);
     return getZeroExtend(Ty, T);
   }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -28,6 +28,11 @@ def CIR_Dialect : Dialect {
   let useDefaultTypePrinterParser = 0;
 
   let extraClassDeclaration = [{
+
+    // Names of CIR parameter attributes.
+    static StringRef getSExtAttrName() { return "cir.signext"; }
+    static StringRef getZExtAttrName() { return "cir.zeroext"; }
+
     void registerAttributes();
     void registerTypes();
 

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -261,6 +261,10 @@ struct MissingFeatures {
   // Despite carrying some information about variadics, we are currently
   // ignoring this to focus only on the code necessary to lower non-variadics.
   static bool variadicFunctions() { return false; }
+
+  // If a store op is guaranteed to execute before the retun value load op, we
+  // can optimize away the store and load ops. Seems like an early optimization.
+  static bool returnValueDominatingStoreOptmiization() { return false; }
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -201,17 +201,31 @@ struct MissingFeatures {
   static bool funcDeclIsInlineBuiltinDeclaration() { return false; }
   static bool funcDeclIsReplaceableGlobalAllocationFunction() { return false; }
   static bool qualTypeIsReferenceType() { return false; }
+  static bool typeGetAsEnumType() { return false; }
+  static bool typeGetAsBuiltinType() { return false; }
+  static bool varDeclIsKNRPromoted() { return false; }
 
   //-- Missing types
 
+  static bool fixedWidthIntegers() { return false; }
   static bool vectorType() { return false; }
 
   //-- Missing LLVM attributes
 
   static bool noReturn() { return false; }
   static bool csmeCall() { return false; }
+  static bool undef() { return false; }
+  static bool noFPClass() { return false; }
 
   //-- Other missing features
+
+  // Empty values might be passed as arguments to serve as padding, ensuring
+  // alignment and compliance (e.g. MIPS). We do not yet support this.
+  static bool argumentPadding() { return false; }
+
+  // Clang has evaluation kinds which determines how code is emitted for certain
+  // group of type classes. We don't have a way to identify type classes.
+  static bool evaluationKind() { return false; }
 
   // Calls with a static chain pointer argument may be optimized (p.e. freeing
   // up argument registers), but we do not yet track such cases.

--- a/clang/include/clang/CIR/TypeEvaluationKind.h
+++ b/clang/include/clang/CIR/TypeEvaluationKind.h
@@ -1,0 +1,12 @@
+#ifndef CLANG_CIR_TYPEEVALUATIONKIND_H
+#define CLANG_CIR_TYPEEVALUATIONKIND_H
+
+namespace cir {
+
+// FIXME: for now we are reusing this from lib/Clang/CIRGenFunction.h, which
+// isn't available in the include dir. Same for getEvaluationKind below.
+enum TypeEvaluationKind { TEK_Scalar, TEK_Complex, TEK_Aggregate };
+
+} // namespace cir
+
+#endif // CLANG_CIR_TYPEEVALUATIONKIND_H

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -267,7 +267,6 @@ static mlir::Value MakeAtomicCmpXchgValue(CIRGenFunction &cgf,
 
   auto intType = builder.getSIntNTy(cgf.getContext().getTypeSize(typ));
   auto cmpVal = cgf.buildScalarExpr(expr->getArg(1));
-  auto valueType = cmpVal.getType();
   cmpVal = buildToInt(cgf, cmpVal, typ, intType);
   auto newVal =
       buildToInt(cgf, cgf.buildScalarExpr(expr->getArg(2)), typ, intType);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -27,6 +27,7 @@
 #include "clang/AST/Type.h"
 #include "clang/Basic/ABI.h"
 #include "clang/Basic/TargetInfo.h"
+#include "clang/CIR/TypeEvaluationKind.h"
 
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Value.h"
@@ -49,9 +50,6 @@ class AggExprEmitter;
 
 namespace cir {
 
-// FIXME: for now we are reusing this from lib/Clang/CIRGenFunction.h, which
-// isn't available in the include dir. Same for getEvaluationKind below.
-enum TypeEvaluationKind { TEK_Scalar, TEK_Complex, TEK_Aggregate };
 struct CGCoroData;
 
 class CIRGenFunction : public CIRGenTypeCache {

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -46,7 +46,7 @@ LowerModule createLowerModule(FuncOp op, PatternRewriter &rewriter) {
   // Create context.
   assert(!::cir::MissingFeatures::langOpts());
   clang::LangOptions langOpts;
-  auto context = CIRLowerContext(module.getContext(), langOpts);
+  auto context = CIRLowerContext(module, langOpts);
   context.initBuiltinTypes(*targetInfo);
 
   return LowerModule(context, module, dataLayoutStr, *targetInfo, rewriter);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.cpp
@@ -13,6 +13,7 @@
 
 #include "ABIInfo.h"
 #include "CIRCXXABI.h"
+#include "CIRLowerContext.h"
 #include "LowerTypes.h"
 
 namespace mlir {
@@ -22,6 +23,17 @@ namespace cir {
 ABIInfo::~ABIInfo() = default;
 
 CIRCXXABI &ABIInfo::getCXXABI() const { return LT.getCXXABI(); }
+
+CIRLowerContext &ABIInfo::getContext() const { return LT.getContext(); }
+
+bool ABIInfo::isPromotableIntegerTypeForABI(Type Ty) const {
+  if (getContext().isPromotableIntegerType(Ty))
+    return true;
+
+  assert(!::cir::MissingFeatures::fixedWidthIntegers());
+
+  return false;
+}
 
 } // namespace cir
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.h
@@ -15,6 +15,7 @@
 #define LLVM_CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_ABIINFO_H
 
 #include "CIRCXXABI.h"
+#include "CIRLowerContext.h"
 #include "LowerFunctionInfo.h"
 #include "llvm/IR/CallingConv.h"
 
@@ -37,7 +38,13 @@ public:
 
   CIRCXXABI &getCXXABI() const;
 
+  CIRLowerContext &getContext() const;
+
   virtual void computeInfo(LowerFunctionInfo &FI) const = 0;
+
+  // Implement the Type::IsPromotableIntegerType for ABI specific needs. The
+  // only difference is that this considers bit-precise integer types as well.
+  bool isPromotableIntegerTypeForABI(Type Ty) const;
 };
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -31,7 +31,7 @@ bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
 }
 
 Type useFirstFieldIfTransparentUnion(Type Ty) {
-  if (auto RT = Ty.dyn_cast<StructType>()) {
+  if (auto RT = dyn_cast<StructType>(Ty)) {
     if (RT.isUnion())
       llvm_unreachable("NYI");
   }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -30,5 +30,13 @@ bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
   return CXXABI.classifyReturnType(FI);
 }
 
+Type useFirstFieldIfTransparentUnion(Type Ty) {
+  if (auto RT = Ty.dyn_cast<StructType>()) {
+    if (RT.isUnion())
+      llvm_unreachable("NYI");
+  }
+  return Ty;
+}
+
 } // namespace cir
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.h
@@ -24,6 +24,10 @@ namespace cir {
 bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
                         const ABIInfo &Info);
 
+/// Pass transparent unions as if they were the type of the first element. Sema
+/// should ensure that all elements of the union have the same "machine type".
+Type useFirstFieldIfTransparentUnion(Type Ty);
+
 } // namespace cir
 } // namespace mlir
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -12,7 +12,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "CIRLowerContext.h"
-#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -21,11 +23,67 @@
 namespace mlir {
 namespace cir {
 
-CIRLowerContext::CIRLowerContext(MLIRContext *MLIRCtx,
-                                 clang::LangOptions &LOpts)
-    : MLIRCtx(MLIRCtx), LangOpts(LOpts) {}
+CIRLowerContext::CIRLowerContext(ModuleOp module, clang::LangOptions &LOpts)
+    : MLIRCtx(module.getContext()), LangOpts(LOpts) {}
 
 CIRLowerContext::~CIRLowerContext() {}
+
+clang::TypeInfo CIRLowerContext::getTypeInfo(Type T) const {
+  // TODO(cir): Memoize type info.
+
+  clang::TypeInfo TI = getTypeInfoImpl(T);
+  return TI;
+}
+
+/// getTypeInfoImpl - Return the size of the specified type, in bits.  This
+/// method does not work on incomplete types.
+///
+/// FIXME: Pointers into different addr spaces could have different sizes and
+/// alignment requirements: getPointerInfo should take an AddrSpace, this
+/// should take a QualType, &c.
+clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const Type T) const {
+  uint64_t Width = 0;
+  unsigned Align = 8;
+  clang::AlignRequirementKind AlignRequirement =
+      clang::AlignRequirementKind::None;
+
+  // TODO(cir): We should implement a better way to identify type kinds and use
+  // builting data layout interface for this.
+  auto typeKind = clang::Type::Builtin;
+  if (T.isa<IntType>()) {
+    typeKind = clang::Type::Builtin;
+  } else {
+    llvm_unreachable("Unhandled type class");
+  }
+
+  // FIXME(cir): Here we fetch the width and alignment of a type considering the
+  // current target. We can likely improve this using MLIR's data layout, or
+  // some other interface, to abstract this away (e.g. type.getWidth() &
+  // type.getAlign()). I'm not sure if data layoot suffices because this would
+  // involve some other types such as vectors and complex numbers.
+  // FIXME(cir): In the original codegen, this receives an AST type, meaning it
+  // differs chars from integers, something that is not possible with the
+  // current level of CIR.
+  switch (typeKind) {
+  case clang::Type::Builtin: {
+    if (auto intTy = T.dyn_cast<IntType>()) {
+      // NOTE(cir): This assumes int types are already ABI-specific.
+      // FIXME(cir): Use data layout interface here instead.
+      Width = intTy.getWidth();
+      // FIXME(cir): Use the proper getABIAlignment method here.
+      Align = std::ceil((float)Width / 8) * 8;
+      break;
+    }
+    llvm_unreachable("Unknown builtin type!");
+    break;
+  }
+  default:
+    llvm_unreachable("Unhandled type class");
+  }
+
+  assert(llvm::isPowerOf2_32(Align) && "Alignment must be power of 2");
+  return clang::TypeInfo(Width, Align, AlignRequirement);
+}
 
 Type CIRLowerContext::initBuiltinType(clang::BuiltinType::Kind K) {
   Type Ty;
@@ -56,6 +114,44 @@ void CIRLowerContext::initBuiltinTypes(const clang::TargetInfo &Target,
     CharTy = initBuiltinType(clang::BuiltinType::Char_S);
   else
     llvm_unreachable("NYI");
+}
+
+/// toCharUnitsFromBits - Convert a size in bits to a size in characters.
+clang::CharUnits CIRLowerContext::toCharUnitsFromBits(int64_t BitSize) const {
+  return clang::CharUnits::fromQuantity(BitSize / getCharWidth());
+}
+
+clang::TypeInfoChars CIRLowerContext::getTypeInfoInChars(Type T) const {
+  if (auto arrTy = dyn_cast<ArrayType>(T))
+    llvm_unreachable("NYI");
+  clang::TypeInfo Info = getTypeInfo(T);
+  return clang::TypeInfoChars(toCharUnitsFromBits(Info.Width),
+                              toCharUnitsFromBits(Info.Align),
+                              Info.AlignRequirement);
+}
+
+bool CIRLowerContext::isPromotableIntegerType(Type T) const {
+  // HLSL doesn't promote all small integer types to int, it
+  // just uses the rank-based promotion rules for all types.
+  if (::cir::MissingFeatures::langOpts())
+    llvm_unreachable("NYI");
+
+  // FIXME(cir): CIR does not distinguish between char, short, etc. So we just
+  // assume it is promotable if smaller than 32 bits. This is wrong since, for
+  // example, Char32 is promotable. Improve CIR or add an AST query here.
+  if (auto intTy = T.dyn_cast<IntType>()) {
+    return T.cast<IntType>().getWidth() < 32;
+  }
+
+  // Enumerated types are promotable to their compatible integer types
+  // (C99 6.3.1.1) a.k.a. its underlying type (C++ [conv.prom]p2).
+  // TODO(cir): CIR doesn't know if a integer originated from an enum. Improve
+  // CIR or add an AST query here.
+  if (::cir::MissingFeatures::typeGetAsEnumType()) {
+    llvm_unreachable("NYI");
+  }
+
+  return false;
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -50,7 +50,7 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const Type T) const {
   // TODO(cir): We should implement a better way to identify type kinds and use
   // builting data layout interface for this.
   auto typeKind = clang::Type::Builtin;
-  if (T.isa<IntType>()) {
+  if (isa<IntType>(T)) {
     typeKind = clang::Type::Builtin;
   } else {
     llvm_unreachable("Unhandled type class");
@@ -66,7 +66,7 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const Type T) const {
   // current level of CIR.
   switch (typeKind) {
   case clang::Type::Builtin: {
-    if (auto intTy = T.dyn_cast<IntType>()) {
+    if (auto intTy = dyn_cast<IntType>(T)) {
       // NOTE(cir): This assumes int types are already ABI-specific.
       // FIXME(cir): Use data layout interface here instead.
       Width = intTy.getWidth();
@@ -139,8 +139,8 @@ bool CIRLowerContext::isPromotableIntegerType(Type T) const {
   // FIXME(cir): CIR does not distinguish between char, short, etc. So we just
   // assume it is promotable if smaller than 32 bits. This is wrong since, for
   // example, Char32 is promotable. Improve CIR or add an AST query here.
-  if (auto intTy = T.dyn_cast<IntType>()) {
-    return T.cast<IntType>().getWidth() < 32;
+  if (auto intTy = dyn_cast<IntType>(T)) {
+    return cast<IntType>(T).getWidth() < 32;
   }
 
   // Enumerated types are promotable to their compatible integer types

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -116,7 +116,7 @@ void CIRLowerContext::initBuiltinTypes(const clang::TargetInfo &Target,
     llvm_unreachable("NYI");
 }
 
-/// toCharUnitsFromBits - Convert a size in bits to a size in characters.
+/// Convert a size in bits to a size in characters.
 clang::CharUnits CIRLowerContext::toCharUnitsFromBits(int64_t BitSize) const {
   return clang::CharUnits::fromQuantity(BitSize / getCharWidth());
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -190,7 +190,7 @@ LogicalResult LowerFunction::buildFunctionEpilog(const LowerFunctionInfo &FI) {
       // the load, zap the store, and usually zap the alloca.
       // NOTE(cir): This seems like a premature optimization case, so I'm
       // skipping it.
-      if (/*findDominatingStoreToReturnValue(*this)=*/false) {
+      if (::cir::MissingFeatures::returnValueDominatingStoreOptmiization()) {
         llvm_unreachable("NYI");
       }
       // Otherwise, we have to do a simple load.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -113,8 +113,8 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
       // Prepare parameter attributes. So far, only attributes for pointer
       // parameters are prepared. See
       // http://llvm.org/docs/LangRef.html#paramattrs.
-      if (ArgI.getDirectOffset() == 0 && LTy.isa<PointerType>() &&
-          ArgI.getCoerceToType().isa<PointerType>()) {
+      if (ArgI.getDirectOffset() == 0 && isa<PointerType>(LTy) &&
+          isa<PointerType>(ArgI.getCoerceToType())) {
         llvm_unreachable("NYI");
       }
 
@@ -413,7 +413,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
       // NOTE(cir): While booleans are lowered directly as `i1`s in the
       // original codegen, in CIR they require a trivial bitcast. This is
       // handled here.
-      if (info_it->type.isa<BoolType>()) {
+      if (isa<BoolType>(info_it->type)) {
         IRCallArgs[FirstIRArg] =
             createBitcast(*I, ArgInfo.getCoerceToType(), *this);
         break;
@@ -424,7 +424,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
           ArgInfo.getDirectOffset() == 0) {
         assert(NumIRArgs == 1);
         Value V;
-        if (!I->getType().isa<StructType>()) {
+        if (isa<StructType>(!I->getType())) {
           V = *I;
         } else {
           llvm_unreachable("NYI");
@@ -435,7 +435,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
         }
 
         if (ArgInfo.getCoerceToType() != V.getType() &&
-            V.getType().isa<IntType>())
+            isa<IntType>(V.getType()))
           llvm_unreachable("NYI");
 
         if (FirstIRArg < IRFuncTy.getNumInputs() &&
@@ -517,7 +517,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
       // NOTE(cir): While booleans are lowered directly as `i1`s in the
       // original codegen, in CIR they require a trivial bitcast. This is
       // handled here.
-      assert(!RetTy.isa<BoolType>());
+      assert(!isa<BoolType>(RetTy));
 
       Type RetIRTy = RetTy;
       if (RetAI.getCoerceToType() == RetIRTy && RetAI.getDirectOffset() == 0) {
@@ -562,9 +562,9 @@ Value LowerFunction::getUndefRValue(Type Ty) {
 
 ::cir::TypeEvaluationKind LowerFunction::getEvaluationKind(Type type) {
   // FIXME(cir): Implement type classes for CIR types.
-  if (type.isa<StructType>())
+  if (isa<StructType>(type))
     return ::cir::TypeEvaluationKind::TEK_Aggregate;
-  if (type.isa<IntType, SingleType, DoubleType>())
+  if (isa<IntType, SingleType, DoubleType>(type))
     return ::cir::TypeEvaluationKind::TEK_Scalar;
   llvm_unreachable("NYI");
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -23,12 +23,23 @@
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/MissingFeatures.h"
+#include "clang/CIR/TypeEvaluationKind.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using ABIArgInfo = ::cir::ABIArgInfo;
 
 namespace mlir {
 namespace cir {
+
+namespace {
+
+// FIXME(cir): Create a custom rewriter class to abstract this away.
+Value createBitcast(Value Src, Type Ty, LowerFunction &LF) {
+  return LF.getRewriter().create<CastOp>(Src.getLoc(), Ty, CastKind::bitcast,
+                                         Src);
+}
+
+} // namespace
 
 // FIXME(cir): Pass SrcFn and NewFn around instead of having then as attributes.
 LowerFunction::LowerFunction(LowerModule &LM, PatternRewriter &rewriter,
@@ -76,26 +87,125 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
   for (MutableArrayRef<BlockArgument>::const_iterator i = Args.begin(),
                                                       e = Args.end();
        i != e; ++i, ++info_it, ++ArgNo) {
-    llvm_unreachable("NYI");
+    const Value Arg = *i;
+    const ABIArgInfo &ArgI = info_it->info;
+
+    bool isPromoted = ::cir::MissingFeatures::varDeclIsKNRPromoted();
+    // We are converting from ABIArgInfo type to VarDecl type directly, unless
+    // the parameter is promoted. In this case we convert to
+    // CGFunctionInfo::ArgInfo type with subsequent argument demotion.
+    Type Ty = {};
+    if (isPromoted)
+      llvm_unreachable("NYI");
+    else
+      Ty = Arg.getType();
+    assert(!::cir::MissingFeatures::evaluationKind());
+
+    unsigned FirstIRArg, NumIRArgs;
+    std::tie(FirstIRArg, NumIRArgs) = IRFunctionArgs.getIRArgs(ArgNo);
+
+    switch (ArgI.getKind()) {
+    case ABIArgInfo::Extend:
+    case ABIArgInfo::Direct: {
+      auto AI = Fn.getArgument(FirstIRArg);
+      Type LTy = Arg.getType();
+
+      // Prepare parameter attributes. So far, only attributes for pointer
+      // parameters are prepared. See
+      // http://llvm.org/docs/LangRef.html#paramattrs.
+      if (ArgI.getDirectOffset() == 0 && LTy.isa<PointerType>() &&
+          ArgI.getCoerceToType().isa<PointerType>()) {
+        llvm_unreachable("NYI");
+      }
+
+      // Prepare the argument value. If we have the trivial case, handle it
+      // with no muss and fuss.
+      if (!isa<StructType>(ArgI.getCoerceToType()) &&
+          ArgI.getCoerceToType() == Ty && ArgI.getDirectOffset() == 0) {
+        assert(NumIRArgs == 1);
+
+        // LLVM expects swifterror parameters to be used in very restricted
+        // ways. Copy the value into a less-restricted temporary.
+        Value V = AI;
+        if (::cir::MissingFeatures::extParamInfo()) {
+          llvm_unreachable("NYI");
+        }
+
+        // Ensure the argument is the correct type.
+        if (V.getType() != ArgI.getCoerceToType())
+          llvm_unreachable("NYI");
+
+        if (isPromoted)
+          llvm_unreachable("NYI");
+
+        ArgVals.push_back(V);
+
+        // NOTE(cir): Here we have a trivial case, which means we can just
+        // replace all uses of the original argument with the new one.
+        Value oldArg = SrcFn.getArgument(ArgNo);
+        Value newArg = Fn.getArgument(FirstIRArg);
+        rewriter.replaceAllUsesWith(oldArg, newArg);
+
+        break;
+      }
+
+      llvm_unreachable("NYI");
+    }
+    default:
+      llvm_unreachable("Unhandled ABIArgInfo::Kind");
+    }
   }
 
   if (getTarget().getCXXABI().areArgsDestroyedLeftToRightInCallee()) {
     llvm_unreachable("NYI");
   } else {
-    // FIXME(cir): In the original codegen, EmitParamDecl is called here. It is
-    // likely that said function considers ABI details during emission, so we
-    // migth have to add a counter part here. Currently, it is not needed.
+    // FIXME(cir): In the original codegen, EmitParamDecl is called here. It
+    // is likely that said function considers ABI details during emission, so
+    // we migth have to add a counter part here. Currently, it is not needed.
   }
 
   return success();
 }
 
 LogicalResult LowerFunction::buildFunctionEpilog(const LowerFunctionInfo &FI) {
+  // NOTE(cir): no-return, naked, and no result functions should be handled in
+  // CIRGen.
+
+  Type RetTy = FI.getReturnType();
   const ABIArgInfo &RetAI = FI.getReturnInfo();
 
   switch (RetAI.getKind()) {
 
   case ABIArgInfo::Ignore:
+    break;
+
+  case ABIArgInfo::Extend:
+  case ABIArgInfo::Direct:
+    // FIXME(cir): Should we call ConvertType(RetTy) here?
+    if (RetAI.getCoerceToType() == RetTy && RetAI.getDirectOffset() == 0) {
+      // The internal return value temp always will have pointer-to-return-type
+      // type, just do a load.
+
+      // If there is a dominating store to ReturnValue, we can elide
+      // the load, zap the store, and usually zap the alloca.
+      // NOTE(cir): This seems like a premature optimization case, so I'm
+      // skipping it.
+      if (/*findDominatingStoreToReturnValue(*this)=*/false) {
+        llvm_unreachable("NYI");
+      }
+      // Otherwise, we have to do a simple load.
+      else {
+        // NOTE(cir): Nothing to do here. The codegen already emitted this load
+        // for us and there is no casting necessary to conform to the ABI. The
+        // zero-extension is enforced by the return value's attribute. Just
+        // early exit.
+        return success();
+      }
+    } else {
+      llvm_unreachable("NYI");
+    }
+
+    // TODO(cir): Should AutoreleaseResult be handled here?
     break;
 
   default:
@@ -154,17 +264,17 @@ LogicalResult LowerFunction::rewriteCallOp(CallOp op,
                                            ReturnValueSlot retValSlot) {
 
   // TODO(cir): Check if BlockCall, CXXMemberCall, CUDAKernelCall, or
-  // CXXOperatorMember require special handling here. These should be handled in
-  // CIRGen, unless there is call conv or ABI-specific stuff to be handled, them
-  // we should do it here.
+  // CXXOperatorMember require special handling here. These should be handled
+  // in CIRGen, unless there is call conv or ABI-specific stuff to be handled,
+  // them we should do it here.
 
   // TODO(cir): Also check if Builtin and CXXPeseudoDtor need special handling
   // here. These should be handled in CIRGen, unless there is call conv or
   // ABI-specific stuff to be handled, them we should do it here.
 
   // NOTE(cir): There is no direct way to fetch the function type from the
-  // CallOp, so we fetch it from the source function. This assumes the function
-  // definition has not yet been lowered.
+  // CallOp, so we fetch it from the source function. This assumes the
+  // function definition has not yet been lowered.
   assert(SrcFn && "No source function");
   auto fnType = SrcFn.getFunctionType();
 
@@ -175,6 +285,8 @@ LogicalResult LowerFunction::rewriteCallOp(CallOp op,
   if (Ret)
     rewriter.replaceAllUsesWith(op.getResult(), Ret);
 
+  // Erase original ABI-agnostic call.
+  rewriter.eraseOp(op);
   return success();
 }
 
@@ -226,13 +338,13 @@ Value LowerFunction::rewriteCallOp(FuncType calleeTy, FuncOp origCallee,
 
   assert(!::cir::MissingFeatures::CUDA());
 
-  // TODO(cir): LLVM IR has the concept of "CallBase", which is a base class for
-  // all types of calls. Perhaps we should have a CIR interface to mimic this
-  // class.
+  // TODO(cir): LLVM IR has the concept of "CallBase", which is a base class
+  // for all types of calls. Perhaps we should have a CIR interface to mimic
+  // this class.
   CallOp CallOrInvoke = {};
-  Value CallResult = {};
-  rewriteCallOp(FnInfo, origCallee, callOp, retValSlot, Args, CallOrInvoke,
-                /*isMustTail=*/false, callOp.getLoc());
+  Value CallResult =
+      rewriteCallOp(FnInfo, origCallee, callOp, retValSlot, Args, CallOrInvoke,
+                    /*isMustTail=*/false, callOp.getLoc());
 
   // NOTE(cir): Skipping debug stuff here.
 
@@ -287,7 +399,61 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
   LowerFunctionInfo::const_arg_iterator info_it = CallInfo.arg_begin();
   for (auto I = CallArgs.begin(), E = CallArgs.end(); I != E;
        ++I, ++info_it, ++ArgNo) {
-    llvm_unreachable("NYI");
+    const ABIArgInfo &ArgInfo = info_it->info;
+
+    if (IRFunctionArgs.hasPaddingArg(ArgNo))
+      llvm_unreachable("NYI");
+
+    unsigned FirstIRArg, NumIRArgs;
+    std::tie(FirstIRArg, NumIRArgs) = IRFunctionArgs.getIRArgs(ArgNo);
+
+    switch (ArgInfo.getKind()) {
+    case ABIArgInfo::Extend:
+    case ABIArgInfo::Direct: {
+      // NOTE(cir): While booleans are lowered directly as `i1`s in the
+      // original codegen, in CIR they require a trivial bitcast. This is
+      // handled here.
+      if (info_it->type.isa<BoolType>()) {
+        IRCallArgs[FirstIRArg] =
+            createBitcast(*I, ArgInfo.getCoerceToType(), *this);
+        break;
+      }
+
+      if (!isa<StructType>(ArgInfo.getCoerceToType()) &&
+          ArgInfo.getCoerceToType() == info_it->type &&
+          ArgInfo.getDirectOffset() == 0) {
+        assert(NumIRArgs == 1);
+        Value V;
+        if (!I->getType().isa<StructType>()) {
+          V = *I;
+        } else {
+          llvm_unreachable("NYI");
+        }
+
+        if (::cir::MissingFeatures::extParamInfo()) {
+          llvm_unreachable("NYI");
+        }
+
+        if (ArgInfo.getCoerceToType() != V.getType() &&
+            V.getType().isa<IntType>())
+          llvm_unreachable("NYI");
+
+        if (FirstIRArg < IRFuncTy.getNumInputs() &&
+            V.getType() != IRFuncTy.getInput(FirstIRArg))
+          llvm_unreachable("NYI");
+
+        if (::cir::MissingFeatures::undef())
+          llvm_unreachable("NYI");
+        IRCallArgs[FirstIRArg] = V;
+        break;
+      }
+
+      llvm_unreachable("NYI");
+    }
+    default:
+      llvm::outs() << "Missing ABIArgInfo::Kind: " << ArgInfo.getKind() << "\n";
+      llvm_unreachable("NYI");
+    }
   }
 
   // 2. Prepare the function pointer.
@@ -327,7 +493,8 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
 
   assert(!::cir::MissingFeatures::vectorType());
 
-  // NOTE(cir): Skipping some ObjC, tail-call, debug, and attribute stuff here.
+  // NOTE(cir): Skipping some ObjC, tail-call, debug, and attribute stuff
+  // here.
 
   // 4. Finish the call.
 
@@ -339,29 +506,66 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
     // NOTE(cir): CIRGen already handled the emission of the return value. We
     // need only to handle the ABI-specific to ABI-agnostic cast here.
     switch (RetAI.getKind()) {
+
     case ::cir::ABIArgInfo::Ignore:
       // If we are ignoring an argument that had a result, make sure to
       // construct the appropriate return value for our caller.
       return getUndefRValue(RetTy);
+
+    case ABIArgInfo::Extend:
+    case ABIArgInfo::Direct: {
+      // NOTE(cir): While booleans are lowered directly as `i1`s in the
+      // original codegen, in CIR they require a trivial bitcast. This is
+      // handled here.
+      assert(!RetTy.isa<BoolType>());
+
+      Type RetIRTy = RetTy;
+      if (RetAI.getCoerceToType() == RetIRTy && RetAI.getDirectOffset() == 0) {
+        switch (getEvaluationKind(RetTy)) {
+        case ::cir::TypeEvaluationKind::TEK_Scalar: {
+          // If the argument doesn't match, perform a bitcast to coerce it.
+          // This can happen due to trivial type mismatches. NOTE(cir):
+          // Perhaps this section should handle CIR's boolean case.
+          Value V = newCallOp.getResult();
+          if (V.getType() != RetIRTy)
+            llvm_unreachable("NYI");
+          return V;
+        }
+        default:
+          llvm_unreachable("NYI");
+        }
+      }
+
+      llvm_unreachable("NYI");
+    }
     default:
       llvm::errs() << "Unhandled ABIArgInfo kind: " << RetAI.getKind() << "\n";
       llvm_unreachable("NYI");
     }
   }();
 
-  // NOTE(cir): Skipping Emissions, lifetime markers, and dtors here that should
-  // be handled in CIRGen.
+  // NOTE(cir): Skipping Emissions, lifetime markers, and dtors here that
+  // should be handled in CIRGen.
 
   return Ret;
 }
 
-// NOTE(cir): This method has partial parity to CodeGenFunction's GetUndefRValue
-// defined in CGExpr.cpp.
+// NOTE(cir): This method has partial parity to CodeGenFunction's
+// GetUndefRValue defined in CGExpr.cpp.
 Value LowerFunction::getUndefRValue(Type Ty) {
   if (isa<VoidType>(Ty))
     return nullptr;
 
   llvm::outs() << "Missing undef handler for value type: " << Ty << "\n";
+  llvm_unreachable("NYI");
+}
+
+::cir::TypeEvaluationKind LowerFunction::getEvaluationKind(Type type) {
+  // FIXME(cir): Implement type classes for CIR types.
+  if (type.isa<StructType>())
+    return ::cir::TypeEvaluationKind::TEK_Aggregate;
+  if (type.isa<IntType, SingleType, DoubleType>())
+    return ::cir::TypeEvaluationKind::TEK_Scalar;
   llvm_unreachable("NYI");
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -424,7 +424,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
           ArgInfo.getDirectOffset() == 0) {
         assert(NumIRArgs == 1);
         Value V;
-        if (isa<StructType>(!I->getType())) {
+        if (!isa<StructType>(I->getType())) {
           V = *I;
         } else {
           llvm_unreachable("NYI");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.h
@@ -21,6 +21,7 @@
 #include "mlir/Support/LogicalResult.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/TypeEvaluationKind.h"
 
 namespace mlir {
 namespace cir {
@@ -53,6 +54,8 @@ public:
 
   LowerModule &LM; // Per-module state.
 
+  PatternRewriter &getRewriter() const { return rewriter; }
+
   const clang::TargetInfo &getTarget() const { return Target; }
 
   // Build ABI/Target-specific function prologue.
@@ -80,6 +83,9 @@ public:
 
   /// Get an appropriate 'undef' value for the given type.
   Value getUndefRValue(Type Ty);
+
+  /// Return the TypeEvaluationKind of Type \c T.
+  static ::cir::TypeEvaluationKind getEvaluationKind(Type T);
 };
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -205,8 +205,6 @@ LogicalResult LowerModule::rewriteFunctionCall(CallOp callOp, FuncOp funcOp) {
           .failed())
     return failure();
 
-  // Erase original ABI-agnostic call.
-  rewriter.eraseOp(callOp);
   return success();
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
@@ -112,7 +112,7 @@ mlir::Type LowerTypes::convertType(Type T) {
   /// keeping it here for parity's sake.
 
   // Certain CIR types are already ABI-specific, so we just return them.
-  if (T.isa<IntType>()) {
+  if (isa<IntType>(T)) {
     return T;
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
@@ -14,12 +14,15 @@
 #include "LowerTypes.h"
 #include "CIRToCIRArgMapping.h"
 #include "LowerModule.h"
+#include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 #include "clang/CIR/ABIArgInfo.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace ::mlir::cir;
+
+using ABIArgInfo = ::cir::ABIArgInfo;
 
 unsigned LowerTypes::clangCallConvToLLVMCallConv(clang::CallingConv CC) {
   switch (CC) {
@@ -42,6 +45,10 @@ FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {
   mlir::Type resultType = {};
   const ::cir::ABIArgInfo &retAI = FI.getReturnInfo();
   switch (retAI.getKind()) {
+  case ABIArgInfo::Extend:
+  case ABIArgInfo::Direct:
+    resultType = retAI.getCoerceToType();
+    break;
   case ::cir::ABIArgInfo::Ignore:
     resultType = VoidType::get(getMLIRContext());
     break;
@@ -63,8 +70,52 @@ FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {
   LowerFunctionInfo::const_arg_iterator it = FI.arg_begin(),
                                         ie = it + FI.getNumRequiredArgs();
   for (; it != ie; ++it, ++ArgNo) {
-    llvm_unreachable("NYI");
+    const ABIArgInfo &ArgInfo = it->info;
+
+    assert(!::cir::MissingFeatures::argumentPadding());
+
+    unsigned FirstIRArg, NumIRArgs;
+    std::tie(FirstIRArg, NumIRArgs) = IRFunctionArgs.getIRArgs(ArgNo);
+
+    switch (ArgInfo.getKind()) {
+    case ABIArgInfo::Extend:
+    case ABIArgInfo::Direct: {
+      // Fast-isel and the optimizer generally like scalar values better than
+      // FCAs, so we flatten them if this is safe to do for this argument.
+      Type argType = ArgInfo.getCoerceToType();
+      StructType st = dyn_cast<StructType>(argType);
+      if (st && ArgInfo.isDirect() && ArgInfo.getCanBeFlattened()) {
+        assert(NumIRArgs == st.getNumElements());
+        for (unsigned i = 0, e = st.getNumElements(); i != e; ++i)
+          ArgTypes[FirstIRArg + i] = st.getMembers()[i];
+      } else {
+        assert(NumIRArgs == 1);
+        ArgTypes[FirstIRArg] = argType;
+      }
+      break;
+    }
+    default:
+      llvm_unreachable("Missing ABIArgInfo::Kind");
+    }
   }
 
   return FuncType::get(getMLIRContext(), ArgTypes, resultType, FI.isVariadic());
+}
+
+/// Convert a CIR type to its ABI-specific default form.
+mlir::Type LowerTypes::convertType(Type T) {
+  /// NOTE(cir): It the original codegen this method is used to get the default
+  /// LLVM IR representation for a given AST type. When a the ABI-specific
+  /// function info sets a nullptr for a return or argument type, the default
+  /// type given by this method is used. In CIR's case, its types are already
+  /// supposed to be ABI-specific, so this method is not really useful here. I'm
+  /// keeping it here for parity's sake.
+
+  // Certain CIR types are already ABI-specific, so we just return them.
+  if (T.isa<IntType>()) {
+    return T;
+  }
+
+  llvm::outs() << "Missing default ABI-specific type for " << T << "\n";
+  llvm_unreachable("NYI");
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.h
@@ -90,6 +90,9 @@ public:
 
   /// Return the ABI-specific function type for a CIR function type.
   FuncType getFunctionType(const LowerFunctionInfo &FI);
+
+  /// Convert a CIR type to its ABI-specific default form.
+  Type convertType(Type T);
 };
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
@@ -63,9 +63,15 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   auto opResTy = op.getType();
   // front end should not produce non-scalar type of VAArgOp
   bool isSupportedType =
+<<<<<<< HEAD
       mlir::isa<mlir::cir::IntType, mlir::cir::SingleType,
                 mlir::cir::PointerType, mlir::cir::BoolType,
                 mlir::cir::DoubleType, mlir::cir::ArrayType>(opResTy);
+=======
+      isa<mlir::cir::IntType, mlir::cir::SingleType, mlir::cir::PointerType,
+          mlir::cir::BoolType, mlir::cir::DoubleType, mlir::cir::ArrayType>(
+          opResTy);
+>>>>>>> 92b5444bae17 (Remove deprecated methods (isa, cast, and dyn_cast))
 
   // Homogenous Aggregate type not supported and indirect arg
   // passing not supported yet. And for these supported types,
@@ -82,7 +88,11 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // but it depends on arg type indirectness and coercion defined by ABI.
   auto baseTy = opResTy;
 
+<<<<<<< HEAD
   if (mlir::isa<mlir::cir::ArrayType>(baseTy)) {
+=======
+  if (isa<mlir::cir::ArrayType>(baseTy)) {
+>>>>>>> 92b5444bae17 (Remove deprecated methods (isa, cast, and dyn_cast))
     llvm_unreachable("ArrayType VAArg loweing NYI");
   }
   // numRegs may not be 1 if ArrayType is supported.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
@@ -63,15 +63,9 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   auto opResTy = op.getType();
   // front end should not produce non-scalar type of VAArgOp
   bool isSupportedType =
-<<<<<<< HEAD
       mlir::isa<mlir::cir::IntType, mlir::cir::SingleType,
                 mlir::cir::PointerType, mlir::cir::BoolType,
                 mlir::cir::DoubleType, mlir::cir::ArrayType>(opResTy);
-=======
-      isa<mlir::cir::IntType, mlir::cir::SingleType, mlir::cir::PointerType,
-          mlir::cir::BoolType, mlir::cir::DoubleType, mlir::cir::ArrayType>(
-          opResTy);
->>>>>>> 92b5444bae17 (Remove deprecated methods (isa, cast, and dyn_cast))
 
   // Homogenous Aggregate type not supported and indirect arg
   // passing not supported yet. And for these supported types,
@@ -88,11 +82,7 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // but it depends on arg type indirectness and coercion defined by ABI.
   auto baseTy = opResTy;
 
-<<<<<<< HEAD
   if (mlir::isa<mlir::cir::ArrayType>(baseTy)) {
-=======
-  if (isa<mlir::cir::ArrayType>(baseTy)) {
->>>>>>> 92b5444bae17 (Remove deprecated methods (isa, cast, and dyn_cast))
     llvm_unreachable("ArrayType VAArg loweing NYI");
   }
   // numRegs may not be 1 if ArrayType is supported.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -11,9 +11,33 @@
 #include <memory>
 
 using X86AVXABILevel = ::cir::X86AVXABILevel;
+using ABIArgInfo = ::cir::ABIArgInfo;
 
 namespace mlir {
 namespace cir {
+
+namespace {
+
+/// Return true if the specified [start,end) bit range is known to either be
+/// off the end of the specified type or being in alignment padding.  The user
+/// type specified is known to be at most 128 bits in size, and have passed
+/// through X86_64ABIInfo::classify with a successful classification that put
+/// one of the two halves in the INTEGER class.
+///
+/// It is conservatively correct to return false.
+static bool BitsContainNoUserData(Type Ty, unsigned StartBit, unsigned EndBit,
+                                  CIRLowerContext &Context) {
+  // If the bytes being queried are off the end of the type, there is no user
+  // data hiding here.  This handles analysis of builtins, vectors and other
+  // types that don't contain interesting padding.
+  unsigned TySize = (unsigned)Context.getTypeSize(Ty);
+  if (TySize <= StartBit)
+    return true;
+
+  llvm_unreachable("NYI");
+}
+
+} // namespace
 
 class X86_64ABIInfo : public ABIInfo {
   using Class = ::cir::X86ArgClass;
@@ -47,10 +71,17 @@ class X86_64ABIInfo : public ABIInfo {
   void classify(Type T, uint64_t OffsetBase, Class &Lo, Class &Hi,
                 bool isNamedArg, bool IsRegCall = false) const;
 
+  Type GetINTEGERTypeAtOffset(Type DestTy, unsigned IROffset, Type SourceTy,
+                              unsigned SourceOffset) const;
+
 public:
   X86_64ABIInfo(LowerTypes &CGT, X86AVXABILevel AVXLevel) : ABIInfo(CGT) {}
 
   ::cir::ABIArgInfo classifyReturnType(Type RetTy) const;
+
+  ABIArgInfo classifyArgumentType(Type Ty, unsigned freeIntRegs,
+                                  unsigned &neededInt, unsigned &neededSSE,
+                                  bool isNamedArg, bool IsRegCall) const;
 
   void computeInfo(LowerFunctionInfo &FI) const override;
 };
@@ -83,6 +114,17 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
   if (/*isBuitinType=*/true) {
     if (isa<VoidType>(Ty)) {
       Current = Class::NoClass;
+    } else if (Ty.isa<IntType>()) {
+
+      // FIXME(cir): Clang's BuiltinType::Kind allow comparisons (GT, LT, etc).
+      // We should implement this in CIR to simplify the conditions below. BTW,
+      // I'm not sure if the comparisons below are truly equivalent to the ones
+      // in Clang.
+      if (Ty.isa<IntType>()) {
+        Current = Class::Integer;
+      }
+      return;
+
     } else {
       llvm::outs() << "Missing X86 classification for type " << Ty << "\n";
       llvm_unreachable("NYI");
@@ -94,6 +136,70 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
 
   llvm::outs() << "Missing X86 classification for non-builtin types\n";
   llvm_unreachable("NYI");
+}
+
+/// The ABI specifies that a value should be passed in an 8-byte GPR.  This
+/// means that we either have a scalar or we are talking about the high or low
+/// part of an up-to-16-byte struct.  This routine picks the best CIR type
+/// to represent this, which may be i64 or may be anything else that the
+/// backend will pass in a GPR that works better (e.g. i8, %foo*, etc).
+///
+/// PrefType is an CIR type that corresponds to (part of) the IR type for
+/// the source type.  IROffset is an offset in bytes into the CIR type that
+/// the 8-byte value references.  PrefType may be null.
+///
+/// SourceTy is the source-level type for the entire argument.  SourceOffset
+/// is an offset into this that we're processing (which is always either 0 or
+/// 8).
+///
+Type X86_64ABIInfo::GetINTEGERTypeAtOffset(Type DestTy, unsigned IROffset,
+                                           Type SourceTy,
+                                           unsigned SourceOffset) const {
+  // If we're dealing with an un-offset CIR type, then it means that we're
+  // returning an 8-byte unit starting with it. See if we can safely use it.
+  if (IROffset == 0) {
+    // Pointers and int64's always fill the 8-byte unit.
+    assert(!isa<PointerType>(DestTy) && "Ptrs are NYI");
+
+    // If we have a 1/2/4-byte integer, we can use it only if the rest of the
+    // goodness in the source type is just tail padding.  This is allowed to
+    // kick in for struct {double,int} on the int, but not on
+    // struct{double,int,int} because we wouldn't return the second int.  We
+    // have to do this analysis on the source type because we can't depend on
+    // unions being lowered a specific way etc.
+    if (auto intTy = dyn_cast<IntType>(DestTy)) {
+      if (intTy.getWidth() == 8 || intTy.getWidth() == 16 ||
+          intTy.getWidth() == 32) {
+        unsigned BitWidth = intTy.getWidth();
+        if (BitsContainNoUserData(SourceTy, SourceOffset * 8 + BitWidth,
+                                  SourceOffset * 8 + 64, getContext()))
+          return DestTy;
+      }
+    }
+  }
+
+  if (auto RT = dyn_cast<StructType>(DestTy)) {
+    llvm_unreachable("NYI");
+  }
+
+  // Okay, we don't have any better idea of what to pass, so we pass this in
+  // an integer register that isn't too big to fit the rest of the struct.
+  unsigned TySizeInBytes =
+      (unsigned)getContext().getTypeSizeInChars(SourceTy).getQuantity();
+
+  assert(TySizeInBytes != SourceOffset && "Empty field?");
+
+  // It is always safe to classify this as an integer type up to i64 that
+  // isn't larger than the structure.
+  // FIXME(cir): Perhaps we should have the concept of singless integers in
+  // CIR, mostly because coerced types should carry sign. On the other hand,
+  // this might not make a difference in practice. For now, we just preserve the
+  // sign as is to avoid unecessary bitcasts.
+  bool isSigned = false;
+  if (auto intTy = dyn_cast<IntType>(SourceTy))
+    isSigned = intTy.isSigned();
+  return IntType::get(LT.getMLIRContext(),
+                      std::min(TySizeInBytes - SourceOffset, 8U) * 8, isSigned);
 }
 
 ::cir::ABIArgInfo X86_64ABIInfo::classifyReturnType(Type RetTy) const {
@@ -108,16 +214,110 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
   assert((Hi != Class::SSEUp || Lo == Class::SSE) &&
          "Invalid SSEUp classification.");
 
+  Type resType = {};
   switch (Lo) {
   case Class::NoClass:
     if (Hi == Class::NoClass)
-      return ::cir::ABIArgInfo::getIgnore();
+      return ABIArgInfo::getIgnore();
+    break;
+
+  case Class::Integer:
+    resType = GetINTEGERTypeAtOffset(RetTy, 0, RetTy, 0);
+
+    // If we have a sign or zero extended integer, make sure to return Extend
+    // so that the parameter gets the right LLVM IR attributes.
+    if (Hi == Class::NoClass && resType.isa<IntType>()) {
+      // NOTE(cir): We skip enum types handling here since CIR represents
+      // enums directly as their unerlying integer types. NOTE(cir): For some
+      // reason, Clang does not set the coerce type here and delays it to
+      // arrangeLLVMFunctionInfo. We do the same to keep parity.
+      if (RetTy.isa<IntType>() && isPromotableIntegerTypeForABI(RetTy))
+        return ABIArgInfo::getExtend(RetTy);
+    }
+    break;
+
+  default:
+    llvm_unreachable("NYI");
+  }
+
+  Type HighPart = {};
+  switch (Hi) {
+
+  case Class::NoClass:
+    break;
+
+  default:
+    llvm_unreachable("NYI");
+  }
+
+  // If a high part was specified, merge it together with the low part.  It is
+  // known to pass in the high eightbyte of the result.  We do this by forming
+  // a first class struct aggregate with the high and low part: {low, high}
+  if (HighPart)
+    llvm_unreachable("NYI");
+
+  return ABIArgInfo::getDirect(RetTy);
+}
+
+ABIArgInfo X86_64ABIInfo::classifyArgumentType(Type Ty, unsigned freeIntRegs,
+                                               unsigned &neededInt,
+                                               unsigned &neededSSE,
+                                               bool isNamedArg,
+                                               bool IsRegCall = false) const {
+  Ty = useFirstFieldIfTransparentUnion(Ty);
+
+  X86_64ABIInfo::Class Lo, Hi;
+  classify(Ty, 0, Lo, Hi, isNamedArg, IsRegCall);
+
+  // Check some invariants.
+  // FIXME: Enforce these by construction.
+  assert((Hi != Class::Memory || Lo == Class::Memory) &&
+         "Invalid memory classification.");
+  assert((Hi != Class::SSEUp || Lo == Class::SSE) &&
+         "Invalid SSEUp classification.");
+
+  neededInt = 0;
+  neededSSE = 0;
+  Type ResType = {};
+  switch (Lo) {
+    // AMD64-ABI 3.2.3p3: Rule 2. If the class is INTEGER, the next
+    // available register of the sequence %rdi, %rsi, %rdx, %rcx, %r8
+    // and %r9 is used.
+  case Class::Integer:
+    ++neededInt;
+
+    // Pick an 8-byte type based on the preferred type.
+    ResType = GetINTEGERTypeAtOffset(Ty, 0, Ty, 0);
+
+    // If we have a sign or zero extended integer, make sure to return Extend
+    // so that the parameter gets the right LLVM IR attributes.
+    if (Hi == Class::NoClass && ResType.isa<IntType>()) {
+      // NOTE(cir): We skip enum types handling here since CIR represents
+      // enums directly as their unerlying integer types. NOTE(cir): For some
+      // reason, Clang does not set the coerce type here and delays it to
+      // arrangeLLVMFunctionInfo. We do the same to keep parity.
+      if (Ty.isa<IntType, BoolType>() && isPromotableIntegerTypeForABI(Ty))
+        return ABIArgInfo::getExtend(Ty);
+    }
+
+    break;
+
+  default:
+    llvm_unreachable("NYI");
+  }
+
+  Type HighPart = {};
+  switch (Hi) {
+  case Class::NoClass:
     break;
   default:
     llvm_unreachable("NYI");
   }
 
-  llvm_unreachable("NYI");
+  if (HighPart)
+    llvm_unreachable("NYI");
+
+  return ABIArgInfo::getDirect(ResType);
 }
 
 void X86_64ABIInfo::computeInfo(LowerFunctionInfo &FI) const {
@@ -132,7 +332,9 @@ void X86_64ABIInfo::computeInfo(LowerFunctionInfo &FI) const {
   bool IsRegCall = CallingConv == llvm::CallingConv::X86_RegCall;
 
   // Keep track of the number of assigned registers.
-  unsigned NeededSSE = 0, MaxVectorWidth = 0;
+  unsigned FreeIntRegs = IsRegCall ? 11 : 6;
+  unsigned FreeSSERegs = IsRegCall ? 16 : 8;
+  unsigned NeededInt = 0, NeededSSE = 0, MaxVectorWidth = 0;
 
   if (!::mlir::cir::classifyReturnType(getCXXABI(), FI, *this)) {
     if (IsRegCall || ::cir::MissingFeatures::regCall()) {
@@ -152,12 +354,32 @@ void X86_64ABIInfo::computeInfo(LowerFunctionInfo &FI) const {
   if (::cir::MissingFeatures::chainCall())
     llvm_unreachable("NYI");
 
+  unsigned NumRequiredArgs = FI.getNumRequiredArgs();
   // AMD64-ABI 3.2.3p3: Once arguments are classified, the registers
   // get assigned (in left-to-right order) for passing as follows...
   unsigned ArgNo = 0;
   for (LowerFunctionInfo::arg_iterator it = FI.arg_begin(), ie = FI.arg_end();
        it != ie; ++it, ++ArgNo) {
-    llvm_unreachable("NYI");
+    bool IsNamedArg = ArgNo < NumRequiredArgs;
+
+    if (IsRegCall && ::cir::MissingFeatures::regCall())
+      llvm_unreachable("NYI");
+    else
+      it->info = classifyArgumentType(it->type, FreeIntRegs, NeededInt,
+                                      NeededSSE, IsNamedArg);
+
+    // AMD64-ABI 3.2.3p3: If there are no registers available for any
+    // eightbyte of an argument, the whole argument is passed on the
+    // stack. If registers have already been assigned for some
+    // eightbytes of such an argument, the assignments get reverted.
+    if (FreeIntRegs >= NeededInt && FreeSSERegs >= NeededSSE) {
+      FreeIntRegs -= NeededInt;
+      FreeSSERegs -= NeededSSE;
+      if (::cir::MissingFeatures::vectorType())
+        llvm_unreachable("NYI");
+    } else {
+      llvm_unreachable("Indirect results are NYI");
+    }
   }
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -114,13 +114,13 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
   if (/*isBuitinType=*/true) {
     if (isa<VoidType>(Ty)) {
       Current = Class::NoClass;
-    } else if (Ty.isa<IntType>()) {
+    } else if (isa<IntType>(Ty)) {
 
       // FIXME(cir): Clang's BuiltinType::Kind allow comparisons (GT, LT, etc).
       // We should implement this in CIR to simplify the conditions below. BTW,
       // I'm not sure if the comparisons below are truly equivalent to the ones
       // in Clang.
-      if (Ty.isa<IntType>()) {
+      if (isa<IntType>(Ty)) {
         Current = Class::Integer;
       }
       return;
@@ -226,12 +226,12 @@ Type X86_64ABIInfo::GetINTEGERTypeAtOffset(Type DestTy, unsigned IROffset,
 
     // If we have a sign or zero extended integer, make sure to return Extend
     // so that the parameter gets the right LLVM IR attributes.
-    if (Hi == Class::NoClass && resType.isa<IntType>()) {
+    if (Hi == Class::NoClass && isa<IntType>(resType)) {
       // NOTE(cir): We skip enum types handling here since CIR represents
       // enums directly as their unerlying integer types. NOTE(cir): For some
       // reason, Clang does not set the coerce type here and delays it to
       // arrangeLLVMFunctionInfo. We do the same to keep parity.
-      if (RetTy.isa<IntType>() && isPromotableIntegerTypeForABI(RetTy))
+      if (isa<IntType>(RetTy) && isPromotableIntegerTypeForABI(RetTy))
         return ABIArgInfo::getExtend(RetTy);
     }
     break;
@@ -291,12 +291,12 @@ ABIArgInfo X86_64ABIInfo::classifyArgumentType(Type Ty, unsigned freeIntRegs,
 
     // If we have a sign or zero extended integer, make sure to return Extend
     // so that the parameter gets the right LLVM IR attributes.
-    if (Hi == Class::NoClass && ResType.isa<IntType>()) {
+    if (Hi == Class::NoClass && isa<IntType>(ResType)) {
       // NOTE(cir): We skip enum types handling here since CIR represents
       // enums directly as their unerlying integer types. NOTE(cir): For some
       // reason, Clang does not set the coerce type here and delays it to
       // arrangeLLVMFunctionInfo. We do the same to keep parity.
-      if (Ty.isa<IntType, BoolType>() && isPromotableIntegerTypeForABI(Ty))
+      if (isa<IntType, BoolType>(Ty) && isPromotableIntegerTypeForABI(Ty))
         return ABIArgInfo::getExtend(Ty);
     }
 

--- a/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
@@ -6,3 +6,31 @@ void Void(void) {
 // CHECK:   cir.call @_Z4Voidv() : () -> ()
   Void();
 }
+
+// Test call conv lowering for trivial zeroext cases.
+
+// CHECK: cir.func @_Z5UCharh(%arg0: !u8i {cir.zeroext} loc({{.+}})) -> (!u8i {cir.zeroext})
+unsigned char UChar(unsigned char c) {
+  // CHECK: cir.call @_Z5UCharh(%2) : (!u8i) -> !u8i
+  return UChar(c);
+}
+// CHECK: cir.func @_Z6UShortt(%arg0: !u16i {cir.zeroext} loc({{.+}})) -> (!u16i {cir.zeroext})
+unsigned short UShort(unsigned short s) {
+  // CHECK: cir.call @_Z6UShortt(%2) : (!u16i) -> !u16i
+  return UShort(s);
+}
+// CHECK: cir.func @_Z4UIntj(%arg0: !u32i loc({{.+}})) -> !u32i
+unsigned int UInt(unsigned int i) {
+  // CHECK: cir.call @_Z4UIntj(%2) : (!u32i) -> !u32i
+  return UInt(i);
+}
+// CHECK: cir.func @_Z5ULongm(%arg0: !u64i loc({{.+}})) -> !u64i
+unsigned long ULong(unsigned long l) {
+  // CHECK: cir.call @_Z5ULongm(%2) : (!u64i) -> !u64i
+  return ULong(l);
+}
+// CHECK: cir.func @_Z9ULongLongy(%arg0: !u64i loc({{.+}})) -> !u64i
+unsigned long long ULongLong(unsigned long long l) {
+  // CHECK: cir.call @_Z9ULongLongy(%2) : (!u64i) -> !u64i
+  return ULongLong(l);
+}


### PR DESCRIPTION
Adds the necessary bits to lower arguments and return values of type unsigned int for the x86_64 target. This includes adding logic for extend and direct argument-passing kinds.