### PR TITLE
[CIR][NFC] Fix bug in MLIR lowering of cir.call

### DIFF
--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -99,7 +99,7 @@ public:
             getTypeConverter()->convertTypes(op.getResultTypes(), types)))
       return mlir::failure();
     rewriter.replaceOpWithNewOp<mlir::func::CallOp>(
-        op, mlir::SymbolRefAttr::get(op), types, adaptor.getOperands());
+        op, op.getCalleeAttr(), types, adaptor.getOperands());
     return mlir::LogicalResult::success();
   }
 };

--- a/clang/test/CIR/Lowering/ThroughMLIR/call.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/call.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+void foo(int i) {}
+
+int test(void) {
+  foo(2);
+  return 0;
+}
+
+// CHECK-LABEL: func.func @test() -> i32 {
+//       CHECK:   %[[ARG:.+]] = arith.constant 2 : i32
+//  CHECK-NEXT:   call @foo(%[[ARG]]) : (i32) -> ()
+//       CHECK: }


### PR DESCRIPTION
This PR fixes the bug described as in https://github.com/llvm/clangir/issues/727#issuecomment-2219515908. It should resolve the crash reported in #727 .