### PR TITLE
[CIR] Add support for complex cast operations

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -59,6 +59,22 @@ public:
     return create<mlir::cir::ConstantOp>(loc, attr.getType(), attr);
   }
 
+  // Creates constant null value for integral type ty.
+  mlir::cir::ConstantOp getNullValue(mlir::Type ty, mlir::Location loc) {
+    return create<mlir::cir::ConstantOp>(loc, ty, getZeroInitAttr(ty));
+  }
+
+  mlir::cir::ConstantOp getBool(bool state, mlir::Location loc) {
+    return create<mlir::cir::ConstantOp>(loc, getBoolTy(),
+                                         getCIRBoolAttr(state));
+  }
+  mlir::cir::ConstantOp getFalse(mlir::Location loc) {
+    return getBool(false, loc);
+  }
+  mlir::cir::ConstantOp getTrue(mlir::Location loc) {
+    return getBool(true, loc);
+  }
+
   mlir::cir::BoolType getBoolTy() {
     return ::mlir::cir::BoolType::get(getContext());
   }
@@ -110,12 +126,16 @@ public:
       return mlir::cir::FPAttr::getZero(fltType);
     if (auto fltType = mlir::dyn_cast<mlir::cir::DoubleType>(ty))
       return mlir::cir::FPAttr::getZero(fltType);
+    if (auto fltType = mlir::dyn_cast<mlir::cir::FP16Type>(ty))
+      return mlir::cir::FPAttr::getZero(fltType);
+    if (auto fltType = mlir::dyn_cast<mlir::cir::BF16Type>(ty))
+      return mlir::cir::FPAttr::getZero(fltType);
     if (auto complexType = mlir::dyn_cast<mlir::cir::ComplexType>(ty))
       return getZeroAttr(complexType);
     if (auto arrTy = mlir::dyn_cast<mlir::cir::ArrayType>(ty))
       return getZeroAttr(arrTy);
     if (auto ptrTy = mlir::dyn_cast<mlir::cir::PointerType>(ty))
-      return getConstPtrAttr(ptrTy, 0);
+      return getConstNullPtrAttr(ptrTy);
     if (auto structTy = mlir::dyn_cast<mlir::cir::StructType>(ty))
       return getZeroAttr(structTy);
     if (mlir::isa<mlir::cir::BoolType>(ty)) {
@@ -546,6 +566,11 @@ public:
         mlir::IntegerAttr::get(mlir::IntegerType::get(t.getContext(), 64), v);
     return mlir::cir::ConstPtrAttr::get(
         getContext(), mlir::cast<mlir::cir::PointerType>(t), val);
+  }
+
+  mlir::TypedAttr getConstNullPtrAttr(mlir::Type t) {
+    assert(mlir::isa<mlir::cir::PointerType>(t) && "expected cir.ptr");
+    return getConstPtrAttr(t, 0);
   }
 
   // Creates constant nullptr for pointer type ty.

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -71,6 +71,18 @@ def CK_BooleanToIntegral : I32EnumAttrCase<"bool_to_int", 11>;
 def CK_IntegralToFloat : I32EnumAttrCase<"int_to_float", 12>;
 def CK_BooleanToFloat : I32EnumAttrCase<"bool_to_float", 13>;
 def CK_AddressSpaceConversion : I32EnumAttrCase<"address_space", 14>;
