### PR TITLE
[CIR] Fix for __atomic_compare_exchange weak arg

### DIFF
--- a/clang/test/CIR/CodeGen/atomic.cpp
+++ b/clang/test/CIR/CodeGen/atomic.cpp
@@ -260,7 +260,7 @@ bool fd4(struct S *a, struct S *b, struct S *c) {
 bool fi4a(int *i) {
   int cmp = 0;
   int desired = 1;
-  return __atomic_compare_exchange(i, &cmp, &desired, 0, memory_order_acquire, memory_order_acquire);
+  return __atomic_compare_exchange(i, &cmp, &desired, false, memory_order_acquire, memory_order_acquire);
 }
 
 // CHECK-LABEL: @_Z4fi4aPi
@@ -273,7 +273,7 @@ bool fi4a(int *i) {
 
 bool fi4b(int *i) {
   int cmp = 0;
-  return __atomic_compare_exchange_n(i, &cmp, 1, 1, memory_order_acquire, memory_order_acquire);
+  return __atomic_compare_exchange_n(i, &cmp, 1, true, memory_order_acquire, memory_order_acquire);
 }
 
 // CHECK-LABEL: @_Z4fi4bPi


### PR DESCRIPTION
ClangIR was failing on
```
__atomic_compare_exchange_n(&a, &old, 42, true, 5, 5);
```
The `true` was the problem.  It would work with a literal `0` or `1`, but not with a literal `true` or `false`.

The bug was in `isCstWeak` in CIRGenAtomic.cpp, which was only looking for an integral constant.  It didn't recognize a boolean constant and was falling back on the non-constant path, which isn't implemented yet.

Rewrite `isCstWeak` to check for both intergral and boolean constants.