### PR TITLE
[CIR][ThroughMLIR] Support array type GlobalOp lowering with initial values

### DIFF
--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -19,6 +19,11 @@ convertStringAttrToDenseElementsAttr(mlir::cir::ConstArrayAttr attr,
   assert(stringAttr && "expected string attribute here");
   for (auto element : stringAttr)
     values.push_back({8, (uint64_t)element});
+  auto arrayTy = mlir::dyn_cast<mlir::cir::ArrayType>(attr.getType());
+  assert(arrayTy && "String attribute must have an array type");
+  if (arrayTy.getSize() != stringAttr.size())
+    llvm_unreachable("array type of the length not equal to that of the string "
+                     "attribute is not supported yet");
   return mlir::DenseElementsAttr::get(
       mlir::RankedTensorType::get({(int64_t)values.size()}, type),
       llvm::ArrayRef(values));

--- a/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
@@ -27,6 +27,7 @@ add_clang_library(clangCIRLoweringThroughMLIR
   clangLex
   clangFrontend
   clangCIR
+  clangCIRLoweringHelpers
   ${dialect_libs}
   MLIRCIR
   MLIRAnalysis

--- a/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
@@ -2,7 +2,16 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 float f[32000];
-double d;
-
 // CHECK: memref.global "public" @f : memref<32000xf32> = dense<0.000000e+00>
+double d;
 // CHECK: memref.global "public" @d : memref<f64> = dense<0.000000e+00>
+float f_init[] = {1.0, 2.0};
+// CHECK: memref.global "public" @f_init : memref<2xf32> = dense<[1.000000e+00, 2.000000e+00]>
+int i_init[2] = {0, 1};
+// CHECK: memref.global "public" @i_init : memref<2xi32> = dense<[0, 1]>
+char string[] = "whatnow";
+// CHECK: memref.global "public" @string : memref<8xi8> = dense<[119, 104, 97, 116, 110, 111, 119, 0]>
+int excess_sint[4] = {1, 2};
+// CHECK: memref.global "public" @excess_sint : memref<4xi32> = dense<[1, 2, 0, 0]>
+int sint[] = {123, 456, 789};
+// CHECK: memref.global "public" @sint : memref<3xi32> = dense<[123, 456, 789]>


### PR DESCRIPTION
This commit makes the changes as following.

1. Enable array type GlobalOp lowering with initial values

2. Add error message when array size is not equal to initial string value size
       E.g. char big_string[10] = "abc";