### PR TITLE
[CIR][CodeGen][LowerToLLVM] Emit OpenCL version metadata for SPIR-V target

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -93,27 +93,6 @@ def OpenCLKernelMetadataAttr
 }
 
 //===----------------------------------------------------------------------===//
-// OpenCLVersionAttr
-//===----------------------------------------------------------------------===//
-
-def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
-  let summary = "OpenCL version";
-  let parameters = (ins "int32_t":$major, "int32_t":$minor);
-  let description = [{
-    Represents the version of OpenCL.
-
-    Example:
-    ```
-    // Module compiled from OpenCL 1.2.
-    module attributes {cir.cl.version = cir.cl.version<1,2>} {}
-    // Module compiled from OpenCL 3.0.
-    module attributes {cir.cl.version = cir.cl.version<3,0>} {}
-    ```
-  }];
-  let assemblyFormat = "`<` $major `,` $minor `>`";
-}
-
-//===----------------------------------------------------------------------===//
 // OpenCLKernelArgMetadataAttr
 //===----------------------------------------------------------------------===//
 
@@ -166,6 +145,27 @@ def OpenCLKernelArgMetadataAttr
   let assemblyFormat = "`<` struct(params) `>`";
 
   let genVerifyDecl = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// OpenCLVersionAttr
+//===----------------------------------------------------------------------===//
+
+def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
+  let summary = "OpenCL version";
+  let parameters = (ins "int32_t":$major, "int32_t":$minor);
+  let description = [{
+    Represents the version of OpenCL.
+
+    Example:
+    ```
+    // Module compiled from OpenCL 1.2.
+    module attributes {cir.cl.version = cir.cl.version<1, 2>} {}
+    // Module compiled from OpenCL 3.0.
+    module attributes {cir.cl.version = cir.cl.version<3, 0>} {}
+    ```
+  }];
+  let assemblyFormat = "`<` $major `,` $minor `>`";
 }
 
 #endif // MLIR_CIR_DIALECT_CIR_OPENCL_ATTRS

--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -160,11 +160,9 @@ def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
     Example:
     ```
     // Module compiled from OpenCL 1.2.
-    #cl_version_attr = #cir.cl.version<1, 2>
-    module attributes {cir.cl.version = #cl_version_attr} {}
+    module attributes {cir.cl.version = cir.cl.version<1, 2>} {}
     // Module compiled from OpenCL 3.0.
-    #cl_version_attr = #cir.cl.version<3, 0>
-    module attributes {cir.cl.version = #cl_version_attr} {}
+    module attributes {cir.cl.version = cir.cl.version<3, 0>} {}
     ```
   }];
   let assemblyFormat = "`<` $major `,` $minor `>`";

--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -160,9 +160,11 @@ def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
     Example:
     ```
     // Module compiled from OpenCL 1.2.
-    module attributes {cir.cl.version = cir.cl.version<1, 2>} {}
+    #cl_version_attr = #cir.cl.version<1, 2>
+    module attributes {cir.cl.version = #cl_version_attr} {}
     // Module compiled from OpenCL 3.0.
-    module attributes {cir.cl.version = cir.cl.version<3, 0>} {}
+    #cl_version_attr = #cir.cl.version<3, 0>
+    module attributes {cir.cl.version = #cl_version_attr} {}
     ```
   }];
   let assemblyFormat = "`<` $major `,` $minor `>`";

--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -93,6 +93,27 @@ def OpenCLKernelMetadataAttr
 }
 
 //===----------------------------------------------------------------------===//
+// OpenCLVersionAttr
+//===----------------------------------------------------------------------===//
+
+def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
+  let summary = "OpenCL version";
+  let parameters = (ins "int32_t":$major, "int32_t":$minor);
+  let description = [{
+    Represents the version of OpenCL.
+
+    Example:
+    ```
+    // Module compiled from OpenCL 1.2.
+    module attributes {cir.cl.version = cir.cl.version<1,2>} {}
+    // Module compiled from OpenCL 3.0.
+    module attributes {cir.cl.version = cir.cl.version<3,0>} {}
+    ```
+  }];
+  let assemblyFormat = "`<` $major `,` $minor `>`";
+}
+
+//===----------------------------------------------------------------------===//
 // OpenCLKernelArgMetadataAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3246,9 +3246,9 @@ void CIRGenModule::buildOpenCLMetadata() {
   // SPIR v2.0 s2.13 - The OpenCL version used by the module is stored in the
   // opencl.ocl.version named metadata node.
   // C++ for OpenCL has a distinct mapping for versions compatibile with OpenCL.
