### PR TITLE
[CIR][Dialect] Emit OpenCL kernel metadata

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -979,4 +979,6 @@ def BitfieldInfoAttr : CIR_Attr<"BitfieldInfo", "bitfield_info"> {
   ];
 }
 
+include "clang/CIR/Dialect/IR/CIROpenCLAttrs.td"
+
 #endif // MLIR_CIR_DIALECT_CIR_ATTRS

--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -1,4 +1,4 @@
-//===- CIRAttrs.td - CIR dialect attrs for OpenCL ----------*- tablegen -*-===//
+//===- CIROpenCLAttrs.td - CIR dialect attrs for OpenCL ----*- tablegen -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -1,0 +1,95 @@
+//===- CIRAttrs.td - CIR dialect attrs for OpenCL ----------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the CIR dialect attributes for OpenCL.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_CIR_DIALECT_CIR_OPENCL_ATTRS
+#define MLIR_CIR_DIALECT_CIR_OPENCL_ATTRS
+
+//===----------------------------------------------------------------------===//
+// OpenCLKernelMetadataAttr
+//===----------------------------------------------------------------------===//
+
+def OpenCLKernelMetadataAttr
+    : CIR_Attr<"OpenCLKernelMetadata", "cl.kernel_metadata"> {
+  
+  let summary = "OpenCL kernel metadata";
+  let description = [{
+    Provide the required information of an OpenCL kernel for the SPIR-V backend.
+
+    The `work_group_size_hint` and `reqd_work_group_size` parameter are integer
+    arrays with 3 elements that provide hints for the work-group size and the
+    required work-group size, respectively.
+
+    The `vec_type_hint` parameter is a type attribute that provides a hint for
+    the vectorization. It can be a CIR or LLVM type, depending on the lowering
+    stage.
+
+    The `vec_type_hint_signedness` parameter is a boolean that indicates the
+    signedness of the vector type hint. It's useful when LLVM type is set in
+    `vec_type_hint`, which is signless by design. It should be set if and only
+    if the `vec_type_hint` is present.
+
+    The `intel_reqd_sub_group_size` parameter is an integer that restricts the
+    sub-group size to the specified value.
+
+    Example:
+    ```
+    #fn_attr = #cir<extra({cl.kernel_metadata = #cir.cl.kernel_metadata<
+      work_group_size_hint = [8 : i32, 16 : i32, 32 : i32],
+      reqd_work_group_size = [1 : i32, 2 : i32, 4 : i32],
+      vec_type_hint = !s32i,
+      vec_type_hint_signedness = 1,
+      intel_reqd_sub_group_size = 8 : i32
+    >})>
+
+    cir.func @kernel(%arg0: !s32i) extra(#fn_attr) {
+      cir.return
+    }
+    ```
+  }];
+
+  let parameters = (ins
+    OptionalParameter<"ArrayAttr">:$work_group_size_hint,
+    OptionalParameter<"ArrayAttr">:$reqd_work_group_size,
+    OptionalParameter<"TypeAttr">:$vec_type_hint,
+    OptionalParameter<"std::optional<bool>">:$vec_type_hint_signedness,
+    OptionalParameter<"IntegerAttr">:$intel_reqd_sub_group_size
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// Extract the signedness from int or int vector types.
+    static std::optional<bool> isSignedHint(mlir::Type vecTypeHint);
+  }];
+
+  let extraClassDefinition = [{
+    std::optional<bool> $cppClass::isSignedHint(mlir::Type hintQTy) {
+      // Only types in CIR carry signedness
+      if (!mlir::isa<mlir::cir::CIRDialect>(hintQTy.getDialect()))
+        return std::nullopt;
+      
+      // See also clang::CodeGen::CodeGenFunction::EmitKernelMetadata
+      auto hintEltQTy = mlir::dyn_cast<mlir::cir::VectorType>(hintQTy);
+      auto isCIRSignedIntType = [](mlir::Type t) {
+        return mlir::isa<mlir::cir::IntType>(t) &&
+               mlir::cast<mlir::cir::IntType>(t).isSigned();
+      };
+      return isCIRSignedIntType(hintQTy) ||
+              (hintEltQTy && isCIRSignedIntType(hintEltQTy.getEltType()));
+    }
+  }];
+
+}
+
+#endif // MLIR_CIR_DIALECT_CIR_OPENCL_ATTRS

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -142,6 +142,7 @@ struct MissingFeatures {
   static bool getFPFeaturesInEffect() { return false; }
   static bool cxxABI() { return false; }
   static bool openCL() { return false; }
+  static bool openCLGenKernelMetadata() { return false; }
   static bool CUDA() { return false; }
   static bool openMP() { return false; }
   static bool openMPRuntime() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -100,6 +100,10 @@ private:
   // enter/leave scopes.
   llvm::DenseMap<const Expr *, mlir::Value> VLASizeMap;
 
+  /// Add OpenCL kernel arg metadata and the kernel attribute metadata to
+  /// the function metadata.
+  void buildKernelMetadata(const FunctionDecl *FD, mlir::cir::FuncOp Fn);
+
 public:
   /// A non-RAII class containing all the information about a bound
   /// opaque value.  OpaqueValueMapping, below, is a RAII wrapper for

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -511,8 +511,8 @@ LogicalResult OpenCLKernelMetadataAttr::verify(
   // If no field is present, the attribute is considered invalid.
   if (!workGroupSizeHint && !reqdWorkGroupSize && !vecTypeHint &&
       !vecTypeHintSignedness && !intelReqdSubGroupSize) {
-    emitError() << "metadata attribute without any field present is invalid";
-    return failure();
+    return emitError()
+           << "metadata attribute without any field present is invalid";
   }
 
   // Check for 3-dim integer tuples
@@ -521,19 +521,18 @@ LogicalResult OpenCLKernelMetadataAttr::verify(
     return arr.size() == 3 && llvm::all_of(arr, isInt);
   };
   if (workGroupSizeHint && !is3dimIntTuple(workGroupSizeHint)) {
-    emitError() << "work_group_size_hint must have exactly 3 integer elements";
-    return failure();
+    return emitError()
+           << "work_group_size_hint must have exactly 3 integer elements";
   }
   if (reqdWorkGroupSize && !is3dimIntTuple(reqdWorkGroupSize)) {
-    emitError() << "reqd_work_group_size must have exactly 3 integer elements";
-    return failure();
+    return emitError()
+           << "reqd_work_group_size must have exactly 3 integer elements";
   }
 
   // Check for co-presence of vecTypeHintSignedness
   if (!!vecTypeHint != vecTypeHintSignedness.has_value()) {
-    emitError() << "vec_type_hint_signedness should be present if and only if "
-                   "vec_type_hint is set";
-    return failure();
+    return emitError() << "vec_type_hint_signedness should be present if and "
+                          "only if vec_type_hint is set";
   }
 
   if (vecTypeHint) {
@@ -541,15 +540,13 @@ LogicalResult OpenCLKernelMetadataAttr::verify(
     if (mlir::isa<cir::CIRDialect>(vecTypeHintValue.getDialect())) {
       // Check for signedness alignment in CIR
       if (isSignedHint(vecTypeHintValue) != vecTypeHintSignedness) {
-        emitError() << "vec_type_hint_signedness must match the signedness of "
-                       "the vec_type_hint type";
-        return failure();
+        return emitError() << "vec_type_hint_signedness must match the "
+                              "signedness of the vec_type_hint type";
       }
       // Check for the dialect of type hint
     } else if (!LLVM::isCompatibleType(vecTypeHintValue)) {
-      emitError() << "vec_type_hint must be a type from the CIR or LLVM "
-                     "dialect";
-      return failure();
+      return emitError() << "vec_type_hint must be a type from the CIR or LLVM "
+                            "dialect";
     }
   }
 

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -15,6 +15,7 @@
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
@@ -493,6 +494,63 @@ LogicalResult DynamicCastInfoAttr::verify(
   if (!isRttiPtr(destRtti.getType())) {
     emitError() << "destRtti must be an RTTI pointer";
     return failure();
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// OpenCLKernelMetadataAttr definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult OpenCLKernelMetadataAttr::verify(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    ArrayAttr workGroupSizeHint, ArrayAttr reqdWorkGroupSize,
+    TypeAttr vecTypeHint, std::optional<bool> vecTypeHintSignedness,
+    IntegerAttr intelReqdSubGroupSize) {
+  // If no field is present, the attribute is considered invalid.
+  if (!workGroupSizeHint && !reqdWorkGroupSize && !vecTypeHint &&
+      !vecTypeHintSignedness && !intelReqdSubGroupSize) {
+    emitError() << "metadata attribute without any field present is invalid";
+    return failure();
+  }
+
+  // Check for 3-dim integer tuples
+  auto is3dimIntTuple = [](ArrayAttr arr) {
+    auto isInt = [](Attribute dim) { return mlir::isa<IntegerAttr>(dim); };
+    return arr.size() == 3 && llvm::all_of(arr, isInt);
+  };
+  if (workGroupSizeHint && !is3dimIntTuple(workGroupSizeHint)) {
+    emitError() << "work_group_size_hint must have exactly 3 integer elements";
+    return failure();
+  }
+  if (reqdWorkGroupSize && !is3dimIntTuple(reqdWorkGroupSize)) {
+    emitError() << "reqd_work_group_size must have exactly 3 integer elements";
+    return failure();
+  }
+
+  // Check for co-presence of vecTypeHintSignedness
+  if (!!vecTypeHint != vecTypeHintSignedness.has_value()) {
+    emitError() << "vec_type_hint_signedness should be present if and only if "
+                   "vec_type_hint is set";
+    return failure();
+  }
+
+  if (vecTypeHint) {
+    Type vecTypeHintValue = vecTypeHint.getValue();
+    if (mlir::isa<cir::CIRDialect>(vecTypeHintValue.getDialect())) {
+      // Check for signedness alignment in CIR
+      if (isSignedHint(vecTypeHintValue) != vecTypeHintSignedness) {
+        emitError() << "vec_type_hint_signedness must match the signedness of "
+                       "the vec_type_hint type";
+        return failure();
+      }
+      // Check for the dialect of type hint
+    } else if (!LLVM::isCompatibleType(vecTypeHintValue)) {
+      emitError() << "vec_type_hint must be a type from the CIR or LLVM "
+                     "dialect";
+      return failure();
+    }
   }
 
   return success();

--- a/clang/test/CIR/CodeGen/OpenCL/kernel-attributes.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/kernel-attributes.cl
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -fclangir -emit-cir -triple x86_64-unknown-linux-gnu %s -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
+// RUN: %clang_cc1 -fclangir -emit-llvm -triple x86_64-unknown-linux-gnu %s -o %t.ll
+// RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
+
+typedef unsigned int uint4 __attribute__((ext_vector_type(4)));
+
+
+kernel  __attribute__((vec_type_hint(int))) __attribute__((reqd_work_group_size(1,2,4))) void kernel1(int a) {}
+
+// CIR-DAG: #fn_attr[[KERNEL1:[0-9]*]] = {{.+}}cl.kernel_metadata = #cir.cl.kernel_metadata<reqd_work_group_size = [1 : i32, 2 : i32, 4 : i32], vec_type_hint = !s32i, vec_type_hint_signedness = 1>{{.+}}
+// CIR-DAG: cir.func @kernel1{{.+}} extra(#fn_attr[[KERNEL1]])
+
+// LLVM-DAG: define{{.*}}@kernel1(i32 {{[^%]*}}%0) {{[^{]+}} !reqd_work_group_size ![[MD1_REQD_WG:[0-9]+]] !vec_type_hint ![[MD1_VEC_TYPE:[0-9]+]]
+// LLVM-DAG: [[MD1_VEC_TYPE]] = !{i32 undef, i32 1}
+// LLVM-DAG: [[MD1_REQD_WG]] = !{i32 1, i32 2, i32 4}
+
+
+kernel __attribute__((vec_type_hint(uint4))) __attribute__((work_group_size_hint(8,16,32))) void kernel2(int a) {}
+
+// CIR-DAG: #fn_attr[[KERNEL2:[0-9]*]] = {{.+}}cl.kernel_metadata = #cir.cl.kernel_metadata<work_group_size_hint = [8 : i32, 16 : i32, 32 : i32], vec_type_hint = !cir.vector<!u32i x 4>, vec_type_hint_signedness = 0>{{.+}}
+// CIR-DAG: cir.func @kernel2{{.+}} extra(#fn_attr[[KERNEL2]])
+
+// LLVM-DAG: define{{.*}}@kernel2(i32 {{[^%]*}}%0) {{[^{]+}} !vec_type_hint ![[MD2_VEC_TYPE:[0-9]+]] !work_group_size_hint ![[MD2_WG_SIZE:[0-9]+]]
+// LLVM-DAG: [[MD2_VEC_TYPE]] = !{<4 x i32> undef, i32 0}
+// LLVM-DAG: [[MD2_WG_SIZE]] = !{i32 8, i32 16, i32 32}
+
+
+kernel __attribute__((intel_reqd_sub_group_size(8))) void kernel3(int a) {}
+
+// CIR-DAG: #fn_attr[[KERNEL3:[0-9]*]] = {{.+}}cl.kernel_metadata = #cir.cl.kernel_metadata<intel_reqd_sub_group_size = 8 : i32>{{.+}}
+// CIR-DAG: cir.func @kernel3{{.+}} extra(#fn_attr[[KERNEL3]])
+
+// LLVM-DAG: define{{.*}}@kernel3(i32 {{[^%]*}}%0) {{[^{]+}} !intel_reqd_sub_group_size ![[MD3_INTEL:[0-9]+]]
+// LLVM-DAG: [[MD3_INTEL]] = !{i32 8}

--- a/clang/test/CIR/IR/invalid-opencl-vec-type-hint.cir
+++ b/clang/test/CIR/IR/invalid-opencl-vec-type-hint.cir
@@ -1,0 +1,7 @@
+// RUN: cir-opt %s -verify-diagnostics -allow-unregistered-dialect
+
+// expected-error@+1 {{vec_type_hint must be a type from the CIR or LLVM dialect}}
+#fn_attr = #cir.cl.kernel_metadata<
+  vec_type_hint = !tensor<7xi8>,
+  vec_type_hint_signedness = 0
+>

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1171,3 +1171,41 @@ cir.func @address_space3(%p : !cir.ptr<!u64i, addrspace(target)>) { // expected-
 cir.func @address_space4(%p : !cir.ptr<!u64i, addrspace(foobar)>) { // expected-error {{invalid addrspace kind keyword: foobar}}
   cir.return
 }
+
+// -----
+
+// expected-error@+1 {{metadata attribute without any field present is invalid}}
+#fn_attr = #cir.cl.kernel_metadata<>
+
+// -----
+
+// expected-error@+1 {{work_group_size_hint must have exactly 3 integer elements}}
+#fn_attr = #cir.cl.kernel_metadata<
+  work_group_size_hint = [2 : i32]
+>
+
+// -----
+
+// expected-error@+1 {{vec_type_hint_signedness should be present if and only if vec_type_hint is set}}
+#fn_attr = #cir.cl.kernel_metadata<
+  vec_type_hint_signedness = 1
+>
+
+// -----
+
+!s32i = !cir.int<s, 32>
+
+// expected-error@+1 {{vec_type_hint_signedness should be present if and only if vec_type_hint is set}}
+#fn_attr = #cir.cl.kernel_metadata<
+  vec_type_hint = !s32i
+>
+
+// -----
+
+!s32i = !cir.int<s, 32>
+
+// expected-error@+1 {{vec_type_hint_signedness must match the signedness of the vec_type_hint type}}
+#fn_attr = #cir.cl.kernel_metadata<
+  vec_type_hint = !s32i,
+  vec_type_hint_signedness = 0
+>

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1186,6 +1186,13 @@ cir.func @address_space4(%p : !cir.ptr<!u64i, addrspace(foobar)>) { // expected-
 
 // -----
 
+// expected-error@+1 {{reqd_work_group_size must have exactly 3 integer elements}}
+#fn_attr = #cir.cl.kernel_metadata<
+  reqd_work_group_size = [3.0 : f32, 1.7 : f32]
+>
+
+// -----
+
 // expected-error@+1 {{vec_type_hint_signedness should be present if and only if vec_type_hint is set}}
 #fn_attr = #cir.cl.kernel_metadata<
   vec_type_hint_signedness = 1


### PR DESCRIPTION
This PR introduces a new attribute `OpenCLKernelMetadataAttr` to model the OpenCL kernel metadata structurally in CIR, with its corresponding implementations of CodeGen, Lowering and Translation.

The `"TypeAttr":$vec_type_hint` part is tricky because of the absence of the signless feature of LLVM IR, while SPIR-V requires it. According to the spec, the final LLVM IR should encode signedness with an extra `i32` boolean value.

In this PR, the droping logic from CIR's `TypeConverter` is still used to avoid code duplication when lowering to LLVM dialect. However, the signedness is then restored (still capsuled by a CIR attribute) and dropped again in the translation into LLVM IR.