### PR TITLE
[CIR][Transforms] Add folders for complex operations

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -275,6 +275,40 @@ def FPAttr : CIR_Attr<"FP", "fp", [TypedAttrInterface]> {
 }
 
 //===----------------------------------------------------------------------===//
+// ComplexAttr
+//===----------------------------------------------------------------------===//
+
+def ComplexAttr : CIR_Attr<"Complex", "complex", [TypedAttrInterface]> {
+  let summary = "An attribute that contains a constant complex value";
+  let description = [{
+    The `#cir.complex` attribute contains a constant value of complex number
+    type. The `real` parameter gives the real part of the complex number and the
+    `imag` parameter gives the imaginary part of the complex number.
+
+    The `real` and `imag` parameter must be either an IntAttr or an FPAttr that
+    contains values of the same CIR type.
+  }];
+
+  let parameters = (ins 
+    AttributeSelfTypeParameter<"", "mlir::cir::ComplexType">:$type,
+    "mlir::TypedAttr":$real, "mlir::TypedAttr":$imag);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "mlir::cir::ComplexType":$type,
+                                        "mlir::TypedAttr":$real,
+                                        "mlir::TypedAttr":$imag), [{
+      return $_get(type.getContext(), type, real, imag);
+    }]>,
+  ];
+
+  let genVerifyDecl = 1;
+
+  let assemblyFormat = [{
+    `<` qualified($real) `,` qualified($imag) `>`
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // ConstPointerAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -27,6 +27,8 @@ def CIR_Dialect : Dialect {
   let useDefaultAttributePrinterParser = 0;
   let useDefaultTypePrinterParser = 0;
 
+  let hasConstantMaterializer = 1;
+
   let extraClassDeclaration = [{
 
     // Names of CIR parameter attributes.

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1217,6 +1217,7 @@ def ComplexCreateOp : CIR_Op<"complex.create", [Pure, SameTypeOperands]> {
   }];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1245,6 +1246,7 @@ def ComplexRealOp : CIR_Op<"complex.real", [Pure]> {
   }];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 def ComplexImagOp : CIR_Op<"complex.imag", [Pure]> {
@@ -1269,6 +1271,7 @@ def ComplexImagOp : CIR_Op<"complex.imag", [Pure]> {
   }];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -363,6 +363,26 @@ LogicalResult cir::FPAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 }
 
 //===----------------------------------------------------------------------===//
+// ComplexAttr definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult ComplexAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                                  mlir::cir::ComplexType type,
+                                  mlir::TypedAttr real, mlir::TypedAttr imag) {
+  auto elemTy = type.getElementTy();
+  if (real.getType() != elemTy) {
+    emitError() << "type of the real part does not match the complex type";
+    return failure();
+  }
+  if (imag.getType() != elemTy) {
+    emitError() << "type of the imaginary part does not match the complex type";
+    return failure();
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // CmpThreeWayInfoAttr definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -124,6 +124,14 @@ void cir::CIRDialect::initialize() {
   addInterfaces<CIROpAsmDialectInterface>();
 }
 
+Operation *cir::CIRDialect::materializeConstant(mlir::OpBuilder &builder,
+                                                mlir::Attribute value,
+                                                mlir::Type type,
+                                                mlir::Location loc) {
+  return builder.create<mlir::cir::ConstantOp>(
+      loc, type, mlir::cast<mlir::TypedAttr>(value));
+}
+
 //===----------------------------------------------------------------------===//
 // Helpers
 //===----------------------------------------------------------------------===//
@@ -344,7 +352,8 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
     return success();
   }
 
