### PR TITLE
[CIR][ABI][NFC] AppleARM64 CXXABI handling in TargetLowering library

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -265,6 +265,9 @@ struct MissingFeatures {
   // We're ignoring several details regarding ABI-halding for Swift.
   static bool swift() { return false; }
 
+  // The AppleARM64 is using ItaniumCXXABI, which is not quite right.
+  static bool appleArm64CXXABI() { return false; }
+
   // Despite carrying some information about variadics, we are currently
   // ignoring this to focus only on the code necessary to lower non-variadics.
   static bool variadicFunctions() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -366,6 +366,7 @@ CIRGenCXXABI *cir::CreateCIRGenItaniumCXXABI(CIRGenModule &CGM) {
   case TargetCXXABI::AppleARM64:
     // TODO: this isn't quite right, clang uses AppleARM64CXXABI which inherits
     // from ARMCXXABI. We'll have to follow suit.
+    assert(!MissingFeatures::appleArm64CXXABI());
     return new CIRGenItaniumCXXABI(CGM);
 
   default:

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -65,6 +65,10 @@ CIRCXXABI *CreateItaniumCXXABI(LowerModule &LM) {
   // include the other 32-bit ARM oddities: constructor/destructor return values
   // and array cookies.
   case clang::TargetCXXABI::GenericAArch64:
+  case clang::TargetCXXABI::AppleARM64:
+    // TODO: this isn't quite right, clang uses AppleARM64CXXABI which inherits
+    // from ARMCXXABI. We'll have to follow suit.
+    assert(!::cir::MissingFeatures::appleArm64CXXABI());
     return new ItaniumCXXABI(LM, /*UseARMMethodPtrABI=*/true,
                              /*UseARMGuardVarABI=*/true);
 


### PR DESCRIPTION
In [this commit](https://github.com/llvm/clangir/commit/e5d840b72c1bdb3276094960e9746e413c6f4456), minimal support for Darwin aarch64 triples was added. But TargetLoweringInfo was not updated correspondingly.

This could lead to a failure of the test `driver.c` with CallConvLowering pass enabled (or `LowerModule` used in some other ways).

This PR fixes the inconsistency and adds an extra missing feature flag for it.