### PR TITLE
[CIR][FrontendAction] Use ClangIR pipeline to emit LLVM bitcode

### DIFF
--- a/clang/include/clang/CIRFrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIRFrontendAction/CIRGenAction.h
@@ -34,6 +34,7 @@ public:
     EmitCIR,
     EmitCIRFlat,
     EmitLLVM,
+    EmitBC,
     EmitMLIR,
     EmitObj,
     None
@@ -104,6 +105,13 @@ class EmitLLVMAction : public CIRGenAction {
 
 public:
   EmitLLVMAction(mlir::MLIRContext *mlirCtx = nullptr);
+};
+
+class EmitBCAction : public CIRGenAction {
+  virtual void anchor();
+
+public:
+  EmitBCAction(mlir::MLIRContext *mlirCtx = nullptr);
 };
 
 class EmitAssemblyAction : public CIRGenAction {

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -78,7 +78,13 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
       return std::make_unique<::cir::EmitAssemblyAction>();
 #endif
     return std::make_unique<EmitAssemblyAction>();
-  case EmitBC:                 return std::make_unique<EmitBCAction>();
+  case EmitBC: {
+#if CLANG_ENABLE_CIR
+    if (UseCIR)
+      return std::make_unique<::cir::EmitBCAction>();
+#endif
+    return std::make_unique<EmitBCAction>();
+  }
 #if CLANG_ENABLE_CIR
   case EmitCIR:                return std::make_unique<::cir::EmitCIRAction>();
   case EmitCIRFlat:

--- a/clang/test/CIR/cc1.c
+++ b/clang/test/CIR/cc1.c
@@ -2,6 +2,9 @@
 // RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-dis %t.bc -o %t.bc.ll
+// RUN: FileCheck --input-file=%t.bc.ll %s -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -S %s -o %t.s
 // RUN: FileCheck --input-file=%t.s %s -check-prefix=ASM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-obj %s -o %t.o

--- a/clang/test/CIR/driver.c
+++ b/clang/test/CIR/driver.c
@@ -6,6 +6,12 @@
 // RUN: FileCheck --input-file=%t1.ll %s -check-prefix=LLVM
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -S -emit-llvm %s -o %t2.ll
 // RUN: FileCheck --input-file=%t2.ll %s -check-prefix=LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fclangir-direct-lowering -c -emit-llvm %s -o %t1.bc
+// RUN: llvm-dis %t1.bc -o %t1.bc.ll
+// RUN: FileCheck --input-file=%t1.bc.ll %s -check-prefix=LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -c -emit-llvm %s -o %t2.bc
+// RUN: llvm-dis %t2.bc -o %t2.bc.ll
+// RUN: FileCheck --input-file=%t2.bc.ll %s -check-prefix=LLVM
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -c %s -o %t.o
 // RUN: llvm-objdump -d %t.o | FileCheck %s -check-prefix=OBJ
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -clangir-disable-passes -S -Xclang -emit-cir %s -o %t.cir


### PR DESCRIPTION
This PR enables ClangIR pipeline for LLVM bitcode output when it's specified properly, aligned with the behavior of text-form LLVM IR.

Some refactors about switch cases are also included to avoid too many dups.