-  if (mlir::isa<mlir::cir::IntAttr, mlir::cir::FPAttr>(attrType)) {
+  if (mlir::isa<mlir::cir::IntAttr, mlir::cir::FPAttr, mlir::cir::ComplexAttr>(
+          attrType)) {
     auto at = cast<TypedAttr>(attrType);
     if (at.getType() != opType) {
       return op->emitOpError("result type (")
@@ -638,6 +647,26 @@ LogicalResult ComplexCreateOp::verify() {
   return success();
 }
 
+OpFoldResult ComplexCreateOp::fold(FoldAdaptor adaptor) {
+  auto real = adaptor.getReal();
+  auto imag = adaptor.getImag();
+
+  if (!real || !imag)
+    return nullptr;
+
+  // When both of real and imag are constants, we can fold the operation into an
+  // `cir.const #cir.complex` operation.
+
+  auto realAttr = mlir::cast<mlir::TypedAttr>(real);
+  auto imagAttr = mlir::cast<mlir::TypedAttr>(imag);
+  assert(realAttr.getType() == imagAttr.getType() &&
+         "real part and imag part should be of the same type");
+
+  auto complexTy =
+      mlir::cir::ComplexType::get(getContext(), realAttr.getType());
+  return mlir::cir::ComplexAttr::get(complexTy, realAttr, imagAttr);
+}
+
 //===----------------------------------------------------------------------===//
 // ComplexRealOp and ComplexImagOp
 //===----------------------------------------------------------------------===//
@@ -650,12 +679,28 @@ LogicalResult ComplexRealOp::verify() {
   return success();
 }
 
+OpFoldResult ComplexRealOp::fold(FoldAdaptor adaptor) {
+  auto input =
+      mlir::cast_if_present<mlir::cir::ComplexAttr>(adaptor.getOperand());
+  if (input)
+    return input.getReal();
+  return nullptr;
+}
+
 LogicalResult ComplexImagOp::verify() {
   if (getType() != getOperand().getType().getElementTy()) {
     emitOpError() << "cir.complex.imag result type does not match operand type";
     return failure();
   }
   return success();
+}
+
+OpFoldResult ComplexImagOp::fold(FoldAdaptor adaptor) {
+  auto input =
+      mlir::cast_if_present<mlir::cir::ComplexAttr>(adaptor.getOperand());
+  if (input)
+    return input.getImag();
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/CIRSimplify.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRSimplify.cpp
@@ -146,7 +146,8 @@ void CIRSimplifyPass::runOnOperation() {
   getOperation()->walk([&](Operation *op) {
     // CastOp here is to perform a manual `fold` in
     // applyOpPatternsAndFold
-    if (isa<BrOp, BrCondOp, ScopeOp, SwitchOp, CastOp, TryOp, UnaryOp>(op))
+    if (isa<BrOp, BrCondOp, ScopeOp, SwitchOp, CastOp, TryOp, UnaryOp,
+            ComplexCreateOp, ComplexRealOp, ComplexImagOp>(op))
       ops.push_back(op);
   });
 

--- a/clang/test/CIR/Lowering/complex.cir
+++ b/clang/test/CIR/Lowering/complex.cir
@@ -1,0 +1,15 @@
+// RUN: cir-translate -cir-to-llvmir -o %t.ll %s
+// RUN: FileCheck --input-file %t.ll -check-prefix=LLVM %s
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.func @complex_const() -> !cir.complex<!s32i> {
+    %0 = cir.const #cir.complex<#cir.int<1> : !s32i, #cir.int<2> : !s32i> : !cir.complex<!s32i>
+    cir.return %0 : !cir.complex<!s32i>
+  }
+
+  // LLVM-LABEL: define { i32, i32 } @complex_const()
+  //  LLVM-NEXT:   ret { i32, i32 } { i32 1, i32 2 }
+  //  LLVM-NEXT: }
+}

--- a/clang/test/CIR/Transforms/complex-fold.cir
+++ b/clang/test/CIR/Transforms/complex-fold.cir
@@ -1,0 +1,44 @@
+// RUN: cir-opt --canonicalize -o %t.cir %s
+// RUN: FileCheck --input-file %t.cir %s
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.func @complex_create_fold() -> !cir.complex<!s32i> {
+    %0 = cir.const #cir.int<1> : !s32i
+    %1 = cir.const #cir.int<2> : !s32i
+    %2 = cir.complex.create %0, %1 : !s32i -> !cir.complex<!s32i>
+    cir.return %2 : !cir.complex<!s32i>
+  }
+
+  // CHECK-LABEL: cir.func @complex_create_fold() -> !cir.complex<!s32i> {
+  //  CHECK-NEXT:   %[[#A:]] = cir.const #cir.complex<#cir.int<1> : !s32i, #cir.int<2> : !s32i> : !cir.complex<!s32i>
+  //  CHECK-NEXT:   cir.return %[[#A]] : !cir.complex<!s32i>
+  //  CHECK-NEXT: }
+
+  cir.func @fold_complex_real() -> !s32i {
+    %0 = cir.const #cir.int<1> : !s32i
+    %1 = cir.const #cir.int<2> : !s32i
+    %2 = cir.complex.create %0, %1 : !s32i -> !cir.complex<!s32i>
+    %3 = cir.complex.real %2 : !cir.complex<!s32i> -> !s32i
+    cir.return %3 : !s32i
+  }
+
+  // CHECK-LABEL: cir.func @fold_complex_real() -> !s32i {
+  //  CHECK-NEXT:   %[[#A:]] = cir.const #cir.int<1> : !s32i
+  //  CHECK-NEXT:   cir.return %[[#A]] : !s32i
+  //  CHECK-NEXT: }
+
+  cir.func @fold_complex_imag() -> !s32i {
+    %0 = cir.const #cir.int<1> : !s32i
+    %1 = cir.const #cir.int<2> : !s32i
+    %2 = cir.complex.create %0, %1 : !s32i -> !cir.complex<!s32i>
+    %3 = cir.complex.imag %2 : !cir.complex<!s32i> -> !s32i
+    cir.return %3 : !s32i
+  }
+
+  // CHECK-LABEL: cir.func @fold_complex_imag() -> !s32i {
+  //  CHECK-NEXT:   %[[#A:]] = cir.const #cir.int<2> : !s32i
+  //  CHECK-NEXT:   cir.return %[[#A]] : !s32i
+  //  CHECK-NEXT: }
+}


### PR DESCRIPTION
This PR adds folders for `cir.complex.create`, `cir.complex.real`, and `cir.complex.imag`.

This PR adds a new attribute `#cir.complex` that represents a constant complex value. Besides, the CIR dialect does not have a constant materializer yet; this PR adds it.

Address #726 .