-  auto version = langOpts.getOpenCLCompatibleVersion();
-  auto major = version / 100;
-  auto minor = (version % 100) / 10;
+  unsigned version = langOpts.getOpenCLCompatibleVersion();
+  unsigned major = version / 100;
+  unsigned minor = (version % 100) / 10;
 
   auto clVersionAttr =
       mlir::cir::OpenCLVersionAttr::get(builder.getContext(), major, minor);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2767,6 +2767,16 @@ void CIRGenModule::Release() {
     // TODO: buildModuleLinkOptions
   }
 
+  // Emit OpenCL specific module metadata: OpenCL/SPIR version.
+  if (langOpts.CUDAIsDevice && getTriple().isSPIRV())
+    llvm_unreachable("CUDA SPIR-V NYI");
+  if (langOpts.OpenCL) {
+    buildOpenCLMetadata();
+    // Emit SPIR version.
+    if (getTriple().isSPIR())
+      llvm_unreachable("SPIR target NYI");
+  }
+
   // TODO: FINISH THE REST OF THIS
 }
 
@@ -3230,4 +3240,18 @@ void CIRGenModule::genKernelArgMetadata(mlir::cir::FuncOp Fn,
     if (shouldEmitArgName)
       llvm_unreachable("NYI HIPSaveKernelArgName");
   }
+}
+
+void CIRGenModule::buildOpenCLMetadata() {
+  // SPIR v2.0 s2.13 - The OpenCL version used by the module is stored in the
+  // opencl.ocl.version named metadata node.
+  // C++ for OpenCL has a distinct mapping for versions compatibile with OpenCL.
+  auto version = langOpts.getOpenCLCompatibleVersion();
+  auto major = version / 100;
+  auto minor = (version % 100) / 10;
+
+  auto clVersionAttr =
+      mlir::cir::OpenCLVersionAttr::get(builder.getContext(), major, minor);
+
+  theModule->setAttr("cir.cl.version", clVersionAttr);
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -702,6 +702,9 @@ public:
                             const FunctionDecl *FD = nullptr,
                             CIRGenFunction *CGF = nullptr);
 
+  /// Emits OpenCL specific Metadata e.g. OpenCL version.
+  void buildOpenCLMetadata();
+
 private:
   // An ordered map of canonical GlobalDecls to their mangled names.
   llvm::MapVector<clang::GlobalDecl, llvm::StringRef> MangledDeclNames;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -41,6 +41,8 @@ public:
       mlir::LLVM::ModuleTranslation &moduleTranslation) const override {
     if (auto func = dyn_cast<mlir::LLVM::LLVMFuncOp>(op)) {
       amendFunction(func, instructions, attribute, moduleTranslation);
+    } else if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
+      amendModule(mod, attribute, moduleTranslation);
     }
     return mlir::success();
   }
@@ -60,6 +62,30 @@ public:
   }
 
 private:
