### PR TITLE
[CIR][Builder][NFC] Refactor `getPointerTo` considering AddressSpaceAttr

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -75,13 +75,19 @@ public:
     return mlir::cir::IntType::get(getContext(), N, true);
   }
 
-  mlir::cir::PointerType
-  getPointerTo(mlir::Type ty, clang::LangAS langAS = clang::LangAS::Default) {
-    mlir::cir::AddressSpaceAttr addrSpaceAttr;
-    if (langAS != clang::LangAS::Default)
-      addrSpaceAttr = mlir::cir::AddressSpaceAttr::get(getContext(), langAS);
+  mlir::cir::AddressSpaceAttr getAddrSpaceAttr(clang::LangAS langAS) {
+    if (langAS == clang::LangAS::Default)
+      return {};
+    return mlir::cir::AddressSpaceAttr::get(getContext(), langAS);
+  }
 
-    return mlir::cir::PointerType::get(getContext(), ty, addrSpaceAttr);
+  mlir::cir::PointerType getPointerTo(mlir::Type ty,
+                                      mlir::cir::AddressSpaceAttr cirAS = {}) {
+    return mlir::cir::PointerType::get(getContext(), ty, cirAS);
+  }
+
+  mlir::cir::PointerType getPointerTo(mlir::Type ty, clang::LangAS langAS) {
+    return getPointerTo(ty, getAddrSpaceAttr(langAS));
   }
 
   mlir::cir::PointerType


### PR DESCRIPTION
After switching to a separate address space attribute in CIR, we need better helper methods in CIR builder.

This PR provides:
* two versions of `getPointerTo`, consuming `LangAS` or `AddressSpaceAttr`.
* an extra helper method `getAddrSpaceAttr(LangAS)` that is used by `getPointerTo(LangAS)` and other potential use cases (mainly about address space cast in the future).

Calls to `getPointerTo` without addrspace will invoke the version consuming `AddressSpaceAttr` and return a type with null addrspace attribute, which should be exactly what we expect for CIRBuilder.