### PR TITLE
[CIR][DirectToLLVM][NFC] Add include of target lowering library to DirectToLLVM

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -41,3 +41,7 @@ add_clang_library(clangCIRLoweringDirectToLLVM
   MLIROpenMPDialect
   MLIROpenMPToLLVMIRTranslation
   )
+
+target_include_directories(clangCIRLoweringDirectToLLVM PRIVATE
+  ${CLANG_SOURCE_DIR}/lib/CIR/Dialect/Transforms/TargetLowering
+  )


### PR DESCRIPTION
TargetLowering should also serve for DirectToLLVM for target-specific information. The library is already linked against DirectToLLVM, but we have to write dirty includes like `#include "../../Dialect/Transforms/TargetLowering/LowerModule.h"`.

This PR adds a private include directory `clang/lib/CIR/Dialect/Transforms/TargetLowering` to the target DirectToLLVM. Then we can simplify the include directive above to `#include "LowerModule.h"`.