### PR TITLE
[CIR][CIRGen] Add CIRGen support for pointer-to-member-functions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -442,6 +442,54 @@ def DataMemberAttr : CIR_Attr<"DataMember", "data_member",
 }
 
 //===----------------------------------------------------------------------===//
+// MethodAttr
+//===----------------------------------------------------------------------===//
+
+def MethodAttr : CIR_Attr<"Method", "method", [TypedAttrInterface]> {
+  let summary = "Holds a constant pointer-to-member-function value";
+  let description = [{
+    A method attribute is a literal attribute that represents a constant
+    pointer-to-member-function value.
+
+    If the member function is a non-virtual function, the `symbol` parameter
+    gives the global symbol for the non-virtual member function.
+
+    If the member function is a virtual function, the `vtable_offset` parameter
+    gives the offset of the vtable entry corresponding to the virtual member
+    function.
+
+    `symbol` and `vtable_offset` cannot be present at the same time. If both of
+    `symbol` and `vtable_offset` are not present, the attribute represents a
+    null pointer constant.
+  }];
+
+  let parameters = (ins AttributeSelfTypeParameter<
+                            "", "mlir::cir::MethodType">:$type,
+                        OptionalParameter<
+                            "std::optional<FlatSymbolRefAttr>">:$symbol,
+                        OptionalParameter<
+                            "std::optional<uint64_t>">:$vtable_offset);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "mlir::cir::MethodType":$type), [{
+      return $_get(type.getContext(), type, std::nullopt, std::nullopt);
+    }]>,
+    AttrBuilderWithInferredContext<(ins "mlir::cir::MethodType":$type,
+                                        "FlatSymbolRefAttr":$symbol), [{
+      return $_get(type.getContext(), type, symbol, std::nullopt);
+    }]>,
+    AttrBuilderWithInferredContext<(ins "mlir::cir::MethodType":$type,
+                                        "uint64_t":$vtable_offset), [{
+      return $_get(type.getContext(), type, std::nullopt, vtable_offset);
+    }]>,
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+
+  let genVerifyDecl = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // SignedOverflowBehaviorAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2590,6 +2590,60 @@ def GetRuntimeMemberOp : CIR_Op<"get_runtime_member"> {
 }
 
 //===----------------------------------------------------------------------===//
