### PR TITLE
[CIR][TargetLowering][NFC] Refactor LowerModule to a unified global state

### DIFF
--- a/clang/include/clang/CIR/Dialect/Transforms/TargetLowering/LowerModuleRegistry.h
+++ b/clang/include/clang/CIR/Dialect/Transforms/TargetLowering/LowerModuleRegistry.h
@@ -1,0 +1,53 @@
+//===- LowerModuleRegistry.h - LowerModule singleton registry ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines the registry of LowerModule so that it can be easily
+// accessed from other libraries.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_LOWERMODULEREGISTRY_H
+#define CLANG_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_LOWERMODULEREGISTRY_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace cir {
+
+class LowerModule;
+
+/// Registry for the LowerModule, enabling easy access to the LowerModule from
+/// various libraries.
+class LowerModuleRegistry {
+  std::unique_ptr<LowerModule> lowerModule;
+  std::optional<PatternRewriter> rewriter;
+
+public:
+  /// Initialize the LowerModuleRegistry with the given module and an internal
+  /// rewriter.
+  void initializeWithModule(ModuleOp module);
+
+  /// Check if the LowerModuleRegistry has been initialized.
+  bool isInitialized() { return lowerModule != nullptr; }
+
+  /// Get the reference to already-initialized LowerModule.
+  LowerModule &get() {
+    assert(isInitialized() && "LowerModuleRegistry not initialized");
+    return *lowerModule;
+  }
+
+  /// Get the LowerModuleRegistry singleton.
+  static LowerModuleRegistry &instance();
+};
+
+} // namespace cir
+} // namespace mlir
+
+#endif // CLANG_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_LOWERMODULEREGISTRY_H

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -8,6 +8,7 @@ add_clang_library(TargetLowering
   LowerCall.cpp
   LowerFunction.cpp
   LowerModule.cpp
+  LowerModuleRegistry.cpp
   LowerTypes.cpp
   RecordLayoutBuilder.cpp
   TargetInfo.cpp

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -11,9 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME(cir): This header file is not exposed to the public API, but can be
-// reused by CIR ABI lowering since it holds target-specific information.
-#include "../../../../Basic/Targets.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/TargetOptions.h"
 
@@ -219,30 +216,6 @@ LogicalResult LowerModule::rewriteFunctionCall(CallOp callOp, FuncOp funcOp) {
     return failure();
 
   return success();
-}
-
-// TODO: not to create it every time
-std::unique_ptr<LowerModule> createLowerModule(ModuleOp module,
-                                               PatternRewriter &rewriter) {
-  // Fetch the LLVM data layout string.
-  auto dataLayoutStr = cast<StringAttr>(
-      module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName()));
-
-  // Fetch target information.
-  llvm::Triple triple(
-      cast<StringAttr>(module->getAttr("cir.triple")).getValue());
-  clang::TargetOptions targetOptions;
-  targetOptions.Triple = triple.str();
-  auto targetInfo = clang::targets::AllocateTarget(triple, targetOptions);
-
-  // FIXME(cir): This just uses the default language options. We need to account
-  // for custom options.
-  // Create context.
-  assert(!::cir::MissingFeatures::langOpts());
-  clang::LangOptions langOpts;
-
-  return std::make_unique<LowerModule>(langOpts, module, dataLayoutStr,
-                                       std::move(targetInfo), rewriter);
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -94,9 +94,6 @@ public:
   LogicalResult rewriteFunctionCall(CallOp callOp, FuncOp funcOp);
 };
 
