### PR TITLE
[CIR][Dialect][Lowering] Add calling convention attribute to FuncOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2797,8 +2797,8 @@ def BaseClassAddrOp : CIR_Op<"base_class_addr"> {
 // The enumeration values are not necessarily in sync with `clang::CallingConv`
 // or `llvm::CallingConv`.
 def CC_C : I32EnumAttrCase<"C", 1, "c">;
-def CC_SpirKernel : I32EnumAttrCase<"SpirKernel", 75, "spir_kernel">;
-def CC_SpirFunction : I32EnumAttrCase<"SpirFunction", 76, "spir_function">;
+def CC_SpirKernel : I32EnumAttrCase<"SpirKernel", 2, "spir_kernel">;
+def CC_SpirFunction : I32EnumAttrCase<"SpirFunction", 3, "spir_function">;
 
 def CallingConv : I32EnumAttr<
     "CallingConv",

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2796,9 +2796,9 @@ def BaseClassAddrOp : CIR_Op<"base_class_addr"> {
 
 // The enumeration values are not necessarily in sync with `clang::CallingConv`
 // or `llvm::CallingConv`.
-def CC_C : I32EnumAttrCase<"C", 1, "cc_c">;
-def CC_SpirKernel : I32EnumAttrCase<"SpirKernel", 75, "cc_spir_kernel">;
-def CC_SpirFunction : I32EnumAttrCase<"SpirFunction", 76, "cc_spir_function">;
+def CC_C : I32EnumAttrCase<"C", 1, "c">;
+def CC_SpirKernel : I32EnumAttrCase<"SpirKernel", 75, "spir_kernel">;
+def CC_SpirFunction : I32EnumAttrCase<"SpirFunction", 76, "spir_function">;
 
 def CallingConv : I32EnumAttr<
     "CallingConv",
@@ -2872,6 +2872,9 @@ def FuncOp : CIR_Op<"func", [
 
     // Linkage information
     cir.func linkonce_odr @some_method(...)
+
+    // Calling convention information
+    cir.func @another_func(...) cc(spir_kernel) extra(#fn_attr)
 
     // Builtin function
     cir.func builtin @__builtin_coro_end(!cir.ptr<i8>, !cir.bool) -> !cir.bool

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2794,6 +2794,19 @@ def BaseClassAddrOp : CIR_Op<"base_class_addr"> {
 // FuncOp
 //===----------------------------------------------------------------------===//
 
+// The enumeration values are not necessarily in sync with `clang::CallingConv`
+// or `llvm::CallingConv`.
+def CC_C : I32EnumAttrCase<"C", 1, "cc_c">;
+def CC_SpirKernel : I32EnumAttrCase<"SpirKernel", 75, "cc_spir_kernel">;
+def CC_SpirFunction : I32EnumAttrCase<"SpirFunction", 76, "cc_spir_function">;
+
+def CallingConv : I32EnumAttr<
+    "CallingConv",
+    "calling convention",
+    [CC_C, CC_SpirKernel, CC_SpirFunction]> {
+  let cppNamespace = "::mlir::cir";
+}
+
 def FuncOp : CIR_Op<"func", [
   AutomaticAllocationScope, CallableOpInterface, FunctionOpInterface,
   DeclareOpInterfaceMethods<CIRGlobalValueInterface>,
@@ -2818,6 +2831,9 @@ def FuncOp : CIR_Op<"func", [
 
     The function linkage information is specified by `linkage`, as defined by
     `GlobalLinkageKind` attribute.
+
+    The `calling_conv` attribute specifies the calling convention of the function.
+    The default calling convention is `CallingConv::C`.
 
     A compiler builtin function must be marked as `builtin` for further
     processing when lowering from CIR.
@@ -2878,6 +2894,8 @@ def FuncOp : CIR_Op<"func", [
                        UnitAttr:$dsolocal,
                        DefaultValuedAttr<GlobalLinkageKind,
                                          "GlobalLinkageKind::ExternalLinkage">:$linkage,
+                       DefaultValuedAttr<CallingConv,
+                                         "CallingConv::C">:$calling_conv,
                        ExtraFuncAttr:$extra_attrs,
                        OptionalAttr<StrAttr>:$sym_visibility,
                        UnitAttr:$comdat,
@@ -2893,6 +2911,7 @@ def FuncOp : CIR_Op<"func", [
   let builders = [OpBuilder<(ins
     "StringRef":$name, "FuncType":$type,
     CArg<"GlobalLinkageKind", "GlobalLinkageKind::ExternalLinkage">:$linkage,
+    CArg<"CallingConv", "CallingConv::C">:$callingConv,
     CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
     CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)
   >];

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -463,6 +463,22 @@ mlir::LLVM::Linkage convertLinkage(mlir::cir::GlobalLinkageKind linkage) {
   };
 }
 
+mlir::LLVM::CConv convertCallingConv(mlir::cir::CallingConv callinvConv) {
+  using CIR = mlir::cir::CallingConv;
+  using LLVM = mlir::LLVM::CConv;
+
+  switch (callinvConv) {
+  case CIR::C:
+    return LLVM::C;
+  case CIR::SpirKernel:
+    return LLVM::SPIR_KERNEL;
+  case CIR::SpirFunction:
+    return LLVM::SPIR_FUNC;
+  default:
+    llvm_unreachable("Unknown calling convention");
+  }
+}
+
 class CIRCopyOpLowering : public mlir::OpConversionPattern<mlir::cir::CopyOp> {
 public:
   using mlir::OpConversionPattern<mlir::cir::CopyOp>::OpConversionPattern;
@@ -1409,6 +1425,7 @@ public:
       if (attr.getName() == mlir::SymbolTable::getSymbolAttrName() ||
           attr.getName() == func.getFunctionTypeAttrName() ||
           attr.getName() == getLinkageAttrNameString() ||
+          attr.getName() == func.getCallingConvAttrName() ||
           (filterArgAndResAttrs &&
            (attr.getName() == func.getArgAttrsAttrName() ||
             attr.getName() == func.getResAttrsAttrName())))
@@ -1494,11 +1511,12 @@ public:
            "expected single location or unknown location here");
 
     auto linkage = convertLinkage(op.getLinkage());
+    auto cconv = convertCallingConv(op.getCallingConv());
     SmallVector<mlir::NamedAttribute, 4> attributes;
     lowerFuncAttributes(op, /*filterArgAndResAttrs=*/false, attributes);
 
     auto fn = rewriter.create<mlir::LLVM::LLVMFuncOp>(
-        Loc, op.getName(), llvmFnTy, linkage, isDsoLocal, mlir::LLVM::CConv::C,
+        Loc, op.getName(), llvmFnTy, linkage, isDsoLocal, cconv,
         mlir::SymbolRefAttr(), attributes);
 
     rewriter.inlineRegionBefore(op.getBody(), fn.getBody(), fn.end());

--- a/clang/test/CIR/IR/func-call-conv.cir
+++ b/clang/test/CIR/IR/func-call-conv.cir
@@ -6,7 +6,7 @@
 #fn_attr = #cir<extra({inline = #cir.inline<no>})>
 
 module {
-    // CHECK: cir.func @foo()
+    // CHECK: cir.func @foo() {
     cir.func @foo() cc(c) {
         cir.return
     }

--- a/clang/test/CIR/IR/func-call-conv.cir
+++ b/clang/test/CIR/IR/func-call-conv.cir
@@ -2,19 +2,25 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 !s32i = !cir.int<s, 32>
+
+#fn_attr = #cir<extra({inline = #cir.inline<no>})>
+
 module {
     // CHECK: cir.func @foo()
-    cir.func cc_c @foo() {
+    cir.func @foo() cc(c) {
         cir.return
     }
 
-    // CHECK: cir.func cc_spir_kernel @bar()
-    cir.func cc_spir_kernel @bar() {
+    // CHECK: cir.func @bar() cc(spir_kernel)
+    cir.func @bar() cc(spir_kernel) {
         cir.return
     }
 
-    // CHECK: cir.func cc_spir_function @baz()
-    cir.func cc_spir_function @baz() {
+    // CHECK: cir.func @bar_alias() alias(@bar) cc(spir_kernel)
+    cir.func @bar_alias() alias(@bar) cc(spir_kernel)
+
+    // CHECK: cir.func @baz() cc(spir_function) extra(#fn_attr)
+    cir.func @baz() cc(spir_function) extra(#fn_attr) {
         cir.return
     }
 }

--- a/clang/test/CIR/IR/func-call-conv.cir
+++ b/clang/test/CIR/IR/func-call-conv.cir
@@ -1,0 +1,21 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+!s32i = !cir.int<s, 32>
+module {
+    // CHECK: cir.func @foo()
+    cir.func cc_c @foo() {
+        cir.return
+    }
+
+    // CHECK: cir.func cc_spir_kernel @bar()
+    cir.func cc_spir_kernel @bar() {
+        cir.return
+    }
+
+    // CHECK: cir.func cc_spir_function @baz()
+    cir.func cc_spir_function @baz() {
+        cir.return
+    }
+}
+

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1216,3 +1216,12 @@ cir.func @address_space4(%p : !cir.ptr<!u64i, addrspace(foobar)>) { // expected-
   vec_type_hint = !s32i,
   vec_type_hint_signedness = 0
 >
+
+// -----
+
+module {
+    // expected-error@+1 {{unknown calling convention}}
+    cir.func @foo() cc(foobar) {
+        cir.return
+    }
+}

--- a/clang/test/CIR/Lowering/func-call-conv.cir
+++ b/clang/test/CIR/Lowering/func-call-conv.cir
@@ -4,18 +4,17 @@
 !s32i = !cir.int<s, 32>
 module {
     // LLVM: define void @foo()
-    cir.func cc_c @foo() {
+    cir.func @foo() cc(c) {
         cir.return
     }
 
     // LLVM: define spir_kernel void @bar()
-    cir.func cc_spir_kernel @bar() {
+    cir.func @bar() cc(spir_kernel) {
         cir.return
     }
 
     // LLVM: define spir_func void @baz()
-    cir.func cc_spir_function @baz() {
+    cir.func @baz() cc(spir_function) {
         cir.return
     }
 }
-

--- a/clang/test/CIR/Lowering/func-call-conv.cir
+++ b/clang/test/CIR/Lowering/func-call-conv.cir
@@ -1,0 +1,21 @@
+// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
+
+!s32i = !cir.int<s, 32>
+module {
+    // LLVM: define void @foo()
+    cir.func cc_c @foo() {
+        cir.return
+    }
+
+    // LLVM: define spir_kernel void @bar()
+    cir.func cc_spir_kernel @bar() {
+        cir.return
+    }
+
+    // LLVM: define spir_func void @baz()
+    cir.func cc_spir_function @baz() {
+        cir.return
+    }
+}
+


### PR DESCRIPTION
This PR simply adds the calling convention attribute to FuncOp with LLVM Lowering support.

The overall approach follows `GlobalLinkageKind`: Extend the ODS, parser, printer and lowering pass. When the call conv is C call conv, it's omitted in the output assembly.