+def CK_FloatToComplex : I32EnumAttrCase<"float_to_complex", 15>;
+def CK_IntegralToComplex : I32EnumAttrCase<"int_to_complex", 16>;
+def CK_FloatComplexToReal : I32EnumAttrCase<"float_complex_to_real", 17>;
+def CK_IntegralComplexToReal : I32EnumAttrCase<"int_complex_to_real", 18>;
+def CK_FloatComplexToBoolean : I32EnumAttrCase<"float_complex_to_bool", 19>;
+def CK_IntegralComplexToBoolean : I32EnumAttrCase<"int_complex_to_bool", 20>;
+def CK_FloatComplexCast : I32EnumAttrCase<"float_complex", 21>;
+def CK_FloatComplexToIntegralComplex
+    : I32EnumAttrCase<"float_complex_to_int_complex", 22>;
+def CK_IntegralComplexCast : I32EnumAttrCase<"int_complex", 23>;
+def CK_IntegralComplexToFloatComplex
+    : I32EnumAttrCase<"int_complex_to_float_complex", 24>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
@@ -79,7 +91,11 @@ def CastKind : I32EnumAttr<
      CK_BitCast, CK_FloatingCast, CK_PtrToBoolean, CK_FloatToIntegral,
      CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean,
      CK_BooleanToIntegral, CK_IntegralToFloat, CK_BooleanToFloat,
-     CK_AddressSpaceConversion]> {
+     CK_AddressSpaceConversion, CK_FloatToComplex, CK_IntegralToComplex,
+     CK_FloatComplexToReal, CK_IntegralComplexToReal, CK_FloatComplexToBoolean,
+     CK_IntegralComplexToBoolean, CK_FloatComplexCast,
+     CK_FloatComplexToIntegralComplex, CK_IntegralComplexCast,
+     CK_IntegralComplexToFloatComplex]> {
   let cppNamespace = "::mlir::cir";
 }
 
@@ -104,6 +120,16 @@ def CastOp : CIR_Op<"cast",
     - `bool_to_int`
     - `bool_to_float`
     - `address_space`
+    - `float_to_complex`
+    - `int_to_complex`
+    - `float_complex_to_real`
+    - `int_complex_to_real`
+    - `float_complex_to_bool`
+    - `int_complex_to_bool`
+    - `float_complex`
+    - `float_complex_to_int_complex`
+    - `int_complex`
+    - `int_complex_to_float_complex`
 
     This is effectively a subset of the rules from
     `llvm-project/clang/include/clang/AST/OperationKinds.def`; but note that some

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -136,11 +136,6 @@ public:
     return mlir::cir::GlobalViewAttr::get(type, symbol, indices);
   }
 
-  mlir::TypedAttr getConstNullPtrAttr(mlir::Type t) {
-    assert(mlir::isa<mlir::cir::PointerType>(t) && "expected cir.ptr");
-    return getConstPtrAttr(t, 0);
-  }
-
   mlir::Attribute getString(llvm::StringRef str, mlir::Type eltTy,
                             unsigned size = 0) {
     unsigned finalSize = size ? size : str.size();
@@ -244,31 +239,6 @@ public:
   mlir::cir::DataMemberAttr
   getNullDataMemberAttr(mlir::cir::DataMemberType ty) {
     return mlir::cir::DataMemberAttr::get(getContext(), ty, std::nullopt);
-  }
-
-  mlir::TypedAttr getZeroInitAttr(mlir::Type ty) {
-    if (mlir::isa<mlir::cir::IntType>(ty))
-      return mlir::cir::IntAttr::get(ty, 0);
-    if (auto fltType = mlir::dyn_cast<mlir::cir::SingleType>(ty))
-      return mlir::cir::FPAttr::getZero(fltType);
-    if (auto fltType = mlir::dyn_cast<mlir::cir::DoubleType>(ty))
-      return mlir::cir::FPAttr::getZero(fltType);
-    if (auto fltType = mlir::dyn_cast<mlir::cir::FP16Type>(ty))
-      return mlir::cir::FPAttr::getZero(fltType);
-    if (auto fltType = mlir::dyn_cast<mlir::cir::BF16Type>(ty))
-      return mlir::cir::FPAttr::getZero(fltType);
-    if (auto complexType = mlir::dyn_cast<mlir::cir::ComplexType>(ty))
-      return getZeroAttr(complexType);
-    if (auto arrTy = mlir::dyn_cast<mlir::cir::ArrayType>(ty))
-      return getZeroAttr(arrTy);
-    if (auto ptrTy = mlir::dyn_cast<mlir::cir::PointerType>(ty))
-      return getConstNullPtrAttr(ptrTy);
-    if (auto structTy = mlir::dyn_cast<mlir::cir::StructType>(ty))
-      return getZeroAttr(structTy);
-    if (mlir::isa<mlir::cir::BoolType>(ty)) {
-      return getCIRBoolAttr(false);
-    }
-    llvm_unreachable("Zero initializer for given type is NYI");
   }
 
   // TODO(cir): Once we have CIR float types, replace this by something like a
@@ -554,26 +524,10 @@ public:
                                          mlir::cir::IntAttr::get(t, C));
   }
 