-std::unique_ptr<LowerModule> createLowerModule(ModuleOp module,
-                                               PatternRewriter &rewriter);
-
 } // namespace cir
 } // namespace mlir
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModuleRegistry.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModuleRegistry.cpp
@@ -1,0 +1,55 @@
+//===- LowerModuleRegistry.cpp - LowerModule singleton registry -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the registry of LowerModule so that it can be easily
+// accessed from other libraries.
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME(cir): This header file is not exposed to the public API, but can be
+// reused by CIR ABI lowering since it holds target-specific information.
+#include "clang/CIR/Dialect/Transforms/TargetLowering/LowerModuleRegistry.h"
+#include "../../../../Basic/Targets.h"
+#include "LowerModule.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+namespace mlir {
+namespace cir {
+
+void LowerModuleRegistry::initializeWithModule(ModuleOp module) {
+  assert(!isInitialized() && "LowerModuleRegistry already initialized");
+  // Create a new rewriter.
+  rewriter.emplace(module->getContext());
+  // Fetch the LLVM data layout string.
+  auto dataLayoutStr = cast<StringAttr>(
+      module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName()));
+
+  // Fetch target information.
+  llvm::Triple triple(
+      cast<StringAttr>(module->getAttr("cir.triple")).getValue());
+  clang::TargetOptions targetOptions;
+  targetOptions.Triple = triple.str();
+  auto targetInfo = clang::targets::AllocateTarget(triple, targetOptions);
+
+  // FIXME(cir): This just uses the default language options. We need to account
+  // for custom options.
+  // Create context.
+  assert(!::cir::MissingFeatures::langOpts());
+  clang::LangOptions langOpts;
+
+  lowerModule = std::make_unique<LowerModule>(langOpts, module, dataLayoutStr,
+                                              std::move(targetInfo), *rewriter);
+}
+
+LowerModuleRegistry &LowerModuleRegistry::instance() {
+  static LowerModuleRegistry lowerModuleRegistry;
+  return lowerModuleRegistry;
+}
+
+} // namespace cir
+} // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModuleRegistry.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModuleRegistry.cpp
@@ -47,8 +47,8 @@ void LowerModuleRegistry::initializeWithModule(ModuleOp module) {
 }
 
 LowerModuleRegistry &LowerModuleRegistry::instance() {
-  static LowerModuleRegistry lowerModuleRegistry;
-  return lowerModuleRegistry;
+  static llvm::ManagedStatic<LowerModuleRegistry> lowerModuleRegistry;
+  return *lowerModuleRegistry;
 }
 
 } // namespace cir

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -25,6 +25,7 @@
 #include "clang/CIR/CIRGenerator.h"
 #include "clang/CIR/CIRToCIRPasses.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Transforms/TargetLowering/LowerModuleRegistry.h"
 #include "clang/CIR/LowerToLLVM.h"
 #include "clang/CIR/Passes.h"
 #include "clang/CodeGen/BackendUtil.h"
@@ -166,6 +167,7 @@ public:
 
     auto mlirMod = gen->getModule();
     auto mlirCtx = gen->takeContext();
+    mlir::cir::LowerModuleRegistry::instance().initializeWithModule(mlirMod);
 
     auto setupCIRPipelineAndExecute = [&] {
       // Sanitize passes options. MLIR uses spaces between pass options


### PR DESCRIPTION
We expect the `LowerModule` to be available most of the time once `CIRGen` is complete, providing various support for lowering passes, especially target-specific information. To maintain a consistent state along the call tree and across all libraries, we should add a non-intrusive singleton class.

This PR creates the singleton class `LowerModuleRegistry` to enable easy access to a lazily initialized `LowerModule` instance. Its header is public for all CIR libraries, but it does not rely on other internal headers in the TargetLowering library.

Before this PR, the initialization process was as follows:

- In `CallConvLoweringPass`, a new `LowerModule` is created for each function.
- In `LowerToLLVMPass`, a new `LowerModule` is created exactly once.

With this PR, each user initializes `LowerModule` if it is not yet initialized. Thus, there are three possible initialization points:

- `CIRGenConsumer::HandleTranslationUnit`, if called from the Clang driver.
- `CallConvLoweringPass::runOnOperation`, if `CallConvLoweringPass` is enabled by `cir-opt`.
- `LowerToLLVMPass`, for `cir-opt` and `cir-translate`.

i.e. in any case, `LowerModule` is created on demand only once. If we uses `cir-opt` without CallConvLowering pass, the registry will keep uninitialized till the end.
