### PR TITLE
[CIR][ABI] Add AArch64 unsigned int CC lowering

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -209,6 +209,8 @@ struct MissingFeatures {
 
   static bool fixedWidthIntegers() { return false; }
   static bool vectorType() { return false; }
+  static bool functionMemberPointerType() { return false; }
+  static bool fixedSizeIntType() { return false; }
 
   //-- Missing LLVM attributes
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -13,7 +13,9 @@
 
 #include "ABIInfo.h"
 #include "CIRCXXABI.h"
+#include "LowerFunction.h"
 #include "LowerFunctionInfo.h"
+#include "clang/CIR/MissingFeatures.h"
 #include "llvm/Support/ErrorHandling.h"
 
 namespace mlir {
@@ -28,6 +30,11 @@ bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
   }
 
   return CXXABI.classifyReturnType(FI);
+}
+
+bool isAggregateTypeForABI(Type T) {
+  assert(!::cir::MissingFeatures::functionMemberPointerType());
+  return !LowerFunction::hasScalarEvaluationKind(T);
 }
 
 Type useFirstFieldIfTransparentUnion(Type Ty) {

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.h
@@ -24,6 +24,8 @@ namespace cir {
 bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
                         const ABIInfo &Info);
 
+bool isAggregateTypeForABI(Type T);
+
 /// Pass transparent unions as if they were the type of the first element. Sema
 /// should ensure that all elements of the union have the same "machine type".
 Type useFirstFieldIfTransparentUnion(Type Ty);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.h
@@ -86,6 +86,10 @@ public:
 
   /// Return the TypeEvaluationKind of Type \c T.
   static ::cir::TypeEvaluationKind getEvaluationKind(Type T);
+
+  static bool hasScalarEvaluationKind(Type T) {
+    return getEvaluationKind(T) == ::cir::TypeEvaluationKind::TEK_Scalar;
+  }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -39,16 +39,20 @@ public:
 
 private:
   AArch64ABIKind getABIKind() const { return Kind; }
+  bool isDarwinPCS() const { return Kind == AArch64ABIKind::DarwinPCS; }
 
   ABIArgInfo classifyReturnType(Type RetTy, bool IsVariadic) const;
+  ABIArgInfo classifyArgumentType(Type RetTy, bool IsVariadic,
+                                  unsigned CallingConvention) const;
 
   void computeInfo(LowerFunctionInfo &FI) const override {
     if (!::mlir::cir::classifyReturnType(getCXXABI(), FI, *this))
       FI.getReturnInfo() =
           classifyReturnType(FI.getReturnType(), FI.isVariadic());
 
-    for (auto &_ : FI.arguments())
-      llvm_unreachable("NYI");
+    for (auto &it : FI.arguments())
+      it.info = classifyArgumentType(it.type, FI.isVariadic(),
+                                     FI.getCallingConvention());
   }
 };
 
@@ -66,6 +70,48 @@ ABIArgInfo AArch64ABIInfo::classifyReturnType(Type RetTy,
                                               bool IsVariadic) const {
   if (isa<VoidType>(RetTy))
     return ABIArgInfo::getIgnore();
+
+  if (const auto _ = dyn_cast<VectorType>(RetTy)) {
+    llvm_unreachable("NYI");
+  }
+
+  // Large vector types should be returned via memory.
+  if (isa<VectorType>(RetTy) && getContext().getTypeSize(RetTy) > 128)
+    llvm_unreachable("NYI");
+
+  if (!isAggregateTypeForABI(RetTy)) {
+    // NOTE(cir): Skip enum handling.
+
+    if (MissingFeature::fixedSizeIntType())
+      llvm_unreachable("NYI");
+
+    return (isPromotableIntegerTypeForABI(RetTy) && isDarwinPCS()
+                ? ABIArgInfo::getExtend(RetTy)
+                : ABIArgInfo::getDirect());
+  }
+
+  llvm_unreachable("NYI");
+}
+
+ABIArgInfo
+AArch64ABIInfo::classifyArgumentType(Type Ty, bool IsVariadic,
+                                     unsigned CallingConvention) const {
+  Ty = useFirstFieldIfTransparentUnion(Ty);
+
+  // TODO(cir): check for illegal vector types.
+  if (MissingFeature::vectorType())
+    llvm_unreachable("NYI");
+
+  if (!isAggregateTypeForABI(Ty)) {
+    // NOTE(cir): Enum is IntType in CIR. Skip enum handling here.
+
+    if (MissingFeature::fixedSizeIntType())
+      llvm_unreachable("NYI");
+
+    return (isPromotableIntegerTypeForABI(Ty) && isDarwinPCS()
+                ? ABIArgInfo::getExtend(Ty)
+                : ABIArgInfo::getDirect());
+  }
 
   llvm_unreachable("NYI");
 }

