### PR TITLE
[CIR][Transforms][TargetLowering][NFC] Add SPIR-V skeleton

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -13,6 +13,7 @@ add_clang_library(TargetLowering
   TargetInfo.cpp
   TargetLoweringInfo.cpp
   Targets/AArch64.cpp
+  Targets/SPIR.cpp
   Targets/X86.cpp
   Targets/LoweringPrepareAArch64CXXABI.cpp
   Targets/LoweringPrepareItaniumCXXABI.cpp

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -80,6 +80,8 @@ createTargetLoweringInfo(LowerModule &LM) {
       return createX86_64TargetLoweringInfo(LM, X86AVXABILevel::None);
     }
   }
+  case llvm::Triple::spirv64:
+    return createSPIRVTargetLoweringInfo(LM);
   default:
     llvm_unreachable("ABI NYI");
   }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetInfo.h
@@ -30,6 +30,9 @@ std::unique_ptr<TargetLoweringInfo>
 createAArch64TargetLoweringInfo(LowerModule &CGM,
                                 ::cir::AArch64ABIKind AVXLevel);
 
+std::unique_ptr<TargetLoweringInfo>
+createSPIRVTargetLoweringInfo(LowerModule &CGM);
+
 } // namespace cir
 } // namespace mlir
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/SPIR.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/SPIR.cpp
@@ -29,7 +29,7 @@ namespace {
 
 class SPIRVABIInfo : public ABIInfo {
 public:
-  SPIRVABIInfo(LowerTypes &CGT) : ABIInfo(CGT) {}
+  SPIRVABIInfo(LowerTypes &LT) : ABIInfo(LT) {}
 
 private:
   void computeInfo(LowerFunctionInfo &FI) const override {
@@ -46,8 +46,8 @@ public:
 } // namespace
 
 std::unique_ptr<TargetLoweringInfo>
-createSPIRVTargetLoweringInfo(LowerModule &CGM) {
-  return std::make_unique<SPIRVTargetLoweringInfo>(CGM.getTypes());
+createSPIRVTargetLoweringInfo(LowerModule &lowerModule) {
+  return std::make_unique<SPIRVTargetLoweringInfo>(lowerModule.getTypes());
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/SPIR.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/SPIR.cpp
@@ -1,0 +1,54 @@
+//===- SPIR.cpp - TargetInfo for SPIR and SPIR-V --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ABIInfoImpl.h"
+#include "LowerFunctionInfo.h"
+#include "LowerTypes.h"
+#include "TargetInfo.h"
+#include "TargetLoweringInfo.h"
+#include "clang/CIR/ABIArgInfo.h"
+#include "clang/CIR/MissingFeatures.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using ABIArgInfo = ::cir::ABIArgInfo;
+using MissingFeature = ::cir::MissingFeatures;
+
+namespace mlir {
+namespace cir {
+
+//===----------------------------------------------------------------------===//
+// SPIR-V ABI Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class SPIRVABIInfo : public ABIInfo {
+public:
+  SPIRVABIInfo(LowerTypes &CGT) : ABIInfo(CGT) {}
+
+private:
+  void computeInfo(LowerFunctionInfo &FI) const override {
+    llvm_unreachable("ABI NYI");
+  }
+};
+
+class SPIRVTargetLoweringInfo : public TargetLoweringInfo {
+public:
+  SPIRVTargetLoweringInfo(LowerTypes &LT)
+      : TargetLoweringInfo(std::make_unique<SPIRVABIInfo>(LT)) {}
+};
+
+} // namespace
+
+std::unique_ptr<TargetLoweringInfo>
+createSPIRVTargetLoweringInfo(LowerModule &CGM) {
+  return std::make_unique<SPIRVTargetLoweringInfo>(CGM.getTypes());
+}
+
+} // namespace cir
+} // namespace mlir


### PR DESCRIPTION
This NFC PR adds the SPIR-V `TargetLoweringInfo` with ABI stuff unimplemented. It's useful for other target-specific information to land first.