### PR TITLE
[CIR][Dialect] Add address space attribute to global op

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2120,6 +2120,7 @@ def GlobalOp : CIR_Op<"global",
                        OptionalAttr<StrAttr>:$sym_visibility,
                        TypeAttr:$sym_type,
                        Arg<GlobalLinkageKind, "linkage type">:$linkage,
+                       OptionalAttr<AddressSpaceAttr>:$addr_space,
                        OptionalAttr<TLSModel>:$tls_model,
                        // Note this can also be a FlatSymbolRefAttr
                        OptionalAttr<AnyAttr>:$initial_value,
@@ -2138,6 +2139,7 @@ def GlobalOp : CIR_Op<"global",
        (`comdat` $comdat^)?
        ($tls_model^)?
        (`dsolocal` $dsolocal^)?
+       (`addrspace` `(` custom<GlobalOpAddrSpace>($addr_space)^ `)`)?
        $sym_name
        custom<GlobalOpTypeAndInitialValue>($sym_type, $initial_value, $ctorRegion, $dtorRegion)
        attr-dict
@@ -2165,6 +2167,7 @@ def GlobalOp : CIR_Op<"global",
       // CIR defaults to external linkage.
       CArg<"cir::GlobalLinkageKind",
             "cir::GlobalLinkageKind::ExternalLinkage">:$linkage,
+      CArg<"cir::AddressSpaceAttr", "{}">:$addrSpace,
       CArg<"function_ref<void(OpBuilder &, Location)>",
            "nullptr">:$ctorBuilder,
       CArg<"function_ref<void(OpBuilder &, Location)>",

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -183,6 +183,11 @@ bool isFPOrFPVectorTy(mlir::Type);
 } // namespace cir
 } // namespace mlir
 
+mlir::ParseResult parseAddrSpaceAttribute(mlir::AsmParser &p,
+                                          mlir::Attribute &addrSpaceAttr);
+void printAddrSpaceAttribute(mlir::AsmPrinter &p,
+                             mlir::Attribute addrSpaceAttr);
+
 //===----------------------------------------------------------------------===//
 // CIR Dialect Tablegen'd Types
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -701,10 +701,12 @@ public:
   [[nodiscard]] mlir::cir::GlobalOp
   createGlobal(mlir::ModuleOp module, mlir::Location loc, mlir::StringRef name,
                mlir::Type type, bool isConst,
-               mlir::cir::GlobalLinkageKind linkage) {
+               mlir::cir::GlobalLinkageKind linkage,
+               mlir::cir::AddressSpaceAttr addrSpace = {}) {
     mlir::OpBuilder::InsertionGuard guard(*this);
     setInsertionPointToStart(module.getBody());
-    return create<mlir::cir::GlobalOp>(loc, name, type, isConst, linkage);
+    return create<mlir::cir::GlobalOp>(loc, name, type, isConst, linkage,
+                                       addrSpace);
   }
 
   /// Creates a versioned global variable. If the symbol is already taken, an ID