-  mlir::cir::ConstantOp getBool(bool state, mlir::Location loc) {
-    return create<mlir::cir::ConstantOp>(loc, getBoolTy(),
-                                         getCIRBoolAttr(state));
-  }
-  mlir::cir::ConstantOp getFalse(mlir::Location loc) {
-    return getBool(false, loc);
-  }
-  mlir::cir::ConstantOp getTrue(mlir::Location loc) {
-    return getBool(true, loc);
-  }
-
   /// Create constant nullptr for pointer-to-data-member type ty.
   mlir::cir::ConstantOp getNullDataMemberPtr(mlir::cir::DataMemberType ty,
                                              mlir::Location loc) {
     return create<mlir::cir::ConstantOp>(loc, ty, getNullDataMemberAttr(ty));
-  }
-
-  // Creates constant null value for integral type ty.
-  mlir::cir::ConstantOp getNullValue(mlir::Type ty, mlir::Location loc) {
-    return create<mlir::cir::ConstantOp>(loc, ty, getZeroInitAttr(ty));
   }
 
   mlir::cir::ConstantOp getZero(mlir::Location loc, mlir::Type ty) {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -523,6 +523,114 @@ LogicalResult CastOp::verify() {
       return emitOpError() << "requires two types differ in addrspace only";
     return success();
   }
+  case cir::CastKind::float_to_complex: {
+    if (!mlir::isa<mlir::cir::CIRFPTypeInterface>(srcType))
+      return emitOpError() << "requires !cir.float type for source";
+    auto resComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(resType);
+    if (!resComplexTy)
+      return emitOpError() << "requires !cir.complex type for result";
+    if (srcType != resComplexTy.getElementTy())
+      return emitOpError() << "requires source type match result element type";
+    return success();
+  }
+  case cir::CastKind::int_to_complex: {
+    if (!mlir::isa<mlir::cir::IntType>(srcType))
+      return emitOpError() << "requires !cir.int type for source";
+    auto resComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(resType);
+    if (!resComplexTy)
+      return emitOpError() << "requires !cir.complex type for result";
+    if (srcType != resComplexTy.getElementTy())
+      return emitOpError() << "requires source type match result element type";
+    return success();
+  }
+  case cir::CastKind::float_complex_to_real: {
+    auto srcComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(srcType);
+    if (!srcComplexTy)
+      return emitOpError() << "requires !cir.complex type for source";
+    if (!mlir::isa<mlir::cir::CIRFPTypeInterface>(resType))
+      return emitOpError() << "requires !cir.float type for result";
+    if (srcComplexTy.getElementTy() != resType)
+      return emitOpError() << "requires source element type match result type";
+    return success();
+  }
+  case cir::CastKind::int_complex_to_real: {
+    auto srcComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(srcType);
+    if (!srcComplexTy)
+      return emitOpError() << "requires !cir.complex type for source";
+    if (!mlir::isa<mlir::cir::IntType>(resType))
+      return emitOpError() << "requires !cir.int type for result";
+    if (srcComplexTy.getElementTy() != resType)
+      return emitOpError() << "requires source element type match result type";
+    return success();
+  }
+  case cir::CastKind::float_complex_to_bool: {
+    auto srcComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(srcType);
+    if (!srcComplexTy ||
+        !mlir::isa<mlir::cir::CIRFPTypeInterface>(srcComplexTy.getElementTy()))
+      return emitOpError()
+             << "requires !cir.complex<!cir.float> type for source";
+    if (!mlir::isa<mlir::cir::BoolType>(resType))
+      return emitOpError() << "requires !cir.bool type for result";
+    return success();
+  }
+  case cir::CastKind::int_complex_to_bool: {
+    auto srcComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(srcType);
+    if (!srcComplexTy ||
+        !mlir::isa<mlir::cir::IntType>(srcComplexTy.getElementTy()))
+      return emitOpError()
+             << "requires !cir.complex<!cir.float> type for source";
+    if (!mlir::isa<mlir::cir::BoolType>(resType))
+      return emitOpError() << "requires !cir.bool type for result";
+    return success();
+  }
+  case cir::CastKind::float_complex: {
+    auto srcComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(srcType);
+    if (!srcComplexTy ||
+        !mlir::isa<mlir::cir::CIRFPTypeInterface>(srcComplexTy.getElementTy()))
+      return emitOpError()
+             << "requires !cir.complex<!cir.float> type for source";
+    auto resComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(resType);
+    if (!resComplexTy ||
+        !mlir::isa<mlir::cir::CIRFPTypeInterface>(resComplexTy.getElementTy()))
+      return emitOpError()
+             << "requires !cir.complex<!cir.float> type for result";
+    return success();
+  }
+  case cir::CastKind::float_complex_to_int_complex: {
+    auto srcComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(srcType);
+    if (!srcComplexTy ||
+        !mlir::isa<mlir::cir::CIRFPTypeInterface>(srcComplexTy.getElementTy()))
+      return emitOpError()
+             << "requires !cir.complex<!cir.float> type for source";
+    auto resComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(resType);
+    if (!resComplexTy ||
+        !mlir::isa<mlir::cir::IntType>(resComplexTy.getElementTy()))
+      return emitOpError() << "requires !cir.complex<!cir.int> type for result";
+    return success();
+  }
+  case cir::CastKind::int_complex: {
+    auto srcComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(srcType);
+    if (!srcComplexTy ||
+        !mlir::isa<mlir::cir::IntType>(srcComplexTy.getElementTy()))
+      return emitOpError() << "requires !cir.complex<!cir.int> type for source";
+    auto resComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(resType);
+    if (!resComplexTy ||
+        !mlir::isa<mlir::cir::IntType>(resComplexTy.getElementTy()))
+      return emitOpError() << "requires !cir.complex<!cir.int> type for result";
+    return success();
+  }
+  case cir::CastKind::int_complex_to_float_complex: {
+    auto srcComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(srcType);
+    if (!srcComplexTy ||
+        !mlir::isa<mlir::cir::IntType>(srcComplexTy.getElementTy()))
+      return emitOpError() << "requires !cir.complex<!cir.int> type for source";
+    auto resComplexTy = mlir::dyn_cast<mlir::cir::ComplexType>(resType);
+    if (!resComplexTy ||
+        !mlir::isa<mlir::cir::CIRFPTypeInterface>(resComplexTy.getElementTy()))
+      return emitOpError()
+             << "requires !cir.complex<!cir.float> type for result";
+    return success();
+  }
   }
 
   llvm_unreachable("Unknown CastOp kind?");
