### PR TITLE
[CIR][Transforms][NFC] Use `unique_ptr` to encapsulate LowerModule

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -36,7 +36,8 @@ struct CallConvLoweringPattern : public OpRewritePattern<FuncOp> {
       return op.emitError("function has no AST information");
 
     auto modOp = op->getParentOfType<ModuleOp>();
-    auto lowerModule = createLowerModule(modOp, rewriter);
+    std::unique_ptr<LowerModule> lowerModule =
+        createLowerModule(modOp, rewriter);
 
     // Rewrite function calls before definitions. This should be done before
     // lowering the definition.

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -36,7 +36,7 @@ struct CallConvLoweringPattern : public OpRewritePattern<FuncOp> {
       return op.emitError("function has no AST information");
 
     auto modOp = op->getParentOfType<ModuleOp>();
-    LowerModule lowerModule = createLowerModule(modOp, rewriter);
+    auto lowerModule = createLowerModule(modOp, rewriter);
 
     // Rewrite function calls before definitions. This should be done before
     // lowering the definition.
@@ -44,14 +44,14 @@ struct CallConvLoweringPattern : public OpRewritePattern<FuncOp> {
     if (calls.has_value()) {
       for (auto call : calls.value()) {
         auto callOp = cast<CallOp>(call.getUser());
-        if (lowerModule.rewriteFunctionCall(callOp, op).failed())
+        if (lowerModule->rewriteFunctionCall(callOp, op).failed())
           return failure();
       }
     }
 
     // TODO(cir): Instead of re-emmiting every load and store, bitcast arguments
     // and return values to their ABI-specific counterparts when possible.
-    if (lowerModule.rewriteFunctionDefinition(op).failed())
+    if (lowerModule->rewriteFunctionDefinition(op).failed())
       return failure();
 
     return success();

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -217,7 +217,8 @@ LogicalResult LowerModule::rewriteFunctionCall(CallOp callOp, FuncOp funcOp) {
 }
 
 // TODO: not to create it every time
-LowerModule createLowerModule(ModuleOp module, PatternRewriter &rewriter) {
+std::unique_ptr<LowerModule> createLowerModule(ModuleOp module,
+                                               PatternRewriter &rewriter) {
   // Fetch the LLVM data layout string.
   auto dataLayoutStr = cast<StringAttr>(
       module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName()));
@@ -237,7 +238,8 @@ LowerModule createLowerModule(ModuleOp module, PatternRewriter &rewriter) {
   auto context = CIRLowerContext(module, langOpts);
   context.initBuiltinTypes(*targetInfo);
 
-  return LowerModule(context, module, dataLayoutStr, *targetInfo, rewriter);
+  return std::make_unique<LowerModule>(context, module, dataLayoutStr,
+                                       *targetInfo, rewriter);
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -91,7 +91,8 @@ public:
   LogicalResult rewriteFunctionCall(CallOp callOp, FuncOp funcOp);
 };
 
-LowerModule createLowerModule(ModuleOp module, PatternRewriter &rewriter);
+std::unique_ptr<LowerModule> createLowerModule(ModuleOp module,
+                                               PatternRewriter &rewriter);
 
 } // namespace cir
 } // namespace mlir


### PR DESCRIPTION
Currently `LowerModule` mimics `CodeGenModule` and uses many raw references. It cannot be moved or copied. Value semantic does not fit the need. For example, we cannot pass LowerModule around.

A better practice would be to use `unique_ptr` to encapsulate it. In the future, we hold its ownership in some long-lived contexts (it's `CodeGeneratorImpl` for `CodeGenModule`) and pass references to it around safely.
