### PR TITLE
[CIR][CodeGen][NFC] Refactor `performAddrSpaceCast` to consume CIR address space attributes

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1055,8 +1055,9 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     // the AST level this is handled within CreateTempAlloca et al., but for the
     // builtin / dynamic alloca we have to handle it here.
     assert(!MissingFeatures::addressSpace());
-    LangAS AAS = getASTAllocaAddressSpace();
-    LangAS EAS = E->getType()->getPointeeType().getAddressSpace();
+    auto AAS = builder.getAddrSpaceAttr(getASTAllocaAddressSpace());
+    auto EAS = builder.getAddrSpaceAttr(
+        E->getType()->getPointeeType().getAddressSpace());
     if (EAS != AAS) {
       assert(false && "Non-default address space for alloca NYI");
     }

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1999,9 +1999,11 @@ LValue CIRGenFunction::buildCastLValue(const CastExpr *E) {
   case CK_AddressSpaceConversion: {
     LValue LV = buildLValue(E->getSubExpr());
     QualType DestTy = getContext().getPointerType(E->getType());
+    auto SrcAS = builder.getAddrSpaceAttr(
+        E->getSubExpr()->getType().getAddressSpace());
+    auto DestAS = builder.getAddrSpaceAttr(E->getType().getAddressSpace());
     mlir::Value V = getTargetHooks().performAddrSpaceCast(
-        *this, LV.getPointer(), E->getSubExpr()->getType().getAddressSpace(),
-        E->getType().getAddressSpace(), ConvertType(DestTy));
+        *this, LV.getPointer(), SrcAS, DestAS, ConvertType(DestTy));
     assert(!MissingFeatures::tbaa());
     return makeAddrLValue(Address(V, getTypes().convertTypeForMem(E->getType()),
                                   LV.getAddress().getAlignment()),

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1604,9 +1604,12 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     }
     // Since target may map different address spaces in AST to the same address
     // space, an address space conversion may end up as a bitcast.
+    auto SrcAS = CGF.builder.getAddrSpaceAttr(
+        E->getType()->getPointeeType().getAddressSpace());
+    auto DestAS = CGF.builder.getAddrSpaceAttr(
+        DestTy->getPointeeType().getAddressSpace());
     return CGF.CGM.getTargetCIRGenInfo().performAddrSpaceCast(
-        CGF, Visit(E), E->getType()->getPointeeType().getAddressSpace(),
-        DestTy->getPointeeType().getAddressSpace(), ConvertType(DestTy));
+        CGF, Visit(E), SrcAS, DestAS, ConvertType(DestTy));
   }
   case CK_AtomicToNonAtomic:
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -530,8 +530,9 @@ ABIArgInfo X86_64ABIInfo::classifyReturnType(QualType RetTy) const {
 }
 
 mlir::Value TargetCIRGenInfo::performAddrSpaceCast(
-    CIRGenFunction &CGF, mlir::Value Src, clang::LangAS SrcAddr,
-    clang::LangAS DestAddr, mlir::Type DestTy, bool IsNonNull) const {
+    CIRGenFunction &CGF, mlir::Value Src, mlir::cir::AddressSpaceAttr SrcAddr,
+    mlir::cir::AddressSpaceAttr DestAddr, mlir::Type DestTy,
+    bool IsNonNull) const {
   // Since target may map different address spaces in AST to the same address
   // space, an address space conversion may end up as a bitcast.
   if (auto globalOp = Src.getDefiningOp<mlir::cir::GlobalOp>())

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -17,6 +17,7 @@
 #include "ABIInfo.h"
 #include "CIRGenValue.h"
 #include "mlir/IR/Types.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
 
 #include <memory>
 
@@ -68,13 +69,13 @@ public:
 
   /// Perform address space cast of an expression of pointer type.
   /// \param V is the value to be casted to another address space.
-  /// \param SrcAddr is the language address space of \p V.
-  /// \param DestAddr is the targeted language address space.
+  /// \param SrcAddr is the CIR address space of \p V.
+  /// \param DestAddr is the targeted CIR address space.
   /// \param DestTy is the destination pointer type.
   /// \param IsNonNull is the flag indicating \p V is known to be non null.
   virtual mlir::Value performAddrSpaceCast(CIRGenFunction &CGF, mlir::Value V,
-                                           clang::LangAS SrcAddr,
-                                           clang::LangAS DestAddr,
+                                           mlir::cir::AddressSpaceAttr SrcAddr,
+                                           mlir::cir::AddressSpaceAttr DestAddr,
                                            mlir::Type DestTy,
                                            bool IsNonNull = false) const;
 


### PR DESCRIPTION
Originally `TargetCodeGenInfo::performAddrSpaceCast` consumes two *unused* parameters typed `clang::LangAS`. This PR changes its type to `mlir::cir::AddressSpaceAttr` to better fit the need of CIRGen.

In [D32248: CodeGen: Cast alloca to expected address space](https://reviews.llvm.org/D32248), the author explained why these AS parameters are not used:

> This is just the default implementation. The idea is that targets that need to do something more complex on a particular conversion — e.g. to make sure that null pointers are translated correctly when they have different bit-patterns — can easily do so.

Further more, I'm confident that the CIR AS is also capable of providing custom behaviors like above for those targets.
