### PR TITLE
[CIR][CIRGen] More on dsolocal: visibility improvements

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -253,7 +253,7 @@ mlir::cir::FuncOp CIRGenModule::codegenCXXStructor(GlobalDecl GD) {
   }
   CurCGF = nullptr;
 
-  // TODO: setNonAliasAttributes
+  setNonAliasAttributes(GD, Fn);
   // TODO: SetLLVMFunctionAttributesForDefinition
   return Fn;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -364,7 +364,7 @@ bool CIRGenModule::MayBeEmittedEagerly(const ValueDecl *Global) {
   return true;
 }
 
-static bool hasDefaultVisibilityForDsoLocal(CIRGlobalValueInterface GV) {
+static bool hasDefaultVisibility(CIRGlobalValueInterface GV) {
   // Since we do not support hidden visibility and private visibility,
   // we can assume that the default visibility is public or private.
   // The way we use private visibility now simply is just treating it
@@ -379,7 +379,7 @@ static bool shouldAssumeDSOLocal(const CIRGenModule &CGM,
   if (GV.hasLocalLinkage())
     return true;
 
-  if (!hasDefaultVisibilityForDsoLocal(GV) && !GV.hasExternalWeakLinkage()) {
+  if (!hasDefaultVisibility(GV) && !GV.hasExternalWeakLinkage()) {
     return true;
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -608,6 +608,7 @@ public:
   getMLIRVisibilityFromCIRLinkage(mlir::cir::GlobalLinkageKind GLK);
   static mlir::SymbolTable::Visibility
   getMLIRVisibility(mlir::cir::GlobalOp op);
+  bool isDefaultVibility(mlir::cir::CIRGlobalValueInterface GV) const;
   mlir::cir::GlobalLinkageKind getFunctionLinkage(GlobalDecl GD);
   mlir::cir::GlobalLinkageKind
   getCIRLinkageForDeclarator(const DeclaratorDecl *D, GVALinkage Linkage,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -608,7 +608,6 @@ public:
   getMLIRVisibilityFromCIRLinkage(mlir::cir::GlobalLinkageKind GLK);
   static mlir::SymbolTable::Visibility
   getMLIRVisibility(mlir::cir::GlobalOp op);
-  bool isDefaultVibility(mlir::cir::CIRGlobalValueInterface GV) const;
   mlir::cir::GlobalLinkageKind getFunctionLinkage(GlobalDecl GD);
   mlir::cir::GlobalLinkageKind
   getCIRLinkageForDeclarator(const DeclaratorDecl *D, GVALinkage Linkage,

--- a/clang/test/CIR/CodeGen/linkage.c
+++ b/clang/test/CIR/CodeGen/linkage.c
@@ -19,7 +19,7 @@ int foo(void) {
 // LLVM: define i32 @foo(
 
 static int var = 0;
-// CIR: cir.global "private" internal @var = #cir.int<0> : !s32i
+// CIR: cir.global "private" internal dsolocal @var = #cir.int<0> : !s32i
 int get_var(void) {
   return var;
 }

--- a/clang/test/CIR/CodeGen/static.cpp
+++ b/clang/test/CIR/CodeGen/static.cpp
@@ -19,7 +19,7 @@ static Init __ioinit2(false);
 // BEFORE:      module {{.*}} {
 // BEFORE-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22Init22>, !cir.bool)
 // BEFORE-NEXT:   cir.func private @_ZN4InitD1Ev(!cir.ptr<!ty_22Init22>)
-// BEFORE-NEXT:   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_22Init22 {
+// BEFORE-NEXT:   cir.global "private" internal dsolocal @_ZL8__ioinit = ctor : !ty_22Init22 {
 // BEFORE-NEXT:     %0 = cir.get_global @_ZL8__ioinit : !cir.ptr<!ty_22Init22>
 // BEFORE-NEXT:     %1 = cir.const #true
 // BEFORE-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22Init22>, !cir.bool) -> ()
@@ -27,7 +27,7 @@ static Init __ioinit2(false);
 // BEFORE-NEXT:      %0 = cir.get_global @_ZL8__ioinit : !cir.ptr<!ty_22Init22>
 // BEFORE-NEXT:      cir.call @_ZN4InitD1Ev(%0) : (!cir.ptr<!ty_22Init22>) -> ()
 // BEFORE-NEXT:   } {ast = #cir.var.decl.ast}
-// BEFORE:        cir.global "private" internal @_ZL9__ioinit2 = ctor : !ty_22Init22 {
+// BEFORE:        cir.global "private" internal dsolocal @_ZL9__ioinit2 = ctor : !ty_22Init22 {
 // BEFORE-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : !cir.ptr<!ty_22Init22>
 // BEFORE-NEXT:     %1 = cir.const #false
 // BEFORE-NEXT:     cir.call @_ZN4InitC1Eb(%0, %1) : (!cir.ptr<!ty_22Init22>, !cir.bool) -> ()
@@ -43,7 +43,7 @@ static Init __ioinit2(false);
 // AFTER-NEXT:   cir.func private @__cxa_atexit(!cir.ptr<!cir.func<!void (!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>)
 // AFTER-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22Init22>, !cir.bool)
 // AFTER-NEXT:   cir.func private @_ZN4InitD1Ev(!cir.ptr<!ty_22Init22>)
-// AFTER-NEXT:   cir.global "private" internal @_ZL8__ioinit =  #cir.zero : !ty_22Init22 {ast = #cir.var.decl.ast}
+// AFTER-NEXT:   cir.global "private" internal dsolocal @_ZL8__ioinit =  #cir.zero : !ty_22Init22 {ast = #cir.var.decl.ast}
 // AFTER-NEXT:   cir.func internal private @__cxx_global_var_init()
 // AFTER-NEXT:     %0 = cir.get_global @_ZL8__ioinit : !cir.ptr<!ty_22Init22>
 // AFTER-NEXT:     %1 = cir.const #true
@@ -55,7 +55,7 @@ static Init __ioinit2(false);
 // AFTER-NEXT:     %6 = cir.get_global @__dso_handle : !cir.ptr<i8>
 // AFTER-NEXT:     cir.call @__cxa_atexit(%4, %5, %6) : (!cir.ptr<!cir.func<!void (!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
 // AFTER-NEXT:     cir.return
-// AFTER:        cir.global "private" internal @_ZL9__ioinit2 =  #cir.zero : !ty_22Init22 {ast = #cir.var.decl.ast}
+// AFTER:        cir.global "private" internal dsolocal @_ZL9__ioinit2 =  #cir.zero : !ty_22Init22 {ast = #cir.var.decl.ast}
 // AFTER-NEXT:   cir.func internal private @__cxx_global_var_init.1()
 // AFTER-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : !cir.ptr<!ty_22Init22>
 // AFTER-NEXT:     %1 = cir.const #false


### PR DESCRIPTION
In this PR, we 
1.  implement defaultVisibility as far as dsolocal is concerned, currently is either MLIR::Visibility isPublic() or isPrivate(). Now, we don't handle hiddenVisibility and protectedVisibility from AST. I put missFeature assert so that If in anyway we translate  hiddenVisibility or protectedVisibility into mlir::SymbolTable::Visibility::Private (hopefully not for it'd be confusing), then we need to revise this defaultVisibility setting.
2.  call setNonAliasAttributes on global op upon discovery of its initialization, thus we have globals dso_local correctly set.

Still missing is lots of function should have dso_local set, but the all depend on comDat implementation, which will come from next PR within the next few days.