### PR TITLE
[CIR][ABI][NFC] Make `createLowerModule` public

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -91,6 +91,8 @@ public:
   LogicalResult rewriteFunctionCall(CallOp callOp, FuncOp funcOp);
 };
 
+LowerModule createLowerModule(ModuleOp module, PatternRewriter &rewriter);
+
 } // namespace cir
 } // namespace mlir
 


### PR DESCRIPTION
Although currently LowerModule is not ready for formal usage, we need it for target-specific lowering to LLVM. This PR temporarily public the symbol `createLowerModule` to reuse the logic of preparing a `LowerModule`, making it easier for future refactor (making `TargetLoweringInfo` available for most stages in CIR Lowering).