### PR TITLE
[CIR][CodeGen][NFCI] Target-independent ABI handling for SpirKernel call conv

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -774,11 +774,16 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeCIRFunctionInfo(
   (void)inserted;
   assert(inserted && "Recursively being processed?");
 
-  // Compute ABI inforamtion.
-  assert(info.getCC() != clang::CallingConv::CC_SpirFunction && "NYI");
-  assert(info.getCC() != CC_Swift && info.getCC() != CC_SwiftAsync &&
-         "Swift NYI");
-  getABIInfo().computeInfo(*FI);
+  // Compute ABI information.
+  if (CC == mlir::cir::CallingConv::SpirKernel) {
+    // Force target independent argument handling for the host visible
+    // kernel functions.
+    computeSPIRKernelABIInfo(CGM, *FI);
+  } else if (info.getCC() == CC_Swift || info.getCC() == CC_SwiftAsync) {
+    llvm_unreachable("Swift NYI");
+  } else {
+    getABIInfo().computeInfo(*FI);
+  }
 
   // Loop over all of the computed argument and return value info. If any of
   // them are direct or extend without a specified coerce type, specify the

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -264,6 +264,16 @@ private:
   }
 };
 } // namespace
+
+namespace cir {
+void computeSPIRKernelABIInfo(CIRGenModule &CGM, CIRGenFunctionInfo &FI) {
+  if (CGM.getTarget().getTriple().isSPIRV())
+    SPIRVABIInfo(CGM.getTypes()).computeInfo(FI);
+  else
+    CommonSPIRABIInfo(CGM.getTypes()).computeInfo(FI);
+}
+} // namespace cir
+
 namespace {
 
 class CommonSPIRTargetCIRGenInfo : public TargetCIRGenInfo {

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -99,6 +99,8 @@ public:
   virtual ~TargetCIRGenInfo() {}
 };
 
+void computeSPIRKernelABIInfo(CIRGenModule &CGM, CIRGenFunctionInfo &FI);
+
 } // namespace cir
 
 #endif


### PR DESCRIPTION
This PR follows OG CodeGen to use SPIR ABI info whatever the target is when analysing the function info of SPIR-V kernels (identified by its calling convention).

For example, when compiling OpenCL kernels to x86-64 target, the kernel should still use SPIR-V's ABIInfo.

As we haven't implemented SPIR-V ABI handling for complex constructs, there should be no functional changes. There is a test for this logic in OG CodeGen: `clang/test/CodeGenOpenCL/kernels-have-spir-cc-by-default.cl`. It mainly involves structs, which is beyond the progress of CIR ABI stuff.