@@ -577,7 +685,9 @@ OpFoldResult CastOp::fold(FoldAdaptor adaptor) {
       return {};
     }
     case mlir::cir::CastKind::bitcast:
-    case mlir::cir::CastKind::address_space: {
+    case mlir::cir::CastKind::address_space:
+    case mlir::cir::CastKind::float_complex:
+    case mlir::cir::CastKind::int_complex: {
       return getSrc();
     }
     default:

--- a/clang/test/CIR/CodeGen/complex-cast.c
+++ b/clang/test/CIR/CodeGen/complex-cast.c
@@ -1,0 +1,205 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare -o %t.cir %s 2>&1 | FileCheck --check-prefixes=CIR-BEFORE,CHECK %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare -o %t.cir %s 2>&1 | FileCheck --check-prefixes=CIR-AFTER,CHECK %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --input-file=%t.ll --check-prefixes=LLVM,CHECK %s
+
+#include <stdbool.h>
+
+volatile double _Complex cd;
+volatile float _Complex cf;
+volatile int _Complex ci;
+volatile short _Complex cs;
+volatile double sd;
+volatile int si;
+volatile bool b;
+
+void scalar_to_complex() {
+  cd = sd;
+  ci = si;
+  cd = si;
+  ci = sd;
+}
+
+// CHECK-LABEL: @scalar_to_complex()
+
+// CIR-BEFORE: %{{.+}} = cir.cast(float_to_complex, %{{.+}} : !cir.double), !cir.complex<!cir.double>
+
+//      CIR-AFTER: %[[#REAL:]] = cir.load volatile %{{.+}} : !cir.ptr<!cir.double>, !cir.double
+// CIR-AFTER-NEXT: %[[#IMAG:]] = cir.const #cir.fp<0.000000e+00> : !cir.double
+// CIR-AFTER-NEXT: %{{.+}} = cir.complex.create %[[#REAL]], %[[#IMAG]] : !cir.double -> !cir.complex<!cir.double>
+
+// CIR-BEFORE: %{{.+}} = cir.cast(int_to_complex, %{{.+}} : !s32i), !cir.complex<!s32i>
+
+//      CIR-AFTER: %[[#REAL:]] = cir.load volatile %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-AFTER-NEXT: %[[#IMAG:]] = cir.const #cir.int<0> : !s32i
+// CIR-AFTER-NEXT: %{{.+}} = cir.complex.create %[[#REAL]], %[[#IMAG]] : !s32i -> !cir.complex<!s32i>
+
+//      CIR-BEFORE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.double
+// CIR-BEFORE-NEXT: %{{.+}} = cir.cast(float_to_complex, %[[#A]] : !cir.double), !cir.complex<!cir.double>
+
+//      CIR-AFTER: %[[#A:]] = cir.load volatile %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CIR-AFTER-NEXT: %[[#REAL:]] = cir.cast(int_to_float, %[[#A]] : !s32i), !cir.double
+// CIR-AFTER-NEXT: %[[#IMAG:]] = cir.const #cir.fp<0.000000e+00> : !cir.double
+// CIR-AFTER-NEXT: %{{.+}} = cir.complex.create %[[#REAL]], %[[#IMAG]] : !cir.double -> !cir.complex<!cir.double>
+
+//      CIR-BEFORE: %[[#A:]] = cir.cast(float_to_int, %{{.+}} : !cir.double), !s32i
+// CIR-BEFORE-NEXT: %{{.+}} = cir.cast(int_to_complex, %[[#A]] : !s32i), !cir.complex<!s32i>
+
+//      CIR-AFTER: %[[#A:]] = cir.load volatile %{{.+}} : !cir.ptr<!cir.double>, !cir.double
+// CIR-AFTER-NEXT: %[[#REAL:]] = cir.cast(float_to_int, %[[#A]] : !cir.double), !s32i
+// CIR-AFTER-NEXT: %[[#IMAG:]] = cir.const #cir.int<0> : !s32i
+// CIR-AFTER-NEXT: %{{.+}} = cir.complex.create %[[#REAL]], %[[#IMAG]] : !s32i -> !cir.complex<!s32i>
+
+//      LLVM: %[[#REAL:]] = load volatile double, ptr @sd, align 8
+// LLVM-NEXT: %[[#A:]] = insertvalue { double, double } undef, double %[[#REAL]], 0
+// LLVM-NEXT: %{{.+}} = insertvalue { double, double } %[[#A]], double 0.000000e+00, 1
+
+//      LLVM: %[[#REAL:]] = load volatile i32, ptr @si, align 4
+// LLVM-NEXT: %[[#A:]] = insertvalue { i32, i32 } undef, i32 %[[#REAL]], 0
+// LLVM-NEXT: %{{.+}} = insertvalue { i32, i32 } %[[#A]], i32 0, 1
+
+//      LLVM: %[[#A:]] = load volatile i32, ptr @si, align 4
+// LLVM-NEXT: %[[#REAL:]] = sitofp i32 %[[#A]] to double
+// LLVM-NEXT: %[[#B:]] = insertvalue { double, double } undef, double %[[#REAL]], 0
+// LLVM-NEXT: %{{.+}} = insertvalue { double, double } %[[#B]], double 0.000000e+00, 1
+
+//      LLVM: %[[#A:]] = load volatile double, ptr @sd, align 8
+// LLVM-NEXT: %[[#REAL:]] = fptosi double %[[#A]] to i32
+// LLVM-NEXT: %[[#B:]] = insertvalue { i32, i32 } undef, i32 %[[#REAL]], 0
+// LLVM-NEXT: %{{.+}} = insertvalue { i32, i32 } %[[#B]], i32 0, 1
+
+// CHECK: }
+
+void complex_to_scalar() {
+  sd = (double)cd;
+  si = (int)ci;
+  sd = (double)ci;
+  si = (int)cd;
+}
+
+// CHECK-LABEL: @complex_to_scalar()
+
+// CIR-BEFORE: %{{.+}} = cir.cast(float_complex_to_real, %{{.+}} : !cir.complex<!cir.double>), !cir.double
+
+// CIR-AFTER: %{{.+}} = cir.complex.real %{{.+}} : !cir.complex<!cir.double> -> !cir.double
+
+// LLVM: %{{.+}} = extractvalue { double, double } %{{.+}}, 0
+
+// CIR-BEFORE: %{{.+}} = cir.cast(int_complex_to_real, %{{.+}} : !cir.complex<!s32i>), !s32i
+
+// CIR-AFTER: %{{.+}} = cir.complex.real %{{.+}} : !cir.complex<!s32i> -> !s32i
+
+// LLVM: %{{.+}} = extractvalue { i32, i32 } %{{.+}}, 0
+
+//      CIR-BEFORE: %[[#A:]] = cir.cast(int_complex_to_real, %{{.+}} : !cir.complex<!s32i>), !s32i
+// CIR-BEFORE-NEXT: %{{.+}} = cir.cast(int_to_float, %[[#A]] : !s32i), !cir.double
+
+//      CIR-AFTER: %[[#A:]] = cir.complex.real %{{.+}} : !cir.complex<!s32i> -> !s32i
+// CIR-AFTER-NEXT: %{{.+}} = cir.cast(int_to_float, %[[#A]] : !s32i), !cir.double
+
+//      LLVM: %[[#A:]] = extractvalue { i32, i32 } %{{.+}}, 0
+// LLVM-NEXT: %{{.+}} = sitofp i32 %[[#A]] to double
+
+//      CIR-BEFORE: %[[#A:]] = cir.cast(float_complex_to_real, %{{.+}} : !cir.complex<!cir.double>), !cir.double
+// CIR-BEFORE-NEXT: %{{.+}} = cir.cast(float_to_int, %[[#A]] : !cir.double), !s32i
+
+//      CIR-AFTER: %[[#A:]] = cir.complex.real %{{.+}} : !cir.complex<!cir.double> -> !cir.double
+// CIR-AFTER-NEXT: %{{.+}} = cir.cast(float_to_int, %[[#A]] : !cir.double), !s32i
+
+//      LLVM: %[[#A:]] = extractvalue { double, double } %{{.+}}, 0
+// LLVM-NEXT: %{{.+}} = fptosi double %[[#A]] to i32
+
+// CHECK: }
+
+void complex_to_bool() {
+  b = (bool)cd;
+  b = (bool)ci;
+}
+
+// CHECK-LABEL: @complex_to_bool()
+
+// CIR-BEFORE: %{{.+}} = cir.cast(float_complex_to_bool, %{{.+}} : !cir.complex<!cir.double>), !cir.bool
+
+//      CIR-AFTER: %[[#REAL:]] = cir.complex.real %{{.+}} : !cir.complex<!cir.double> -> !cir.double
+// CIR-AFTER-NEXT: %[[#IMAG:]] = cir.complex.imag %{{.+}} : !cir.complex<!cir.double> -> !cir.double
+// CIR-AFTER-NEXT: %[[#RB:]] = cir.cast(float_to_bool, %[[#REAL]] : !cir.double), !cir.bool
+// CIR-AFTER-NEXT: %[[#IB:]] = cir.cast(float_to_bool, %[[#IMAG]] : !cir.double), !cir.bool
+// CIR-AFTER-NEXT: %{{.+}} = cir.ternary(%[[#RB]], true {
+// CIR-AFTER-NEXT:   %[[#A:]] = cir.const #true
+// CIR-AFTER-NEXT:   cir.yield %[[#A]] : !cir.bool
+// CIR-AFTER-NEXT: }, false {
+// CIR-AFTER-NEXT:   %[[#B:]] = cir.ternary(%[[#IB]], true {
+// CIR-AFTER-NEXT:     %[[#C:]] = cir.const #true
+// CIR-AFTER-NEXT:     cir.yield %[[#C]] : !cir.bool
+// CIR-AFTER-NEXT:   }, false {
+// CIR-AFTER-NEXT:     %[[#D:]] = cir.const #false
+// CIR-AFTER-NEXT:     cir.yield %[[#D]] : !cir.bool
+// CIR-AFTER-NEXT:   }) : (!cir.bool) -> !cir.bool
+// CIR-AFTER-NEXT:   cir.yield %[[#B]] : !cir.bool
+// CIR-AFTER-NEXT: }) : (!cir.bool) -> !cir.bool
+
+//      LLVM:   %[[#REAL:]] = extractvalue { double, double } %{{.+}}, 0
+// LLVM-NEXT:   %[[#IMAG:]] = extractvalue { double, double } %{{.+}}, 1
+// LLVM-NEXT:   %[[#RB:]] = fcmp une double %[[#REAL]], 0.000000e+00
+// LLVM-NEXT:   %[[#IB:]] = fcmp une double %[[#IMAG]], 0.000000e+00
+// LLVM-NEXT:   br i1 %[[#RB]], label %[[#LABEL_RB:]], label %[[#LABEL_RB_NOT:]]
+//      LLVM: [[#LABEL_RB]]:
+// LLVM-NEXT:   br label %[[#LABEL_EXIT:]]
+//      LLVM: [[#LABEL_RB_NOT]]:
+// LLVM-NEXT:   br i1 %[[#IB]], label %[[#LABEL_IB:]], label %[[#LABEL_IB_NOT:]]
+//      LLVM: [[#LABEL_IB]]:
+// LLVM-NEXT:   br label %[[#LABEL_A:]]
+//      LLVM: [[#LABEL_IB_NOT]]:
+// LLVM-NEXT:   br label %[[#LABEL_A]]
+//      LLVM: [[#LABEL_A]]:
+// LLVM-NEXT:   %[[#A:]] = phi i8 [ 0, %[[#LABEL_IB_NOT]] ], [ 1, %[[#LABEL_IB]] ]
+// LLVM-NEXT:   br label %[[#LABEL_B:]]
+//      LLVM: [[#LABEL_B]]:
+// LLVM-NEXT:   br label %[[#LABEL_EXIT]]
+//      LLVM: [[#LABEL_EXIT]]:
+// LLVM-NEXT:   %{{.+}} = phi i8 [ %[[#A]], %[[#LABEL_B]] ], [ 1, %[[#LABEL_RB]] ]
+// LLVM-NEXT:   br label %{{.+}}
+
+// CIR-BEFORE: %{{.+}} = cir.cast(int_complex_to_bool, %{{.+}} : !cir.complex<!s32i>), !cir.bool
+
+//      CIR-AFTER: %[[#REAL:]] = cir.complex.real %{{.+}} : !cir.complex<!s32i> -> !s32i
+// CIR-AFTER-NEXT: %[[#IMAG:]] = cir.complex.imag %{{.+}} : !cir.complex<!s32i> -> !s32i
+// CIR-AFTER-NEXT: %[[#RB:]] = cir.cast(int_to_bool, %[[#REAL]] : !s32i), !cir.bool
+// CIR-AFTER-NEXT: %[[#IB:]] = cir.cast(int_to_bool, %[[#IMAG]] : !s32i), !cir.bool
+// CIR-AFTER-NEXT: %{{.+}} = cir.ternary(%[[#RB]], true {
+// CIR-AFTER-NEXT:   %[[#A:]] = cir.const #true
+// CIR-AFTER-NEXT:   cir.yield %[[#A]] : !cir.bool
+// CIR-AFTER-NEXT: }, false {
+// CIR-AFTER-NEXT:   %[[#B:]] = cir.ternary(%[[#IB]], true {
+// CIR-AFTER-NEXT:     %[[#C:]] = cir.const #true
+// CIR-AFTER-NEXT:     cir.yield %[[#C]] : !cir.bool
+// CIR-AFTER-NEXT:   }, false {
+// CIR-AFTER-NEXT:     %[[#D:]] = cir.const #false
+// CIR-AFTER-NEXT:     cir.yield %[[#D]] : !cir.bool
+// CIR-AFTER-NEXT:   }) : (!cir.bool) -> !cir.bool
+// CIR-AFTER-NEXT:   cir.yield %[[#B]] : !cir.bool
+// CIR-AFTER-NEXT: }) : (!cir.bool) -> !cir.bool
+
+//      LLVM:   %[[#REAL:]] = extractvalue { i32, i32 } %{{.+}}, 0
+// LLVM-NEXT:   %[[#IMAG:]] = extractvalue { i32, i32 } %{{.+}}, 1
+// LLVM-NEXT:   %[[#RB:]] = icmp ne i32 %[[#REAL]], 0
+// LLVM-NEXT:   %[[#IB:]] = icmp ne i32 %[[#IMAG]], 0
+// LLVM-NEXT:   br i1 %[[#RB]], label %[[#LABEL_RB:]], label %[[#LABEL_RB_NOT:]]
+//      LLVM: [[#LABEL_RB]]:
+// LLVM-NEXT:   br label %[[#LABEL_EXIT:]]
+//      LLVM: [[#LABEL_RB_NOT]]:
+// LLVM-NEXT:   br i1 %[[#IB]], label %[[#LABEL_IB:]], label %[[#LABEL_IB_NOT:]]
+//      LLVM: [[#LABEL_IB]]:
+// LLVM-NEXT:   br label %[[#LABEL_A:]]
+//      LLVM: [[#LABEL_IB_NOT]]:
+// LLVM-NEXT:   br label %[[#LABEL_A]]
+//      LLVM: [[#LABEL_A]]:
+// LLVM-NEXT:   %[[#A:]] = phi i8 [ 0, %[[#LABEL_IB_NOT]] ], [ 1, %[[#LABEL_IB]] ]
+// LLVM-NEXT:   br label %[[#LABEL_B:]]
+//      LLVM: [[#LABEL_B]]:
+// LLVM-NEXT:   br label %[[#LABEL_EXIT]]
+//      LLVM: [[#LABEL_EXIT]]:
+// LLVM-NEXT:   %{{.+}} = phi i8 [ %[[#A]], %[[#LABEL_B]] ], [ 1, %[[#LABEL_RB]] ]
+// LLVM-NEXT:   br label %{{.+}}
+
+// CHECK: }


### PR DESCRIPTION
This PR adds support for complex cast operations. It adds the following new cast kind variants to the `cir.cast` operation:

  - `float_to_complex`,
  - `int_to_complex`,
  - `float_complex_to_real`,
  - `int_complex_to_real`,
  - `float_complex_to_bool`,
  - `int_complex_to_bool`,
  - `float_complex`,
  - `float_complex_to_int_complex`,
  - `int_complex`, and
  - `int_complex_to_float_complex`.

CIRGen and LLVM IR support for these new cast variants are also included.