### PR TITLE
[CIR][LowerToLLVM] Support address space lowering for global ops

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1877,6 +1877,16 @@ class CIRGlobalOpLowering
 public:
   using OpConversionPattern<mlir::cir::GlobalOp>::OpConversionPattern;
 
+  // Get addrspace by converting a pointer type.
+  // TODO: Use a more direct way to get the addrspace.
+  inline unsigned getGlobalOpTargetAddrSpace(mlir::cir::GlobalOp op) const {
+    auto tempPtrTy = mlir::cir::PointerType::get(getContext(), op.getSymType(),
+                                                 op.getAddrSpaceAttr());
+    return cast<mlir::LLVM::LLVMPointerType>(
+               typeConverter->convertType(tempPtrTy))
+        .getAddressSpace();
+  }
+
   /// Replace CIR global with a region initialized LLVM global and update
   /// insertion point to the end of the initializer block.
   inline void setupRegionInitializedLLVMGlobalOp(
@@ -1885,7 +1895,8 @@ public:
     SmallVector<mlir::NamedAttribute> attributes;
     auto newGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
         op, llvmType, op.getConstant(), convertLinkage(op.getLinkage()),
-        op.getSymName(), nullptr, /*alignment*/ 0, /*addrSpace*/ 0,
+        op.getSymName(), nullptr, /*alignment*/ 0,
+        /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
         /*dsoLocal*/ false, /*threadLocal*/ (bool)op.getTlsModelAttr(),
         /*comdat*/ mlir::SymbolRefAttr(), attributes);
     newGlobalOp.getRegion().push_back(new mlir::Block());
@@ -1915,7 +1926,7 @@ public:
     if (!init.has_value()) {
       rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
           op, llvmType, isConst, linkage, symbol, mlir::Attribute(),
-          /*alignment*/ 0, /*addrSpace*/ 0,
+          /*alignment*/ 0, /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
           /*dsoLocal*/ isDsoLocal, /*threadLocal*/ (bool)op.getTlsModelAttr(),
           /*comdat*/ mlir::SymbolRefAttr(), attributes);
       return mlir::success();
@@ -2003,7 +2014,7 @@ public:
     // Rewrite op.
     auto llvmGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
         op, llvmType, isConst, linkage, symbol, init.value(),
-        /*alignment*/ 0, /*addrSpace*/ 0,
+        /*alignment*/ 0, /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
         /*dsoLocal*/ false, /*threadLocal*/ (bool)op.getTlsModelAttr(),
         /*comdat*/ mlir::SymbolRefAttr(), attributes);
     auto mod = op->getParentOfType<mlir::ModuleOp>();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1879,7 +1879,7 @@ public:
 
   // Get addrspace by converting a pointer type.
   // TODO: Use a more direct way to get the addrspace.
-  inline unsigned getGlobalOpTargetAddrSpace(mlir::cir::GlobalOp op) const {
+  unsigned getGlobalOpTargetAddrSpace(mlir::cir::GlobalOp op) const {
     auto tempPtrTy = mlir::cir::PointerType::get(getContext(), op.getSymType(),
                                                  op.getAddrSpaceAttr());
     return cast<mlir::LLVM::LLVMPointerType>(

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1878,7 +1878,9 @@ public:
   using OpConversionPattern<mlir::cir::GlobalOp>::OpConversionPattern;
 
   // Get addrspace by converting a pointer type.
-  // TODO: Use a more direct way to get the addrspace.
+  // TODO: The approach here is a little hacky. We should access the target info
+  // directly to convert the address space of global op, similar to what we do
+  // for type converter.
   unsigned getGlobalOpTargetAddrSpace(mlir::cir::GlobalOp op) const {
     auto tempPtrTy = mlir::cir::PointerType::get(getContext(), op.getSymType(),
                                                  op.getAddrSpaceAttr());

--- a/clang/test/CIR/Lowering/address-space.cir
+++ b/clang/test/CIR/Lowering/address-space.cir
@@ -7,6 +7,15 @@ module attributes {
   cir.triple = "spirv64-unknown-unknown",
   llvm.data_layout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
 } {
+  cir.global external addrspace(offload_global) @addrspace1 = #cir.int<1> : !s32i
+  // LLVM: @addrspace1 = addrspace(1) global i32
+
+  cir.global "private" internal addrspace(offload_local) @addrspace2 : !s32i
+  // LLVM: @addrspace2 = internal addrspace(3) global i32 undef
+
+  cir.global external addrspace(target<7>) @addrspace3 = #cir.int<3> : !s32i
+  // LLVM: @addrspace3 = addrspace(7) global i32
+
   // LLVM: define void @foo(ptr %0)
   cir.func @foo(%arg0: !cir.ptr<!s32i>) {
     // LLVM-NEXT: alloca ptr,


### PR DESCRIPTION
This PR set a proper addrspace attribute for LLVM globals. For simplicity, a temporary pointer type is created and consumed by our LLVM type converter. The correct address space is then extracted from the converted pointer type of LLVM.