### PR TITLE
Use unique ID to distinguish same name structure.

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2055,6 +2055,103 @@ def GlobalOp : CIR_Op<"global",
 }
 
 //===----------------------------------------------------------------------===//
+// RGOp
+//===----------------------------------------------------------------------===//
+
+// well, following code is copy from GlobalOP
+
+// Linkage types. This is currently a replay of llvm/IR/GlobalValue.h, this is
+// currently handy as part of forwarding appropriate linkage types for LLVM
+// lowering, specially useful for C++ support.
+
+// remove GlobalLinkageKind
+
+// remove SignedOverflowBehavior
+
+// remove thread local related
+
+// In my mind, RG is similar to Global, but each RG represent a special register
+// which label is from '__asm__' key word.
+
+
+def RGOp : CIR_Op<"RG", [Symbol]> {
+  let summary = "Declares or defines a RG";
+  let description = [{
+    The `cir.global` operation declares or defines a named global variable.
+
+    The backing memory for the variable is allocated statically and is
+    described by the type of the variable.
+
+    The operation is a declaration if no `inital_value` is
+    specified, else it is a definition.
+
+    The global variable can also be marked constant using the
+    `constant` unit attribute. Writing to such constant global variables is
+    undefined.
+
+    The `linkage` tracks C/C++ linkage types, currently very similar to LLVM's.
+    Symbol visibility in `sym_visibility` is defined in terms of MLIR's visibility
+    and verified to be in accordance to `linkage`.
+
+    Example:
+
+    ```mlir
+    // Public and constant variable with initial value.
+    cir.global public constant @c : i32 = 4;
+    ```
+
+    The above is description of global variable, and here is RG description in
+    comparison with the above
+
+    1. The `cir.RG` operation declares a named register global.
+
+    2. The backing memory for the RG make no sence as this no address info could
+    represent register address. While read and write intrinsic just have 32&64
+    bit output.
+
+    3. The operation could only be a declaration
+
+    4. RGV hasn't constant attribute.
+
+    5. There's no decision whether reserve linkage info or not.
+
+  }];
+
+  // Note that both sym_name and sym_visibility are tied to Symbol trait.
+  // TODO: sym_visibility can possibly be represented by implementing the
+  // necessary Symbol's interface in terms of linkage instead.
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       OptionalAttr<StrAttr>:$sym_visibility,
+                       TypeAttr:$sym_type,
+                       // Arg<GlobalLinkageKind, "linkage type">:$linkage,
+                       // Note this can also be a FlatSymbolRefAttr
+                       // OptionalAttr<AnyAttr>:$initial_value,
+                       // UnitAttr:$constant,
+                       OptionalAttr<I64Attr>:$alignment
+                      //  OptionalAttr<ASTVarDeclInterface>:$ast,
+                      //  OptionalAttr<StrAttr>:$section
+                       );
+  // let regions = (region AnyRegion:$ctorRegion, AnyRegion:$dtorRegion);
+  let assemblyFormat = [{
+       ($sym_visibility^)?
+       $sym_name
+       $sym_type
+       attr-dict
+  }];
+
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      // MLIR's default visibility is public.
+      "StringRef":$sym_name,
+      "Type":$sym_type)>
+  ];
+
+  let hasVerifier = 0;
+}
+
+//===----------------------------------------------------------------------===//
 // GetGlobalOp
 //===----------------------------------------------------------------------===//
 
@@ -2087,6 +2184,51 @@ def GetGlobalOp : CIR_Op<"get_global",
   }];
 
   // `GetGlobalOp` is fully verified by its traits.
