### PR TITLE
[CIR][CIRGen] Add support for exact dynamic cast

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -309,7 +309,7 @@ public:
                                        QualType SrcRecordTy,
                                        QualType DestRecordTy,
                                        mlir::cir::PointerType DestCIRTy,
-                                       bool isRefCast, mlir::Value Src) = 0;
+                                       bool isRefCast, Address Src) = 0;
 };
 
 /// Creates and Itanium-family ABI

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -293,7 +293,7 @@ public:
   mlir::Value buildDynamicCast(CIRGenFunction &CGF, mlir::Location Loc,
                                QualType SrcRecordTy, QualType DestRecordTy,
                                mlir::cir::PointerType DestCIRTy, bool isRefCast,
-                               mlir::Value Src) override;
+                               Address Src) override;
 
   /**************************** RTTI Uniqueness ******************************/
 protected:
@@ -2213,14 +2213,18 @@ static mlir::cir::FuncOp getBadCastFn(CIRGenFunction &CGF) {
   return CGF.CGM.createRuntimeFunction(FTy, "__cxa_bad_cast");
 }
 
-void CIRGenItaniumCXXABI::buildBadCastCall(CIRGenFunction &CGF,
-                                           mlir::Location loc) {
+static void buildCallToBadCast(CIRGenFunction &CGF, mlir::Location loc) {
   // TODO(cir): set the calling convention to the runtime function.
   assert(!MissingFeatures::setCallingConv());
 
   CGF.buildRuntimeCall(loc, getBadCastFn(CGF));
   CGF.getBuilder().create<mlir::cir::UnreachableOp>(loc);
   CGF.getBuilder().clearInsertionPoint();
+}
+
+void CIRGenItaniumCXXABI::buildBadCastCall(CIRGenFunction &CGF,
+                                           mlir::Location loc) {
+  buildCallToBadCast(CGF, loc);
 }
 
 static CharUnits computeOffsetHint(ASTContext &Context,
@@ -2294,14 +2298,146 @@ static mlir::cir::FuncOp getItaniumDynamicCastFn(CIRGenFunction &CGF) {
   return CGF.CGM.createRuntimeFunction(FTy, "__dynamic_cast");
 }
 
-static mlir::Value buildDynamicCastToVoid(CIRGenFunction &CGF,
-                                          mlir::Location Loc,
-                                          QualType SrcRecordTy,
-                                          mlir::Value Src) {
+static Address buildDynamicCastToVoid(CIRGenFunction &CGF, mlir::Location Loc,
+                                      QualType SrcRecordTy, Address Src) {
   auto vtableUsesRelativeLayout =
       CGF.CGM.getItaniumVTableContext().isRelativeLayout();
-  return CGF.getBuilder().createDynCastToVoid(Loc, Src,
-                                              vtableUsesRelativeLayout);
+  auto ptr = CGF.getBuilder().createDynCastToVoid(Loc, Src.getPointer(),
+                                                  vtableUsesRelativeLayout);
+  return Address{ptr, Src.getAlignment()};
+}
+
+static mlir::Value
+buildExactDynamicCast(CIRGenItaniumCXXABI &ABI, CIRGenFunction &CGF,
+                      mlir::Location Loc, QualType SrcRecordTy,
+                      QualType DestRecordTy, mlir::cir::PointerType DestCIRTy,
+                      bool IsRefCast, Address Src) {
+  // Find all the inheritance paths from SrcRecordTy to DestRecordTy.
+  const CXXRecordDecl *SrcDecl = SrcRecordTy->getAsCXXRecordDecl();
+  const CXXRecordDecl *DestDecl = DestRecordTy->getAsCXXRecordDecl();
+  CXXBasePaths Paths(/*FindAmbiguities=*/true, /*RecordPaths=*/true,
+                     /*DetectVirtual=*/false);
+  (void)DestDecl->isDerivedFrom(SrcDecl, Paths);
+
+  // Find an offset within `DestDecl` where a `SrcDecl` instance and its vptr
+  // might appear.
+  std::optional<CharUnits> Offset;
+  for (const CXXBasePath &Path : Paths) {
+    // dynamic_cast only finds public inheritance paths.
+    if (Path.Access != AS_public)
+      continue;
+
+    CharUnits PathOffset;
+    for (const CXXBasePathElement &PathElement : Path) {
+      // Find the offset along this inheritance step.
+      const CXXRecordDecl *Base =
+          PathElement.Base->getType()->getAsCXXRecordDecl();
+      if (PathElement.Base->isVirtual()) {
+        // For a virtual base class, we know that the derived class is exactly
+        // DestDecl, so we can use the vbase offset from its layout.
+        const ASTRecordLayout &L =
+            CGF.getContext().getASTRecordLayout(DestDecl);
+        PathOffset = L.getVBaseClassOffset(Base);
+      } else {
+        const ASTRecordLayout &L =
+            CGF.getContext().getASTRecordLayout(PathElement.Class);
+        PathOffset += L.getBaseClassOffset(Base);
+      }
+    }
+
+    if (!Offset)
+      Offset = PathOffset;
+    else if (Offset != PathOffset) {
+      // Base appears in at least two different places. Find the most-derived
+      // object and see if it's a DestDecl. Note that the most-derived object
+      // must be at least as aligned as this base class subobject, and must
+      // have a vptr at offset 0.
+      Src = buildDynamicCastToVoid(CGF, Loc, SrcRecordTy, Src);
+      SrcDecl = DestDecl;
+      Offset = CharUnits::Zero();
+      break;
+    }
+  }
+
+  if (!Offset) {
+    // If there are no public inheritance paths, the cast always fails.
+    mlir::Value NullPtrValue = CGF.getBuilder().getNullPtr(DestCIRTy, Loc);
+    if (IsRefCast) {
+      auto *CurrentRegion = CGF.getBuilder().getBlock()->getParent();
+      buildCallToBadCast(CGF, Loc);
+
+      // The call to bad_cast will terminate the block. Create a new block to
+      // hold any follow up code.
+      CGF.getBuilder().createBlock(CurrentRegion, CurrentRegion->end());
+    }
+
+    return NullPtrValue;
+  }
+
+  // Compare the vptr against the expected vptr for the destination type at
+  // this offset. Note that we do not know what type Src points to in the case
+  // where the derived class multiply inherits from the base class so we can't
+  // use GetVTablePtr, so we load the vptr directly instead.
+
+  mlir::Value ExpectedVPtr =
+      ABI.getVTableAddressPoint(BaseSubobject(SrcDecl, *Offset), DestDecl);
+
+  // TODO(cir): handle address space here.
+  assert(!MissingFeatures::addressSpace());
+  mlir::Type VPtrTy = ExpectedVPtr.getType();
+  mlir::Type VPtrPtrTy = CGF.getBuilder().getPointerTo(VPtrTy);
+  Address SrcVPtrPtr(
+      CGF.getBuilder().createBitcast(Src.getPointer(), VPtrPtrTy),
+      Src.getAlignment());
+  mlir::Value SrcVPtr = CGF.getBuilder().createLoad(Loc, SrcVPtrPtr);
+
+  // TODO(cir): decorate SrcVPtr with TBAA info.
+  assert(!MissingFeatures::tbaa());
+
+  mlir::Value Success = CGF.getBuilder().createCompare(
+      Loc, mlir::cir::CmpOpKind::eq, SrcVPtr, ExpectedVPtr);
+
+  auto buildCastResult = [&] {
+    if (Offset->isZero())
+      return CGF.getBuilder().createBitcast(Src.getPointer(), DestCIRTy);
+
+    // TODO(cir): handle address space here.
+    assert(!MissingFeatures::addressSpace());
+    mlir::Type U8PtrTy =
+        CGF.getBuilder().getPointerTo(CGF.getBuilder().getUInt8Ty());
+
+    mlir::Value StrideToApply = CGF.getBuilder().getConstInt(
+        Loc, CGF.getBuilder().getUInt64Ty(), Offset->getQuantity());
+    mlir::Value SrcU8Ptr =
+        CGF.getBuilder().createBitcast(Src.getPointer(), U8PtrTy);
+    mlir::Value ResultU8Ptr = CGF.getBuilder().create<mlir::cir::PtrStrideOp>(
+        Loc, U8PtrTy, SrcU8Ptr, StrideToApply);
+    return CGF.getBuilder().createBitcast(ResultU8Ptr, DestCIRTy);
+  };
+
+  if (IsRefCast) {
+    mlir::Value Failed = CGF.getBuilder().createNot(Success);
+    CGF.getBuilder().create<mlir::cir::IfOp>(
+        Loc, Failed, /*withElseRegion=*/false,
+        [&](mlir::OpBuilder &, mlir::Location) {
+          buildCallToBadCast(CGF, Loc);
+        });
+    return buildCastResult();
+  }
+
+  return CGF.getBuilder()
+      .create<mlir::cir::TernaryOp>(
+          Loc, Success,
+          [&](mlir::OpBuilder &, mlir::Location) {
+            auto Result = buildCastResult();
+            CGF.getBuilder().createYield(Loc, Result);
+          },
+          [&](mlir::OpBuilder &, mlir::Location) {
+            mlir::Value NullPtrValue =
+                CGF.getBuilder().getNullPtr(DestCIRTy, Loc);
+            CGF.getBuilder().createYield(Loc, NullPtrValue);
+          })
+      .getResult();
 }
 
 static mlir::cir::DynamicCastInfoAttr
@@ -2332,14 +2468,21 @@ buildDynamicCastInfo(CIRGenFunction &CGF, mlir::Location Loc,
 mlir::Value CIRGenItaniumCXXABI::buildDynamicCast(
     CIRGenFunction &CGF, mlir::Location Loc, QualType SrcRecordTy,
     QualType DestRecordTy, mlir::cir::PointerType DestCIRTy, bool isRefCast,
-    mlir::Value Src) {
+    Address Src) {
   bool isCastToVoid = DestRecordTy.isNull();
   assert((!isCastToVoid || !isRefCast) && "cannot cast to void reference");
 
   if (isCastToVoid)
-    return buildDynamicCastToVoid(CGF, Loc, SrcRecordTy, Src);
+    return buildDynamicCastToVoid(CGF, Loc, SrcRecordTy, Src).getPointer();
+
+  // If the destination is effectively final, the cast succeeds if and only
+  // if the dynamic type of the pointer is exactly the destination type.
+  if (DestRecordTy->getAsCXXRecordDecl()->isEffectivelyFinal() &&
+      CGF.CGM.getCodeGenOpts().OptimizationLevel > 0)
+    return buildExactDynamicCast(*this, CGF, Loc, SrcRecordTy, DestRecordTy,
+                                 DestCIRTy, isRefCast, Src);
 
   auto castInfo = buildDynamicCastInfo(CGF, Loc, SrcRecordTy, DestRecordTy);
-  return CGF.getBuilder().createDynCast(Loc, Src, DestCIRTy, isRefCast,
-                                        castInfo);
+  return CGF.getBuilder().createDynCast(Loc, Src.getPointer(), DestCIRTy,
+                                        isRefCast, castInfo);
 }

--- a/clang/test/CIR/CodeGen/dynamic-cast-exact.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast-exact.cpp
@@ -1,0 +1,87 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O1 -fclangir -clangir-disable-passes -emit-cir -o %t.cir %s
+// RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O1 -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
+
+struct Base1 {
+  virtual ~Base1();
+};
+
+struct Base2 {
+  virtual ~Base2();
+};
+
+struct Derived final : Base1 {};
+
+Derived *ptr_cast(Base1 *ptr) {
+  return dynamic_cast<Derived *>(ptr);
+  //      CHECK: %[[#SRC:]] = cir.load %{{.+}} : !cir.ptr<!cir.ptr<!ty_22Base122>>, !cir.ptr<!ty_22Base122>
+  // CHECK-NEXT: %[[#EXPECTED_VPTR:]] = cir.vtable.address_point(@_ZTV7Derived, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
+  // CHECK-NEXT: %[[#SRC_VPTR_PTR:]] = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_22Base122>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+  // CHECK-NEXT: %[[#SRC_VPTR:]] = cir.load %[[#SRC_VPTR_PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>, !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
+  // CHECK-NEXT: %[[#SUCCESS:]] = cir.cmp(eq, %[[#SRC_VPTR]], %[[#EXPECTED_VPTR]]) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.bool
+  // CHECK-NEXT: %{{.+}} = cir.ternary(%[[#SUCCESS]], true {
+  // CHECK-NEXT:   %[[#RES:]] = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_22Base122>), !cir.ptr<!ty_22Derived22>
+  // CHECK-NEXT:   cir.yield %[[#RES]] : !cir.ptr<!ty_22Derived22>
+  // CHECK-NEXT: }, false {
+  // CHECK-NEXT:   %[[#NULL:]] = cir.const #cir.ptr<null> : !cir.ptr<!ty_22Derived22>
+  // CHECK-NEXT:   cir.yield %[[#NULL]] : !cir.ptr<!ty_22Derived22>
+  // CHECK-NEXT: }) : (!cir.bool) -> !cir.ptr<!ty_22Derived22>
+}
+
+//      LLVM: define ptr @_Z8ptr_castP5Base1(ptr readonly %[[#SRC:]])
+// LLVM-NEXT:   %[[#VPTR:]] = load ptr, ptr %[[#SRC]], align 8
+// LLVM-NEXT:   %[[#SUCCESS:]] = icmp eq ptr %[[#VPTR]], getelementptr inbounds (i8, ptr @_ZTV7Derived, i64 16)
+// LLVM-NEXT:   %[[RESULT:.+]] = select i1 %[[#SUCCESS]], ptr %[[#SRC]], ptr null
+// LLVM-NEXT:   ret ptr %[[RESULT]]
+// LLVM-NEXT: }
+
+Derived &ref_cast(Base1 &ref) {
+  return dynamic_cast<Derived &>(ref);
+  //      CHECK: %[[#SRC:]] = cir.load %{{.+}} : !cir.ptr<!cir.ptr<!ty_22Base122>>, !cir.ptr<!ty_22Base122>
+  // CHECK-NEXT: %[[#EXPECTED_VPTR:]] = cir.vtable.address_point(@_ZTV7Derived, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
+  // CHECK-NEXT: %[[#SRC_VPTR_PTR:]] = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_22Base122>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+  // CHECK-NEXT: %[[#SRC_VPTR:]] = cir.load %[[#SRC_VPTR_PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>, !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
+  // CHECK-NEXT: %[[#SUCCESS:]] = cir.cmp(eq, %[[#SRC_VPTR]], %[[#EXPECTED_VPTR]]) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.bool
+  // CHECK-NEXT: %[[#FAILED:]] = cir.unary(not, %[[#SUCCESS]]) : !cir.bool, !cir.bool
+  // CHECK-NEXT: cir.if %[[#FAILED]] {
+  // CHECK-NEXT:   cir.call @__cxa_bad_cast() : () -> ()
+  // CHECK-NEXT:   cir.unreachable
+  // CHECK-NEXT: }
+  // CHECK-NEXT: %{{.+}} = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_22Base122>), !cir.ptr<!ty_22Derived22>
+}
+
+//      LLVM: define noundef ptr @_Z8ref_castR5Base1(ptr readonly returned %[[#SRC:]])
+// LLVM-NEXT:   %[[#VPTR:]] = load ptr, ptr %[[#SRC]], align 8
+// LLVM-NEXT:   %[[OK:.+]] = icmp eq ptr %[[#VPTR]], getelementptr inbounds (i8, ptr @_ZTV7Derived, i64 16)
+// LLVM-NEXT:   br i1 %[[OK]], label %[[#LABEL_OK:]], label %[[#LABEL_FAIL:]]
+//      LLVM: [[#LABEL_FAIL]]:
+// LLVM-NEXT:   tail call void @__cxa_bad_cast()
+// LLVM-NEXT:   unreachable
+//      LLVM: [[#LABEL_OK]]:
+// LLVM-NEXT:   ret ptr %[[#SRC]]
+// LLVM-NEXT: }
+
+Derived *ptr_cast_always_fail(Base2 *ptr) {
+  return dynamic_cast<Derived *>(ptr);
+  //      CHECK: %{{.+}} = cir.load %{{.+}} : !cir.ptr<!cir.ptr<!ty_22Base222>>, !cir.ptr<!ty_22Base222>
+  // CHECK-NEXT: %[[#RESULT:]] = cir.const #cir.ptr<null> : !cir.ptr<!ty_22Derived22>
+  // CHECK-NEXT: cir.store %[[#RESULT]], %{{.+}} : !cir.ptr<!ty_22Derived22>, !cir.ptr<!cir.ptr<!ty_22Derived22>>
+}
+
+//      LLVM: define noalias noundef ptr @_Z20ptr_cast_always_failP5Base2(ptr nocapture readnone %{{.+}})
+// LLVM-NEXT:   ret ptr null
+// LLVM-NEXT: }
+
+Derived &ref_cast_always_fail(Base2 &ref) {
+  return dynamic_cast<Derived &>(ref);
+  //      CHECK: %{{.+}} = cir.load %{{.+}} : !cir.ptr<!cir.ptr<!ty_22Base222>>, !cir.ptr<!ty_22Base222>
+  // CHECK-NEXT: %{{.+}} = cir.const #cir.ptr<null> : !cir.ptr<!ty_22Derived22>
+  // CHECK-NEXT: cir.call @__cxa_bad_cast() : () -> ()
+  // CHECK-NEXT: cir.unreachable
+}
+
+//      LLVM: define noalias noundef nonnull ptr @_Z20ref_cast_always_failR5Base2(ptr nocapture readnone %{{.+}})
+// LLVM-NEXT:   tail call void @__cxa_bad_cast()
+// LLVM-NEXT:   unreachable
+// LLVM-NEXT: }


### PR DESCRIPTION
This PR implements the last piece to make CIR catch up upstream CodeGen on `dynamic_cast` support. It ports an upstream optimization "exact cast" to CIR.

The basic idea of exact cast is when `dynamic_cast` to a final class, we don't have to call into the runtime -- we could just check if the dynamic type of the source object is exactly the destination type by quickly comparing the vtable pointers. To give a concrete example of this optimization:

```cpp
struct Base { virtual ~Base(); };
struct Derived final : Base {};

Derived *test(Base *src) { return dynamic_cast<Derived *>(src); }
```

Without the optimization, we have to call the runtime function `__dynamic_cast` to do the heavy and slow type check. After enabling the optimization, we could quickly carry out the runtime type check by inline checking whether the vtable ptr of `src` points to the vtable of `Derived`.

This PR also fixes a bug in existing dynamic_cast CIRGen code. The bug mistakenly removes the insertion point after emitting a call to bad_cast, causing the CIRGen of any follow up statements to crash.