+// GetMethodOp
+//===----------------------------------------------------------------------===//
+
+def GetMethodOp : CIR_Op<"get_method"> {
+  let summary = "Resolve a method to a function pointer as callee";
+  let description = [{
+    The `cir.get_method` operation takes a method and an object as input, and
+    yields a function pointer that points to the actual function corresponding
+    to the input method. The operation also applies any necessary adjustments to
+    the input object pointer for calling the method and yields the adjusted
+    pointer.
+
+    This operation is generated when calling a method through a pointer-to-
+    member-function in C++:
+
+    ```cpp
+    // Foo *object;
+    // int arg;
+    // void (Foo::*method)(int);
+
+    (object->*method)(arg);
+    ```
+
+    The code above will generate CIR similar as:
+
+    ```mlir
+    // %object = ...
+    // %arg = ...
+    // %method = ...
+    %callee, %this = cir.get_method %method, %object
+    cir.call %callee(%this, %arg)
+    ```
+
+    The method type must match the callee type. That is:
+    - The return type of the method must match the return type of the callee.
+    - The first parameter of the callee must have type `!cir.ptr<!cir.void>`.
+    - Types of other parameters of the callee must match the parameters of the
+      method.
+  }];
+
+  let arguments = (ins CIR_MethodType:$method, StructPtr:$object);
+  let results = (outs FuncPtr:$callee, VoidPtr:$adjusted_this);
+
+  let assemblyFormat = [{
+    $method `,` $object
+    `:` `(` qualified(type($method)) `,` qualified(type($object)) `)`
+    `->` `(` qualified(type($callee)) `,` qualified(type($adjusted_this)) `)`
+    attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // VecInsertOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -409,6 +409,26 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
 }
 
 //===----------------------------------------------------------------------===//
+// MethodType
+//===----------------------------------------------------------------------===//
+
+def CIR_MethodType : CIR_Type<"Method", "method",
+    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
+  let summary = "CIR type that represents C++ pointer-to-member-function type";
+  let description = [{
+    `cir.method` models the pointer-to-member-function type in C++. The layout
+    of this type is ABI-dependent.
+  }];
+
+  let parameters = (ins "mlir::cir::FuncType":$memberFuncTy,
+                        "mlir::cir::StructType":$clsTy);
+
+  let assemblyFormat = [{
+    `<` qualified($memberFuncTy) `in` $clsTy `>`
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Exception info type
 //
 // By introducing an exception info type, exception related operations can be
@@ -517,6 +537,15 @@ def ArrayPtr : Type<
     ]>, "!cir.ptr<!cir.eh_info>"> {
 }
 
+// Pointer to functions
+def FuncPtr : Type<
+    And<[
+      CPred<"::mlir::isa<::mlir::cir::PointerType>($_self)">,
+      CPred<"::mlir::isa<::mlir::cir::FuncType>("
+            "::mlir::cast<::mlir::cir::PointerType>($_self).getPointee())">,
+    ]>, "!cir.ptr<!cir.func>"> {
+}
+
 //===----------------------------------------------------------------------===//
 // StructType (defined in cpp files)
 //===----------------------------------------------------------------------===//
@@ -529,9 +558,10 @@ def CIR_StructType : Type<CPred<"::mlir::isa<::mlir::cir::StructType>($_self)">,
 //===----------------------------------------------------------------------===//
 
 def CIR_AnyType : AnyTypeOf<[
-  CIR_IntType, CIR_PointerType, CIR_DataMemberType, CIR_BoolType, CIR_ArrayType,
-  CIR_VectorType, CIR_FuncType, CIR_VoidType, CIR_StructType, CIR_ExceptionType,
-  CIR_AnyFloat, CIR_FP16, CIR_BFloat16, CIR_ComplexType
+  CIR_IntType, CIR_PointerType, CIR_DataMemberType, CIR_MethodType,
+  CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_FuncType, CIR_VoidType,
+  CIR_StructType, CIR_ExceptionType, CIR_AnyFloat, CIR_FP16, CIR_BFloat16,
+  CIR_ComplexType
 ]>;
 
 #endif // MLIR_CIR_DIALECT_CIR_TYPES

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -241,6 +241,16 @@ public:
     return mlir::cir::DataMemberAttr::get(getContext(), ty, std::nullopt);
   }
 
+  mlir::cir::MethodAttr getMethodAttr(mlir::cir::MethodType ty,
+                                      mlir::cir::FuncOp methodFuncOp) {
+    auto methodFuncSymbolRef = mlir::FlatSymbolRefAttr::get(methodFuncOp);
+    return mlir::cir::MethodAttr::get(ty, methodFuncSymbolRef);
+  }
+
+  mlir::cir::MethodAttr getNullMethodAttr(mlir::cir::MethodType ty) {
+    return mlir::cir::MethodAttr::get(ty);
+  }
+
   // TODO(cir): Once we have CIR float types, replace this by something like a
   // NullableValueInterface to allow for type-independent queries.
   bool isNullValue(mlir::Attribute attr) const {
@@ -518,6 +528,11 @@ public:
   mlir::cir::ConstantOp getNullDataMemberPtr(mlir::cir::DataMemberType ty,
                                              mlir::Location loc) {
     return create<mlir::cir::ConstantOp>(loc, ty, getNullDataMemberAttr(ty));
+  }
+
+  mlir::cir::ConstantOp getNullMethodPtr(mlir::cir::MethodType ty,
+                                         mlir::Location loc) {
+    return create<mlir::cir::ConstantOp>(loc, ty, getNullMethodAttr(ty));
   }
 
   mlir::cir::ConstantOp getZero(mlir::Location loc, mlir::Type ty) {

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -310,6 +310,10 @@ public:
                                        QualType DestRecordTy,
                                        mlir::cir::PointerType DestCIRTy,
                                        bool isRefCast, Address Src) = 0;
+
+  virtual mlir::cir::MethodAttr
+  buildVirtualMethodAttr(mlir::cir::MethodType MethodTy,
+                         const CXXMethodDecl *MD) = 0;
 };
 
 /// Creates and Itanium-family ABI

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -731,7 +731,7 @@ RValue CIRGenFunction::buildCall(const CIRGenFunctionInfo &CallInfo,
       [[maybe_unused]] auto resultTypes = CalleePtr->getResultTypes();
       [[maybe_unused]] auto FuncPtrTy =
           mlir::dyn_cast<mlir::cir::PointerType>(resultTypes.front());
-      assert((resultTypes.size() == 1) && FuncPtrTy &&
+      assert(FuncPtrTy &&
              mlir::isa<mlir::cir::FuncType>(FuncPtrTy.getPointee()) &&
              "expected pointer to function");
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2834,7 +2834,7 @@ RValue CIRGenFunction::buildCXXMemberCallExpr(const CXXMemberCallExpr *CE,
   const Expr *callee = CE->getCallee()->IgnoreParens();
 
   if (isa<BinaryOperator>(callee))
-    llvm_unreachable("NYI");
+    return buildCXXMemberPointerCallExpr(CE, ReturnValue);
 
   const auto *ME = cast<MemberExpr>(callee);
   const auto *MD = cast<CXXMethodDecl>(ME->getMemberDecl());

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1680,7 +1680,10 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     assert(!MissingFeatures::cxxABI());
 
     const MemberPointerType *MPT = CE->getType()->getAs<MemberPointerType>();
-    assert(!MPT->isMemberFunctionPointerType() && "NYI");
+    if (MPT->isMemberFunctionPointerType()) {
+      auto Ty = mlir::cast<mlir::cir::MethodType>(CGF.getCIRType(DestTy));
+      return Builder.getNullMethodPtr(Ty, CGF.getLoc(E->getExprLoc()));
+    }
 
     auto Ty = mlir::cast<mlir::cir::DataMemberType>(CGF.getCIRType(DestTy));
     return Builder.getNullDataMemberPtr(Ty, CGF.getLoc(E->getExprLoc()));

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -622,6 +622,8 @@ public:
 
   RValue buildCXXMemberCallExpr(const clang::CXXMemberCallExpr *E,
                                 ReturnValueSlot ReturnValue);
+  RValue buildCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
+                                       ReturnValueSlot ReturnValue);
   RValue buildCXXMemberOrOperatorMemberCallExpr(
       const clang::CallExpr *CE, const clang::CXXMethodDecl *MD,
       ReturnValueSlot ReturnValue, bool HasQualifier,

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -712,13 +712,18 @@ mlir::Type CIRGenTypes::ConvertType(QualType T) {
 
   case Type::MemberPointer: {
     const auto *MPT = cast<MemberPointerType>(Ty);
-    assert(MPT->isMemberDataPointer() && "ptr-to-member-function is NYI");
 
     auto memberTy = ConvertType(MPT->getPointeeType());
     auto clsTy = mlir::cast<mlir::cir::StructType>(
         ConvertType(QualType(MPT->getClass(), 0)));
-    ResultType =
-        mlir::cir::DataMemberType::get(Builder.getContext(), memberTy, clsTy);
+    if (MPT->isMemberDataPointer())
+      ResultType =
+          mlir::cir::DataMemberType::get(Builder.getContext(), memberTy, clsTy);
+    else {
+      auto memberFuncTy = mlir::cast<mlir::cir::FuncType>(memberTy);
+      ResultType =
+          mlir::cir::MethodType::get(Builder.getContext(), memberFuncTy, clsTy);
+    }
     break;
   }
 

--- a/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+struct Foo {
+  void m1(int);
+  virtual void m2(int);
+  virtual void m3(int);
+};
+
+auto make_non_virtual() -> void (Foo::*)(int) {
+  return &Foo::m1;
+}
+
+// CHECK-LABEL: cir.func @_Z16make_non_virtualv() -> !cir.method<!cir.func<!void (!s32i)> in !ty_22Foo22>
+//       CHECK:   %{{.+}} = cir.const #cir.method<@_ZN3Foo2m1Ei> : !cir.method<!cir.func<!void (!s32i)> in !ty_22Foo22>
+//       CHECK: }
+
+auto make_virtual() -> void (Foo::*)(int) {
+  return &Foo::m3;
+}
+
+// CHECK-LABEL: cir.func @_Z12make_virtualv() -> !cir.method<!cir.func<!void (!s32i)> in !ty_22Foo22>
+//       CHECK:   %{{.+}} = cir.const #cir.method<vtable_offset = 8> : !cir.method<!cir.func<!void (!s32i)> in !ty_22Foo22>
+//       CHECK: }
+
+auto make_null() -> void (Foo::*)(int) {
+  return nullptr;
+}
+
+// CHECK-LABEL: cir.func @_Z9make_nullv() -> !cir.method<!cir.func<!void (!s32i)> in !ty_22Foo22>
+//       CHECK:   %{{.+}} = cir.const #cir.method<null> : !cir.method<!cir.func<!void (!s32i)> in !ty_22Foo22>
+//       CHECK: }
+
+void call(Foo *obj, void (Foo::*func)(int), int arg) {
+  (obj->*func)(arg);
+}
+
+// CHECK-LABEL: cir.func @_Z4callP3FooMS_FviEi
+//       CHECK:   %[[CALLEE:.+]], %[[THIS:.+]] = cir.get_method %{{.+}}, %{{.+}} : (!cir.method<!cir.func<!void (!s32i)> in !ty_22Foo22>, !cir.ptr<!ty_22Foo22>) -> (!cir.ptr<!cir.func<!void (!cir.ptr<!void>, !s32i)>>, !cir.ptr<!void>)
+//  CHECK-NEXT:   %[[#ARG:]] = cir.load %{{.+}} : !cir.ptr<!s32i>, !s32i
+//  CHECK-NEXT:   cir.call %[[CALLEE]](%[[THIS]], %[[#ARG]]) : (!cir.ptr<!cir.func<!void (!cir.ptr<!void>, !s32i)>>, !cir.ptr<!void>, !s32i) -> ()
+//       CHECK: }


### PR DESCRIPTION
This PR adds the initial CIRGen support for pointer-to-member-functions. It contains the following new types, attributes, and operations:

  - `!cir.method`, which represents the pointer-to-member-function type.
  - `#cir.method`, which represents a literal pointer-to-member-function value that points to ~~non-virtual~~ member functions.
  - ~~`#cir.virtual_method`, which represents a literal pointer-to-member-function value that points to virtual member functions.~~
  - ~~`cir.get_method_callee`~~ `cir.get_method`, which resolves a pointer-to-member-function to a function pointer as the callee.

See the new test at `clang/test/CIR/CIRGen/pointer-to-member-func.cpp` for how these new CIR stuff works to support pointer-to-member-functions.