### PR TITLE
[CIR][NFC] Replace uses of isa/dyn_cast/cast/... member functions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -125,11 +125,11 @@ def ConstArrayAttr : CIR_Attr<"ConstArray", "const_array", [TypedAttrInterface]>
     AttrBuilderWithInferredContext<(ins "mlir::cir::ArrayType":$type,
                                         "Attribute":$elts), [{
       int zeros = 0;
-      auto typeSize = type.cast<mlir::cir::ArrayType>().getSize();
-      if (auto str = elts.dyn_cast<mlir::StringAttr>())
+      auto typeSize = mlir::cast<mlir::cir::ArrayType>(type).getSize();
+      if (auto str = mlir::dyn_cast<mlir::StringAttr>(elts))
         zeros = typeSize - str.size();
       else
-        zeros = typeSize - elts.cast<mlir::ArrayAttr>().size();
+        zeros = typeSize - mlir::cast<mlir::ArrayAttr>(elts).size();
 
       return $_get(type.getContext(), type, elts, zeros);
     }]>
@@ -200,7 +200,7 @@ def IntAttr : CIR_Attr<"Int", "int", [TypedAttrInterface]> {
       return $_get(type.getContext(), type, value);
     }]>,
     AttrBuilderWithInferredContext<(ins "Type":$type, "int64_t":$value), [{
-      IntType intType = type.cast<IntType>();
+      IntType intType = mlir::cast<IntType>(type);
       mlir::APInt apValue(intType.getWidth(), value, intType.isSigned());
       return $_get(intType.getContext(), intType, apValue);
     }]>,
@@ -209,7 +209,7 @@ def IntAttr : CIR_Attr<"Int", "int", [TypedAttrInterface]> {
     int64_t getSInt() const { return getValue().getSExtValue(); }
     uint64_t getUInt() const { return getValue().getZExtValue(); }
     bool isNullValue() const { return getValue() == 0; }
-    uint64_t getBitWidth() const { return getType().cast<IntType>().getWidth(); }
+    uint64_t getBitWidth() const { return mlir::cast<IntType>(getType()).getWidth(); }
   }];
   let genVerifyDecl = 1;
   let hasCustomAssemblyFormat = 1;
