### PR TITLE
[CIR][LowerToLLVM][NFC] Refactor `amendOperation` to dispatch different ops

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -40,10 +40,7 @@ public:
       mlir::NamedAttribute attribute,
       mlir::LLVM::ModuleTranslation &moduleTranslation) const override {
     if (auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op)) {
-      auto result = amendOperationOnFunction(func, instructions, attribute,
-                                             moduleTranslation);
-      if (failed(result))
-        return result;
+      amendFunction(func, instructions, attribute, moduleTranslation);
     }
     return mlir::success();
   }
@@ -64,11 +61,10 @@ public:
 
 private:
   // Translate CIR's extra function attributes to LLVM's function attributes.
-  mlir::LogicalResult amendOperationOnFunction(
-      mlir::LLVM::LLVMFuncOp func,
-      llvm::ArrayRef<llvm::Instruction *> instructions,
-      mlir::NamedAttribute attribute,
-      mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+  void amendFunction(mlir::LLVM::LLVMFuncOp func,
+                     llvm::ArrayRef<llvm::Instruction *> instructions,
+                     mlir::NamedAttribute attribute,
+                     mlir::LLVM::ModuleTranslation &moduleTranslation) const {
     llvm::Function *llvmFunc = moduleTranslation.lookupFunction(func.getName());
     if (auto extraAttr = mlir::dyn_cast<mlir::cir::ExtraFuncAttributesAttr>(
             attribute.getValue())) {
@@ -98,7 +94,6 @@ private:
 
     // Drop ammended CIR attribute from LLVM op.
     func->removeAttr(attribute.getName());
-    return mlir::success();
   }
 
   void emitOpenCLKernelMetadata(

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -39,10 +39,36 @@ public:
       mlir::Operation *op, llvm::ArrayRef<llvm::Instruction *> instructions,
       mlir::NamedAttribute attribute,
       mlir::LLVM::ModuleTranslation &moduleTranslation) const override {
-    // Translate CIR's extra function attributes to LLVM's function attributes.
-    auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op);
-    if (!func)
-      return mlir::success();
+    if (auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op)) {
+      auto result = amendOperationOnFunction(func, instructions, attribute,
+                                             moduleTranslation);
+      if (failed(result))
+        return result;
+    }
+    return mlir::success();
+  }
+
+  /// Translates the given operation to LLVM IR using the provided IR builder
+  /// and saving the state in `moduleTranslation`.
+  mlir::LogicalResult convertOperation(
+      mlir::Operation *op, llvm::IRBuilderBase &builder,
+      mlir::LLVM::ModuleTranslation &moduleTranslation) const final {
+
+    if (auto cirOp = llvm::dyn_cast<mlir::LLVM::ZeroOp>(op))
+      moduleTranslation.mapValue(cirOp.getResult()) =
+          llvm::Constant::getNullValue(
+              moduleTranslation.convertType(cirOp.getType()));
+
+    return mlir::success();
+  }
+
+private:
+  // Translate CIR's extra function attributes to LLVM's function attributes.
+  mlir::LogicalResult amendOperationOnFunction(
+      mlir::LLVM::LLVMFuncOp func,
+      llvm::ArrayRef<llvm::Instruction *> instructions,
+      mlir::NamedAttribute attribute,
+      mlir::LLVM::ModuleTranslation &moduleTranslation) const {
     llvm::Function *llvmFunc = moduleTranslation.lookupFunction(func.getName());
     if (auto extraAttr = mlir::dyn_cast<mlir::cir::ExtraFuncAttributesAttr>(
             attribute.getValue())) {
@@ -71,25 +97,10 @@ public:
     }
 
     // Drop ammended CIR attribute from LLVM op.
-    op->removeAttr(attribute.getName());
+    func->removeAttr(attribute.getName());
     return mlir::success();
   }
 
-  /// Translates the given operation to LLVM IR using the provided IR builder
-  /// and saving the state in `moduleTranslation`.
-  mlir::LogicalResult convertOperation(
-      mlir::Operation *op, llvm::IRBuilderBase &builder,
-      mlir::LLVM::ModuleTranslation &moduleTranslation) const final {
-
-    if (auto cirOp = llvm::dyn_cast<mlir::LLVM::ZeroOp>(op))
-      moduleTranslation.mapValue(cirOp.getResult()) =
-          llvm::Constant::getNullValue(
-              moduleTranslation.convertType(cirOp.getType()));
-
-    return mlir::success();
-  }
-
-private:
   void emitOpenCLKernelMetadata(
       mlir::cir::OpenCLKernelMetadataAttr clKernelMetadata,
       llvm::Function *llvmFunc,


### PR DESCRIPTION
Soon I would like to submit a patch emitting OpenCL module metadata in LowerToLLVM path, which requires to attach the metadata to LLVM module when `amendOperaion` is called for MLIR module op. This PR refactors the method to a dispatcher to make the future changes cleaner.