+  // Translate CIR's module attributes to LLVM's module metadata
+  void amendModule(
+      mlir::ModuleOp module, mlir::NamedAttribute attribute,
+      mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+    llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
+    llvm::LLVMContext &llvmContext = llvmModule->getContext();
+
+    if (auto openclVersionAttr = mlir::dyn_cast<mlir::cir::OpenCLVersionAttr>(
+            attribute.getValue())) {
+      auto *int32Ty = llvm::IntegerType::get(llvmContext, 32);
+      llvm::Metadata *OCLVerElts[] = {
+          llvm::ConstantAsMetadata::get(
+              llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMajor())),
+          llvm::ConstantAsMetadata::get(
+              llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMinor()))};
+      llvm::NamedMDNode *OCLVerMD =
+          llvmModule->getOrInsertNamedMetadata("opencl.ocl.version");
+      OCLVerMD->addOperand(llvm::MDNode::get(llvmContext, OCLVerElts));
+    }
+
+    // Drop ammended CIR attribute from LLVM op.
+    module->removeAttr(attribute.getName());
+  }
+
   // Translate CIR's extra function attributes to LLVM's function attributes.
   void amendFunction(mlir::LLVM::LLVMFuncOp func,
                      llvm::ArrayRef<llvm::Instruction *> instructions,

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -71,14 +71,14 @@ private:
     if (auto openclVersionAttr = mlir::dyn_cast<mlir::cir::OpenCLVersionAttr>(
             attribute.getValue())) {
       auto *int32Ty = llvm::IntegerType::get(llvmContext, 32);
-      llvm::Metadata *olcVerElts[] = {
+      llvm::Metadata *oclVerElts[] = {
           llvm::ConstantAsMetadata::get(
               llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMajor())),
           llvm::ConstantAsMetadata::get(
               llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMinor()))};
       llvm::NamedMDNode *oclVerMD =
           llvmModule->getOrInsertNamedMetadata("opencl.ocl.version");
-      oclVerMD->addOperand(llvm::MDNode::get(llvmContext, olcVerElts));
+      oclVerMD->addOperand(llvm::MDNode::get(llvmContext, oclVerElts));
     }
 
     // Drop ammended CIR attribute from LLVM op.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -63,23 +63,22 @@ public:
 
 private:
   // Translate CIR's module attributes to LLVM's module metadata
-  void amendModule(
-      mlir::ModuleOp module, mlir::NamedAttribute attribute,
-      mlir::LLVM::ModuleTranslation &moduleTranslation) const {
+  void amendModule(mlir::ModuleOp module, mlir::NamedAttribute attribute,
+                   mlir::LLVM::ModuleTranslation &moduleTranslation) const {
     llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
     llvm::LLVMContext &llvmContext = llvmModule->getContext();
 
     if (auto openclVersionAttr = mlir::dyn_cast<mlir::cir::OpenCLVersionAttr>(
             attribute.getValue())) {
       auto *int32Ty = llvm::IntegerType::get(llvmContext, 32);
-      llvm::Metadata *OCLVerElts[] = {
+      llvm::Metadata *olcVerElts[] = {
           llvm::ConstantAsMetadata::get(
               llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMajor())),
           llvm::ConstantAsMetadata::get(
               llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMinor()))};
-      llvm::NamedMDNode *OCLVerMD =
+      llvm::NamedMDNode *oclVerMD =
           llvmModule->getOrInsertNamedMetadata("opencl.ocl.version");
-      OCLVerMD->addOperand(llvm::MDNode::get(llvmContext, OCLVerElts));
+      oclVerMD->addOperand(llvm::MDNode::get(llvmContext, olcVerElts));
     }
 
     // Drop ammended CIR attribute from LLVM op.

--- a/clang/test/CIR/CodeGen/OpenCL/opencl-version.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/opencl-version.cl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR-CL30
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM-CL30
+// RUN: %clang_cc1 -cl-std=CL1.2 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR-CL12
+// RUN: %clang_cc1 -cl-std=CL1.2 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM-CL12
+
+// CIR-CL30: module {{.*}} attributes {{{.*}}cir.cl.version = #cir.cl.version<3, 0>
+// LLVM-CL30: !opencl.ocl.version = !{![[MDCL30:[0-9]+]]}
+// LLVM-CL30: ![[MDCL30]] = !{i32 3, i32 0}
+
+// CIR-CL12: module {{.*}} attributes {{{.*}}cir.cl.version = #cir.cl.version<1, 2>
+// LLVM-CL12: !opencl.ocl.version = !{![[MDCL12:[0-9]+]]}
+// LLVM-CL12: ![[MDCL12]] = !{i32 1, i32 2}


### PR DESCRIPTION
Similar to #767, this PR emit the module level OpenCL version metadata following the OG CodeGen skeleton.

We use a full qualified `cir.cl.version` attribute on the module op to store the info in CIR.