@@ -257,11 +257,11 @@ def ConstPtrAttr : CIR_Attr<"ConstPtr", "ptr", [TypedAttrInterface]> {
   }];
   let builders = [
     AttrBuilderWithInferredContext<(ins "Type":$type, "mlir::IntegerAttr":$value), [{
-      return $_get(type.getContext(), type.cast<mlir::cir::PointerType>(), value);
+      return $_get(type.getContext(), mlir::cast<mlir::cir::PointerType>(type), value);
     }]>,
     AttrBuilder<(ins "Type":$type,
                      "mlir::IntegerAttr":$value), [{
-      return $_get($_ctxt, type.cast<mlir::cir::PointerType>(), value);
+      return $_get($_ctxt, mlir::cast<mlir::cir::PointerType>(type), value);
     }]>,
   ];
   let extraClassDeclaration = [{

--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -44,11 +44,12 @@ public:
   // `useABI` is `true` if not using prefered alignment.
   unsigned getAlignment(mlir::Type ty, bool useABI) const {
     if (llvm::isa<mlir::cir::StructType>(ty)) {
-      auto sTy = ty.cast<mlir::cir::StructType>();
+      auto sTy = mlir::cast<mlir::cir::StructType>(ty);
       if (sTy.getPacked() && useABI)
         return 1;
     } else if (llvm::isa<mlir::cir::ArrayType>(ty)) {
-      return getAlignment(ty.cast<mlir::cir::ArrayType>().getEltType(), useABI);
+      return getAlignment(mlir::cast<mlir::cir::ArrayType>(ty).getEltType(),
+                          useABI);
     }
 
     return useABI ? layout.getTypeABIAlignment(ty)
@@ -86,7 +87,7 @@ public:
   }
 
   unsigned getPointerTypeSizeInBits(mlir::Type Ty) const {
-    assert(Ty.isa<mlir::cir::PointerType>() &&
+    assert(mlir::isa<mlir::cir::PointerType>(Ty) &&
            "This should only be called with a pointer type");
     return layout.getTypeSizeInBits(Ty);
   }
@@ -96,7 +97,7 @@ public:
   }
 
   mlir::Type getIntPtrType(mlir::Type Ty) const {
-    assert(Ty.isa<mlir::cir::PointerType>() && "Expected pointer type");
+    assert(mlir::isa<mlir::cir::PointerType>(Ty) && "Expected pointer type");
     auto IntTy = mlir::cir::IntType::get(Ty.getContext(),
                                          getPointerTypeSizeInBits(Ty), false);
     return IntTy;

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -302,7 +302,7 @@ def PtrStrideOp : CIR_Op<"ptr_stride",
   let extraClassDeclaration = [{
     // Get type pointed by the base pointer.
     mlir::Type getElementTy() {
-      return getBase().getType().cast<mlir::cir::PointerType>().getPointee();
+      return mlir::cast<mlir::cir::PointerType>(getBase().getType()).getPointee();
     }
   }];
 
@@ -343,7 +343,7 @@ def ConstantOp : CIR_Op<"const",
 
   let extraClassDeclaration = [{
      bool isNullPtr() {
-      if (const auto ptrAttr = getValue().dyn_cast<mlir::cir::ConstPtrAttr>())
+      if (const auto ptrAttr = mlir::dyn_cast<mlir::cir::ConstPtrAttr>(getValue()))
        return ptrAttr.isNullValue();
       return false;
      }
@@ -389,7 +389,7 @@ class AllocaTypesMatchWith<string summary, string lhsArg, string rhsArg,
 def AllocaOp : CIR_Op<"alloca", [
   AllocaTypesMatchWith<"'allocaType' matches pointee type of 'addr'",
                  "addr", "allocaType",
-                 "$_self.cast<PointerType>().getPointee()">]> {
+                 "cast<PointerType>($_self).getPointee()">]> {
   let summary = "Defines a scope-local variable";
   let description = [{
     The `cir.alloca` operation defines a scope-local variable.
@@ -449,7 +449,7 @@ def AllocaOp : CIR_Op<"alloca", [
 
   let extraClassDeclaration = [{
     // Whether the alloca input type is a pointer.
-    bool isPointerType() { return getAllocaType().isa<::mlir::cir::PointerType>(); }
+    bool isPointerType() { return ::mlir::isa<::mlir::cir::PointerType>(getAllocaType()); }
 
     bool isDynamic() { return (bool)getDynAllocSize(); }
   }];
@@ -473,7 +473,7 @@ def AllocaOp : CIR_Op<"alloca", [
 def LoadOp : CIR_Op<"load", [
   TypesMatchWith<"type of 'result' matches pointee type of 'addr'",
                  "addr", "result",
-                 "$_self.cast<PointerType>().getPointee()">]> {
+                 "cast<PointerType>($_self).getPointee()">]> {
 
   let summary = "Load value from memory adddress";
   let description = [{
@@ -531,7 +531,7 @@ def LoadOp : CIR_Op<"load", [
 def StoreOp : CIR_Op<"store", [
   TypesMatchWith<"type of 'value' matches pointee type of 'addr'",
                  "addr", "value",
-                 "$_self.cast<PointerType>().getPointee()">]> {
+                 "cast<PointerType>($_self).getPointee()">]> {
 
   let summary = "Store value to memory address";
   let description = [{
@@ -1459,7 +1459,7 @@ def CmpThreeWayOp : CIR_Op<"cmp3way", [Pure, SameTypeOperands]> {
 
     /// Determine whether this three-way comparison compares integral operands.
     bool isIntegralComparison() {
-      return getLhs().getType().isa<mlir::cir::IntType>();
+      return mlir::isa<mlir::cir::IntType>(getLhs().getType());
     }
   }];
 }
@@ -2269,7 +2269,7 @@ def GetMemberOp : CIR_Op<"get_member"> {
 
     /// Return the result type.
     mlir::cir::PointerType getResultTy() {
-      return getResult().getType().cast<mlir::cir::PointerType>();
+      return mlir::cast<mlir::cir::PointerType>(getResult().getType());
     }
   }];
 
@@ -2339,7 +2339,7 @@ def GetRuntimeMemberOp : CIR_Op<"get_runtime_member"> {
 
 def VecInsertOp : CIR_Op<"vec.insert", [Pure,
   TypesMatchWith<"argument type matches vector element type", "vec", "value",
-                 "$_self.cast<VectorType>().getEltType()">,
+                 "cast<VectorType>($_self).getEltType()">,
   AllTypesMatch<["result", "vec"]>]> {
 
   let summary = "Insert one element into a vector object";
@@ -2366,7 +2366,7 @@ def VecInsertOp : CIR_Op<"vec.insert", [Pure,
 
 def VecExtractOp : CIR_Op<"vec.extract", [Pure,
   TypesMatchWith<"type of 'result' matches element type of 'vec'", "vec",
-                 "result", "$_self.cast<VectorType>().getEltType()">]> {
+                 "result", "cast<VectorType>($_self).getEltType()">]> {
 
   let summary = "Extract one element from a vector object";
   let description = [{
@@ -2419,7 +2419,7 @@ def VecCreateOp : CIR_Op<"vec.create", [Pure]> {
 
 def VecSplatOp : CIR_Op<"vec.splat", [Pure,
   TypesMatchWith<"type of 'value' matches element type of 'result'", "result",
-                 "value", "$_self.cast<VectorType>().getEltType()">]> {
+                 "value", "cast<VectorType>($_self).getEltType()">]> {
 
   let summary = "Convert a scalar into a vector";
   let description = [{
@@ -2834,7 +2834,7 @@ def CallOp : CIR_CallOp<"call"> {
       $_state.addOperands(operands);
       if (callee)
         $_state.addAttribute("callee", callee);
-      if (resType && !resType.isa<VoidType>())
+      if (resType && !isa<VoidType>(resType))
         $_state.addTypes(resType);
     }]>,
     OpBuilder<(ins "Value":$ind_target,
@@ -3427,7 +3427,7 @@ def VAArgOp : CIR_Op<"va.arg">,
 def AllocException : CIR_Op<"alloc_exception", [
   AllocaTypesMatchWith<"'allocType' matches pointee type of 'addr'",
                  "addr", "allocType",
-                 "$_self.cast<PointerType>().getPointee()">]> {
+                 "cast<PointerType>($_self).getPointee()">]> {
   let summary = "Defines a scope-local variable";
   let description = [{
     Implements a slightly higher level __cxa_allocate_exception:

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -78,9 +78,9 @@ def CIR_IntType : CIR_Type<"Int", "int",
 // Unsigned integer type of a specific width.
 class UInt<int width>
   : Type<And<[
-        CPred<"$_self.isa<::mlir::cir::IntType>()">,
-        CPred<"$_self.cast<::mlir::cir::IntType>().isUnsigned()">,
-        CPred<"$_self.cast<::mlir::cir::IntType>().getWidth() == " # width>
+        CPred<"::mlir::isa<::mlir::cir::IntType>($_self)">,
+        CPred<"::mlir::cast<::mlir::cir::IntType>($_self).isUnsigned()">,
+        CPred<"::mlir::cast<::mlir::cir::IntType>($_self).getWidth() == " # width>
         ]>, width # "-bit unsigned integer", "::mlir::cir::IntType">,
     BuildableType<
       "mlir::cir::IntType::get($_builder.getContext(), "
@@ -97,9 +97,9 @@ def UInt64 : UInt<64>;
 // Signed integer type of a specific width.
 class SInt<int width>
   : Type<And<[
-        CPred<"$_self.isa<::mlir::cir::IntType>()">,
-        CPred<"$_self.cast<::mlir::cir::IntType>().isSigned()">,
-        CPred<"$_self.cast<::mlir::cir::IntType>().getWidth() == " # width>
+        CPred<"::mlir::isa<::mlir::cir::IntType>($_self)">,
+        CPred<"::mlir::cast<::mlir::cir::IntType>($_self).isSigned()">,
+        CPred<"::mlir::cast<::mlir::cir::IntType>($_self).getWidth() == " # width>
         ]>, width # "-bit signed integer", "::mlir::cir::IntType">,
     BuildableType<
       "mlir::cir::IntType::get($_builder.getContext(), "
@@ -230,7 +230,7 @@ def CIR_PointerType : CIR_Type<"Pointer", "ptr",
 
   let extraClassDeclaration = [{
     bool isVoidPtr() const {
-      return getPointee().isa<mlir::cir::VoidType>();
+      return mlir::isa<mlir::cir::VoidType>(getPointee());
     }
   }];
 }
@@ -412,9 +412,9 @@ def CIR_VoidType : CIR_Type<"Void", "void"> {
 // Pointer to void
 def VoidPtr : Type<
     And<[
-      CPred<"$_self.isa<::mlir::cir::PointerType>()">,
-      CPred<"$_self.cast<::mlir::cir::PointerType>()"
-            ".getPointee().isa<::mlir::cir::VoidType>()">,
+      CPred<"::mlir::isa<::mlir::cir::PointerType>($_self)">,
+      CPred<"::mlir::isa<::mlir::cir::VoidType>("
+            "::mlir::cast<::mlir::cir::PointerType>($_self).getPointee())">,
     ]>, "void*">,
     BuildableType<
       "mlir::cir::PointerType::get($_builder.getContext(),"
@@ -424,28 +424,28 @@ def VoidPtr : Type<
 // Pointer to a primitive int, float or double
 def PrimitiveIntOrFPPtr : Type<
     And<[
-      CPred<"$_self.isa<::mlir::cir::PointerType>()">,
-      CPred<"$_self.cast<::mlir::cir::PointerType>()"
-            ".getPointee().isa<::mlir::cir::IntType,"
-            "::mlir::cir::SingleType, ::mlir::cir::DoubleType>()">,
+      CPred<"::mlir::isa<::mlir::cir::PointerType>($_self)">,
+      CPred<"::mlir::isa<::mlir::cir::IntType, ::mlir::cir::SingleType,"
+            "::mlir::cir::DoubleType>("
+            "::mlir::cast<::mlir::cir::PointerType>($_self).getPointee())">,
     ]>, "{int,void}*"> {
 }
 
 // Pointer to struct
 def StructPtr : Type<
     And<[
-      CPred<"$_self.isa<::mlir::cir::PointerType>()">,
-      CPred<"$_self.cast<::mlir::cir::PointerType>()"
-            ".getPointee().isa<::mlir::cir::StructType>()">,
+      CPred<"::mlir::isa<::mlir::cir::PointerType>($_self)">,
+      CPred<"::mlir::isa<::mlir::cir::StructType>("
+            "::mlir::cast<::mlir::cir::PointerType>($_self).getPointee())">
     ]>, "!cir.struct*"> {
 }
 
 // Pointers to exception info
 def ExceptionInfoPtr : Type<
     And<[
-      CPred<"$_self.isa<::mlir::cir::PointerType>()">,
-      CPred<"$_self.cast<::mlir::cir::PointerType>()"
-            ".getPointee().isa<::mlir::cir::ExceptionInfoType>()">,
+      CPred<"::mlir::isa<::mlir::cir::PointerType>($_self)">,
+      CPred<"::mlir::isa<::mlir::cir::ExceptionInfoType>("
+            "::mlir::cast<::mlir::cir::PointerType>($_self).getPointee())">
     ]>, "!cir.eh_info*">,
     BuildableType<
       "mlir::cir::PointerType::get($_builder.getContext(),"
@@ -455,13 +455,14 @@ def ExceptionInfoPtr : Type<
 // Pooint to pointers to exception info
 def ExceptionInfoPtrPtr : Type<
     And<[
-      CPred<"$_self.isa<::mlir::cir::PointerType>()">,
+      CPred<"::mlir::isa<::mlir::cir::PointerType>($_self)">,
       And<[
-        CPred<"$_self.cast<::mlir::cir::PointerType>()"
-              ".getPointee().isa<::mlir::cir::PointerType>()">,
-        CPred<"$_self.cast<::mlir::cir::PointerType>()"
-              ".getPointee().cast<::mlir::cir::PointerType>()"
-              ".getPointee().isa<::mlir::cir::ExceptionInfoType>()">,
+        CPred<"::mlir::isa<::mlir::cir::PointerType>("
+              "::mlir::cast<::mlir::cir::PointerType>($_self).getPointee()">,
+        CPred<"::mlir::isa<::mlir::cir::ExceptionInfoType>("
+              "::mlir::cast<::mlir::cir::PointerType>("
+              "::mlir::cast<::mlir::cir::PointerType>($_self).getPointee())"
+              ".getPointee()))">
       ]>
     ]>, "!cir.eh_info**">,
     BuildableType<
@@ -473,11 +474,11 @@ def ExceptionInfoPtrPtr : Type<
 // Vector of integral type
 def IntegerVector : Type<
     And<[
-      CPred<"$_self.isa<::mlir::cir::VectorType>()">,
-      CPred<"$_self.cast<::mlir::cir::VectorType>()"
-            ".getEltType().isa<::mlir::cir::IntType>()">,
-      CPred<"$_self.cast<::mlir::cir::VectorType>()"
-            ".getEltType().cast<::mlir::cir::IntType>()"
+      CPred<"::mlir::isa<::mlir::cir::VectorType>($_self)">,
+      CPred<"::mlir::isa<::mlir::cir::IntType>("
+            "::mlir::cast<::mlir::cir::VectorType>($_self).getEltType())">,
+      CPred<"::mlir::cast<::mlir::cir::IntType>("
+            "::mlir::cast<::mlir::cir::VectorType>($_self).getEltType())"
             ".isPrimitive()">
     ]>, "!cir.vector of !cir.int"> {
 }
@@ -485,9 +486,9 @@ def IntegerVector : Type<
 // Pointer to Arrays
 def ArrayPtr : Type<
     And<[
-      CPred<"$_self.isa<::mlir::cir::PointerType>()">,
-      CPred<"$_self.cast<::mlir::cir::PointerType>()"
-            ".getPointee().isa<::mlir::cir::ArrayType>()">,
+      CPred<"::mlir::isa<::mlir::cir::PointerType>($_self)">,
+      CPred<"::mlir::isa<::mlir::cir::ArrayType>("
+            "::mlir::cast<::mlir::cir::PointerType>($_self).getPointee())">,
     ]>, "!cir.ptr<!cir.eh_info>"> {
 }
 
@@ -495,7 +496,7 @@ def ArrayPtr : Type<
 // StructType (defined in cpp files)
 //===----------------------------------------------------------------------===//
 
-def CIR_StructType : Type<CPred<"$_self.isa<::mlir::cir::StructType>()">,
+def CIR_StructType : Type<CPred<"::mlir::isa<::mlir::cir::StructType>($_self)">,
                           "CIR struct type">;
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CMakeLists.txt
+++ b/clang/lib/CIR/CMakeLists.txt
@@ -1,6 +1,8 @@
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
+add_compile_options("-Werror=deprecated-declarations")
+
 add_subdirectory(Dialect)
 add_subdirectory(CodeGen)
 add_subdirectory(FrontendAction)

--- a/clang/lib/CIR/CMakeLists.txt
+++ b/clang/lib/CIR/CMakeLists.txt
@@ -1,7 +1,12 @@
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
-add_compile_options("-Werror=deprecated-declarations")
+# Report use of deprecated APIs as errors
+if (MSVC)
+  add_compile_options("/we4996")
+else()
+  add_compile_options("-Werror=deprecated-declarations")
+endif(MSVC)
 
 add_subdirectory(Dialect)
 add_subdirectory(CodeGen)

--- a/clang/lib/CIR/CodeGen/Address.h
+++ b/clang/lib/CIR/CodeGen/Address.h
@@ -40,7 +40,7 @@ public:
           KnownNonNull_t IsKnownNonNull = NotKnownNonNull)
       : PointerAndKnownNonNull(pointer, IsKnownNonNull),
         ElementType(elementType), Alignment(alignment) {
-    assert(pointer.getType().isa<mlir::cir::PointerType>() &&
+    assert(mlir::isa<mlir::cir::PointerType>(pointer.getType()) &&
            "Expected cir.ptr type");
 
     assert(pointer && "Pointer cannot be null");
@@ -48,9 +48,10 @@ public:
     assert(!alignment.isZero() && "Alignment cannot be zero");
   }
   Address(mlir::Value pointer, clang::CharUnits alignment)
-      : Address(pointer,
-                pointer.getType().cast<mlir::cir::PointerType>().getPointee(),
-                alignment) {
+      : Address(
+            pointer,
+            mlir::cast<mlir::cir::PointerType>(pointer.getType()).getPointee(),
+            alignment) {
 
     assert((!alignment.isZero() || pointer == nullptr) &&
            "creating valid address with invalid alignment");
@@ -104,7 +105,7 @@ public:
 
   /// Return the type of the pointer value.
   mlir::cir::PointerType getType() const {
-    return getPointer().getType().cast<mlir::cir::PointerType>();
+    return mlir::cast<mlir::cir::PointerType>(getPointer().getType());
   }
 
   mlir::Type getElementType() const {

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -294,7 +294,7 @@ static void buildAsmStores(CIRGenFunction &CGF, const AsmStmt &S,
 
       // Truncate the integer result to the right size, note that TruncTy can be
       // a pointer.
-      if (TruncTy.isa<mlir::FloatType>())
+      if (mlir::isa<mlir::FloatType>(TruncTy))
         Tmp = Builder.createFloatingCast(Tmp, TruncTy);
       else if (isa<mlir::cir::PointerType>(TruncTy) &&
                isa<mlir::cir::IntType>(Tmp.getType())) {
@@ -652,7 +652,7 @@ mlir::LogicalResult CIRGenFunction::buildAsmStmt(const AsmStmt &S) {
     for (auto typ : ArgElemTypes) {
       if (typ) {
         auto op = Args[i++];
-        assert(op.getType().isa<mlir::cir::PointerType>() &&
+        assert(mlir::isa<mlir::cir::PointerType>(op.getType()) &&
                "pointer type expected");
         assert(cast<mlir::cir::PointerType>(op.getType()).getPointee() == typ &&
                "element type differs from pointee type!");

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -302,7 +302,7 @@ bool AtomicInfo::requiresMemSetZero(mlir::Type ty) const {
 }
 
 Address AtomicInfo::castToAtomicIntPointer(Address addr) const {
-  auto intTy = addr.getElementType().dyn_cast<mlir::cir::IntType>();
+  auto intTy = mlir::dyn_cast<mlir::cir::IntType>(addr.getElementType());
   // Don't bother with int casts if the integer size is the same.
   if (intTy && intTy.getWidth() == AtomicSizeInBits)
     return addr;
@@ -342,8 +342,8 @@ static mlir::cir::IntAttr getConstOpIntAttr(mlir::Value v) {
   while (auto c = dyn_cast<mlir::cir::CastOp>(op))
     op = c.getOperand().getDefiningOp();
   if (auto c = dyn_cast<mlir::cir::ConstantOp>(op)) {
-    if (c.getType().isa<mlir::cir::IntType>())
-      constVal = c.getValue().cast<mlir::cir::IntAttr>();
+    if (mlir::isa<mlir::cir::IntType>(c.getType()))
+      constVal = mlir::cast<mlir::cir::IntAttr>(c.getValue());
   }
   return constVal;
 }
@@ -376,7 +376,8 @@ static void buildAtomicCmpXchg(CIRGenFunction &CGF, AtomicExpr *E, bool IsWeak,
   auto cmp = builder.createNot(cmpxchg.getCmp());
   builder.create<mlir::cir::IfOp>(
       loc, cmp, false, [&](mlir::OpBuilder &, mlir::Location) {
-        auto ptrTy = Val1.getPointer().getType().cast<mlir::cir::PointerType>();
+        auto ptrTy =
+            mlir::cast<mlir::cir::PointerType>(Val1.getPointer().getType());
         if (Val1.getElementType() != ptrTy.getPointee()) {
           Val1 = Val1.withPointer(builder.createPtrBitcast(
               Val1.getPointer(), Val1.getElementType()));
@@ -494,7 +495,8 @@ static void buildAtomicOp(CIRGenFunction &CGF, AtomicExpr *E, Address Dest,
 
     // TODO(cir): this logic should be part of createStore, but doing so
     // currently breaks CodeGen/union.cpp and CodeGen/union.cpp.
-    auto ptrTy = Dest.getPointer().getType().cast<mlir::cir::PointerType>();
+    auto ptrTy =
+        mlir::cast<mlir::cir::PointerType>(Dest.getPointer().getType());
     if (Dest.getElementType() != ptrTy.getPointee()) {
       Dest = Dest.withPointer(
           builder.createPtrBitcast(Dest.getPointer(), Dest.getElementType()));
@@ -659,7 +661,7 @@ static void buildAtomicOp(CIRGenFunction &CGF, AtomicExpr *E, Address Dest,
 
   // TODO(cir): this logic should be part of createStore, but doing so currently
   // breaks CodeGen/union.cpp and CodeGen/union.cpp.
-  auto ptrTy = Dest.getPointer().getType().cast<mlir::cir::PointerType>();
+  auto ptrTy = mlir::cast<mlir::cir::PointerType>(Dest.getPointer().getType());
   if (Dest.getElementType() != ptrTy.getPointee()) {
     Dest = Dest.withPointer(
         builder.createPtrBitcast(Dest.getPointer(), Dest.getElementType()));

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -553,7 +553,7 @@ RValue CIRGenFunction::buildCall(const CIRGenFunctionInfo &CallInfo,
 
     switch (ArgInfo.getKind()) {
     case ABIArgInfo::Direct: {
-      if (!ArgInfo.getCoerceToType().isa<mlir::cir::StructType>() &&
+      if (!mlir::isa<mlir::cir::StructType>(ArgInfo.getCoerceToType()) &&
           ArgInfo.getCoerceToType() == convertType(info_it->type) &&
           ArgInfo.getDirectOffset() == 0) {
         assert(NumCIRArgs == 1);
@@ -567,7 +567,7 @@ RValue CIRGenFunction::buildCall(const CIRGenFunctionInfo &CallInfo,
 
         // We might have to widen integers, but we should never truncate.
         if (ArgInfo.getCoerceToType() != V.getType() &&
-            V.getType().isa<mlir::cir::IntType>())
+            mlir::isa<mlir::cir::IntType>(V.getType()))
           llvm_unreachable("NYI");
 
         // If the argument doesn't match, perform a bitcast to coerce it. This
@@ -733,9 +733,9 @@ RValue CIRGenFunction::buildCall(const CIRGenFunctionInfo &CallInfo,
     } else {
       [[maybe_unused]] auto resultTypes = CalleePtr->getResultTypes();
       [[maybe_unused]] auto FuncPtrTy =
-          resultTypes.front().dyn_cast<mlir::cir::PointerType>();
+          mlir::dyn_cast<mlir::cir::PointerType>(resultTypes.front());
       assert((resultTypes.size() == 1) && FuncPtrTy &&
-             FuncPtrTy.getPointee().isa<mlir::cir::FuncType>() &&
+             mlir::isa<mlir::cir::FuncType>(FuncPtrTy.getPointee()) &&
              "expected pointer to function");
 
       indirectFuncTy = CIRFuncTy;
@@ -946,7 +946,8 @@ void CIRGenFunction::buildCallArgs(
   // First, if a prototype was provided, use those argument types.
   bool IsVariadic = false;
   if (Prototype.P) {
-    const auto *MD = Prototype.P.dyn_cast<const ObjCMethodDecl *>();
+    const auto *MD =
+        mlir::dyn_cast_if_present<const ObjCMethodDecl *>(Prototype.P);
     assert(!MD && "ObjCMethodDecl NYI");
 
     const auto *FPT = Prototype.P.get<const FunctionProtoType *>();

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -946,8 +946,7 @@ void CIRGenFunction::buildCallArgs(
   // First, if a prototype was provided, use those argument types.
   bool IsVariadic = false;
   if (Prototype.P) {
-    const auto *MD =
-        mlir::dyn_cast_if_present<const ObjCMethodDecl *>(Prototype.P);
+    const auto *MD = mlir::dyn_cast<const ObjCMethodDecl *>(Prototype.P);
     assert(!MD && "ObjCMethodDecl NYI");
 
     const auto *FPT = Prototype.P.get<const FunctionProtoType *>();

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -1614,7 +1614,8 @@ void CIRGenFunction::buildCXXAggrConstructorCall(
   auto constantCount =
       dyn_cast<mlir::cir::ConstantOp>(numElements.getDefiningOp());
   if (constantCount) {
-    auto constIntAttr = constantCount.getValue().dyn_cast<mlir::cir::IntAttr>();
+    auto constIntAttr =
+        mlir::dyn_cast<mlir::cir::IntAttr>(constantCount.getValue());
     // Just skip out if the constant count is zero.
     if (constIntAttr && constIntAttr.getUInt() == 0)
       return;
@@ -1623,7 +1624,8 @@ void CIRGenFunction::buildCXXAggrConstructorCall(
     llvm_unreachable("NYI");
   }
 
-  auto arrayTy = arrayBase.getElementType().dyn_cast<mlir::cir::ArrayType>();
+  auto arrayTy =
+      mlir::dyn_cast<mlir::cir::ArrayType>(arrayBase.getElementType());
   assert(arrayTy && "expected array type");
   auto elementType = arrayTy.getEltType();
   auto ptrToElmType = builder.getPointerTo(elementType);

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -467,7 +467,7 @@ void AggExprEmitter::buildArrayInit(Address DestPtr, mlir::cir::ArrayType AType,
   for (uint64_t i = 0; i != NumInitElements; ++i) {
     if (i == 1)
       one = CGF.getBuilder().getConstInt(
-          loc, CGF.PtrDiffTy.cast<mlir::cir::IntType>(), 1);
+          loc, mlir::cast<mlir::cir::IntType>(CGF.PtrDiffTy), 1);
 
     // Advance to the next element.
     if (i > 0) {
@@ -502,8 +502,8 @@ void AggExprEmitter::buildArrayInit(Address DestPtr, mlir::cir::ArrayType AType,
 
     // Advance to the start of the rest of the array.
     if (NumInitElements) {
-      auto one =
-          builder.getConstInt(loc, CGF.PtrDiffTy.cast<mlir::cir::IntType>(), 1);
+      auto one = builder.getConstInt(
+          loc, mlir::cast<mlir::cir::IntType>(CGF.PtrDiffTy), 1);
       element = builder.create<mlir::cir::PtrStrideOp>(loc, cirElementPtrType,
                                                        element, one);
 
@@ -519,7 +519,7 @@ void AggExprEmitter::buildArrayInit(Address DestPtr, mlir::cir::ArrayType AType,
 
     // Compute the end of array
     auto numArrayElementsConst = builder.getConstInt(
-        loc, CGF.PtrDiffTy.cast<mlir::cir::IntType>(), NumArrayElements);
+        loc, mlir::cast<mlir::cir::IntType>(CGF.PtrDiffTy), NumArrayElements);
     mlir::Value end = builder.create<mlir::cir::PtrStrideOp>(
         loc, cirElementPtrType, begin, numArrayElementsConst);
 
@@ -554,7 +554,7 @@ void AggExprEmitter::buildArrayInit(Address DestPtr, mlir::cir::ArrayType AType,
 
           // Advance pointer and store them to temporary variable
           auto one = builder.getConstInt(
-              loc, CGF.PtrDiffTy.cast<mlir::cir::IntType>(), 1);
+              loc, mlir::cast<mlir::cir::IntType>(CGF.PtrDiffTy), 1);
           auto nextElement = builder.create<mlir::cir::PtrStrideOp>(
               loc, cirElementPtrType, currentElement, one);
           CGF.buildStoreThroughLValue(RValue::get(nextElement), tmpLV);

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1088,7 +1088,7 @@ void CIRGenFunction::buildDeleteCall(const FunctionDecl *DeleteFD,
 static mlir::Value buildDynamicCastToNull(CIRGenFunction &CGF,
                                           mlir::Location Loc, QualType DestTy) {
   mlir::Type DestCIRTy = CGF.ConvertType(DestTy);
-  assert(DestCIRTy.isa<mlir::cir::PointerType>() &&
+  assert(mlir::isa<mlir::cir::PointerType>(DestCIRTy) &&
          "result of dynamic_cast should be a ptr");
 
   mlir::Value NullPtrValue = CGF.getBuilder().getNullPtr(DestCIRTy, Loc);
@@ -1136,7 +1136,7 @@ mlir::Value CIRGenFunction::buildDynamicCast(Address ThisAddr,
   if (DCE->isAlwaysNull())
     return buildDynamicCastToNull(*this, loc, destTy);
 
-  auto destCirTy = ConvertType(destTy).cast<mlir::cir::PointerType>();
+  auto destCirTy = mlir::cast<mlir::cir::PointerType>(ConvertType(destTy));
   return CGM.getCXXABI().buildDynamicCast(*this, loc, srcRecordTy, destRecordTy,
                                           destCirTy, isRefCast,
                                           ThisAddr.getPointer());

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1263,7 +1263,7 @@ private:
   ConstantLValue applyOffset(ConstantLValue &C) {
 
     // Handle attribute constant LValues.
-    if (auto Attr = mlir::dyn_cast_if_present<mlir::Attribute>(C.Value)) {
+    if (auto Attr = mlir::dyn_cast<mlir::Attribute>(C.Value)) {
       if (auto GV = mlir::dyn_cast<mlir::cir::GlobalViewAttr>(Attr)) {
         auto baseTy =
             mlir::cast<mlir::cir::PointerType>(GV.getType()).getPointee();

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -151,7 +151,7 @@ static void replace(Container &C, size_t BeginOff, size_t EndOff, Range Vals) {
 bool ConstantAggregateBuilder::add(mlir::Attribute A, CharUnits Offset,
                                    bool AllowOverwrite) {
   // FIXME(cir): migrate most of this file to use mlir::TypedAttr directly.
-  mlir::TypedAttr C = A.dyn_cast<mlir::TypedAttr>();
+  mlir::TypedAttr C = mlir::dyn_cast<mlir::TypedAttr>(A);
   assert(C && "expected typed attribute");
   // Common case: appending to a layout.
   if (Offset >= Size) {
@@ -319,7 +319,7 @@ std::optional<size_t> ConstantAggregateBuilder::splitAt(CharUnits Pos) {
     // We found an element starting before Pos. Check for overlap.
     // FIXME(cir): migrate most of this file to use mlir::TypedAttr directly.
     mlir::TypedAttr C =
-        Elems[LastAtOrBeforePosIndex].dyn_cast<mlir::TypedAttr>();
+        mlir::dyn_cast<mlir::TypedAttr>(Elems[LastAtOrBeforePosIndex]);
     assert(C && "expected typed attribute");
     if (Offsets[LastAtOrBeforePosIndex] + getSize(C) <= Pos)
       return LastAtOrBeforePosIndex + 1;
@@ -349,7 +349,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
 
   // If we want an array type, see if all the elements are the same type and
   // appropriately spaced.
-  if (auto aty = DesiredTy.dyn_cast<mlir::cir::ArrayType>()) {
+  if (auto aty = mlir::dyn_cast<mlir::cir::ArrayType>(DesiredTy)) {
     llvm_unreachable("NYI");
   }
 
@@ -366,7 +366,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   CharUnits Align = CharUnits::One();
   for (auto e : Elems) {
     // FIXME(cir): migrate most of this file to use mlir::TypedAttr directly.
-    auto C = e.dyn_cast<mlir::TypedAttr>();
+    auto C = mlir::dyn_cast<mlir::TypedAttr>(e);
     assert(C && "expected typed attribute");
     Align = std::max(Align, Utils.getAlignment(C));
   }
@@ -395,7 +395,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   if (!NaturalLayout) {
     CharUnits SizeSoFar = CharUnits::Zero();
     for (size_t I = 0; I != Elems.size(); ++I) {
-      mlir::TypedAttr C = Elems[I].dyn_cast<mlir::TypedAttr>();
+      mlir::TypedAttr C = mlir::dyn_cast<mlir::TypedAttr>(Elems[I]);
       assert(C && "expected typed attribute");
 
       CharUnits Align = Utils.getAlignment(C);
@@ -452,7 +452,7 @@ void ConstantAggregateBuilder::condense(CharUnits Offset,
     return;
 
   // FIXME(cir): migrate most of this file to use mlir::TypedAttr directly.
-  mlir::TypedAttr C = Elems[First].dyn_cast<mlir::TypedAttr>();
+  mlir::TypedAttr C = mlir::dyn_cast<mlir::TypedAttr>(Elems[First]);
   assert(C && "expected typed attribute");
   if (Length == 1 && Offsets[First] == Offset && getSize(C) == Size) {
     // Re-wrap single element structs if necessary. Otherwise, leave any single
@@ -1263,9 +1263,10 @@ private:
   ConstantLValue applyOffset(ConstantLValue &C) {
 
     // Handle attribute constant LValues.
-    if (auto Attr = C.Value.dyn_cast<mlir::Attribute>()) {
-      if (auto GV = Attr.dyn_cast<mlir::cir::GlobalViewAttr>()) {
-        auto baseTy = GV.getType().cast<mlir::cir::PointerType>().getPointee();
+    if (auto Attr = mlir::dyn_cast_if_present<mlir::Attribute>(C.Value)) {
+      if (auto GV = mlir::dyn_cast<mlir::cir::GlobalViewAttr>(Attr)) {
+        auto baseTy =
+            mlir::cast<mlir::cir::PointerType>(GV.getType()).getPointee();
         auto destTy = CGM.getTypes().convertTypeForMem(DestType);
         assert(!GV.getIndices() && "Global view is already indexed");
         return mlir::cir::GlobalViewAttr::get(destTy, GV.getSymbol(),
@@ -1292,7 +1293,7 @@ mlir::Attribute ConstantLValueEmitter::tryEmit() {
   // non-zero null pointer and addrspace casts that aren't trivially
   // represented in LLVM IR.
   auto destTy = CGM.getTypes().convertTypeForMem(DestType);
-  assert(destTy.isa<mlir::cir::PointerType>());
+  assert(mlir::isa<mlir::cir::PointerType>(destTy));
 
   // If there's no base at all, this is a null or absolute pointer,
   // possibly cast back to an integer type.
@@ -1315,7 +1316,7 @@ mlir::Attribute ConstantLValueEmitter::tryEmit() {
 
   // Convert to the appropriate type; this could be an lvalue for
   // an integer. FIXME: performAddrSpaceCast
-  if (destTy.isa<mlir::cir::PointerType>()) {
+  if (mlir::isa<mlir::cir::PointerType>(destTy)) {
     if (value.is<mlir::Attribute>())
       return value.get<mlir::Attribute>();
     llvm_unreachable("NYI");
@@ -1328,7 +1329,7 @@ mlir::Attribute ConstantLValueEmitter::tryEmit() {
 /// bitcast to pointer type.
 mlir::Attribute ConstantLValueEmitter::tryEmitAbsolute(mlir::Type destTy) {
   // If we're producing a pointer, this is easy.
-  auto destPtrTy = destTy.dyn_cast<mlir::cir::PointerType>();
+  auto destPtrTy = mlir::dyn_cast<mlir::cir::PointerType>(destTy);
   assert(destPtrTy && "expected !cir.ptr type");
   return CGM.getBuilder().getConstPtrAttr(
       destPtrTy, Value.getLValueOffset().getQuantity());
@@ -1652,8 +1653,8 @@ mlir::Attribute ConstantEmitter::emitForMemory(CIRGenModule &CGM,
   }
 
   // Zero-extend bool.
-  auto typed = C.dyn_cast<mlir::TypedAttr>();
-  if (typed && typed.getType().isa<mlir::cir::BoolType>()) {
+  auto typed = mlir::dyn_cast<mlir::TypedAttr>(C);
+  if (typed && mlir::isa<mlir::cir::BoolType>(typed.getType())) {
     // Already taken care given that bool values coming from
     // integers only carry true/false.
   }
@@ -1666,7 +1667,7 @@ mlir::TypedAttr ConstantEmitter::tryEmitPrivate(const Expr *E,
   assert(!destType->isVoidType() && "can't emit a void constant");
 
   if (auto C = ConstExprEmitter(*this).Visit(const_cast<Expr *>(E), destType)) {
-    if (auto TypedC = C.dyn_cast_or_null<mlir::TypedAttr>())
+    if (auto TypedC = mlir::dyn_cast_if_present<mlir::TypedAttr>(C))
       return TypedC;
     llvm_unreachable("this should always be typed");
   }
@@ -1683,7 +1684,7 @@ mlir::TypedAttr ConstantEmitter::tryEmitPrivate(const Expr *E,
 
   if (Success && !Result.hasSideEffects()) {
     auto C = tryEmitPrivate(Result.Val, destType);
-    if (auto TypedC = C.dyn_cast_or_null<mlir::TypedAttr>())
+    if (auto TypedC = mlir::dyn_cast_if_present<mlir::TypedAttr>(C))
       return TypedC;
     llvm_unreachable("this should always be typed");
   }
@@ -1702,9 +1703,9 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
     assert(0 && "not implemented");
   case APValue::Int: {
     mlir::Type ty = CGM.getCIRType(DestType);
-    if (ty.isa<mlir::cir::BoolType>())
+    if (mlir::isa<mlir::cir::BoolType>(ty))
       return builder.getCIRBoolAttr(Value.getInt().getZExtValue());
-    assert(ty.isa<mlir::cir::IntType>() && "expected integral type");
+    assert(mlir::isa<mlir::cir::IntType>(ty) && "expected integral type");
     return CGM.getBuilder().getAttr<mlir::cir::IntAttr>(ty, Value.getInt());
   }
   case APValue::Float: {
@@ -1715,7 +1716,7 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
       assert(0 && "not implemented");
     else {
       mlir::Type ty = CGM.getCIRType(DestType);
-      assert(ty.isa<mlir::cir::CIRFPTypeInterface>() &&
+      assert(mlir::isa<mlir::cir::CIRFPTypeInterface>(ty) &&
              "expected floating-point type");
       return CGM.getBuilder().getAttr<mlir::cir::FPAttr>(ty, Init);
     }
@@ -1748,8 +1749,9 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
       if (!C)
         return {};
 
-      assert(C.isa<mlir::TypedAttr>() && "This should always be a TypedAttr.");
-      auto CTyped = C.cast<mlir::TypedAttr>();
+      assert(mlir::isa<mlir::TypedAttr>(C) &&
+             "This should always be a TypedAttr.");
+      auto CTyped = mlir::cast<mlir::TypedAttr>(C);
 
       if (I == 0)
         CommonElementType = CTyped.getType();
@@ -1779,8 +1781,8 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
     if (const auto *memberFuncDecl = dyn_cast<CXXMethodDecl>(memberDecl))
       assert(0 && "not implemented");
 
-    auto cirTy =
-        CGM.getTypes().ConvertType(DestType).cast<mlir::cir::DataMemberType>();
+    auto cirTy = mlir::cast<mlir::cir::DataMemberType>(
+        CGM.getTypes().ConvertType(DestType));
 
     const auto *fieldDecl = cast<FieldDecl>(memberDecl);
     return builder.getDataMemberAttr(cirTy, fieldDecl->getFieldIndex());
@@ -1835,7 +1837,7 @@ mlir::Value CIRGenModule::buildMemberPointerConstant(const UnaryOperator *E) {
   if (const auto *methodDecl = dyn_cast<CXXMethodDecl>(decl))
     assert(0 && "not implemented");
 
-  auto ty = getCIRType(E->getType()).cast<mlir::cir::DataMemberType>();
+  auto ty = mlir::cast<mlir::cir::DataMemberType>(getCIRType(E->getType()));
 
   // Otherwise, a member data pointer.
   const auto *fieldDecl = cast<FieldDecl>(decl);
@@ -1846,7 +1848,7 @@ mlir::Value CIRGenModule::buildMemberPointerConstant(const UnaryOperator *E) {
 mlir::Attribute ConstantEmitter::emitAbstract(const Expr *E,
                                               QualType destType) {
   auto state = pushAbstract();
-  auto C = tryEmitPrivate(E, destType).cast<mlir::Attribute>();
+  auto C = mlir::cast<mlir::Attribute>(tryEmitPrivate(E, destType));
   C = validateAndPopAbstract(C, state);
   if (!C) {
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -1688,14 +1688,16 @@ CIRGenFunction::buildArrayLength(const clang::ArrayType *origArrayType,
 
   // llvm::ArrayType *llvmArrayType =
   //     dyn_cast<llvm::ArrayType>(addr.getElementType());
-  auto cirArrayType = addr.getElementType().dyn_cast<mlir::cir::ArrayType>();
+  auto cirArrayType =
+      mlir::dyn_cast<mlir::cir::ArrayType>(addr.getElementType());
 
   while (cirArrayType) {
     assert(isa<ConstantArrayType>(arrayType));
     countFromCLAs *= cirArrayType.getSize();
     eltType = arrayType->getElementType();
 
-    cirArrayType = cirArrayType.getEltType().dyn_cast<mlir::cir::ArrayType>();
+    cirArrayType =
+        mlir::dyn_cast<mlir::cir::ArrayType>(cirArrayType.getEltType());
 
     arrayType = getContext().getAsArrayType(arrayType->getElementType());
     assert((!cirArrayType || arrayType) &&

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1089,7 +1089,7 @@ public:
 
     mlir::TypedAttr getValue() const {
       assert(!isReference());
-      return ValueAndIsReference.getPointer().cast<mlir::TypedAttr>();
+      return mlir::cast<mlir::TypedAttr>(ValueAndIsReference.getPointer());
     }
   };
 
@@ -1923,7 +1923,7 @@ public:
         Depth++;
 
       // Has multiple locations: overwrite with separate start and end locs.
-      if (const auto fusedLoc = loc.dyn_cast<mlir::FusedLoc>()) {
+      if (const auto fusedLoc = mlir::dyn_cast<mlir::FusedLoc>(loc)) {
         assert(fusedLoc.getLocations().size() == 2 && "too many locations");
         BeginLoc = fusedLoc.getLocations()[0];
         EndLoc = fusedLoc.getLocations()[1];

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -2169,9 +2169,9 @@ void CIRGenItaniumCXXABI::buildThrow(CIRGenFunction &CGF,
   CGF.buildAnyExprToExn(E->getSubExpr(), Address(exceptionPtr, exnAlign));
 
   // Get the RTTI symbol address.
-  auto typeInfo = CGM.getAddrOfRTTIDescriptor(subExprLoc, clangThrowType,
-                                              /*ForEH=*/true)
-                      .dyn_cast_or_null<mlir::cir::GlobalViewAttr>();
+  auto typeInfo = mlir::dyn_cast_if_present<mlir::cir::GlobalViewAttr>(
+      CGM.getAddrOfRTTIDescriptor(subExprLoc, clangThrowType,
+                                  /*ForEH=*/true));
   assert(typeInfo && "expected GlobalViewAttr typeinfo");
   assert(!typeInfo.getIndices() && "expected no indirection");
 
@@ -2307,10 +2307,10 @@ static mlir::Value buildDynamicCastToVoid(CIRGenFunction &CGF,
 static mlir::cir::DynamicCastInfoAttr
 buildDynamicCastInfo(CIRGenFunction &CGF, mlir::Location Loc,
                      QualType SrcRecordTy, QualType DestRecordTy) {
-  auto srcRtti = CGF.CGM.getAddrOfRTTIDescriptor(Loc, SrcRecordTy)
-                     .cast<mlir::cir::GlobalViewAttr>();
-  auto destRtti = CGF.CGM.getAddrOfRTTIDescriptor(Loc, DestRecordTy)
-                      .cast<mlir::cir::GlobalViewAttr>();
+  auto srcRtti = mlir::cast<mlir::cir::GlobalViewAttr>(
+      CGF.CGM.getAddrOfRTTIDescriptor(Loc, SrcRecordTy));
+  auto destRtti = mlir::cast<mlir::cir::GlobalViewAttr>(
+      CGF.CGM.getAddrOfRTTIDescriptor(Loc, DestRecordTy));
 
   auto runtimeFuncOp = getItaniumDynamicCastFn(CGF);
   auto badCastFuncOp = getBadCastFn(CGF);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -969,7 +969,7 @@ mlir::Operation *CIRGenModule::getWeakRefReference(const ValueDecl *VD) {
   }
 
   mlir::Type DeclTy = getTypes().convertTypeForMem(VD->getType());
-  if (DeclTy.isa<mlir::cir::FuncType>()) {
+  if (mlir::isa<mlir::cir::FuncType>(DeclTy)) {
     auto F = GetOrCreateCIRFunction(AA->getAliasee(), DeclTy,
                                     GlobalDecl(cast<FunctionDecl>(VD)),
                                     /*ForVtable=*/false);
@@ -1110,23 +1110,23 @@ void CIRGenModule::buildGlobalVarDefinition(const clang::VarDecl *D,
   //
   // TODO(cir): create another attribute to contain the final type and abstract
   // away SymbolRefAttr.
-  if (auto symAttr = Init.dyn_cast<mlir::SymbolRefAttr>()) {
+  if (auto symAttr = mlir::dyn_cast<mlir::SymbolRefAttr>(Init)) {
     auto cstGlobal = mlir::SymbolTable::lookupSymbolIn(theModule, symAttr);
     assert(isa<mlir::cir::GlobalOp>(cstGlobal) &&
            "unaware of other symbol providers");
     auto g = cast<mlir::cir::GlobalOp>(cstGlobal);
-    auto arrayTy = g.getSymType().dyn_cast<mlir::cir::ArrayType>();
+    auto arrayTy = mlir::dyn_cast<mlir::cir::ArrayType>(g.getSymType());
     // TODO(cir): pointer to array decay. Should this be modeled explicitly in
     // CIR?
     if (arrayTy)
       InitType = mlir::cir::PointerType::get(builder.getContext(),
                                              arrayTy.getEltType());
   } else {
-    assert(Init.isa<mlir::TypedAttr>() && "This should have a type");
-    auto TypedInitAttr = Init.cast<mlir::TypedAttr>();
+    assert(mlir::isa<mlir::TypedAttr>(Init) && "This should have a type");
+    auto TypedInitAttr = mlir::cast<mlir::TypedAttr>(Init);
     InitType = TypedInitAttr.getType();
   }
-  assert(!InitType.isa<mlir::NoneType>() && "Should have a type by now");
+  assert(!mlir::isa<mlir::NoneType>(InitType) && "Should have a type by now");
 
   auto Entry = buildGlobal(D, InitType, ForDefinition_t(!IsTentative));
   // TODO(cir): Strip off pointer casts from Entry if we get them?
@@ -1305,11 +1305,11 @@ CIRGenModule::getConstantArrayFromStringLiteral(const StringLiteral *E) {
     return builder.getString(Str, eltTy, finalSize);
   }
 
-  auto arrayTy =
-      getTypes().ConvertType(E->getType()).dyn_cast<mlir::cir::ArrayType>();
+  auto arrayTy = mlir::dyn_cast<mlir::cir::ArrayType>(
+      getTypes().ConvertType(E->getType()));
   assert(arrayTy && "string literals must be emitted as an array type");
 
-  auto arrayEltTy = arrayTy.getEltType().dyn_cast<mlir::cir::IntType>();
+  auto arrayEltTy = mlir::dyn_cast<mlir::cir::IntType>(arrayTy.getEltType());
   assert(arrayEltTy &&
          "string literal elements must be emitted as integral type");
 
@@ -1428,7 +1428,7 @@ CIRGenModule::getAddrOfConstantStringFromLiteral(const StringLiteral *S,
     assert(!cir::MissingFeatures::reportGlobalToASan() && "NYI");
   }
 
-  auto ArrayTy = GV.getSymType().dyn_cast<mlir::cir::ArrayType>();
+  auto ArrayTy = mlir::dyn_cast<mlir::cir::ArrayType>(GV.getSymType());
   assert(ArrayTy && "String literal must be array");
   auto PtrTy =
       mlir::cir::PointerType::get(builder.getContext(), ArrayTy.getEltType());
@@ -2376,8 +2376,8 @@ mlir::cir::FuncOp CIRGenModule::GetOrCreateCIRFunction(
   bool IsIncompleteFunction = false;
 
   mlir::cir::FuncType FTy;
-  if (Ty.isa<mlir::cir::FuncType>()) {
-    FTy = Ty.cast<mlir::cir::FuncType>();
+  if (mlir::isa<mlir::cir::FuncType>(Ty)) {
+    FTy = mlir::cast<mlir::cir::FuncType>(Ty);
   } else {
     assert(false && "NYI");
     // FTy = mlir::FunctionType::get(VoidTy, false);

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -714,8 +714,8 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
     assert(MPT->isMemberDataPointer() && "ptr-to-member-function is NYI");
 
     auto memberTy = ConvertType(MPT->getPointeeType());
-    auto clsTy =
-        ConvertType(QualType(MPT->getClass(), 0)).cast<mlir::cir::StructType>();
+    auto clsTy = mlir::cast<mlir::cir::StructType>(
+        ConvertType(QualType(MPT->getClass(), 0)));
     ResultType =
         mlir::cir::DataMemberType::get(Builder.getContext(), memberTy, clsTy);
     break;

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -202,8 +202,8 @@ void CIRGenVTables::addVTableComponent(ConstantArrayBuilder &builder,
       //                             vtableHasLocalLinkage,
       //                             /*isCompleteDtor=*/false);
     } else {
-      assert((rtti.isa<mlir::cir::GlobalViewAttr>() ||
-              rtti.isa<mlir::cir::ConstPtrAttr>()) &&
+      assert((mlir::isa<mlir::cir::GlobalViewAttr>(rtti) ||
+              mlir::isa<mlir::cir::ConstPtrAttr>(rtti)) &&
              "expected GlobalViewAttr or ConstPtrAttr");
       return builder.add(rtti);
     }

--- a/clang/lib/CIR/CodeGen/CIRGenValue.h
+++ b/clang/lib/CIR/CodeGen/CIRGenValue.h
@@ -293,7 +293,7 @@ public:
 
     LValue R;
     R.LVType = Simple;
-    assert(address.getPointer().getType().cast<mlir::cir::PointerType>());
+    assert(mlir::cast<mlir::cir::PointerType>(address.getPointer().getType()));
     R.V = address.getPointer();
     R.ElementType = address.getElementType();
     R.Initialize(type, qs, address.getAlignment(),

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
@@ -34,8 +34,7 @@ mlir::Type ConstantInitFuture::getType() const {
 
 void ConstantInitFuture::abandon() {
   assert(Data && "abandoning null future");
-  if (auto builder =
-          mlir::dyn_cast_if_present<ConstantInitBuilderBase *>(Data)) {
+  if (auto builder = mlir::dyn_cast<ConstantInitBuilderBase *>(Data)) {
     builder->abandon(0);
   }
   Data = nullptr;

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
@@ -24,7 +24,7 @@ ConstantInitBuilderBase::ConstantInitBuilderBase(CIRGenModule &CGM)
 mlir::Type ConstantInitFuture::getType() const {
   assert(Data && "dereferencing null future");
   if (Data.is<mlir::Attribute>()) {
-    auto attr = Data.get<mlir::Attribute>().dyn_cast<mlir::TypedAttr>();
+    auto attr = mlir::dyn_cast<mlir::TypedAttr>(Data.get<mlir::Attribute>());
     assert(attr && "expected typed attribute");
     return attr.getType();
   } else {
@@ -34,7 +34,8 @@ mlir::Type ConstantInitFuture::getType() const {
 
 void ConstantInitFuture::abandon() {
   assert(Data && "abandoning null future");
-  if (auto builder = Data.dyn_cast<ConstantInitBuilderBase *>()) {
+  if (auto builder =
+          mlir::dyn_cast_if_present<ConstantInitBuilderBase *>(Data)) {
     builder->abandon(0);
   }
   Data = nullptr;

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
@@ -405,7 +405,7 @@ public:
                                  bool forVTable = false) {
     assert(!this->Parent && "finishing non-root builder");
     mlir::Attribute init = asImpl().finishImpl(global.getContext());
-    auto initCSA = init.dyn_cast<mlir::cir::ConstStructAttr>();
+    auto initCSA = mlir::dyn_cast<mlir::cir::ConstStructAttr>(init);
     assert(initCSA &&
            "expected #cir.const_struct attribute to represent vtable data");
     return this->Builder.setGlobalInitializer(

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -370,7 +370,7 @@ ABIArgInfo X86_64ABIInfo::classifyArgumentType(QualType Ty,
 
     // If we have a sign or zero extended integer, make sure to return Extend so
     // that the parameter gets the right LLVM IR attributes.
-    if (Hi == NoClass && ResType.isa<mlir::cir::IntType>()) {
+    if (Hi == NoClass && mlir::isa<mlir::cir::IntType>(ResType)) {
       assert(!Ty->getAs<EnumType>() && "NYI");
       if (Ty->isSignedIntegerOrEnumerationType() &&
           isPromotableIntegerTypeForABI(Ty))
@@ -499,7 +499,7 @@ ABIArgInfo X86_64ABIInfo::classifyReturnType(QualType RetTy) const {
     // If we have a sign or zero extended integer, make sure to return Extend so
     // that the parameter gets the right LLVM IR attributes.
     // TODO: extend the above consideration to MLIR
-    if (Hi == NoClass && ResType.isa<mlir::cir::IntType>()) {
+    if (Hi == NoClass && mlir::isa<mlir::cir::IntType>(ResType)) {
       // Treat an enum type as its underlying type.
       if (const auto *EnumTy = RetTy->getAs<EnumType>())
         RetTy = EnumTy->getDecl()->getIntegerType();

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -140,7 +140,7 @@ static ParseResult parseStructMembers(mlir::AsmParser &parser,
 LogicalResult ConstStructAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     mlir::Type type, ArrayAttr members) {
-  auto sTy = type.dyn_cast_or_null<mlir::cir::StructType>();
+  auto sTy = mlir::dyn_cast_if_present<mlir::cir::StructType>(type);
   if (!sTy) {
     emitError() << "expected !cir.struct type";
     return failure();
@@ -153,7 +153,7 @@ LogicalResult ConstStructAttr::verify(
 
   unsigned attrIdx = 0;
   for (auto &member : sTy.getMembers()) {
-    auto m = members[attrIdx].dyn_cast_or_null<TypedAttr>();
+    auto m = dyn_cast_if_present<TypedAttr>(members[attrIdx]);
     if (!m) {
       emitError() << "expected mlir::TypedAttr attribute";
       return failure();
@@ -175,7 +175,7 @@ LogicalResult StructLayoutAttr::verify(
     unsigned alignment, bool padded, mlir::Type largest_member,
     mlir::ArrayAttr offsets) {
   if (not std::all_of(offsets.begin(), offsets.end(), [](mlir::Attribute attr) {
-        return attr.isa<mlir::IntegerAttr>();
+        return mlir::isa<mlir::IntegerAttr>(attr);
       })) {
     return emitError() << "all index values must be integers";
   }
@@ -244,9 +244,9 @@ static void printConstPtr(AsmPrinter &p, mlir::IntegerAttr value) {
 Attribute IntAttr::parse(AsmParser &parser, Type odsType) {
   mlir::APInt APValue;
 
-  if (!odsType.isa<IntType>())
+  if (!mlir::isa<IntType>(odsType))
     return {};
-  auto type = odsType.cast<IntType>();
+  auto type = mlir::cast<IntType>(odsType);
 
   // Consume the '<' symbol.
   if (parser.parseLess())
@@ -279,7 +279,7 @@ Attribute IntAttr::parse(AsmParser &parser, Type odsType) {
 }
 
 void IntAttr::print(AsmPrinter &printer) const {
-  auto type = getType().cast<IntType>();
+  auto type = mlir::cast<IntType>(getType());
   printer << '<';
   if (type.isSigned())
     printer << getSInt();
@@ -290,12 +290,12 @@ void IntAttr::print(AsmPrinter &printer) const {
 
 LogicalResult IntAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                               Type type, APInt value) {
-  if (!type.isa<IntType>()) {
+  if (!mlir::isa<IntType>(type)) {
     emitError() << "expected 'simple.int' type";
     return failure();
   }
 
-  auto intType = type.cast<IntType>();
+  auto intType = mlir::cast<IntType>(type);
   if (value.getBitWidth() != intType.getWidth()) {
     emitError() << "type and value bitwidth mismatch: " << intType.getWidth()
                 << " != " << value.getBitWidth();
@@ -326,7 +326,7 @@ parseFloatLiteral(mlir::AsmParser &parser,
   auto losesInfo = false;
   value.emplace(rawValue);
 
-  auto tyFpInterface = ty.dyn_cast<cir::CIRFPTypeInterface>();
+  auto tyFpInterface = dyn_cast<cir::CIRFPTypeInterface>(ty);
   if (!tyFpInterface) {
     // Parsing of the current floating-point literal has succeeded, but the
     // given attribute type is invalid. This error will be reported later when
@@ -340,14 +340,14 @@ parseFloatLiteral(mlir::AsmParser &parser,
 }
 
 cir::FPAttr cir::FPAttr::getZero(mlir::Type type) {
-  return get(type,
-             APFloat::getZero(
-                 type.cast<cir::CIRFPTypeInterface>().getFloatSemantics()));
+  return get(
+      type, APFloat::getZero(
+                mlir::cast<cir::CIRFPTypeInterface>(type).getFloatSemantics()));
 }
 
 LogicalResult cir::FPAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                                   Type type, APFloat value) {
-  auto fltTypeInterface = type.dyn_cast<cir::CIRFPTypeInterface>();
+  auto fltTypeInterface = mlir::dyn_cast<cir::CIRFPTypeInterface>(type);
   if (!fltTypeInterface) {
     emitError() << "expected floating-point type";
     return failure();
@@ -474,11 +474,11 @@ LogicalResult DynamicCastInfoAttr::verify(
   auto isRttiPtr = [](mlir::Type ty) {
     // RTTI pointers are !cir.ptr<!u8i>.
 
-    auto ptrTy = ty.dyn_cast<mlir::cir::PointerType>();
+    auto ptrTy = mlir::dyn_cast<mlir::cir::PointerType>(ty);
     if (!ptrTy)
       return false;
 
-    auto pointeeIntTy = ptrTy.getPointee().dyn_cast<mlir::cir::IntType>();
+    auto pointeeIntTy = mlir::dyn_cast<mlir::cir::IntType>(ptrTy.getPointee());
     if (!pointeeIntTy)
       return false;
 

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -11,7 +11,7 @@ CIRDataLayout::CIRDataLayout(mlir::ModuleOp modOp) : layout{modOp} {
 
   for (auto entry : entries) {
     auto entryKey = entry.getKey();
-    auto strKey = mlir::dyn_cast_if_present<mlir::StringAttr>(entryKey);
+    auto strKey = mlir::dyn_cast<mlir::StringAttr>(entryKey);
     if (!strKey)
       continue;
     auto entryName = strKey.strref();

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -4,19 +4,19 @@
 namespace cir {
 
 CIRDataLayout::CIRDataLayout(mlir::ModuleOp modOp) : layout{modOp} {
-  auto dlSpec = modOp->getAttr(mlir::DLTIDialect::kDataLayoutAttrName)
-                    .dyn_cast<mlir::DataLayoutSpecAttr>();
+  auto dlSpec = mlir::dyn_cast<mlir::DataLayoutSpecAttr>(
+      modOp->getAttr(mlir::DLTIDialect::kDataLayoutAttrName));
   assert(dlSpec && "expected dl_spec in the module");
   auto entries = dlSpec.getEntries();
 
   for (auto entry : entries) {
     auto entryKey = entry.getKey();
-    auto strKey = entryKey.dyn_cast<mlir::StringAttr>();
+    auto strKey = mlir::dyn_cast_if_present<mlir::StringAttr>(entryKey);
     if (!strKey)
       continue;
     auto entryName = strKey.strref();
     if (entryName == mlir::DLTIDialect::kDataLayoutEndiannessKey) {
-      auto value = entry.getValue().dyn_cast<mlir::StringAttr>();
+      auto value = mlir::dyn_cast<mlir::StringAttr>(entry.getValue());
       assert(value && "expected string attribute");
       auto endian = value.getValue();
       if (endian == mlir::DLTIDialect::kDataLayoutEndiannessBig)

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -58,7 +58,7 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
 
   AliasResult getAlias(Type type, raw_ostream &os) const final {
-    if (auto structType = type.dyn_cast<StructType>()) {
+    if (auto structType = dyn_cast<StructType>(type)) {
       if (!structType.getName()) {
         os << "ty_anon_" << structType.getKindAsStr();
         return AliasResult::OverridableAlias;
@@ -66,7 +66,7 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
       os << "ty_" << structType.getName();
       return AliasResult::OverridableAlias;
     }
-    if (auto intType = type.dyn_cast<IntType>()) {
+    if (auto intType = dyn_cast<IntType>(type)) {
       // We only provide alias for standard integer types (i.e. integer types
       // whose width is divisible by 8).
       if (intType.getWidth() % 8 != 0)
@@ -74,7 +74,7 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
       os << intType.getAlias();
       return AliasResult::OverridableAlias;
     }
-    if (auto voidType = type.dyn_cast<VoidType>()) {
+    if (auto voidType = dyn_cast<VoidType>(type)) {
       os << voidType.getAlias();
       return AliasResult::OverridableAlias;
     }
@@ -83,26 +83,26 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
   }
 
   AliasResult getAlias(Attribute attr, raw_ostream &os) const final {
-    if (auto boolAttr = attr.dyn_cast<mlir::cir::BoolAttr>()) {
+    if (auto boolAttr = mlir::dyn_cast<mlir::cir::BoolAttr>(attr)) {
       os << (boolAttr.getValue() ? "true" : "false");
       return AliasResult::FinalAlias;
     }
-    if (auto bitfield = attr.dyn_cast<mlir::cir::BitfieldInfoAttr>()) {
+    if (auto bitfield = mlir::dyn_cast<mlir::cir::BitfieldInfoAttr>(attr)) {
       os << "bfi_" << bitfield.getName().str();
       return AliasResult::FinalAlias;
     }
     if (auto extraFuncAttr =
-            attr.dyn_cast<mlir::cir::ExtraFuncAttributesAttr>()) {
+            mlir::dyn_cast<mlir::cir::ExtraFuncAttributesAttr>(attr)) {
       os << "fn_attr";
       return AliasResult::FinalAlias;
     }
     if (auto cmpThreeWayInfoAttr =
-            attr.dyn_cast<mlir::cir::CmpThreeWayInfoAttr>()) {
+            mlir::dyn_cast<mlir::cir::CmpThreeWayInfoAttr>(attr)) {
       os << cmpThreeWayInfoAttr.getAlias();
       return AliasResult::FinalAlias;
     }
     if (auto dynCastInfoAttr =
-            attr.dyn_cast<mlir::cir::DynamicCastInfoAttr>()) {
+            mlir::dyn_cast<mlir::cir::DynamicCastInfoAttr>(attr)) {
       os << dynCastInfoAttr.getAlias();
       return AliasResult::FinalAlias;
     }
@@ -303,33 +303,33 @@ LogicalResult ConditionOp::verify() {
 
 static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
                                         mlir::Attribute attrType) {
-  if (attrType.isa<ConstPtrAttr>()) {
-    if (opType.isa<::mlir::cir::PointerType>())
+  if (isa<ConstPtrAttr>(attrType)) {
+    if (::mlir::isa<::mlir::cir::PointerType>(opType))
       return success();
     return op->emitOpError("nullptr expects pointer type");
   }
 
-  if (attrType.isa<DataMemberAttr>()) {
+  if (isa<DataMemberAttr>(attrType)) {
     // More detailed type verifications are already done in
     // DataMemberAttr::verify. Don't need to repeat here.
     return success();
   }
 
-  if (attrType.isa<ZeroAttr>()) {
-    if (opType.isa<::mlir::cir::StructType, ::mlir::cir::ArrayType>())
+  if (isa<ZeroAttr>(attrType)) {
+    if (::mlir::isa<::mlir::cir::StructType, ::mlir::cir::ArrayType>(opType))
       return success();
     return op->emitOpError("zero expects struct or array type");
   }
 
-  if (attrType.isa<mlir::cir::BoolAttr>()) {
-    if (!opType.isa<mlir::cir::BoolType>())
+  if (mlir::isa<mlir::cir::BoolAttr>(attrType)) {
+    if (!mlir::isa<mlir::cir::BoolType>(opType))
       return op->emitOpError("result type (")
              << opType << ") must be '!cir.bool' for '" << attrType << "'";
     return success();
   }
 
-  if (attrType.isa<mlir::cir::IntAttr, mlir::cir::FPAttr>()) {
-    auto at = attrType.cast<TypedAttr>();
+  if (mlir::isa<mlir::cir::IntAttr, mlir::cir::FPAttr>(attrType)) {
+    auto at = cast<TypedAttr>(attrType);
     if (at.getType() != opType) {
       return op->emitOpError("result type (")
              << opType << ") does not match value type (" << at.getType()
@@ -338,24 +338,24 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
     return success();
   }
 
-  if (attrType.isa<SymbolRefAttr>()) {
-    if (opType.isa<::mlir::cir::PointerType>())
+  if (isa<SymbolRefAttr>(attrType)) {
+    if (::mlir::isa<::mlir::cir::PointerType>(opType))
       return success();
     return op->emitOpError("symbolref expects pointer type");
   }
 
-  if (attrType.isa<mlir::cir::GlobalViewAttr>() ||
-      attrType.isa<mlir::cir::TypeInfoAttr>() ||
-      attrType.isa<mlir::cir::ConstArrayAttr>() ||
-      attrType.isa<mlir::cir::ConstStructAttr>() ||
-      attrType.isa<mlir::cir::VTableAttr>())
+  if (mlir::isa<mlir::cir::GlobalViewAttr>(attrType) ||
+      mlir::isa<mlir::cir::TypeInfoAttr>(attrType) ||
+      mlir::isa<mlir::cir::ConstArrayAttr>(attrType) ||
+      mlir::isa<mlir::cir::ConstStructAttr>(attrType) ||
+      mlir::isa<mlir::cir::VTableAttr>(attrType))
     return success();
-  if (attrType.isa<mlir::cir::IntAttr>())
+  if (mlir::isa<mlir::cir::IntAttr>(attrType))
     return success();
 
-  assert(attrType.isa<TypedAttr>() && "What else could we be looking at here?");
+  assert(isa<TypedAttr>(attrType) && "What else could we be looking at here?");
   return op->emitOpError("global with type ")
-         << attrType.cast<TypedAttr>().getType() << " not supported";
+         << cast<TypedAttr>(attrType).getType() << " not supported";
 }
 
 LogicalResult ConstantOp::verify() {
@@ -385,43 +385,44 @@ LogicalResult CastOp::verify() {
   auto resType = getResult().getType();
   auto srcType = getSrc().getType();
 
-  if (srcType.isa<mlir::cir::VectorType>() &&
-      resType.isa<mlir::cir::VectorType>()) {
+  if (mlir::isa<mlir::cir::VectorType>(srcType) &&
+      mlir::isa<mlir::cir::VectorType>(resType)) {
     // Use the element type of the vector to verify the cast kind. (Except for
     // bitcast, see below.)
-    srcType = srcType.dyn_cast<mlir::cir::VectorType>().getEltType();
-    resType = resType.dyn_cast<mlir::cir::VectorType>().getEltType();
+    srcType = mlir::dyn_cast<mlir::cir::VectorType>(srcType).getEltType();
+    resType = mlir::dyn_cast<mlir::cir::VectorType>(resType).getEltType();
   }
 
   switch (getKind()) {
   case cir::CastKind::int_to_bool: {
-    if (!resType.isa<mlir::cir::BoolType>())
+    if (!mlir::isa<mlir::cir::BoolType>(resType))
       return emitOpError() << "requires !cir.bool type for result";
-    if (!srcType.isa<mlir::cir::IntType>())
+    if (!mlir::isa<mlir::cir::IntType>(srcType))
       return emitOpError() << "requires !cir.int type for source";
     return success();
   }
   case cir::CastKind::ptr_to_bool: {
-    if (!resType.isa<mlir::cir::BoolType>())
+    if (!mlir::isa<mlir::cir::BoolType>(resType))
       return emitOpError() << "requires !cir.bool type for result";
-    if (!srcType.isa<mlir::cir::PointerType>())
+    if (!mlir::isa<mlir::cir::PointerType>(srcType))
       return emitOpError() << "requires !cir.ptr type for source";
     return success();
   }
   case cir::CastKind::integral: {
-    if (!resType.isa<mlir::cir::IntType>())
+    if (!mlir::isa<mlir::cir::IntType>(resType))
       return emitOpError() << "requires !cir.int type for result";
-    if (!srcType.isa<mlir::cir::IntType>())
+    if (!mlir::isa<mlir::cir::IntType>(srcType))
       return emitOpError() << "requires !cir.int type for source";
     return success();
   }
   case cir::CastKind::array_to_ptrdecay: {
-    auto arrayPtrTy = srcType.dyn_cast<mlir::cir::PointerType>();
-    auto flatPtrTy = resType.dyn_cast<mlir::cir::PointerType>();
+    auto arrayPtrTy = mlir::dyn_cast<mlir::cir::PointerType>(srcType);
+    auto flatPtrTy = mlir::dyn_cast<mlir::cir::PointerType>(resType);
     if (!arrayPtrTy || !flatPtrTy)
       return emitOpError() << "requires !cir.ptr type for source and result";
 
-    auto arrayTy = arrayPtrTy.getPointee().dyn_cast<mlir::cir::ArrayType>();
+    auto arrayTy =
+        mlir::dyn_cast<mlir::cir::ArrayType>(arrayPtrTy.getPointee());
     if (!arrayTy)
       return emitOpError() << "requires !cir.array pointee";
 
@@ -433,72 +434,72 @@ LogicalResult CastOp::verify() {
   case cir::CastKind::bitcast: {
     // This is the only cast kind where we don't want vector types to decay
     // into the element type.
-    if ((!getSrc().getType().isa<mlir::cir::PointerType>() ||
-         !getResult().getType().isa<mlir::cir::PointerType>()) &&
-        (!getSrc().getType().isa<mlir::cir::VectorType>() ||
-         !getResult().getType().isa<mlir::cir::VectorType>()))
+    if ((!mlir::isa<mlir::cir::PointerType>(getSrc().getType()) ||
+         !mlir::isa<mlir::cir::PointerType>(getResult().getType())) &&
+        (!mlir::isa<mlir::cir::VectorType>(getSrc().getType()) ||
+         !mlir::isa<mlir::cir::VectorType>(getResult().getType())))
       return emitOpError()
              << "requires !cir.ptr or !cir.vector type for source and result";
     return success();
   }
   case cir::CastKind::floating: {
-    if (!srcType.isa<mlir::cir::CIRFPTypeInterface>() ||
-        !resType.isa<mlir::cir::CIRFPTypeInterface>())
+    if (!mlir::isa<mlir::cir::CIRFPTypeInterface>(srcType) ||
+        !mlir::isa<mlir::cir::CIRFPTypeInterface>(resType))
       return emitOpError() << "requires !cir.float type for source and result";
     return success();
   }
   case cir::CastKind::float_to_int: {
-    if (!srcType.isa<mlir::cir::CIRFPTypeInterface>())
+    if (!mlir::isa<mlir::cir::CIRFPTypeInterface>(srcType))
       return emitOpError() << "requires !cir.float type for source";
-    if (!resType.dyn_cast<mlir::cir::IntType>())
+    if (!mlir::dyn_cast<mlir::cir::IntType>(resType))
       return emitOpError() << "requires !cir.int type for result";
     return success();
   }
   case cir::CastKind::int_to_ptr: {
-    if (!srcType.dyn_cast<mlir::cir::IntType>())
+    if (!mlir::dyn_cast<mlir::cir::IntType>(srcType))
       return emitOpError() << "requires !cir.int type for source";
-    if (!resType.dyn_cast<mlir::cir::PointerType>())
+    if (!mlir::dyn_cast<mlir::cir::PointerType>(resType))
       return emitOpError() << "requires !cir.ptr type for result";
     return success();
   }
   case cir::CastKind::ptr_to_int: {
-    if (!srcType.dyn_cast<mlir::cir::PointerType>())
+    if (!mlir::dyn_cast<mlir::cir::PointerType>(srcType))
       return emitOpError() << "requires !cir.ptr type for source";
-    if (!resType.dyn_cast<mlir::cir::IntType>())
+    if (!mlir::dyn_cast<mlir::cir::IntType>(resType))
       return emitOpError() << "requires !cir.int type for result";
     return success();
   }
   case cir::CastKind::float_to_bool: {
-    if (!srcType.isa<mlir::cir::CIRFPTypeInterface>())
+    if (!mlir::isa<mlir::cir::CIRFPTypeInterface>(srcType))
       return emitOpError() << "requires !cir.float type for source";
-    if (!resType.isa<mlir::cir::BoolType>())
+    if (!mlir::isa<mlir::cir::BoolType>(resType))
       return emitOpError() << "requires !cir.bool type for result";
     return success();
   }
   case cir::CastKind::bool_to_int: {
-    if (!srcType.isa<mlir::cir::BoolType>())
+    if (!mlir::isa<mlir::cir::BoolType>(srcType))
       return emitOpError() << "requires !cir.bool type for source";
-    if (!resType.isa<mlir::cir::IntType>())
+    if (!mlir::isa<mlir::cir::IntType>(resType))
       return emitOpError() << "requires !cir.int type for result";
     return success();
   }
   case cir::CastKind::int_to_float: {
-    if (!srcType.isa<mlir::cir::IntType>())
+    if (!mlir::isa<mlir::cir::IntType>(srcType))
       return emitOpError() << "requires !cir.int type for source";
-    if (!resType.isa<mlir::cir::CIRFPTypeInterface>())
+    if (!mlir::isa<mlir::cir::CIRFPTypeInterface>(resType))
       return emitOpError() << "requires !cir.float type for result";
     return success();
   }
   case cir::CastKind::bool_to_float: {
-    if (!srcType.isa<mlir::cir::BoolType>())
+    if (!mlir::isa<mlir::cir::BoolType>(srcType))
       return emitOpError() << "requires !cir.bool type for source";
-    if (!resType.isa<mlir::cir::CIRFPTypeInterface>())
+    if (!mlir::isa<mlir::cir::CIRFPTypeInterface>(resType))
       return emitOpError() << "requires !cir.float type for result";
     return success();
   }
   case cir::CastKind::address_space: {
-    auto srcPtrTy = srcType.dyn_cast<mlir::cir::PointerType>();
-    auto resPtrTy = resType.dyn_cast<mlir::cir::PointerType>();
+    auto srcPtrTy = mlir::dyn_cast<mlir::cir::PointerType>(srcType);
+    auto resPtrTy = mlir::dyn_cast<mlir::cir::PointerType>(resType);
     if (!srcPtrTy || !resPtrTy)
       return emitOpError() << "requires !cir.ptr type for source and result";
     if (srcPtrTy.getPointee() != resPtrTy.getPointee())
@@ -537,8 +538,9 @@ OpFoldResult CastOp::fold(FoldAdaptor adaptor) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult DynamicCastOp::verify() {
-  auto resultPointeeTy = getType().cast<mlir::cir::PointerType>().getPointee();
-  if (!resultPointeeTy.isa<mlir::cir::VoidType, mlir::cir::StructType>())
+  auto resultPointeeTy =
+      mlir::cast<mlir::cir::PointerType>(getType()).getPointee();
+  if (!mlir::isa<mlir::cir::VoidType, mlir::cir::StructType>(resultPointeeTy))
     return emitOpError()
            << "cir.dyn_cast must produce a void ptr or struct ptr";
 
@@ -579,7 +581,7 @@ LogicalResult VecTernaryOp::verify() {
   // other operands.  (The automatic verification already checked that all
   // operands are vector types and that the second and third operands are the
   // same type.)
-  if (getCond().getType().cast<mlir::cir::VectorType>().getSize() !=
+  if (mlir::cast<mlir::cir::VectorType>(getCond().getType()).getSize() !=
       getVec1().getType().getSize()) {
     return emitOpError() << ": the number of elements in "
                          << getCond().getType() << " and "
@@ -608,7 +610,7 @@ LogicalResult VecShuffleOp::verify() {
   // The indices must all be integer constants
   if (not std::all_of(getIndices().begin(), getIndices().end(),
                       [](mlir::Attribute attr) {
-                        return attr.isa<mlir::cir::IntAttr>();
+                        return mlir::isa<mlir::cir::IntAttr>(attr);
                       })) {
     return emitOpError() << "all index values must be integers";
   }
@@ -622,7 +624,7 @@ LogicalResult VecShuffleOp::verify() {
 LogicalResult VecShuffleDynamicOp::verify() {
   // The number of elements in the two input vectors must match.
   if (getVec().getType().getSize() !=
-      getIndices().getType().cast<mlir::cir::VectorType>().getSize()) {
+      mlir::cast<mlir::cir::VectorType>(getIndices().getType()).getSize()) {
     return emitOpError() << ": the number of elements in " << getVec().getType()
                          << " and " << getIndices().getType() << " don't match";
   }
@@ -991,7 +993,7 @@ mlir::SuccessorOperands BrCondOp::getSuccessorOperands(unsigned index) {
 }
 
 Block *BrCondOp::getSuccessorForOperands(ArrayRef<Attribute> operands) {
-  if (IntegerAttr condAttr = operands.front().dyn_cast_or_null<IntegerAttr>())
+  if (IntegerAttr condAttr = dyn_cast_if_present<IntegerAttr>(operands.front()))
     return condAttr.getValue().isOne() ? getDestTrue() : getDestFalse();
   return nullptr;
 }
@@ -1175,7 +1177,7 @@ void printSwitchOp(OpAsmPrinter &p, SwitchOp op,
   for (auto &r : regions) {
     p << "case (";
 
-    auto attr = casesAttr[idx].cast<CaseAttr>();
+    auto attr = cast<CaseAttr>(casesAttr[idx]);
     auto kind = attr.getKind().getValue();
     assert((kind == CaseOpKind::Default || kind == CaseOpKind::Equal ||
             kind == CaseOpKind::Anyof || kind == CaseOpKind::Range) &&
@@ -1188,8 +1190,8 @@ void printSwitchOp(OpAsmPrinter &p, SwitchOp op,
     switch (kind) {
     case cir::CaseOpKind::Equal: {
       p << ", ";
-      auto intAttr = attr.getValue()[0].cast<cir::IntAttr>();
-      auto intAttrTy = intAttr.getType().cast<cir::IntType>();
+      auto intAttr = cast<cir::IntAttr>(attr.getValue()[0]);
+      auto intAttrTy = cast<cir::IntType>(intAttr.getType());
       (intAttrTy.isSigned() ? p << intAttr.getSInt() : p << intAttr.getUInt());
       break;
     }
@@ -1200,13 +1202,13 @@ void printSwitchOp(OpAsmPrinter &p, SwitchOp op,
     case cir::CaseOpKind::Anyof: {
       p << ", [";
       llvm::interleaveComma(attr.getValue(), p, [&](const Attribute &a) {
-        auto intAttr = a.cast<cir::IntAttr>();
-        auto intAttrTy = intAttr.getType().cast<cir::IntType>();
+        auto intAttr = cast<cir::IntAttr>(a);
+        auto intAttrTy = cast<cir::IntType>(intAttr.getType());
         (intAttrTy.isSigned() ? p << intAttr.getSInt()
                               : p << intAttr.getUInt());
       });
       p << "] : ";
-      auto typedAttr = attr.getValue()[0].dyn_cast<TypedAttr>();
+      auto typedAttr = dyn_cast<TypedAttr>(attr.getValue()[0]);
       assert(typedAttr && "this should never not have a type!");
       p.printType(typedAttr.getType());
       break;
@@ -1357,7 +1359,7 @@ static void printSwitchFlatOpCases(OpAsmPrinter &p, SwitchFlatOp op,
       [&](auto i) {
         p << "  ";
         mlir::Attribute a = std::get<0>(i);
-        p << a.cast<mlir::cir::IntAttr>().getValue();
+        p << mlir::cast<mlir::cir::IntAttr>(a).getValue();
         p << ": ";
         p.printSuccessorAndUseList(std::get<1>(i), caseOperands[index++]);
       },
@@ -1457,7 +1459,7 @@ void printCatchOp(OpAsmPrinter &p, CatchOp op,
     p.increaseIndent();
     auto exRtti = a;
 
-    if (a.isa<mlir::cir::CatchUnwindAttr>()) {
+    if (mlir::isa<mlir::cir::CatchUnwindAttr>(a)) {
       p.printAttribute(a);
     } else if (!exRtti) {
       p << "all";
@@ -1622,9 +1624,9 @@ static ParseResult parseGlobalOpTypeAndInitialValue(OpAsmParser &parser,
       if (parseConstantValue(parser, initialValueAttr).failed())
         return failure();
 
-      assert(initialValueAttr.isa<mlir::TypedAttr>() &&
+      assert(mlir::isa<mlir::TypedAttr>(initialValueAttr) &&
              "Non-typed attrs shouldn't appear here.");
-      auto typedAttr = initialValueAttr.cast<mlir::TypedAttr>();
+      auto typedAttr = mlir::cast<mlir::TypedAttr>(initialValueAttr);
       opTy = typedAttr.getType();
     }
 
@@ -1810,7 +1812,7 @@ GetGlobalOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   else
     llvm_unreachable("shall not get here");
 
-  auto resultType = getAddr().getType().dyn_cast<PointerType>();
+  auto resultType = dyn_cast<PointerType>(getAddr().getType());
   if (!resultType || symTy != resultType.getPointee())
     return emitOpError("result type pointee type '")
            << resultType.getPointee() << "' does not match type " << symTy
@@ -2188,7 +2190,7 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
 // getNumArguments hook not failing.
 LogicalResult cir::FuncOp::verifyType() {
   auto type = getFunctionType();
-  if (!type.isa<cir::FuncType>())
+  if (!isa<cir::FuncType>(type))
     return emitOpError("requires '" + getFunctionTypeAttrName().str() +
                        "' attribute of function type");
   if (!getNoProto() && type.isVarArg() && type.getNumInputs() == 0)
@@ -2706,12 +2708,12 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     ::mlir::Type type, Attribute attr, int trailingZerosNum) {
 
-  if (!(attr.isa<mlir::ArrayAttr>() || attr.isa<mlir::StringAttr>()))
+  if (!(mlir::isa<mlir::ArrayAttr>(attr) || mlir::isa<mlir::StringAttr>(attr)))
     return emitError() << "constant array expects ArrayAttr or StringAttr";
 
-  if (auto strAttr = attr.dyn_cast<mlir::StringAttr>()) {
-    mlir::cir::ArrayType at = type.cast<mlir::cir::ArrayType>();
-    auto intTy = at.getEltType().dyn_cast<cir::IntType>();
+  if (auto strAttr = mlir::dyn_cast<mlir::StringAttr>(attr)) {
+    mlir::cir::ArrayType at = mlir::cast<mlir::cir::ArrayType>(type);
+    auto intTy = mlir::dyn_cast<cir::IntType>(at.getEltType());
 
     // TODO: add CIR type for char.
     if (!intTy || intTy.getWidth() != 8) {
@@ -2722,9 +2724,9 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
     return success();
   }
 
-  assert(attr.isa<mlir::ArrayAttr>());
-  auto arrayAttr = attr.cast<mlir::ArrayAttr>();
-  auto at = type.cast<ArrayType>();
+  assert(mlir::isa<mlir::ArrayAttr>(attr));
+  auto arrayAttr = mlir::cast<mlir::ArrayAttr>(attr);
+  auto at = mlir::cast<ArrayType>(type);
 
   // Make sure both number of elements and subelement types match type.
   if (at.getSize() != arrayAttr.size() + trailingZerosNum)
@@ -2735,7 +2737,7 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
         // Once we find a mismatch, stop there.
         if (eltTypeCheck.failed())
           return;
-        auto typedAttr = attr.dyn_cast<TypedAttr>();
+        auto typedAttr = mlir::dyn_cast<TypedAttr>(attr);
         if (!typedAttr || typedAttr.getType() != at.getEltType()) {
           eltTypeCheck = failure();
           emitError()
@@ -2767,7 +2769,7 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
   }
 
   // ArrayAttrrs have per-element type, not the type of the array...
-  if (resultVal->dyn_cast<ArrayAttr>()) {
+  if (mlir::dyn_cast<ArrayAttr>(*resultVal)) {
     // Array has implicit type: infer from const array type.
     if (parser.parseOptionalColon().failed()) {
       resultTy = type;
@@ -2782,10 +2784,10 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
       }
     }
   } else {
-    assert(resultVal->isa<TypedAttr>() && "IDK");
-    auto ta = resultVal->cast<TypedAttr>();
+    assert(mlir::isa<TypedAttr>(*resultVal) && "IDK");
+    auto ta = mlir::cast<TypedAttr>(*resultVal);
     resultTy = ta.getType();
-    if (resultTy->isa<mlir::NoneType>()) {
+    if (mlir::isa<mlir::NoneType>(*resultTy)) {
       parser.emitError(parser.getCurrentLocation(),
                        "expected type declaration for string literal");
       return {};
@@ -2795,12 +2797,13 @@ LogicalResult mlir::cir::ConstArrayAttr::verify(
   auto zeros = 0;
   if (parser.parseOptionalComma().succeeded()) {
     if (parser.parseOptionalKeyword("trailing_zeros").succeeded()) {
-      auto typeSize = resultTy.value().cast<mlir::cir::ArrayType>().getSize();
+      auto typeSize =
+          mlir::cast<mlir::cir::ArrayType>(resultTy.value()).getSize();
       auto elts = resultVal.value();
-      if (auto str = elts.dyn_cast<mlir::StringAttr>())
+      if (auto str = mlir::dyn_cast<mlir::StringAttr>(elts))
         zeros = typeSize - str.size();
       else
-        zeros = typeSize - elts.cast<mlir::ArrayAttr>().size();
+        zeros = typeSize - mlir::cast<mlir::ArrayAttr>(elts).size();
     } else {
       return {};
     }
@@ -2871,7 +2874,7 @@ LogicalResult TypeInfoAttr::verify(
 LogicalResult
 VTableAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
                    ::mlir::Type type, ::mlir::ArrayAttr vtableData) {
-  auto sTy = type.dyn_cast_or_null<mlir::cir::StructType>();
+  auto sTy = mlir::dyn_cast_if_present<mlir::cir::StructType>(type);
   if (!sTy) {
     emitError() << "expected !cir.struct type result";
     return failure();
@@ -2883,8 +2886,9 @@ VTableAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
 
   for (size_t i = 0; i < sTy.getMembers().size(); ++i) {
 
-    auto arrayTy = sTy.getMembers()[i].dyn_cast<mlir::cir::ArrayType>();
-    auto constArrayAttr = vtableData[i].dyn_cast<mlir::cir::ConstArrayAttr>();
+    auto arrayTy = mlir::dyn_cast<mlir::cir::ArrayType>(sTy.getMembers()[i]);
+    auto constArrayAttr =
+        mlir::dyn_cast<mlir::cir::ConstArrayAttr>(vtableData[i]);
     if (!arrayTy || !constArrayAttr) {
       emitError() << "expected struct type with one array element";
       return failure();
@@ -2895,10 +2899,11 @@ VTableAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
       return failure();
 
     LogicalResult eltTypeCheck = success();
-    if (auto arrayElts = constArrayAttr.getElts().dyn_cast<ArrayAttr>()) {
+    if (auto arrayElts = mlir::dyn_cast<ArrayAttr>(constArrayAttr.getElts())) {
       arrayElts.walkImmediateSubElements(
           [&](Attribute attr) {
-            if (attr.isa<GlobalViewAttr>() || attr.isa<ConstPtrAttr>())
+            if (mlir::isa<GlobalViewAttr>(attr) ||
+                mlir::isa<ConstPtrAttr>(attr))
               return;
             emitError() << "expected GlobalViewAttr attribute";
             eltTypeCheck = failure();
@@ -2952,7 +2957,7 @@ LogicalResult MemCpyOp::verify() {
 
 LogicalResult GetMemberOp::verify() {
 
-  const auto recordTy = getAddrTy().getPointee().dyn_cast<StructType>();
+  const auto recordTy = dyn_cast<StructType>(getAddrTy().getPointee());
   if (!recordTy)
     return emitError() << "expected pointer to a record type";
 
@@ -2974,7 +2979,7 @@ LogicalResult GetMemberOp::verify() {
 
 LogicalResult GetRuntimeMemberOp::verify() {
   auto recordTy =
-      getAddr().getType().cast<PointerType>().getPointee().cast<StructType>();
+      cast<StructType>(getAddr().getType().cast<PointerType>().getPointee());
   auto memberPtrTy = getMember().getType();
 
   if (recordTy != memberPtrTy.getClsTy()) {
@@ -3179,7 +3184,7 @@ LogicalResult AtomicFetch::verify() {
       getBinop() == mlir::cir::AtomicFetchKind::Sub)
     return mlir::success();
 
-  if (!getVal().getType().isa<mlir::cir::IntType>())
+  if (!mlir::isa<mlir::cir::IntType>(getVal().getType()))
     return emitError() << "only operates on integer values";
 
   return mlir::success();

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2979,7 +2979,7 @@ LogicalResult GetMemberOp::verify() {
 
 LogicalResult GetRuntimeMemberOp::verify() {
   auto recordTy =
-      cast<StructType>(getAddr().getType().cast<PointerType>().getPointee());
+      cast<StructType>(cast<PointerType>(getAddr().getType()).getPointee());
   auto memberPtrTy = getMember().getType();
 
   if (recordTy != memberPtrTy.getClsTy()) {

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -111,7 +111,7 @@ void BoolType::print(mlir::AsmPrinter &printer) const {}
 Type StructType::getLargestMember(const ::mlir::DataLayout &dataLayout) const {
   if (!layoutInfo)
     computeSizeAndAlignment(dataLayout);
-  return layoutInfo.cast<mlir::cir::StructLayoutAttr>().getLargestMember();
+  return mlir::cast<mlir::cir::StructLayoutAttr>(layoutInfo).getLargestMember();
 }
 
 Type StructType::parse(mlir::AsmParser &parser) {
@@ -194,8 +194,8 @@ Type StructType::parse(mlir::AsmParser &parser) {
     type = getChecked(eLoc, context, membersRef, name, packed, kind);
     // If the record has a self-reference, its type already exists in a
     // incomplete state. In this case, we must complete it.
-    if (type.cast<StructType>().isIncomplete())
-      type.cast<StructType>().complete(membersRef, packed, ast);
+    if (mlir::cast<StructType>(type).isIncomplete())
+      mlir::cast<StructType>(type).complete(membersRef, packed, ast);
   } else if (!name && !incomplete) { // anonymous & complete
     type = getChecked(eLoc, context, membersRef, packed, kind);
   } else { // anonymous & incomplete
@@ -457,7 +457,7 @@ StructType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
   if (!layoutInfo)
     computeSizeAndAlignment(dataLayout);
   return llvm::TypeSize::getFixed(
-      layoutInfo.cast<mlir::cir::StructLayoutAttr>().getSize() * 8);
+      mlir::cast<mlir::cir::StructLayoutAttr>(layoutInfo).getSize() * 8);
 }
 
 uint64_t
@@ -465,7 +465,7 @@ StructType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
                             ::mlir::DataLayoutEntryListRef params) const {
   if (!layoutInfo)
     computeSizeAndAlignment(dataLayout);
-  return layoutInfo.cast<mlir::cir::StructLayoutAttr>().getAlignment();
+  return mlir::cast<mlir::cir::StructLayoutAttr>(layoutInfo).getAlignment();
 }
 
 uint64_t
@@ -477,7 +477,7 @@ StructType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
 bool StructType::isPadded(const ::mlir::DataLayout &dataLayout) const {
   if (!layoutInfo)
     computeSizeAndAlignment(dataLayout);
-  return layoutInfo.cast<mlir::cir::StructLayoutAttr>().getPadded();
+  return mlir::cast<mlir::cir::StructLayoutAttr>(layoutInfo).getPadded();
 }
 
 uint64_t StructType::getElementOffset(const ::mlir::DataLayout &dataLayout,
@@ -485,8 +485,9 @@ uint64_t StructType::getElementOffset(const ::mlir::DataLayout &dataLayout,
   assert(idx < getMembers().size() && "access not valid");
   if (!layoutInfo)
     computeSizeAndAlignment(dataLayout);
-  auto offsets = layoutInfo.cast<mlir::cir::StructLayoutAttr>().getOffsets();
-  auto intAttr = offsets[idx].cast<mlir::IntegerAttr>();
+  auto offsets =
+      mlir::cast<mlir::cir::StructLayoutAttr>(layoutInfo).getOffsets();
+  auto intAttr = mlir::cast<mlir::IntegerAttr>(offsets[idx]);
   return intAttr.getInt();
 }
 
@@ -513,7 +514,7 @@ void StructType::computeSizeAndAlignment(
     auto ty = members[i];
 
     // Found a nested union: recurse into it to fetch its largest member.
-    auto structMember = ty.dyn_cast<StructType>();
+    auto structMember = mlir::dyn_cast<StructType>(ty);
     if (structMember && structMember.isUnion()) {
       auto candidate = structMember.getLargestMember(dataLayout);
       if (dataLayout.getTypeSize(candidate) > largestMemberSize) {
@@ -755,38 +756,35 @@ FP80Type::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
 }
 
 const llvm::fltSemantics &LongDoubleType::getFloatSemantics() const {
-  return getUnderlying()
-      .cast<mlir::cir::CIRFPTypeInterface>()
+  return mlir::cast<mlir::cir::CIRFPTypeInterface>(getUnderlying())
       .getFloatSemantics();
 }
 
 llvm::TypeSize
 LongDoubleType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
                                   mlir::DataLayoutEntryListRef params) const {
-  return getUnderlying()
-      .cast<mlir::DataLayoutTypeInterface>()
+  return mlir::cast<mlir::DataLayoutTypeInterface>(getUnderlying())
       .getTypeSizeInBits(dataLayout, params);
 }
 
 uint64_t
 LongDoubleType::getABIAlignment(const mlir::DataLayout &dataLayout,
                                 mlir::DataLayoutEntryListRef params) const {
-  return getUnderlying().cast<mlir::DataLayoutTypeInterface>().getABIAlignment(
-      dataLayout, params);
+  return mlir::cast<mlir::DataLayoutTypeInterface>(getUnderlying())
+      .getABIAlignment(dataLayout, params);
 }
 
 uint64_t LongDoubleType::getPreferredAlignment(
     const ::mlir::DataLayout &dataLayout,
     mlir::DataLayoutEntryListRef params) const {
-  return getUnderlying()
-      .cast<mlir::DataLayoutTypeInterface>()
+  return mlir::cast<mlir::DataLayoutTypeInterface>(getUnderlying())
       .getPreferredAlignment(dataLayout, params);
 }
 
 LogicalResult
 LongDoubleType::verify(function_ref<InFlightDiagnostic()> emitError,
                        mlir::Type underlying) {
-  if (!underlying.isa<DoubleType, FP80Type>()) {
+  if (!mlir::isa<DoubleType, FP80Type>(underlying)) {
     emitError() << "invalid underlying type for long double";
     return failure();
   }
@@ -811,7 +809,7 @@ bool mlir::cir::isFPOrFPVectorTy(mlir::Type t) {
 
   if (isa<mlir::cir::VectorType>(t)) {
     return isAnyFloatingPointType(
-        t.dyn_cast<mlir::cir::VectorType>().getEltType());
+        mlir::dyn_cast<mlir::cir::VectorType>(t).getEltType());
   }
   return isAnyFloatingPointType(t);
 }
@@ -873,7 +871,7 @@ llvm::ArrayRef<mlir::Type> FuncType::getReturnTypes() const {
   return static_cast<detail::FuncTypeStorage *>(getImpl())->returnType;
 }
 
-bool FuncType::isVoid() const { return getReturnType().isa<VoidType>(); }
+bool FuncType::isVoid() const { return mlir::isa<VoidType>(getReturnType()); }
 
 //===----------------------------------------------------------------------===//
 // CIR Dialect

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -583,9 +583,9 @@ Type IntType::parse(mlir::AsmParser &parser) {
   llvm::StringRef sign;
   if (parser.parseKeyword(&sign))
     return {};
-  if (sign.equals("s"))
+  if (sign == "s")
     isSigned = true;
-  else if (sign.equals("u"))
+  else if (sign == "u")
     isSigned = false;
   else {
     parser.emitError(loc, "expected 's' or 'u'");

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -31,12 +31,12 @@ LowerModule createLowerModule(FuncOp op, PatternRewriter &rewriter) {
   auto module = op->getParentOfType<mlir::ModuleOp>();
 
   // Fetch the LLVM data layout string.
-  auto dataLayoutStr = mlir::cast<StringAttr>(
+  auto dataLayoutStr = cast<StringAttr>(
       module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName()));
 
   // Fetch target information.
   llvm::Triple triple(
-      mlir::cast<StringAttr>(module->getAttr("cir.triple")).getValue());
+      cast<StringAttr>(module->getAttr("cir.triple")).getValue());
   clang::TargetOptions targetOptions;
   targetOptions.Triple = triple.str();
   auto targetInfo = clang::targets::AllocateTarget(triple, targetOptions);

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -31,13 +31,12 @@ LowerModule createLowerModule(FuncOp op, PatternRewriter &rewriter) {
   auto module = op->getParentOfType<mlir::ModuleOp>();
 
   // Fetch the LLVM data layout string.
-  auto dataLayoutStr =
-      module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName())
-          .cast<StringAttr>();
+  auto dataLayoutStr = mlir::cast<StringAttr>(
+      module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName()));
 
   // Fetch target information.
   llvm::Triple triple(
-      module->getAttr("cir.triple").cast<StringAttr>().getValue());
+      mlir::cast<StringAttr>(module->getAttr("cir.triple")).getValue());
   clang::TargetOptions targetOptions;
   targetOptions.Triple = triple.str();
   auto targetInfo = clang::targets::AllocateTarget(triple, targetOptions);

--- a/clang/lib/CIR/Dialect/Transforms/DropAST.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/DropAST.cpp
@@ -33,7 +33,7 @@ void DropASTPass::runOnOperation() {
   op->walk([&](Operation *op) {
     if (auto alloca = dyn_cast<AllocaOp>(op)) {
       alloca.removeAstAttr();
-      auto ty = alloca.getAllocaType().dyn_cast<mlir::cir::StructType>();
+      auto ty = mlir::dyn_cast<mlir::cir::StructType>(alloca.getAllocaType());
       if (!ty)
         return;
       ty.dropAst();

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -330,7 +330,8 @@ public:
     // Digest the case statements values and bodies.
     for (size_t i = 0; i < op.getCases()->size(); ++i) {
       auto &region = op.getRegion(i);
-      auto caseAttr = op.getCases()->getValue()[i].cast<mlir::cir::CaseAttr>();
+      auto caseAttr =
+          mlir::cast<mlir::cir::CaseAttr>(op.getCases()->getValue()[i]);
 
       // Found default case: save destination and operands.
       switch (caseAttr.getKind().getValue()) {
@@ -342,8 +343,9 @@ public:
         assert(caseAttr.getValue().size() == 2 &&
                "Case range should have 2 case value");
         rangeValues.push_back(
-            {caseAttr.getValue()[0].cast<mlir::cir::IntAttr>().getValue(),
-             caseAttr.getValue()[1].cast<mlir::cir::IntAttr>().getValue()});
+            {mlir::cast<mlir::cir::IntAttr>(caseAttr.getValue()[0]).getValue(),
+             mlir::cast<mlir::cir::IntAttr>(caseAttr.getValue()[1])
+                 .getValue()});
         rangeDestinations.push_back(&region.front());
         rangeOperands.push_back(region.getArguments());
         break;
@@ -351,7 +353,8 @@ public:
       case mlir::cir::CaseOpKind::Equal:
         // AnyOf cases kind can have multiple values, hence the loop below.
         for (auto &value : caseAttr.getValue()) {
-          caseValues.push_back(value.cast<mlir::cir::IntAttr>().getValue());
+          caseValues.push_back(
+              mlir::cast<mlir::cir::IntAttr>(value).getValue());
           caseOperands.push_back(region.getArguments());
           caseDestinations.push_back(&region.front());
         }

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -330,8 +330,7 @@ public:
     // Digest the case statements values and bodies.
     for (size_t i = 0; i < op.getCases()->size(); ++i) {
       auto &region = op.getRegion(i);
-      auto caseAttr =
-          mlir::cast<mlir::cir::CaseAttr>(op.getCases()->getValue()[i]);
+      auto caseAttr = cast<mlir::cir::CaseAttr>(op.getCases()->getValue()[i]);
 
       // Found default case: save destination and operands.
       switch (caseAttr.getKind().getValue()) {
@@ -343,9 +342,8 @@ public:
         assert(caseAttr.getValue().size() == 2 &&
                "Case range should have 2 case value");
         rangeValues.push_back(
-            {mlir::cast<mlir::cir::IntAttr>(caseAttr.getValue()[0]).getValue(),
-             mlir::cast<mlir::cir::IntAttr>(caseAttr.getValue()[1])
-                 .getValue()});
+            {cast<mlir::cir::IntAttr>(caseAttr.getValue()[0]).getValue(),
+             cast<mlir::cir::IntAttr>(caseAttr.getValue()[1]).getValue()});
         rangeDestinations.push_back(&region.front());
         rangeOperands.push_back(region.getArguments());
         break;
@@ -353,8 +351,7 @@ public:
       case mlir::cir::CaseOpKind::Equal:
         // AnyOf cases kind can have multiple values, hence the loop below.
         for (auto &value : caseAttr.getValue()) {
-          caseValues.push_back(
-              mlir::cast<mlir::cir::IntAttr>(value).getValue());
+          caseValues.push_back(cast<mlir::cir::IntAttr>(value).getValue());
           caseOperands.push_back(region.getArguments());
           caseDestinations.push_back(&region.front());
         }

--- a/clang/lib/CIR/Dialect/Transforms/IdiomRecognizer.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/IdiomRecognizer.cpp
@@ -116,8 +116,8 @@ static bool isIteratorLikeType(mlir::Type t) {
   // TODO: some iterators are going to be represented with structs,
   // in which case we could look at ASTRecordDeclInterface for more
   // information.
-  auto pTy = t.dyn_cast<PointerType>();
-  if (!pTy || !pTy.getPointee().isa<mlir::cir::IntType>())
+  auto pTy = dyn_cast<PointerType>(t);
+  if (!pTy || !mlir::isa<mlir::cir::IntType>(pTy.getPointee()))
     return false;
   return true;
 }
@@ -144,7 +144,7 @@ bool IdiomRecognizerPass::raiseIteratorBeginEnd(CallOp call) {
     return false;
 
   // First argument is the container "this" pointer.
-  auto thisPtr = call.getOperand(0).getType().dyn_cast<PointerType>();
+  auto thisPtr = dyn_cast<PointerType>(call.getOperand(0).getType());
   if (!thisPtr || !isIteratorInStdContainter(thisPtr.getPointee()))
     return false;
 

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -131,7 +131,7 @@ void LibOptPass::xformStdFindIntoMemchr(StdFindOp findOp) {
   auto first = findOp.getOperand(0);
   auto last = findOp.getOperand(1);
   auto value = findOp->getOperand(2);
-  if (!first.getType().isa<PointerType>() || !last.getType().isa<PointerType>())
+  if (!isa<PointerType>(first.getType()) || !isa<PointerType>(last.getType()))
     return;
 
   // Transformation:
@@ -139,9 +139,9 @@ void LibOptPass::xformStdFindIntoMemchr(StdFindOp findOp) {
   //   - Assert the Iterator is a pointer to primitive type.
   //   - Check IterBeginOp is char sized. TODO: add other types that map to
   //   char size.
-  auto iterResTy = findOp.getType().dyn_cast<PointerType>();
+  auto iterResTy = dyn_cast<PointerType>(findOp.getType());
   assert(iterResTy && "expected pointer type for iterator");
-  auto underlyingDataTy = iterResTy.getPointee().dyn_cast<IntType>();
+  auto underlyingDataTy = dyn_cast<IntType>(iterResTy.getPointee());
   if (!underlyingDataTy || underlyingDataTy.getWidth() != 8)
     return;
 
@@ -149,7 +149,7 @@ void LibOptPass::xformStdFindIntoMemchr(StdFindOp findOp) {
   //   - Check it's a pointer type.
   //   - Load the pattern from memory
   //   - cast it to `int`.
-  auto patternAddrTy = value.getType().dyn_cast<PointerType>();
+  auto patternAddrTy = dyn_cast<PointerType>(value.getType());
   if (!patternAddrTy || patternAddrTy.getPointee() != underlyingDataTy)
     return;
 
@@ -178,7 +178,7 @@ void LibOptPass::xformStdFindIntoMemchr(StdFindOp findOp) {
 
       // Look at this pointer to retrieve container information.
       auto thisPtr =
-          iterBegin.getOperand().getType().cast<PointerType>().getPointee();
+          cast<PointerType>(iterBegin.getOperand().getType()).getPointee();
       auto containerTy = dyn_cast<StructType>(thisPtr);
 
       unsigned staticSize = 0;

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -1682,7 +1682,7 @@ void LifetimeCheckPass::checkForOwnerAndPointerArguments(CallOp callOp,
     if (aggregates.count(arg)) {
       int memberIdx = 0;
       auto sTy =
-          dyn_cast<StructType>(arg.getType().cast<PointerType>().getPointee());
+          dyn_cast<StructType>(cast<PointerType>(arg.getType()).getPointee());
       assert(sTy && "expected struct type");
       for (auto m : sTy.getMembers()) {
         auto ptrMemberAddr = aggregates[arg][memberIdx];

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -498,7 +498,7 @@ static std::string getVarNameFromValue(mlir::Value v) {
 }
 
 static Location getEndLoc(Location loc, int idx = 1) {
-  auto fusedLoc = loc.dyn_cast<FusedLoc>();
+  auto fusedLoc = dyn_cast<FusedLoc>(loc);
   if (!fusedLoc)
     return loc;
   return fusedLoc.getLocations()[idx];
@@ -867,9 +867,9 @@ void LifetimeCheckPass::checkIf(IfOp ifOp) {
 }
 
 template <class T> bool isStructAndHasAttr(mlir::Type ty) {
-  if (!ty.isa<mlir::cir::StructType>())
+  if (!mlir::isa<mlir::cir::StructType>(ty))
     return false;
-  return hasAttr<T>(ty.cast<mlir::cir::StructType>().getAst());
+  return hasAttr<T>(mlir::cast<mlir::cir::StructType>(ty).getAst());
 }
 
 static bool isOwnerType(mlir::Type ty) {
@@ -901,12 +901,12 @@ static bool isOwnerType(mlir::Type ty) {
 static bool containsPointerElts(mlir::cir::StructType s) {
   auto members = s.getMembers();
   return std::any_of(members.begin(), members.end(), [](mlir::Type t) {
-    return t.isa<mlir::cir::PointerType>();
+    return mlir::isa<mlir::cir::PointerType>(t);
   });
 }
 
 static bool isAggregateType(LifetimeCheckPass *pass, mlir::Type agg) {
-  auto t = agg.dyn_cast<mlir::cir::StructType>();
+  auto t = mlir::dyn_cast<mlir::cir::StructType>(agg);
   if (!t)
     return false;
   // Lambdas have their special handling, and shall not be considered as
@@ -956,7 +956,7 @@ static bool isPointerType(mlir::Type t) {
   // library headers, the following well- known standard types are treated as-if
   // annotated as Pointers, in addition to raw pointers and references: ref-
   // erence_wrapper, and vector<bool>::reference.
-  if (t.isa<mlir::cir::PointerType>())
+  if (mlir::isa<mlir::cir::PointerType>(t))
     return true;
   return isStructAndHasAttr<clang::PointerAttr>(t);
 }
@@ -1017,7 +1017,7 @@ void LifetimeCheckPass::classifyAndInitTypeCategories(mlir::Value addr,
       break;
 
     // Map values for members to it's index in the aggregate.
-    auto members = t.cast<mlir::cir::StructType>().getMembers();
+    auto members = mlir::cast<mlir::cir::StructType>(t).getMembers();
     SmallVector<mlir::Value, 4> fieldVals;
     fieldVals.assign(members.size(), {});
 
@@ -1035,7 +1035,7 @@ void LifetimeCheckPass::classifyAndInitTypeCategories(mlir::Value addr,
         return;
 
       auto eltTy =
-          eltAddr.getType().cast<mlir::cir::PointerType>().getPointee();
+          mlir::cast<mlir::cir::PointerType>(eltAddr.getType()).getPointee();
 
       // Classify exploded types. Keep alloca original location.
       classifyAndInitTypeCategories(eltAddr, eltTy, loc, ++nestLevel);
@@ -1139,12 +1139,12 @@ void LifetimeCheckPass::updatePointsToForConstStruct(
   assert(aggregates.count(addr) && "expected association with aggregate");
   int memberIdx = 0;
   for (auto &attr : value.getMembers()) {
-    auto ta = attr.dyn_cast<mlir::TypedAttr>();
+    auto ta = mlir::dyn_cast<mlir::TypedAttr>(attr);
     assert(ta && "expected typed attribute");
     auto fieldAddr = aggregates[addr][memberIdx];
     // Unseen fields are not tracked.
-    if (fieldAddr && ta.getType().isa<mlir::cir::PointerType>()) {
-      assert(ta.isa<mlir::cir::ConstPtrAttr>() &&
+    if (fieldAddr && mlir::isa<mlir::cir::PointerType>(ta.getType())) {
+      assert(mlir::isa<mlir::cir::ConstPtrAttr>(ta) &&
              "other than null not implemented");
       markPsetNull(fieldAddr, loc);
     }
@@ -1160,7 +1160,7 @@ void LifetimeCheckPass::updatePointsToForZeroStruct(mlir::Value addr,
   for (auto &t : sTy.getMembers()) {
     auto fieldAddr = aggregates[addr][memberIdx];
     // Unseen fields are not tracked.
-    if (fieldAddr && t.isa<mlir::cir::PointerType>()) {
+    if (fieldAddr && mlir::isa<mlir::cir::PointerType>(t)) {
       markPsetNull(fieldAddr, loc);
     }
     memberIdx++;
@@ -1217,13 +1217,13 @@ void LifetimeCheckPass::updatePointsTo(mlir::Value addr, mlir::Value data,
     // individual exploded fields.
     if (aggregates.count(addr)) {
       if (auto constStruct =
-              cstOp.getValue().dyn_cast<mlir::cir::ConstStructAttr>()) {
+              mlir::dyn_cast<mlir::cir::ConstStructAttr>(cstOp.getValue())) {
         updatePointsToForConstStruct(addr, constStruct, loc);
         return;
       }
 
-      if (auto zero = cstOp.getValue().dyn_cast<mlir::cir::ZeroAttr>()) {
-        if (auto zeroStructTy = zero.getType().dyn_cast<StructType>()) {
+      if (auto zero = mlir::dyn_cast<mlir::cir::ZeroAttr>(cstOp.getValue())) {
+        if (auto zeroStructTy = dyn_cast<StructType>(zero.getType())) {
           updatePointsToForZeroStruct(addr, zeroStructTy, loc);
           return;
         }
@@ -1682,11 +1682,11 @@ void LifetimeCheckPass::checkForOwnerAndPointerArguments(CallOp callOp,
     if (aggregates.count(arg)) {
       int memberIdx = 0;
       auto sTy =
-          arg.getType().cast<PointerType>().getPointee().dyn_cast<StructType>();
+          dyn_cast<StructType>(arg.getType().cast<PointerType>().getPointee());
       assert(sTy && "expected struct type");
       for (auto m : sTy.getMembers()) {
         auto ptrMemberAddr = aggregates[arg][memberIdx];
-        if (m.isa<PointerType>() && ptrMemberAddr) {
+        if (isa<PointerType>(m) && ptrMemberAddr) {
           ptrsToDeref.insert(ptrMemberAddr);
         }
         memberIdx++;
@@ -1732,7 +1732,7 @@ bool LifetimeCheckPass::isLambdaType(mlir::Type ty) {
     return IsLambdaTyCache[ty];
 
   IsLambdaTyCache[ty] = false;
-  auto taskTy = ty.dyn_cast<mlir::cir::StructType>();
+  auto taskTy = mlir::dyn_cast<mlir::cir::StructType>(ty);
   if (!taskTy)
     return false;
   if (taskTy.getAst().isLambda())
@@ -1747,7 +1747,7 @@ bool LifetimeCheckPass::isTaskType(mlir::Value taskVal) {
     return IsTaskTyCache[ty];
 
   bool result = [&] {
-    auto taskTy = taskVal.getType().dyn_cast<mlir::cir::StructType>();
+    auto taskTy = mlir::dyn_cast<mlir::cir::StructType>(taskVal.getType());
     if (!taskTy)
       return false;
     return taskTy.getAst().hasPromiseType();

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -570,11 +570,9 @@ void LoweringPreparePass::lowerArrayDtor(ArrayDtor op) {
   builder.setInsertionPointAfter(op.getOperation());
 
   auto eltTy = op->getRegion(0).getArgument(0).getType();
-  auto arrayLen = op.getAddr()
-                      .getType()
-                      .cast<mlir::cir::PointerType>()
-                      .getPointee()
-                      .cast<mlir::cir::ArrayType>()
+  auto arrayLen = mlir::cast<mlir::cir::ArrayType>(
+                      mlir::cast<mlir::cir::PointerType>(op.getAddr().getType())
+                          .getPointee())
                       .getSize();
   lowerArrayDtorCtorIntoLoop(builder, op, eltTy, op.getAddr(), arrayLen);
 }
@@ -584,11 +582,9 @@ void LoweringPreparePass::lowerArrayCtor(ArrayCtor op) {
   builder.setInsertionPointAfter(op.getOperation());
 
   auto eltTy = op->getRegion(0).getArgument(0).getType();
-  auto arrayLen = op.getAddr()
-                      .getType()
-                      .cast<mlir::cir::PointerType>()
-                      .getPointee()
-                      .cast<mlir::cir::ArrayType>()
+  auto arrayLen = mlir::cast<mlir::cir::ArrayType>(
+                      mlir::cast<mlir::cir::PointerType>(op.getAddr().getType())
+                          .getPointee())
                       .getSize();
   lowerArrayDtorCtorIntoLoop(builder, op, eltTy, op.getAddr(), arrayLen);
 }

--- a/clang/lib/CIR/Dialect/Transforms/StdHelpers.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/StdHelpers.cpp
@@ -12,7 +12,7 @@ namespace mlir {
 namespace cir {
 
 bool isStdArrayType(mlir::Type t) {
-  auto sTy = t.dyn_cast<StructType>();
+  auto sTy = mlir::dyn_cast<StructType>(t);
   if (!sTy)
     return false;
   auto recordDecl = sTy.getAst();

--- a/clang/lib/CIR/Dialect/Transforms/StdHelpers.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/StdHelpers.cpp
@@ -12,7 +12,7 @@ namespace mlir {
 namespace cir {
 
 bool isStdArrayType(mlir::Type t) {
-  auto sTy = mlir::dyn_cast<StructType>(t);
+  auto sTy = dyn_cast<StructType>(t);
   if (!sTy)
     return false;
   auto recordDecl = sTy.getAst();

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -23,7 +23,7 @@ bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
                         const ABIInfo &Info) {
   Type Ty = FI.getReturnType();
 
-  if (const auto RT = mlir::dyn_cast<StructType>(Ty)) {
+  if (const auto RT = dyn_cast<StructType>(Ty)) {
     llvm_unreachable("NYI");
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -23,7 +23,7 @@ bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
                         const ABIInfo &Info) {
   Type Ty = FI.getReturnType();
 
-  if (const auto RT = Ty.dyn_cast<StructType>()) {
+  if (const auto RT = mlir::dyn_cast<StructType>(Ty)) {
     llvm_unreachable("NYI");
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -48,7 +48,7 @@ public:
 } // namespace
 
 bool ItaniumCXXABI::classifyReturnType(LowerFunctionInfo &FI) const {
-  const StructType RD = FI.getReturnType().dyn_cast<StructType>();
+  const StructType RD = mlir::dyn_cast<StructType>(FI.getReturnType());
   if (!RD)
     return false;
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -48,7 +48,7 @@ public:
 } // namespace
 
 bool ItaniumCXXABI::classifyReturnType(LowerFunctionInfo &FI) const {
-  const StructType RD = mlir::dyn_cast<StructType>(FI.getReturnType());
+  const StructType RD = dyn_cast<StructType>(FI.getReturnType());
   if (!RD)
     return false;
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -358,7 +358,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
 // NOTE(cir): This method has partial parity to CodeGenFunction's GetUndefRValue
 // defined in CGExpr.cpp.
 Value LowerFunction::getUndefRValue(Type Ty) {
-  if (Ty.isa<VoidType>())
+  if (mlir::isa<VoidType>(Ty))
     return nullptr;
 
   llvm::outs() << "Missing undef handler for value type: " << Ty << "\n";

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -358,7 +358,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
 // NOTE(cir): This method has partial parity to CodeGenFunction's GetUndefRValue
 // defined in CGExpr.cpp.
 Value LowerFunction::getUndefRValue(Type Ty) {
-  if (mlir::isa<VoidType>(Ty))
+  if (isa<VoidType>(Ty))
     return nullptr;
 
   llvm::outs() << "Missing undef handler for value type: " << Ty << "\n";

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -64,7 +64,7 @@ public:
 
 ABIArgInfo AArch64ABIInfo::classifyReturnType(Type RetTy,
                                               bool IsVariadic) const {
-  if (mlir::isa<VoidType>(RetTy))
+  if (isa<VoidType>(RetTy))
     return ABIArgInfo::getIgnore();
 
   llvm_unreachable("NYI");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -64,7 +64,7 @@ public:
 
 ABIArgInfo AArch64ABIInfo::classifyReturnType(Type RetTy,
                                               bool IsVariadic) const {
-  if (RetTy.isa<VoidType>())
+  if (mlir::isa<VoidType>(RetTy))
     return ABIArgInfo::getIgnore();
 
   llvm_unreachable("NYI");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
@@ -63,9 +63,9 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   auto opResTy = op.getType();
   // front end should not produce non-scalar type of VAArgOp
   bool isSupportedType =
-      opResTy.isa<mlir::cir::IntType, mlir::cir::SingleType,
-                  mlir::cir::PointerType, mlir::cir::BoolType,
-                  mlir::cir::DoubleType, mlir::cir::ArrayType>();
+      mlir::isa<mlir::cir::IntType, mlir::cir::SingleType,
+                mlir::cir::PointerType, mlir::cir::BoolType,
+                mlir::cir::DoubleType, mlir::cir::ArrayType>(opResTy);
 
   // Homogenous Aggregate type not supported and indirect arg
   // passing not supported yet. And for these supported types,
@@ -82,7 +82,7 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // but it depends on arg type indirectness and coercion defined by ABI.
   auto baseTy = opResTy;
 
-  if (baseTy.isa<mlir::cir::ArrayType>()) {
+  if (mlir::isa<mlir::cir::ArrayType>(baseTy)) {
     llvm_unreachable("ArrayType VAArg loweing NYI");
   }
   // numRegs may not be 1 if ArrayType is supported.
@@ -340,7 +340,7 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   builder.setInsertionPoint(op);
   contBlock->addArgument(onStackPtr.getType(), loc);
   auto resP = contBlock->getArgument(0);
-  assert(resP.getType().isa<mlir::cir::PointerType>());
+  assert(mlir::isa<mlir::cir::PointerType>(resP.getType()));
   auto opResPTy = mlir::cir::PointerType::get(builder.getContext(), opResTy);
   auto castResP = builder.createBitcast(resP, opResPTy);
   auto res = builder.create<mlir::cir::LoadOp>(loc, castResP);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
@@ -66,7 +66,7 @@ static mlir::Value buildDynamicCastAfterNullCheck(CIRBaseBuilderTy &builder,
                         dynCastFuncArgs)
           .getResult();
 
-  assert(castedPtr.getType().isa<mlir::cir::PointerType>() &&
+  assert(mlir::isa<mlir::cir::PointerType>(castedPtr.getType()) &&
          "the return value of __dynamic_cast should be a ptr");
 
   /// C++ [expr.dynamic.cast]p9:

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -81,7 +81,7 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
   // FIXME(cir): There's currently no direct way to identify if a type is a
   // builtin.
   if (/*isBuitinType=*/true) {
-    if (Ty.isa<VoidType>()) {
+    if (mlir::isa<VoidType>(Ty)) {
       Current = Class::NoClass;
     } else {
       llvm::outs() << "Missing X86 classification for type " << Ty << "\n";

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -81,7 +81,7 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
   // FIXME(cir): There's currently no direct way to identify if a type is a
   // builtin.
   if (/*isBuitinType=*/true) {
-    if (mlir::isa<VoidType>(Ty)) {
+    if (isa<VoidType>(Ty)) {
       Current = Class::NoClass;
     } else {
       llvm::outs() << "Missing X86 classification for type " << Ty << "\n";

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -44,11 +44,11 @@ public:
     if (!func)
       return mlir::success();
     llvm::Function *llvmFunc = moduleTranslation.lookupFunction(func.getName());
-    if (auto extraAttr = attribute.getValue()
-                             .dyn_cast<mlir::cir::ExtraFuncAttributesAttr>()) {
+    if (auto extraAttr = mlir::dyn_cast<mlir::cir::ExtraFuncAttributesAttr>(
+            attribute.getValue())) {
       for (auto attr : extraAttr.getElements()) {
         if (auto inlineAttr =
-                attr.getValue().dyn_cast<mlir::cir::InlineAttr>()) {
+                mlir::dyn_cast<mlir::cir::InlineAttr>(attr.getValue())) {
           if (inlineAttr.isNoInline())
             llvmFunc->addFnAttr(llvm::Attribute::NoInline);
           else if (inlineAttr.isAlwaysInline())
@@ -57,9 +57,9 @@ public:
             llvmFunc->addFnAttr(llvm::Attribute::InlineHint);
           else
             llvm_unreachable("Unknown inline kind");
-        } else if (attr.getValue().dyn_cast<mlir::cir::OptNoneAttr>()) {
+        } else if (mlir::dyn_cast<mlir::cir::OptNoneAttr>(attr.getValue())) {
           llvmFunc->addFnAttr(llvm::Attribute::OptimizeNone);
-        } else if (attr.getValue().dyn_cast<mlir::cir::NoThrowAttr>()) {
+        } else if (mlir::dyn_cast<mlir::cir::NoThrowAttr>(attr.getValue())) {
           llvmFunc->addFnAttr(llvm::Attribute::NoUnwind);
         }
       }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LoweringHelpers.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LoweringHelpers.h
@@ -20,8 +20,8 @@ mlir::Value createIntCast(mlir::OpBuilder &bld, mlir::Value src,
   auto srcTy = src.getType();
   assert(isa<mlir::IntegerType>(srcTy));
 
-  auto srcWidth = srcTy.cast<mlir::IntegerType>().getWidth();
-  auto dstWidth = dstTy.cast<mlir::IntegerType>().getWidth();
+  auto srcWidth = mlir::cast<mlir::IntegerType>(srcTy).getWidth();
+  auto dstWidth = mlir::cast<mlir::IntegerType>(dstTy).getWidth();
   auto loc = src.getLoc();
 
   if (dstWidth > srcWidth && isSigned)

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRLoopToSCF.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRLoopToSCF.cpp
@@ -71,7 +71,7 @@ private:
 
 static int64_t getConstant(mlir::cir::ConstantOp op) {
   auto attr = op->getAttrs().front().getValue();
-  const auto IntAttr = attr.dyn_cast<mlir::cir::IntAttr>();
+  const auto IntAttr = mlir::dyn_cast<mlir::cir::IntAttr>(attr);
   return IntAttr.getValue().getSExtValue();
 }
 
@@ -143,7 +143,7 @@ mlir::cir::CmpOp SCFLoop::findCmpOp() {
     llvm_unreachable("Can't find loop CmpOp");
 
   auto type = cmpOp.getLhs().getType();
-  if (!type.isa<mlir::cir::IntType>())
+  if (!mlir::isa<mlir::cir::IntType>(type))
     llvm_unreachable("Non-integer type IV is not supported");
 
   auto lhsDefOp = cmpOp.getLhs().getDefiningOp();

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -337,8 +337,9 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::ShiftOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto cirAmtTy = op.getAmount().getType().dyn_cast<mlir::cir::IntType>();
-    auto cirValTy = op.getValue().getType().dyn_cast<mlir::cir::IntType>();
+    auto cirAmtTy =
+        mlir::dyn_cast<mlir::cir::IntType>(op.getAmount().getType());
+    auto cirValTy = mlir::dyn_cast<mlir::cir::IntType>(op.getValue().getType());
     auto mlirTy = getTypeConverter()->convertType(op.getType());
     mlir::Value amt = adaptor.getAmount();
     mlir::Value val = adaptor.getValue();
@@ -397,9 +398,8 @@ public:
   matchAndRewrite(CIROp op,
                   typename mlir::OpConversionPattern<CIROp>::OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto resultIntTy = this->getTypeConverter()
-                           ->convertType(op.getType())
-                           .template cast<mlir::IntegerType>();
+    auto resultIntTy = mlir::cast<mlir::IntegerType>(
+        this->getTypeConverter()->convertType(op.getType()));
     auto res = rewriter.create<MLIROp>(op->getLoc(), adaptor.getInput());
     auto newOp = createIntCast(rewriter, res->getResult(0), resultIntTy,
                                /*isSigned=*/false);
@@ -438,8 +438,8 @@ public:
     auto select = rewriter.create<mlir::arith::SelectOp>(
         op.getLoc(), isNeg, flipped, adaptor.getInput());
 
-    auto resTy =
-        getTypeConverter()->convertType(op.getType()).cast<mlir::IntegerType>();
+    auto resTy = mlir::cast<mlir::IntegerType>(
+        getTypeConverter()->convertType(op.getType()));
     auto clz =
         rewriter.create<mlir::math::CountLeadingZerosOp>(op->getLoc(), select);
     auto newClz = createIntCast(rewriter, clz, resTy);
@@ -519,9 +519,9 @@ public:
     if (mlir::isa<mlir::cir::BoolType>(op.getType())) {
       auto boolValue = mlir::cast<mlir::cir::BoolAttr>(op.getValue());
       value = rewriter.getIntegerAttr(ty, boolValue.getValue());
-    } else if (op.getType().isa<mlir::cir::CIRFPTypeInterface>()) {
+    } else if (mlir::isa<mlir::cir::CIRFPTypeInterface>(op.getType())) {
       value = rewriter.getFloatAttr(
-          ty, op.getValue().cast<mlir::cir::FPAttr>().getValue());
+          ty, mlir::cast<mlir::cir::FPAttr>(op.getValue()).getValue());
     } else {
       auto cirIntAttr = mlir::dyn_cast<mlir::cir::IntAttr>(op.getValue());
       assert(cirIntAttr && "NYI non cir.int attr");
@@ -627,19 +627,19 @@ public:
     assert((adaptor.getLhs().getType() == adaptor.getRhs().getType()) &&
            "inconsistent operands' types not supported yet");
     mlir::Type mlirType = getTypeConverter()->convertType(op.getType());
-    assert((mlirType.isa<mlir::IntegerType>() ||
-            mlirType.isa<mlir::FloatType>() ||
-            mlirType.isa<mlir::VectorType>()) &&
+    assert((mlir::isa<mlir::IntegerType>(mlirType) ||
+            mlir::isa<mlir::FloatType>(mlirType) ||
+            mlir::isa<mlir::VectorType>(mlirType)) &&
            "operand type not supported yet");
 
     auto type = op.getLhs().getType();
-    if (auto VecType = type.dyn_cast<mlir::cir::VectorType>()) {
+    if (auto VecType = mlir::dyn_cast<mlir::cir::VectorType>(type)) {
       type = VecType.getEltType();
     }
 
     switch (op.getKind()) {
     case mlir::cir::BinOpKind::Add:
-      if (type.isa<mlir::cir::IntType>())
+      if (mlir::isa<mlir::cir::IntType>(type))
         rewriter.replaceOpWithNewOp<mlir::arith::AddIOp>(
             op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       else
@@ -647,7 +647,7 @@ public:
             op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Sub:
-      if (type.isa<mlir::cir::IntType>())
+      if (mlir::isa<mlir::cir::IntType>(type))
         rewriter.replaceOpWithNewOp<mlir::arith::SubIOp>(
             op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       else
@@ -655,7 +655,7 @@ public:
             op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Mul:
-      if (type.isa<mlir::cir::IntType>())
+      if (mlir::isa<mlir::cir::IntType>(type))
         rewriter.replaceOpWithNewOp<mlir::arith::MulIOp>(
             op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       else
@@ -663,7 +663,7 @@ public:
             op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Div:
-      if (auto ty = type.dyn_cast<mlir::cir::IntType>()) {
+      if (auto ty = mlir::dyn_cast<mlir::cir::IntType>(type)) {
         if (ty.isUnsigned())
           rewriter.replaceOpWithNewOp<mlir::arith::DivUIOp>(
               op, mlirType, adaptor.getLhs(), adaptor.getRhs());
@@ -675,7 +675,7 @@ public:
             op, mlirType, adaptor.getLhs(), adaptor.getRhs());
       break;
     case mlir::cir::BinOpKind::Rem:
-      if (auto ty = type.dyn_cast<mlir::cir::IntType>()) {
+      if (auto ty = mlir::dyn_cast<mlir::cir::IntType>(type)) {
         if (ty.isUnsigned())
           rewriter.replaceOpWithNewOp<mlir::arith::RemUIOp>(
               op, mlirType, adaptor.getLhs(), adaptor.getRhs());
@@ -715,15 +715,15 @@ public:
 
     mlir::Value mlirResult;
 
-    if (auto ty = type.dyn_cast<mlir::cir::IntType>()) {
+    if (auto ty = mlir::dyn_cast<mlir::cir::IntType>(type)) {
       auto kind = convertCmpKindToCmpIPredicate(op.getKind(), ty.isSigned());
       mlirResult = rewriter.create<mlir::arith::CmpIOp>(
           op.getLoc(), kind, adaptor.getLhs(), adaptor.getRhs());
-    } else if (auto ty = type.dyn_cast<mlir::cir::CIRFPTypeInterface>()) {
+    } else if (auto ty = mlir::dyn_cast<mlir::cir::CIRFPTypeInterface>(type)) {
       auto kind = convertCmpKindToCmpFPredicate(op.getKind());
       mlirResult = rewriter.create<mlir::arith::CmpFOp>(
           op.getLoc(), kind, adaptor.getLhs(), adaptor.getRhs());
-    } else if (auto ty = type.dyn_cast<mlir::cir::PointerType>()) {
+    } else if (auto ty = mlir::dyn_cast<mlir::cir::PointerType>(type)) {
       llvm_unreachable("pointer comparison not supported yet");
     } else {
       return op.emitError() << "unsupported type for CmpOp: " << type;
@@ -911,7 +911,7 @@ public:
     mlir::Attribute initialValue = mlir::Attribute();
     std::optional<mlir::Attribute> init = op.getInitialValue();
     if (init.has_value()) {
-      if (auto constArr = init.value().dyn_cast<mlir::cir::ZeroAttr>()) {
+      if (auto constArr = mlir::dyn_cast<mlir::cir::ZeroAttr>(init.value())) {
         if (memrefType.getShape().size()) {
           auto rtt = mlir::RankedTensorType::get(memrefType.getShape(),
                                                  memrefType.getElementType());
@@ -920,13 +920,16 @@ public:
           auto rtt = mlir::RankedTensorType::get({}, convertedType);
           initialValue = mlir::DenseIntElementsAttr::get(rtt, 0);
         }
-      } else if (auto intAttr = init.value().dyn_cast<mlir::cir::IntAttr>()) {
+      } else if (auto intAttr =
+                     mlir::dyn_cast<mlir::cir::IntAttr>(init.value())) {
         auto rtt = mlir::RankedTensorType::get({}, convertedType);
         initialValue = mlir::DenseIntElementsAttr::get(rtt, intAttr.getValue());
-      } else if (auto fltAttr = init.value().dyn_cast<mlir::cir::FPAttr>()) {
+      } else if (auto fltAttr =
+                     mlir::dyn_cast<mlir::cir::FPAttr>(init.value())) {
         auto rtt = mlir::RankedTensorType::get({}, convertedType);
         initialValue = mlir::DenseFPElementsAttr::get(rtt, fltAttr.getValue());
-      } else if (auto boolAttr = init.value().dyn_cast<mlir::cir::BoolAttr>()) {
+      } else if (auto boolAttr =
+                     mlir::dyn_cast<mlir::cir::BoolAttr>(init.value())) {
         auto rtt = mlir::RankedTensorType::get({}, convertedType);
         initialValue =
             mlir::DenseIntElementsAttr::get(rtt, (char)boolAttr.getValue());
@@ -979,7 +982,7 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::VecCreateOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto vecTy = op.getType().dyn_cast<mlir::cir::VectorType>();
+    auto vecTy = mlir::dyn_cast<mlir::cir::VectorType>(op.getType());
     assert(vecTy && "result type of cir.vec.create op is not VectorType");
     auto elementTy = typeConverter->convertType(vecTy.getEltType());
     auto loc = op.getLoc();
@@ -1037,19 +1040,19 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::VecCmpOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    assert(op.getType().isa<mlir::cir::VectorType>() &&
-           op.getLhs().getType().isa<mlir::cir::VectorType>() &&
-           op.getRhs().getType().isa<mlir::cir::VectorType>() &&
+    assert(mlir::isa<mlir::cir::VectorType>(op.getType()) &&
+           mlir::isa<mlir::cir::VectorType>(op.getLhs().getType()) &&
+           mlir::isa<mlir::cir::VectorType>(op.getRhs().getType()) &&
            "Vector compare with non-vector type");
     auto elementType =
-        op.getLhs().getType().cast<mlir::cir::VectorType>().getEltType();
+        mlir::cast<mlir::cir::VectorType>(op.getLhs().getType()).getEltType();
     mlir::Value bitResult;
-    if (auto intType = elementType.dyn_cast<mlir::cir::IntType>()) {
+    if (auto intType = mlir::dyn_cast<mlir::cir::IntType>(elementType)) {
       bitResult = rewriter.create<mlir::arith::CmpIOp>(
           op.getLoc(),
           convertCmpKindToCmpIPredicate(op.getKind(), intType.isSigned()),
           adaptor.getLhs(), adaptor.getRhs());
-    } else if (elementType.isa<mlir::cir::CIRFPTypeInterface>()) {
+    } else if (mlir::isa<mlir::cir::CIRFPTypeInterface>(elementType)) {
       bitResult = rewriter.create<mlir::arith::CmpFOp>(
           op.getLoc(), convertCmpKindToCmpFPredicate(op.getKind()),
           adaptor.getLhs(), adaptor.getRhs());
@@ -1080,7 +1083,7 @@ public:
     using CIR = mlir::cir::CastKind;
     switch (op.getKind()) {
     case CIR::array_to_ptrdecay: {
-      auto newDstType = convertTy(dstType).cast<mlir::MemRefType>();
+      auto newDstType = mlir::cast<mlir::MemRefType>(convertTy(dstType));
       rewriter.replaceOpWithNewOp<mlir::memref::ReinterpretCastOp>(
           op, newDstType, src, 0, std::nullopt, std::nullopt);
       return mlir::success();
@@ -1097,7 +1100,7 @@ public:
     case CIR::integral: {
       auto newDstType = convertTy(dstType);
       auto srcType = op.getSrc().getType();
-      mlir::cir::IntType srcIntType = srcType.cast<mlir::cir::IntType>();
+      mlir::cir::IntType srcIntType = mlir::cast<mlir::cir::IntType>(srcType);
       auto newOp =
           createIntCast(rewriter, src, newDstType, srcIntType.isSigned());
       rewriter.replaceOp(op, newOp);
@@ -1108,12 +1111,12 @@ public:
       auto srcTy = op.getSrc().getType();
       auto dstTy = op.getResult().getType();
 
-      if (!dstTy.isa<mlir::cir::CIRFPTypeInterface>() ||
-          !srcTy.isa<mlir::cir::CIRFPTypeInterface>())
+      if (!mlir::isa<mlir::cir::CIRFPTypeInterface>(dstTy) ||
+          !mlir::isa<mlir::cir::CIRFPTypeInterface>(srcTy))
         return op.emitError() << "NYI cast from " << srcTy << " to " << dstTy;
 
       auto getFloatWidth = [](mlir::Type ty) -> unsigned {
-        return ty.cast<mlir::cir::CIRFPTypeInterface>().getWidth();
+        return mlir::cast<mlir::cir::CIRFPTypeInterface>(ty).getWidth();
       };
 
       if (getFloatWidth(srcTy) > getFloatWidth(dstTy))
@@ -1123,7 +1126,7 @@ public:
       return mlir::success();
     }
     case CIR::float_to_bool: {
-      auto dstTy = op.getType().cast<mlir::cir::BoolType>();
+      auto dstTy = mlir::cast<mlir::cir::BoolType>(op.getType());
       auto newDstType = convertTy(dstTy);
       auto kind = mlir::arith::CmpFPredicate::UNE;
 
@@ -1139,8 +1142,8 @@ public:
       return mlir::success();
     }
     case CIR::bool_to_int: {
-      auto dstTy = op.getType().cast<mlir::cir::IntType>();
-      auto newDstType = convertTy(dstTy).cast<mlir::IntegerType>();
+      auto dstTy = mlir::cast<mlir::cir::IntType>(op.getType());
+      auto newDstType = mlir::cast<mlir::IntegerType>(convertTy(dstTy));
       auto newOp = createIntCast(rewriter, src, newDstType);
       rewriter.replaceOp(op, newOp);
       return mlir::success();
@@ -1154,7 +1157,7 @@ public:
     case CIR::int_to_float: {
       auto dstTy = op.getType();
       auto newDstType = convertTy(dstTy);
-      if (op.getSrc().getType().cast<mlir::cir::IntType>().isSigned())
+      if (mlir::cast<mlir::cir::IntType>(op.getSrc().getType()).isSigned())
         rewriter.replaceOpWithNewOp<mlir::arith::SIToFPOp>(op, newDstType, src);
       else
         rewriter.replaceOpWithNewOp<mlir::arith::UIToFPOp>(op, newDstType, src);
@@ -1163,7 +1166,7 @@ public:
     case CIR::float_to_int: {
       auto dstTy = op.getType();
       auto newDstType = convertTy(dstTy);
-      if (op.getResult().getType().cast<mlir::cir::IntType>().isSigned())
+      if (mlir::cast<mlir::cir::IntType>(op.getResult().getType()).isSigned())
         rewriter.replaceOpWithNewOp<mlir::arith::FPToSIOp>(op, newDstType, src);
       else
         rewriter.replaceOpWithNewOp<mlir::arith::FPToUIOp>(op, newDstType, src);
@@ -1246,7 +1249,7 @@ public:
       return mlir::failure();
     auto base = baseOp->getOperand(0);
     auto dstType = op.getResult().getType();
-    auto newDstType = convertTy(dstType).cast<mlir::MemRefType>();
+    auto newDstType = mlir::cast<mlir::MemRefType>(convertTy(dstType));
     auto stride = adaptor.getStride();
     auto indexType = rewriter.getIndexType();
     // Generate casting if the stride is not index type.

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerToMLIRHelpers.h
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerToMLIRHelpers.h
@@ -24,8 +24,8 @@ mlir::Value createIntCast(mlir::ConversionPatternRewriter &rewriter,
   assert(mlir::isa<mlir::IntegerType>(srcTy));
   assert(mlir::isa<mlir::IntegerType>(dstTy));
 
-  auto srcWidth = srcTy.cast<mlir::IntegerType>().getWidth();
-  auto dstWidth = dstTy.cast<mlir::IntegerType>().getWidth();
+  auto srcWidth = mlir::cast<mlir::IntegerType>(srcTy).getWidth();
+  auto dstWidth = mlir::cast<mlir::IntegerType>(dstTy).getWidth();
   auto loc = src.getLoc();
 
   if (dstWidth > srcWidth && isSigned)


### PR DESCRIPTION
Mechanical rewrite to use the corresponding free functions; fixes #702.

I used a slightly modified version of the `clang-tidy` check provided in https://discourse.llvm.org/t/psa-deprecating-cast-isa-methods-in-some-classes/70909 to rewrite the C++ source files, regular expressions for the TableGen files, and manual cleanups where needed (e.g. chains like `x.foo().cast<A>().bar().cast<B>()`)

I applied the following heuristic to determine which namespace prefix to use:
- If the target type is not qualified, and the TU has `using namespace mlir` or the code is inside the `mlir` namespace -> use a plain `isa`/`cast`/...
   - Exception: Always qualify inside custom types and attributes, because their base classes define the very members we want to get rid of.
- Else. i.e. the target type is qualified as `::mlir::` or `mlir::`, use that prefix.

The `clang-tidy` check also rewrote `dyn_cast_or_null` to `dyn_cast_if_present`. I think that's useful because the former variant is going to be deprecated as well in the future.

I'm using `-Werror=deprecated-declarations` to test the change (see 6b7420a93278ee01d37d95882dec39358378cfb3); this required also changing two occurrences of `StringRef::equals` to `==`. I could also just drop the commit here; maybe we want to enable `-Werror` in general (there aren't too many other warnings left in the codebase).