### PR TITLE
[CIR] Add support for complex related intrinsics

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -718,6 +718,47 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   switch (BuiltinIDIfNoAsmLabel) {
   default:
     break;
+
+  case Builtin::BI__builtin_complex: {
+    mlir::Value Real = buildScalarExpr(E->getArg(0));
+    mlir::Value Imag = buildScalarExpr(E->getArg(1));
+    mlir::Value Complex =
+        builder.createComplexCreate(getLoc(E->getExprLoc()), Real, Imag);
+    return RValue::getComplex(Complex);
+  }
+
+  case Builtin::BI__builtin_creal:
+  case Builtin::BI__builtin_crealf:
+  case Builtin::BI__builtin_creall:
+  case Builtin::BIcreal:
+  case Builtin::BIcrealf:
+  case Builtin::BIcreall: {
+    mlir::Value ComplexVal = buildComplexExpr(E->getArg(0));
+    mlir::Value Real =
+        builder.createComplexReal(getLoc(E->getExprLoc()), ComplexVal);
+    return RValue::get(Real);
+  }
+
+  case Builtin::BI__builtin_cimag:
+  case Builtin::BI__builtin_cimagf:
+  case Builtin::BI__builtin_cimagl:
+  case Builtin::BIcimag:
+  case Builtin::BIcimagf:
+  case Builtin::BIcimagl: {
+    mlir::Value ComplexVal = buildComplexExpr(E->getArg(0));
+    mlir::Value Real =
+        builder.createComplexImag(getLoc(E->getExprLoc()), ComplexVal);
+    return RValue::get(Real);
+  }
+
+  case Builtin::BI__builtin_conj:
+  case Builtin::BI__builtin_conjf:
+  case Builtin::BI__builtin_conjl:
+  case Builtin::BIconj:
+  case Builtin::BIconjf:
+  case Builtin::BIconjl:
+    llvm_unreachable("NYI");
+
   case Builtin::BI__builtin___CFStringMakeConstantString:
   case Builtin::BI__builtin___NSStringMakeConstantString:
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
@@ -129,7 +129,7 @@ public:
     return buildCast(E->getCastKind(), E->getSubExpr(), E->getType());
   }
   mlir::Value VisitCastExpr(CastExpr *E) { llvm_unreachable("NYI"); }
-  mlir::Value VisitCallExpr(const CallExpr *E) { llvm_unreachable("NYI"); }
+  mlir::Value VisitCallExpr(const CallExpr *E);
   mlir::Value VisitStmtExpr(const StmtExpr *E) { llvm_unreachable("NYI"); }
 
   // Operators.
@@ -499,6 +499,13 @@ mlir::Value ComplexExprEmitter::buildCast(CastKind CK, Expr *Op,
   }
 
   llvm_unreachable("unknown cast resulting in complex value");
+}
+
+mlir::Value ComplexExprEmitter::VisitCallExpr(const CallExpr *E) {
+  if (E->getCallReturnType(CGF.getContext())->isReferenceType())
+    return buildLoadOfLValue(E);
+
+  return CGF.buildCallExpr(E).getComplexVal();
 }
 
 ComplexExprEmitter::BinOpInfo

--- a/clang/test/CIR/CodeGen/complex.c
+++ b/clang/test/CIR/CodeGen/complex.c
@@ -48,6 +48,21 @@ void list_init_2(double r, double i) {
 // LLVM-NEXT:   store { double, double } %[[#B]], ptr %5, align 8
 //      LLVM: }
 
+void builtin_init(double r, double i) {
+  double _Complex c = __builtin_complex(r, i);
+}
+
+//     C: cir.func @builtin_init
+//   CPP: cir.func @_Z12builtin_initdd
+// CHECK:   %{{.+}} = cir.complex.create %{{.+}}, %{{.+}} : !cir.double -> !cir.complex<!cir.double>
+// CHECK: }
+
+//      LLVM: define void @builtin_init
+//      LLVM:   %[[#A:]] = insertvalue { double, double } undef, double %{{.+}}, 0
+// LLVM-NEXT:   %[[#B:]] = insertvalue { double, double } %[[#A]], double %{{.+}}, 1
+// LLVM-NEXT:   store { double, double } %[[#B]], ptr %{{.+}}, align 8
+//      LLVM: }
+
 void imag_literal() {
   c = 3.0i;
   ci = 3i;
@@ -114,6 +129,38 @@ void load_store_volatile() {
 // LLVM-NEXT:   store volatile { double, double } %[[#A]], ptr @vc, align 8
 // LLVM-NEXT:   %[[#B:]] = load volatile { i32, i32 }, ptr @vci2, align 4
 // LLVM-NEXT:   store volatile { i32, i32 } %[[#B]], ptr @vci, align 4
+//      LLVM: }
+
+void real() {
+  double r = __builtin_creal(c);
+}
+
+//          C: cir.func no_proto @real()
+//        CPP: cir.func @_Z4realv()
+//      CHECK:   %[[#A:]] = cir.get_global @c : !cir.ptr<!cir.complex<!cir.double>>
+// CHECK-NEXT:   %[[#B:]] = cir.load %[[#A]] : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
+// CHECK-NEXT:   %{{.+}} = cir.complex.real %[[#B]] : !cir.complex<!cir.double> -> !cir.double
+//      CHECK: }
+
+//      LLVM: define void @real()
+//      LLVM:   %[[#A:]] = extractvalue { double, double } %{{.+}}, 0
+// LLVM-NEXT:   store double %[[#A]], ptr %{{.+}}, align 8
+//      LLVM: }
+
+void imag() {
+  double i = __builtin_cimag(c);
+}
+
+//          C: cir.func no_proto @imag()
+//        CPP: cir.func @_Z4imagv()
+//      CHECK:   %[[#A:]] = cir.get_global @c : !cir.ptr<!cir.complex<!cir.double>>
+// CHECK-NEXT:   %[[#B:]] = cir.load %[[#A]] : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
+// CHECK-NEXT:   %{{.+}} = cir.complex.imag %[[#B]] : !cir.complex<!cir.double> -> !cir.double
+//      CHECK: }
+
+//      LLVM: define void @imag()
+//      LLVM:   %[[#A:]] = extractvalue { double, double } %{{.+}}, 1
+// LLVM-NEXT:   store double %[[#A]], ptr %{{.+}}, align 8
 //      LLVM: }
 
 void real_ptr() {


### PR DESCRIPTION
This PR adds CIRGen for the following complex related intrinsics:

  - `__builtin_complex`,
  - `__builtin_creal`, and
  - `__builtin_cimag`.

The generated CIR does not include any new ops so LLVM IR lowering is already done.