### PR TITLE
[CIR][CIRGen] Add setNonAliasAttributes for GlobalOp and FuncOp

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -50,6 +50,11 @@ struct MissingFeatures {
   static bool addCompilerUsedGlobal() { return false; }
   static bool supportIFuncAttr() { return false; }
   static bool setDefaultVisibility() { return false; }
+  static bool addUsedOrCompilerUsedGlobal() { return false; }
+  static bool addUsedGlobal() { return false; }
+  static bool addSectionAttributes() { return false; }
+  static bool setSectionForFuncOp() { return false; }
+  static bool updateCPUAndFeaturesAttributes() { return false; }
 
   // Sanitizers
   static bool reportGlobalToASan() { return false; }
@@ -146,7 +151,6 @@ struct MissingFeatures {
   static bool setNonGC() { return false; }
   static bool volatileLoadOrStore() { return false; }
   static bool armComputeVolatileBitfields() { return false; }
-  static bool setCommonAttributes() { return false; }
   static bool insertBuiltinUnpredictable() { return false; }
   static bool createInvariantGroup() { return false; }
   static bool addAutoInitAnnotation() { return false; }
@@ -265,6 +269,8 @@ struct MissingFeatures {
   // If a store op is guaranteed to execute before the retun value load op, we
   // can optimize away the store and load ops. Seems like an early optimization.
   static bool returnValueDominatingStoreOptmiization() { return false; }
+  // Globals (vars and functions) may have attributes that are target depedent.
+  static bool setTargetAttributes() { return false; }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -590,7 +590,7 @@ void CIRGenModule::buildGlobalFunctionDefinition(GlobalDecl GD,
   }
   CurCGF = nullptr;
 
-  // TODO: setNonAliasAttributes
+  setNonAliasAttributes(GD, Op);
   // TODO: SetLLVMFunctionAttributesForDeclaration
 
   if (const ConstructorAttr *CA = D->getAttr<ConstructorAttr>())
@@ -678,7 +678,67 @@ mlir::cir::GlobalOp CIRGenModule::createGlobalOp(CIRGenModule &CGM,
 }
 
 void CIRGenModule::setCommonAttributes(GlobalDecl GD, mlir::Operation *GV) {
-  assert(!MissingFeatures::setCommonAttributes());
+  const Decl *D = GD.getDecl();
+  if (isa_and_nonnull<NamedDecl>(D))
+    setGVProperties(GV, dyn_cast<NamedDecl>(D));
+  else
+    assert(!MissingFeatures::setDefaultVisibility());
+
+  if (D && D->hasAttr<UsedAttr>())
+    assert(!MissingFeatures::addUsedOrCompilerUsedGlobal());
+
+  if (const auto *VD = dyn_cast_if_present<VarDecl>(D);
+      VD &&
+      ((codeGenOpts.KeepPersistentStorageVariables &&
+        (VD->getStorageDuration() == SD_Static ||
+         VD->getStorageDuration() == SD_Thread)) ||
+       (codeGenOpts.KeepStaticConsts && VD->getStorageDuration() == SD_Static &&
+        VD->getType().isConstQualified())))
+    assert(!MissingFeatures::addUsedOrCompilerUsedGlobal());
+}
+
+void CIRGenModule::setNonAliasAttributes(GlobalDecl GD, mlir::Operation *GO) {
+  const Decl *D = GD.getDecl();
+  setCommonAttributes(GD, GO);
+
+  if (D) {
+    auto GV = llvm::dyn_cast_or_null<mlir::cir::GlobalOp>(GO);
+    if (GV) {
+      if (D->hasAttr<RetainAttr>())
+        assert(!MissingFeatures::addUsedGlobal());
+      if (auto *SA = D->getAttr<PragmaClangBSSSectionAttr>())
+        assert(!MissingFeatures::addSectionAttributes());
+      if (auto *SA = D->getAttr<PragmaClangDataSectionAttr>())
+        assert(!MissingFeatures::addSectionAttributes());
+      if (auto *SA = D->getAttr<PragmaClangRodataSectionAttr>())
+        assert(!MissingFeatures::addSectionAttributes());
+      if (auto *SA = D->getAttr<PragmaClangRelroSectionAttr>())
+        assert(!MissingFeatures::addSectionAttributes());
+    }
+    auto F = llvm::dyn_cast_or_null<mlir::cir::FuncOp>(GO);
+    if (F) {
+      if (D->hasAttr<RetainAttr>())
+        assert(!MissingFeatures::addUsedGlobal());
+      if (auto *SA = D->getAttr<PragmaClangTextSectionAttr>())
+        if (!D->getAttr<SectionAttr>())
+          assert(!MissingFeatures::setSectionForFuncOp());
+
+      assert(!MissingFeatures::updateCPUAndFeaturesAttributes());
+    }
+
+    if (const auto *CSA = D->getAttr<CodeSegAttr>()) {
+      assert(!MissingFeatures::setSectionForFuncOp());
+      if (GV)
+        GV.setSection(CSA->getName());
+      if (F)
+        assert(!MissingFeatures::setSectionForFuncOp());
+    } else if (const auto *SA = D->getAttr<SectionAttr>())
+      if (GV)
+        GV.setSection(SA->getName());
+    if (F)
+      assert(!MissingFeatures::setSectionForFuncOp());
+  }
+  assert(!MissingFeatures::setTargetAttributes());
 }
 
 void CIRGenModule::replaceGlobal(mlir::cir::GlobalOp Old,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -693,6 +693,7 @@ private:
   /// Call replaceAllUsesWith on all pairs in Replacements.
   void applyReplacements();
 
+  void setNonAliasAttributes(GlobalDecl GD, mlir::Operation *GV);
   /// Map source language used to a CIR attribute.
   mlir::cir::SourceLanguage getCIRSourceLanguage();
 };

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -608,6 +608,7 @@ public:
   getMLIRVisibilityFromCIRLinkage(mlir::cir::GlobalLinkageKind GLK);
   static mlir::SymbolTable::Visibility
   getMLIRVisibility(mlir::cir::GlobalOp op);
+  bool isDefaultVibility(mlir::cir::CIRGlobalValueInterface GV) const;
   mlir::cir::GlobalLinkageKind getFunctionLinkage(GlobalDecl GD);
   mlir::cir::GlobalLinkageKind
   getCIRLinkageForDeclarator(const DeclaratorDecl *D, GVALinkage Linkage,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -608,7 +608,6 @@ public:
   getMLIRVisibilityFromCIRLinkage(mlir::cir::GlobalLinkageKind GLK);
   static mlir::SymbolTable::Visibility
   getMLIRVisibility(mlir::cir::GlobalOp op);
-  bool isDefaultVibility(mlir::cir::CIRGlobalValueInterface GV) const;
   mlir::cir::GlobalLinkageKind getFunctionLinkage(GlobalDecl GD);
   mlir::cir::GlobalLinkageKind
   getCIRLinkageForDeclarator(const DeclaratorDecl *D, GVALinkage Linkage,

--- a/clang/test/CIR/CodeGen/func_dsolocal_pie.c
+++ b/clang/test/CIR/CodeGen/func_dsolocal_pie.c
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -pic-is-pie -pic-level 1 %s -o %t1.cir
+// RUN: FileCheck --input-file=%t1.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -pic-is-pie -pic-level 1 %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+void foo(int i) {
+
+}
+
+int main() {
+  foo(2);
+  return 0;
+}
+
+// CIR: cir.func dsolocal @foo(%arg0: !s32i
+// CIR-NEXT:   [[TMP0:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
+// CIR-NEXT:   cir.store %arg0, [[TMP0]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   cir.return
+
+// CIR: cir.func no_proto dsolocal @main() -> !s32i
+// CIR: [[TMP1:%.*]] = cir.const #cir.int<2> : !s32i
+// CIR: cir.call @foo([[TMP1]]) : (!s32i) -> ()
+
+// LLVM: define dso_local void @foo(i32 [[TMP3:%.*]])
+// LLVM: [[ARG_STACK:%.*]] = alloca i32, i64 1, align 4,
+// LLVM: store i32 [[TMP3]], ptr [[ARG_STACK]], align 4
+// LLVM: ret void,
+
+// LLVM: define dso_local i32 @main()
+// LLVM: [[TMP4:%.*]] = alloca i32, i64 1, align 4,
+// LLVM: call void @foo(i32 2),
+// LLVM: store i32 0, ptr [[TMP4]], align 4
+// LLVM: [[RET_VAL:%.*]] = load i32, ptr [[TMP4]], align 4
+// LLVM: ret i32 [[RET_VAL]],

--- a/clang/test/CIR/driver.c
+++ b/clang/test/CIR/driver.c
@@ -11,18 +11,30 @@
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -clangir-disable-passes -S -Xclang -emit-cir %s -o %t.cir
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -clangir-disable-verifier -S -Xclang -emit-cir %s -o %t.cir
 // RUN: %clang -target arm64-apple-macosx12.0.0 -fclangir -S -Xclang -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR_MACOS
+// RUN: %clang -target arm64-apple-macosx12.0.0 -fclangir -S -emit-llvm %s -o %t3.ll
+// RUN: FileCheck --input-file=%t3.ll %s -check-prefix=LLVM_MACOS
 
 void foo(void) {}
 
 //      CIR: module {{.*}} {
-// CIR-NEXT:   cir.func @foo()
+// CIR-NEXT:   cir.func dsolocal @foo()
 // CIR-NEXT:     cir.return
 // CIR-NEXT:   }
 // CIR-NEXT: }
 
-//      LLVM: define void @foo()
+//      CIR_MACOS: module {{.*}} {
+// CIR_MACOS-NEXT:   cir.func @foo()
+// CIR_MACOS-NEXT:     cir.return
+// CIR_MACOS-NEXT:   }
+// CIR_MACOS-NEXT: }
+
+//      LLVM: define dso_local void @foo()
 // LLVM-NEXT:   ret void
 // LLVM-NEXT: }
+
+//      LLVM_MACOS: define void @foo()
+// LLVM_MACOS-NEXT:   ret void
+// LLVM_MACOS-NEXT: }
 
 // OBJ: 0: c3 retq


### PR DESCRIPTION
In this PR:
as title we added setNonAliasAttributes in the skeleton of OG's setNonAliasAttributes, and call this function in buildGlobalFunctionDefinition after code for FuncOP is generated. This is needed for CIR OG to know FuncOP is not declaration anymore, thus giving shouldAssumeDsoLocal another run to make dso_local right.

A couple of notes about test;
1. having to changed driver.c, because in terms of dso_local for func, masOS is different from other targets as even in OG, as [macOS is   !isOSBinFormatELF()](https://github.com/llvm/clangir/blob/f78f9a55e7cd6b9e350556e35097616676cf1f3e/clang/lib/CodeGen/CodeGenModule.cpp#L1599), thus even OG doesn't set dso_local for its functions. 

3. most of functions in existing tests still not getting dso_local in LLVM yet because they fall into case of [(RM != llvm::Reloc::Static && !LOpts.PIE) ](https://github.com/llvm/clangir/blob/f78f9a55e7cd6b9e350556e35097616676cf1f3e/clang/lib/CodeGen/CodeGenModule.cpp#L1605C6-L1605C47), which is more complicated to implement as we need to get canBenefitFromLocalAlias right.  So I treated it as a missing feature and default it to false. We gonna leave it to another PR to address. In this PR, I just added additional test with -fpie option to my test so we get dso_local for functions without having to deal with this case.

Next 2 PRs:
PR1. call setNonAliasAttributes in buildGlobalVarDefinition, after initialization for GlobalOP is found, similar to FuncOp.
didn't to it in this PR as there are many more test cases needed to be fixed/added for this case.
PR2: try to implement canBenefitFromLocalAlias. 