+  let hasVerifier = 0;
+}
+
+//===----------------------------------------------------------------------===//
+// GetRGOp
+//===----------------------------------------------------------------------===//
+
+def GetRGOp : CIR_Op<"get_RG",
+    [Pure, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Get the abstraction address of a register";
+  let description = [{
+    The `cir.get_global` operation retrieves the address pointing to a
+    named global variable. If the global variable is marked constant, writing
+    to the resulting address (such as through a `cir.store` operation) is
+    undefined. Resulting type must always be a `!cir.ptr<...>` type.
+
+    Addresses of thread local globals can only be retrieved if this operation
+    is marked `thread_local`, which indicates the address isn't constant.
+
+    Example:
+    ```mlir
+    %x = cir.get_global @foo : !cir.ptr<i32>
+    ...
+    %y = cir.get_global thread_local @batata : !cir.ptr<i32>
+    ```
+
+    The above is description of get_global, and here is get_RG description in
+    comparison with the above
+
+    1. The `cir.get_RG` operation retrieves the abstract address pointing to a
+    named register.
+
+    2. Resulting type must always be a `!cir.ptr<...>` type. Actually, i wanna
+    keep the type !cir.ptr<!u64i>. The coming problem is that we have to trunc
+    the type for 32bit integer.
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$name);
+  let results = (outs Res<CIR_PointerType, "", []>:$addr);
+
+  let assemblyFormat = [{
+    $name `:` qualified(type($addr)) attr-dict
+  }];
+
+  // `GetRG` is fully verified by its traits.
   let hasVerifier = 0;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -949,6 +949,47 @@ static LValue buildFunctionDeclLValue(CIRGenFunction &CGF, const Expr *E,
                             AlignmentSource::Decl);
 }
 
+static LValue buildGlobalNamedRegister(CIRGenFunction &CGF, const Expr *E,
+                                      const VarDecl *VD) {
+  // SmallString<64> Nmae("llvm.named.register.");
+  // AsmLabelAttr *Asm = VD->getAttr<AsmLabelAttr>();
+  // assert(Asm->getLabel().size() < 64-Name.size() &&
+  //     "Register name too big");
+  // Name.append(Asm->getLabel());
+
+  QualType T = E->getType();
+
+  // ptr->u64i
+  auto V = CGF.CGM.getAddrOfRG(VD);
+
+  // here's cast(bitcast) operation
+  // As 'V' here is always ptr which points to u64i, it seems a good way to just
+  // bitcast current ptr to another ptr with different type.
+
+  auto RealVarTy = CGF.getTypes().convertTypeForMem(VD->getType());
+  auto realPtrTy = CGF.getBuilder().getPointerTo(RealVarTy);
+
+  if (realPtrTy != V.getType())
+    V = CGF.getBuilder().createBitcast(V.getLoc(), V, realPtrTy);
+
+  // The following is copied from ``buildGlobalVarDeclLValue``
+  CharUnits Alignment = CGF.getContext().getDeclAlign(VD);
+  Address Addr(V, RealVarTy, Alignment);
+  // Emit reference to the private copy of the variable if it is an OpenMP
+  // threadprivate variable.
+  if (CGF.getLangOpts().OpenMP && !CGF.getLangOpts().OpenMPSimd &&
+      VD->hasAttr<clang::OMPThreadPrivateDeclAttr>()) {
+    assert(0 && "NYI");
+  }
+  LValue LV;
+  if (VD->getType()->isReferenceType())
+    assert(0 && "NYI");
+  else
+    LV = CGF.makeAddrLValue(Addr, T, AlignmentSource::Decl);
+  assert(!MissingFeatures::setObjCGCLValueClass() && "NYI");
+  return LV;
+}
+
 LValue CIRGenFunction::buildDeclRefLValue(const DeclRefExpr *E) {
   const NamedDecl *ND = E->getDecl();
   QualType T = E->getType();
@@ -960,7 +1001,8 @@ LValue CIRGenFunction::buildDeclRefLValue(const DeclRefExpr *E) {
     // Global Named registers access via intrinsics only
     if (VD->getStorageClass() == SC_Register && VD->hasAttr<AsmLabelAttr>() &&
         !VD->isLocalVarDecl())
-      llvm_unreachable("NYI");
+      return buildGlobalNamedRegister(*this, E, VD);
+      // llvm_unreachable("NYI");
 
     assert(E->isNonOdrUse() != NOUR_Constant && "not implemented");
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1004,6 +1004,87 @@ mlir::Value CIRGenModule::getAddrOfGlobalVar(const VarDecl *D, mlir::Type Ty,
       getLoc(D->getSourceRange()), ptrTy, g.getSymName(), tlsAccess);
 }
 
+// static class method
+mlir::cir::RGOp CIRGenModule::createRGOp(CIRGenModule &CGM,
+                                  mlir::Location loc, StringRef name,
+                                  mlir::Type type,
+                                  mlir::Operation *insertPoint) {
+  mlir::cir::RGOp rg;
+  auto &builder = CGM.getBuilder();
+  {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+
+    auto *curCGF = CGM.getCurrCIRGenFun();
+
+    if (!curCGF)
+      llvm_unreachable("NYI");
+
+    builder.setInsertionPoint(curCGF->CurFn);
+
+    rg = builder.create<mlir::cir::RGOp>(loc, name, type);
+
+    mlir::SymbolTable::setSymbolVisibility(
+        rg, mlir::SymbolTable::Visibility::Private);
+  }
+
+  return rg;
+}
+
+mlir::cir::RGOp
+CIRGenModule::getOrCreateCIRRG(StringRef RGNameRef, mlir::Type Ty,
+                              const VarDecl *D) {
+  mlir::cir::RGOp Entry;
+
+  if (auto *V = getGlobalValue(RGNameRef)) {
+    assert(isa<mlir::cir::RGOp>(V) && "only supports RGOp for now");
+    Entry = dyn_cast_or_null<mlir::cir::RGOp>(V);
+  }
+
+  if (Entry) {
+    if (Entry.getSymType() == Ty) {
+      return Entry;
+    }
+  }
+
+  auto loc = getLoc(D->getSourceRange());
+
+  auto RGV = createRGOp(*this, loc, RGNameRef, Ty, nullptr);
+
+  return RGV;
+}
+
+
+mlir::cir::RGOp CIRGenModule::buildRG(const VarDecl *D, mlir::Type Ty) {
+  assert(D->hasGlobalStorage() && "Not a global variable");
+
+  if (!Ty)
+    llvm_unreachable("NYI");
+
+  SmallString<64> RGName("llvm.named.register.");
+  AsmLabelAttr *Asm = D->getAttr<AsmLabelAttr>();
+  assert(Asm->getLabel().size() < 64 - RGName.size() &&
+      "Register name too big");
+  RGName.append(Asm->getLabel());
+
+  StringRef RGNameRef(RGName);
+
+  return getOrCreateCIRRG(RGNameRef, Ty, D);
+}
+
+mlir::Value CIRGenModule::getAddrOfRG(const VarDecl *D, mlir::Type Ty) {
+  if (!Ty) {
+    Ty = this->UInt64Ty;
+  }
+
+  auto rg = buildRG(D, Ty);
+
+  auto ptrTy =
+      mlir::cir::PointerType::get(builder.getContext(), rg.getSymType());
+
+  return builder.create<mlir::cir::GetRGOp>(
+      getLoc(D->getSourceRange()), ptrTy, rg.getSymName());
+}
+
 mlir::cir::GlobalViewAttr
 CIRGenModule::getAddrOfGlobalVarAttr(const VarDecl *D, mlir::Type Ty,
                                      ForDefinition_t IsForDefinition) {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -191,6 +191,9 @@ public:
                        const VarDecl *D,
                        ForDefinition_t IsForDefinition = NotForDefinition);
 
+  mlir::cir::RGOp
+  getOrCreateCIRRG(StringRef RGNameRef, mlir::Type Ty, const VarDecl *D);
+
   mlir::cir::GlobalOp getStaticLocalDeclAddress(const VarDecl *D) {
     return StaticLocalDeclMap[D];
   }
@@ -205,6 +208,8 @@ public:
 
   mlir::cir::GlobalOp buildGlobal(const VarDecl *D, mlir::Type Ty,
                                   ForDefinition_t IsForDefinition);
+
+  mlir::cir::RGOp buildRG(const VarDecl *D, mlir::Type Ty);
 
   /// TODO(cir): once we have cir.module, add this as a convenience method
   /// there instead of here.
@@ -228,6 +233,11 @@ public:
                  mlir::Type t, bool isCst = false,
                  mlir::Operation *insertPoint = nullptr);
 
+  static mlir::cir::RGOp createRGOp(CIRGenModule &CGM,
+                                    mlir::Location loc, StringRef name,
+                                    mlir::Type type,
+                                    mlir::Operation *insertPoint = nullptr);
+
   // FIXME: Hardcoding priority here is gross.
   void AddGlobalCtor(mlir::cir::FuncOp Ctor, int Priority = 65535);
   void AddGlobalDtor(mlir::cir::FuncOp Dtor, int Priority = 65535,
@@ -242,6 +252,9 @@ public:
   mlir::Value
   getAddrOfGlobalVar(const VarDecl *D, mlir::Type Ty = {},
                      ForDefinition_t IsForDefinition = NotForDefinition);
+
+  mlir::Value
+  getAddrOfRG(const VarDecl *D, mlir::Type Ty = {});
 
   /// Return the mlir::GlobalViewAttr for the address of the given global.
   mlir::cir::GlobalViewAttr

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -52,6 +52,12 @@ CIRGenTypes::~CIRGenTypes() {
 // This is CIR's version of CIRGenTypes::addRecordTypeName
 std::string CIRGenTypes::getRecordTypeName(const clang::RecordDecl *recordDecl,
                                            StringRef suffix) {
+
+  const auto *key = Context.getTagDeclType(recordDecl).getTypePtr();
+  if (nameOfRecordDeclTypes.find(key) != nameOfRecordDeclTypes.end()) {
+    return nameOfRecordDeclTypes[key];
+  };
+
   llvm::SmallString<256> typeName;
   llvm::raw_svector_ostream outStream(typeName);
 
@@ -89,7 +95,18 @@ std::string CIRGenTypes::getRecordTypeName(const clang::RecordDecl *recordDecl,
   if (!suffix.empty())
     outStream << suffix;
 
-  return std::string(typeName);
+  if (nameUniqueIDOfRDtypes.find(typeName) != nameUniqueIDOfRDtypes.end()) {
+    unsigned int nameUniqueID = (++nameUniqueIDOfRDtypes[typeName]);
+
+    outStream << ".";
+    outStream << std::to_string(nameUniqueID);
+  } else {
+    nameUniqueIDOfRDtypes[typeName] = 0;
+  }
+
+  nameOfRecordDeclTypes[key] = std::string(typeName);
+
+  return nameOfRecordDeclTypes[key];
 }
 
 /// Return true if the specified type is already completely laid out.

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.h
@@ -94,6 +94,10 @@ class CIRGenTypes {
   /// Contains the CIR type for any converted RecordDecl
   llvm::DenseMap<const clang::Type *, mlir::cir::StructType> recordDeclTypes;
 
+  /// Contains the final name for any converted RecordDecl
+  llvm::DenseMap<const clang::Type *, std::string> nameOfRecordDeclTypes;
+  llvm::StringMap<unsigned int> nameUniqueIDOfRDtypes;
+
   /// Hold memoized CIRGenFunctionInfo results
   llvm::FoldingSet<CIRGenFunctionInfo> FunctionInfos;
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1805,6 +1805,18 @@ void GlobalOp::getSuccessorRegions(mlir::RegionBranchPoint point,
 }
 
 //===----------------------------------------------------------------------===//
+// RGOp
+//===----------------------------------------------------------------------===//
+void RGOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                     StringRef sym_name, Type sym_type) {
+  odsState.addAttribute(getSymNameAttrName(odsState.name),
+                        odsBuilder.getStringAttr(sym_name));
+  odsState.addAttribute(getSymTypeAttrName(odsState.name),
+                        ::mlir::TypeAttr::get(sym_type));
+}
+
+
+//===----------------------------------------------------------------------===//
 // GetGlobalOp
 //===----------------------------------------------------------------------===//
 
@@ -1837,6 +1849,37 @@ GetGlobalOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
            << " of the global @" << getName();
   return success();
 }
+
+//===----------------------------------------------------------------------===//
+// GetRGOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+GetRGOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // Verify that the result type underlying pointer type matches the type of
+  // the referenced cir.RG op.
+  auto op = symbolTable.lookupNearestSymbolFrom(*this, getNameAttr());
+  if (!(isa<RGOp>(op)))
+    return emitOpError("'")
+           << getName()
+           << "' does not reference a valid cir.RG";
+
+  mlir::Type symTy;
+  if (auto g = dyn_cast<RGOp>(op)) {
+    // i64???
+    symTy = g.getSymType();
+  } else
+    llvm_unreachable("shall not get here");
+
+  // result is always ptr<i64>???
+  auto resultType = getAddr().getType().dyn_cast<PointerType>();
+  if (!resultType || symTy != resultType.getPointee())
+    return emitOpError("result type pointee type '")
+           << resultType.getPointee() << "' does not match type " << symTy
+           << " of the RG @" << getName();
+  return success();
+}
+
 
 //===----------------------------------------------------------------------===//
 // VTableAddrPointOp


### PR DESCRIPTION
1. Use unique ID to distinguish same name structure.
2. Realize RG and GET_RG op to realize global register variale.
3. Achieve union's bitfields.