### PR TITLE
[CIR][Dialect] Add OpenCL C language in cir.lang

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -43,9 +43,10 @@ class CIRUnitAttr<string name, string attrMnemonic, list<Trait> traits = []>
 
 def C : I32EnumAttrCase<"C", 1, "c">;
 def CXX : I32EnumAttrCase<"CXX", 2, "cxx">;
+def OpenCLC : I32EnumAttrCase<"OpenCLC", 3, "opencl_c">;
 
 def SourceLanguage : I32EnumAttr<"SourceLanguage", "Source language", [
-  C, CXX
+  C, CXX, OpenCLC
 ]> {
   let cppNamespace = "::mlir::cir";
   let genSpecializedAttr = 0;

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3048,6 +3048,9 @@ mlir::cir::SourceLanguage CIRGenModule::getCIRSourceLanguage() {
   using CIRLang = mlir::cir::SourceLanguage;
   auto opts = getLangOpts();
 
+  if (opts.OpenCL && !opts.OpenCLCPlusPlus)
+    return CIRLang::OpenCLC;
+
   if (opts.CPlusPlus || opts.CPlusPlus11 || opts.CPlusPlus14 ||
       opts.CPlusPlus17 || opts.CPlusPlus20 || opts.CPlusPlus23 ||
       opts.CPlusPlus26)

--- a/clang/test/CIR/CodeGen/OpenCL/opencl-c-lang.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/opencl-c-lang.cl
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+// CIR: module{{.*}} attributes {{{.*}}cir.lang = #cir.lang<opencl_c>


### PR DESCRIPTION
This PR adds OpenCL C language case to the enum `mlir::cir::SourceLanguage`, and maps `opts.OpenCL && !opts.OpenCLCPlusPlus` to it.