@@ -713,7 +715,8 @@ public:
   [[nodiscard]] mlir::cir::GlobalOp
   createVersionedGlobal(mlir::ModuleOp module, mlir::Location loc,
                         mlir::StringRef name, mlir::Type type, bool isConst,
-                        mlir::cir::GlobalLinkageKind linkage) {
+                        mlir::cir::GlobalLinkageKind linkage,
+                        mlir::cir::AddressSpaceAttr addrSpace = {}) {
     // Create a unique name if the given name is already taken.
     std::string uniqueName;
     if (unsigned version = GlobalsVersioning[name.str()]++)
@@ -721,7 +724,8 @@ public:
     else
       uniqueName = name.str();
 
-    return createGlobal(module, loc, uniqueName, type, isConst, linkage);
+    return createGlobal(module, loc, uniqueName, type, isConst, linkage,
+                        addrSpace);
   }
 
   mlir::Value createGetGlobal(mlir::cir::GlobalOp global,

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1566,6 +1566,16 @@ static void printConstant(OpAsmPrinter &p, Attribute value) {
   p.printAttribute(value);
 }
 
+static ParseResult parseGlobalOpAddrSpace(OpAsmParser &p,
+                                          AddressSpaceAttr &addrSpaceAttr) {
+  return parseAddrSpaceAttribute(p, addrSpaceAttr);
+}
+
+static void printGlobalOpAddrSpace(OpAsmPrinter &p, GlobalOp op,
+                                   AddressSpaceAttr addrSpaceAttr) {
+  printAddrSpaceAttribute(p, addrSpaceAttr);
+}
+
 static void printGlobalOpTypeAndInitialValue(OpAsmPrinter &p, GlobalOp op,
                                              TypeAttr type, Attribute initAttr,
                                              mlir::Region &ctorRegion,
@@ -1739,6 +1749,7 @@ LogicalResult GlobalOp::verify() {
 void GlobalOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                      StringRef sym_name, Type sym_type, bool isConstant,
                      cir::GlobalLinkageKind linkage,
+                     cir::AddressSpaceAttr addrSpace,
                      function_ref<void(OpBuilder &, Location)> ctorBuilder,
                      function_ref<void(OpBuilder &, Location)> dtorBuilder) {
   odsState.addAttribute(getSymNameAttrName(odsState.name),
@@ -1752,6 +1763,9 @@ void GlobalOp::build(OpBuilder &odsBuilder, OperationState &odsState,
   ::mlir::cir::GlobalLinkageKindAttr linkageAttr =
       cir::GlobalLinkageKindAttr::get(odsBuilder.getContext(), linkage);
   odsState.addAttribute(getLinkageAttrName(odsState.name), linkageAttr);
+
+  if (addrSpace)
+    odsState.addAttribute(getAddrSpaceAttrName(odsState.name), addrSpace);
 
   Region *ctorRegion = odsState.addRegion();
   if (ctorBuilder) {

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -946,8 +946,8 @@ PointerType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
   return mlir::success();
 }
 
-mlir::ParseResult parsePointerAddrSpace(mlir::AsmParser &p,
-                                        mlir::Attribute &addrSpaceAttr) {
+mlir::ParseResult parseAddrSpaceAttribute(mlir::AsmParser &p,
+                                          mlir::Attribute &addrSpaceAttr) {
   using mlir::cir::AddressSpaceAttr;
   auto attrLoc = p.getCurrentLocation();
 
@@ -979,8 +979,8 @@ mlir::ParseResult parsePointerAddrSpace(mlir::AsmParser &p,
   return mlir::success();
 }
 
-void printPointerAddrSpace(mlir::AsmPrinter &p,
-                           mlir::Attribute rawAddrSpaceAttr) {
+void printAddrSpaceAttribute(mlir::AsmPrinter &p,
+                             mlir::Attribute rawAddrSpaceAttr) {
   using mlir::cir::AddressSpaceAttr;
   auto addrSpaceAttr = mlir::cast<AddressSpaceAttr>(rawAddrSpaceAttr);
   if (addrSpaceAttr.isTarget()) {
@@ -989,6 +989,16 @@ void printPointerAddrSpace(mlir::AsmPrinter &p,
   } else {
     p << AddressSpaceAttr::stringifyValue(addrSpaceAttr.getValue());
   }
+}
+
+mlir::ParseResult parsePointerAddrSpace(mlir::AsmParser &p,
+                                        mlir::Attribute &addrSpaceAttr) {
+  return parseAddrSpaceAttribute(p, addrSpaceAttr);
+}
+
+void printPointerAddrSpace(mlir::AsmPrinter &p,
+                           mlir::Attribute rawAddrSpaceAttr) {
+  printAddrSpaceAttribute(p, rawAddrSpaceAttr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -69,6 +69,10 @@ module {
     %0 = cir.get_global thread_local @batata : !cir.ptr<!s32i>
     cir.return
   }
+
+  cir.global external addrspace(offload_global) @addrspace1 = #cir.int<1> : !s32i
+  cir.global "private" internal addrspace(offload_local) @addrspace2 : !s32i
+  cir.global external addrspace(target<1>) @addrspace3 = #cir.int<3> : !s32i
 }
 
 // CHECK: cir.global external @a = #cir.int<3> : !s32i
@@ -104,3 +108,7 @@ module {
 // CHECK:   %0 = cir.get_global thread_local @batata : !cir.ptr<!s32i>
 // CHECK:   cir.return
 // CHECK: }
+
+// CHECK: cir.global external addrspace(offload_global) @addrspace1 = #cir.int<1> : !s32i
+// CHECK: cir.global "private" internal addrspace(offload_local) @addrspace2 : !s32i
+// CHECK: cir.global external addrspace(target<1>) @addrspace3 = #cir.int<3> : !s32i


### PR DESCRIPTION
This PR adds the CIR address space attribute to GlobalOp and starts to resolve the missing feature flag `addressSpaceInGlobalVar`.

The same asm format in pointer type is used:

```
cir.global external addrspace(offload_global) @addrspace1 = #cir.int<1> : !s32i
```

The parsing and printing helper is extracted into a common function to be reused by both `GlobalOp` and `PointerType` with two custom format proxy to it. That's because the signature of ODS generated method differs from the one for PointerType. 

Lowering to LLVM IR and CIRGen will come sequentially.