--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -399,7 +399,7 @@ AArch64ABIInfo::classifyArgumentType(QualType Ty, bool IsVariadic,
   return getNaturalAlignIndirect(Ty, /*ByVal=*/false);
 }
 
-ABIArgInfo AArch64ABIInfo:: classifyReturnType(QualType RetTy,
+ABIArgInfo AArch64ABIInfo::classifyReturnType(QualType RetTy,
                                               bool IsVariadic) const {
   if (RetTy->isVoidType())
     return ABIArgInfo::getIgnore();

--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -399,7 +399,7 @@ AArch64ABIInfo::classifyArgumentType(QualType Ty, bool IsVariadic,
   return getNaturalAlignIndirect(Ty, /*ByVal=*/false);
 }
 
-ABIArgInfo AArch64ABIInfo::classifyReturnType(QualType RetTy,
+ABIArgInfo AArch64ABIInfo:: classifyReturnType(QualType RetTy,
                                               bool IsVariadic) const {
   if (RetTy->isVoidType())
     return ABIArgInfo::getIgnore();

--- a/clang/test/CIR/Transforms/Target/aarch64/aarch64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/aarch64/aarch64-call-conv-lowering-pass.cpp
@@ -6,3 +6,31 @@ void Void(void) {
 // CHECK:   cir.call @_Z4Voidv() : () -> ()
   Void();
 }
+
+// Test call conv lowering for trivial usinged integer cases.
+
+// CHECK: cir.func @_Z5UCharh(%arg0: !u8i loc({{.+}})) -> !u8i
+unsigned char UChar(unsigned char c) {
+  // CHECK: cir.call @_Z5UCharh(%2) : (!u8i) -> !u8i
+  return UChar(c);
+}
+// CHECK: cir.func @_Z6UShortt(%arg0: !u16i loc({{.+}})) -> !u16i
+unsigned short UShort(unsigned short s) {
+  // CHECK: cir.call @_Z6UShortt(%2) : (!u16i) -> !u16i
+  return UShort(s);
+}
+// CHECK: cir.func @_Z4UIntj(%arg0: !u32i loc({{.+}})) -> !u32i
+unsigned int UInt(unsigned int i) {
+  // CHECK: cir.call @_Z4UIntj(%2) : (!u32i) -> !u32i
+  return UInt(i);
+}
+// CHECK: cir.func @_Z5ULongm(%arg0: !u64i loc({{.+}})) -> !u64i
+unsigned long ULong(unsigned long l) {
+  // CHECK: cir.call @_Z5ULongm(%2) : (!u64i) -> !u64i
+  return ULong(l);
+}
+// CHECK: cir.func @_Z9ULongLongy(%arg0: !u64i loc({{.+}})) -> !u64i
+unsigned long long ULongLong(unsigned long long l) {
+  // CHECK: cir.call @_Z9ULongLongy(%2) : (!u64i) -> !u64i
+  return ULongLong(l);
+}


### PR DESCRIPTION
Adds the necessary bits to lower arguments and return values of type unsigned int for the x86_64 target.