### PR TITLE
[CIR][ABI] Add X86_64 and AArch64 bool CC lowering

### DIFF
--- a/clang/include/clang/CIR/ABIArgInfo.h
+++ b/clang/include/clang/CIR/ABIArgInfo.h
@@ -185,7 +185,8 @@ public:
   }
   static ABIArgInfo getExtend(mlir::Type Ty, mlir::Type T = nullptr) {
     // NOTE(cir): The original can apply this method on both integers and
-    // enumerations, but in CIR, these two types are one and the same.
+    // enumerations, but in CIR, these two types are one and the same. Booleans
+    // will also fall into this category, but they have their own type.
     if (mlir::isa<mlir::cir::IntType>(Ty) &&
         mlir::cast<mlir::cir::IntType>(Ty).isSigned())
       return getSignExtend(mlir::cast<mlir::cir::IntType>(Ty), T);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
@@ -112,7 +112,7 @@ mlir::Type LowerTypes::convertType(Type T) {
   /// keeping it here for parity's sake.
 
   // Certain CIR types are already ABI-specific, so we just return them.
-  if (isa<IntType>(T)) {
+  if (isa<BoolType, IntType>(T)) {
     return T;
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -7,6 +7,7 @@
 #include "TargetInfo.h"
 #include "clang/CIR/ABIArgInfo.h"
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <memory>
@@ -157,6 +158,8 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
       Current = Class::SSE;
       return;
 
+    } else if (isa<BoolType>(Ty)) {
+      Current = Class::Integer;
     } else {
       llvm::outs() << "Missing X86 classification for type " << Ty << "\n";
       llvm_unreachable("NYI");
@@ -294,7 +297,7 @@ Type X86_64ABIInfo::GetINTEGERTypeAtOffset(Type DestTy, unsigned IROffset,
       // enums directly as their unerlying integer types. NOTE(cir): For some
       // reason, Clang does not set the coerce type here and delays it to
       // arrangeLLVMFunctionInfo. We do the same to keep parity.
-      if (isa<IntType>(RetTy) && isPromotableIntegerTypeForABI(RetTy))
+      if (isa<IntType, BoolType>(RetTy) && isPromotableIntegerTypeForABI(RetTy))
         return ABIArgInfo::getExtend(RetTy);
     }
     break;

--- a/clang/test/CIR/Transforms/Target/aarch64/aarch64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/aarch64/aarch64-call-conv-lowering-pass.cpp
@@ -9,6 +9,12 @@ void Void(void) {
 
 // Test call conv lowering for trivial usinged integer cases.
 
+// CHECK: @_Z4Boolb(%arg0: !cir.bool loc({{.+}})) -> !cir.bool
+bool Bool(bool a) {
+// CHECK:   cir.call @_Z4Boolb({{.+}}) : (!cir.bool) -> !cir.bool
+  return Bool(a);
+}
+
 // CHECK: cir.func @_Z5UCharh(%arg0: !u8i loc({{.+}})) -> !u8i
 unsigned char UChar(unsigned char c) {
   // CHECK: cir.call @_Z5UCharh(%2) : (!u8i) -> !u8i

--- a/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-after=cir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
+// Test call conv lowering for trivial cases. //
+
 // CHECK: @_Z4Voidv()
 void Void(void) {
 // CHECK:   cir.call @_Z4Voidv() : () -> ()
@@ -8,6 +10,16 @@ void Void(void) {
 }
 
 // Test call conv lowering for trivial zeroext cases.
+
+// Bools are a bit of an odd case in CIR's x86_64 representation: they are considered i8
+// everywhere except in the function return/arguments, where they are considered i1. To
+// match LLVM's behavior, we need to zero-extend them when passing them as arguments.
+
+// CHECK: @_Z4Boolb(%arg0: !cir.bool {cir.zeroext} loc({{.+}})) -> (!cir.bool {cir.zeroext})
+bool Bool(bool a) {
+// CHECK:   cir.call @_Z4Boolb({{.+}}) : (!cir.bool) -> !cir.bool
+  return Bool(a);
+}
 
 // CHECK: cir.func @_Z5UCharh(%arg0: !u8i {cir.zeroext} loc({{.+}})) -> (!u8i {cir.zeroext})
 unsigned char UChar(unsigned char c) {


### PR DESCRIPTION
Implements calling convention lowering of bool arguments and return value calling conventions for X86_64 and AArch64.

For x86_64, this is a bit of an odd case. In the orignal codegen bools are represented as i8 everywhere, except for function arguments/return values. In CIR, we don't allow i1 types, so bools are still represented as `cir.bool` when in functions. However, when lowering to LLVM Dialect, we need to ensure bools will be converted to i1 when in function's argument/return values.