### PR TITLE
[CIR][ABI] Add X86_64 float and double CC lowering

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.cpp
@@ -15,6 +15,7 @@
 #include "CIRCXXABI.h"
 #include "CIRLowerContext.h"
 #include "LowerTypes.h"
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 
 namespace mlir {
 namespace cir {
@@ -25,6 +26,10 @@ ABIInfo::~ABIInfo() = default;
 CIRCXXABI &ABIInfo::getCXXABI() const { return LT.getCXXABI(); }
 
 CIRLowerContext &ABIInfo::getContext() const { return LT.getContext(); }
+
+const ::cir::CIRDataLayout &ABIInfo::getDataLayout() const {
+  return LT.getDataLayout();
+}
 
 bool ABIInfo::isPromotableIntegerTypeForABI(Type Ty) const {
   if (getContext().isPromotableIntegerType(Ty))

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.h
@@ -17,6 +17,7 @@
 #include "CIRCXXABI.h"
 #include "CIRLowerContext.h"
 #include "LowerFunctionInfo.h"
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "llvm/IR/CallingConv.h"
 
 namespace mlir {
@@ -38,7 +39,9 @@ public:
 
   CIRCXXABI &getCXXABI() const;
 
-  CIRLowerContext &getContext() const;
+  CIRLowerContext &getContext() const;\
+
+  const ::cir::CIRDataLayout &getDataLayout() const;
 
   virtual void computeInfo(LowerFunctionInfo &FI) const = 0;
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.h
@@ -39,7 +39,7 @@ public:
 
   CIRCXXABI &getCXXABI() const;
 
-  CIRLowerContext &getContext() const;\
+  CIRLowerContext &getContext() const;
 
   const ::cir::CIRDataLayout &getDataLayout() const;
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -50,7 +50,7 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const Type T) const {
   // TODO(cir): We should implement a better way to identify type kinds and use
   // builting data layout interface for this.
   auto typeKind = clang::Type::Builtin;
-  if (isa<IntType>(T)) {
+  if (isa<IntType, SingleType, DoubleType>(T)) {
     typeKind = clang::Type::Builtin;
   } else {
     llvm_unreachable("Unhandled type class");
@@ -72,6 +72,16 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const Type T) const {
       Width = intTy.getWidth();
       // FIXME(cir): Use the proper getABIAlignment method here.
       Align = std::ceil((float)Width / 8) * 8;
+      break;
+    }
+    if (auto floatTy = dyn_cast<SingleType>(T)) {
+      Width = Target->getFloatWidth();
+      Align = Target->getFloatAlign();
+      break;
+    }
+    if (auto doubleTy = dyn_cast<DoubleType>(T)) {
+      Width = Target->getDoubleWidth();
+      Align = Target->getDoubleAlign();
       break;
     }
     llvm_unreachable("Unknown builtin type!");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -14,6 +14,7 @@
 // FIXME(cir): This header file is not exposed to the public API, but can be
 // reused by CIR ABI lowering since it holds target-specific information.
 #include "../../../../Basic/Targets.h"
+#include "clang/Basic/LangOptions.h"
 #include "clang/Basic/TargetOptions.h"
 
 #include "CIRLowerContext.h"
@@ -87,11 +88,15 @@ createTargetLoweringInfo(LowerModule &LM) {
   }
 }
 
-LowerModule::LowerModule(CIRLowerContext &C, ModuleOp &module, StringAttr DL,
-                         const clang::TargetInfo &target,
+LowerModule::LowerModule(clang::LangOptions opts, ModuleOp &module,
+                         StringAttr DL,
+                         std::unique_ptr<clang::TargetInfo> target,
                          PatternRewriter &rewriter)
-    : context(C), module(module), Target(target), ABI(createCXXABI(*this)),
-      types(*this, DL.getValue()), rewriter(rewriter) {}
+    : context(module, opts), module(module), Target(std::move(target)),
+      ABI(createCXXABI(*this)), types(*this, DL.getValue()),
+      rewriter(rewriter) {
+  context.initBuiltinTypes(*Target);
+}
 
 const TargetLoweringInfo &LowerModule::getTargetLoweringInfo() {
   if (!TheTargetCodeGenInfo)
@@ -235,11 +240,9 @@ std::unique_ptr<LowerModule> createLowerModule(ModuleOp module,
   // Create context.
   assert(!::cir::MissingFeatures::langOpts());
   clang::LangOptions langOpts;
-  auto context = CIRLowerContext(module, langOpts);
-  context.initBuiltinTypes(*targetInfo);
 
-  return std::make_unique<LowerModule>(context, module, dataLayoutStr,
-                                       *targetInfo, rewriter);
+  return std::make_unique<LowerModule>(langOpts, module, dataLayoutStr,
+                                       std::move(targetInfo), rewriter);
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.h
@@ -56,6 +56,7 @@ public:
   LowerTypes(LowerModule &LM, StringRef DLString);
   ~LowerTypes() = default;
 
+  const ::cir::CIRDataLayout &getDataLayout() const { return DL; }
   LowerModule &getLM() const { return LM; }
   CIRCXXABI &getCXXABI() const { return CXXABI; }
   CIRLowerContext &getContext() { return context; }

--- a/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
@@ -62,3 +62,16 @@ long long LongLong(long long l) {
   // CHECK: cir.call @_Z8LongLongx(%{{.+}}) : (!s64i) -> !s64i
   return LongLong(l);
 }
+
+/// Test call conv lowering for floating point. ///
+
+// CHECK: cir.func @_Z5Floatf(%arg0: !cir.float loc({{.+}})) -> !cir.float
+float Float(float f) {
+  // cir.call @_Z5Floatf(%{{.+}}) : (!cir.float) -> !cir.float
+  return Float(f);
+}
+// CHECK: cir.func @_Z6Doubled(%arg0: !cir.double loc({{.+}})) -> !cir.double
+double Double(double d) {
+  // cir.call @_Z6Doubled(%{{.+}}) : (!cir.double) -> !cir.double
+  return Double(d);
+}


### PR DESCRIPTION
Implements calling convention lowering of float and double arguments and return values conventions for X86_64.