### PR TITLE
[CIR][LowerToLLVM][NFC] Add data layout verification of alloca as

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1012,6 +1012,8 @@ public:
       auto dlAllocaASAttr = mlir::cast_if_present<mlir::IntegerAttr>(
           dataLayout.getAllocaMemorySpace());
       // Absence means 0
+      // TODO: The query for the alloca AS should be done through CIRDataLayout
+      // instead to reuse the logic of interpret null attr as 0.
       auto dlAllocaAS = dlAllocaASAttr ? dlAllocaASAttr.getInt() : 0;
       assert(dlAllocaAS == resPtrTy.getAddressSpace() &&
              "Alloca address space doesn't match the one from the data layout");

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1015,8 +1015,11 @@ public:
       // TODO: The query for the alloca AS should be done through CIRDataLayout
       // instead to reuse the logic of interpret null attr as 0.
       auto dlAllocaAS = dlAllocaASAttr ? dlAllocaASAttr.getInt() : 0;
-      assert(dlAllocaAS == resPtrTy.getAddressSpace() &&
-             "Alloca address space doesn't match the one from the data layout");
+      if (dlAllocaAS != resPtrTy.getAddressSpace()) {
+        return op.emitError() << "alloca address space doesn't match the one "
+                                 "from the target data layout: "
+                              << dlAllocaAS;
+      }
     }
     rewriter.replaceOpWithNewOp<mlir::LLVM::AllocaOp>(
         op, resultTy, elementTy, size, op.getAlignmentAttr().getInt());


### PR DESCRIPTION
There are two sources for the target allocation address space: one from `TargetCIRGenInfo::getCIRAllocaAddressSpace()` and another from `targetDataLayout.getAllocaMemorySpace()`. Since both are provided by the specific target, they should be consistent. This PR adds a check to ensure this consistency and avoid potential errors.

The ctor of `CIRAllocaLowering` pattern is updated to pass the data layout in.