### PR TITLE
[CIR][NFC] Don't enforce deprecated API check on MSVC

### DIFF
--- a/clang/lib/CIR/CMakeLists.txt
+++ b/clang/lib/CIR/CMakeLists.txt
@@ -1,12 +1,12 @@
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
-# Report use of deprecated APIs as errors
-if (MSVC)
-  add_compile_options("/we4996")
-else()
+# Report use of deprecated APIs as errors.
+# TODO: Consider adding `/we4996` for MSVC when upstream MLIR resolves
+#       https://github.com/llvm/llvm-project/issues/65255.
+if (NOT MSVC)
   add_compile_options("-Werror=deprecated-declarations")
-endif(MSVC)
+endif()
 
 add_subdirectory(Dialect)
 add_subdirectory(CodeGen)


### PR DESCRIPTION
Implements approach 2 in https://github.com/llvm/clangir/pull/703#issuecomment-2194665478, as discussed in the community call.