### PR TITLE
[CIR][ABI] Implement basic struct CC lowering for x86_64

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -12,10 +12,8 @@
 #ifndef LLVM_CLANG_CIR_DIALECT_IR_CIRDATALAYOUT_H
 #define LLVM_CLANG_CIR_DIALECT_IR_CIRDATALAYOUT_H
 
-#include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
-#include "llvm/ADT/StringRef.h"
 
 namespace cir {
 
@@ -25,19 +23,14 @@ class CIRDataLayout {
 public:
   mlir::DataLayout layout;
 
-  /// Constructs a DataLayout from a specification string. See reset().
-  explicit CIRDataLayout(llvm::StringRef dataLayout, mlir::ModuleOp module)
-      : layout(module) {
-    reset(dataLayout);
-  }
+  /// Constructs a DataLayout the module's data layout attribute.
+  CIRDataLayout(mlir::ModuleOp modOp);
 
   /// Parse a data layout string (with fallback to default values).
-  void reset(llvm::StringRef dataLayout);
+  void reset();
 
   // Free all internal data structures.
   void clear();
-
-  CIRDataLayout(mlir::ModuleOp modOp);
 
   bool isBigEndian() const { return bigEndian; }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -589,6 +589,12 @@ def StoreOp : CIR_Op<"store", [
     ```
   }];
 
+  let builders = [
+    OpBuilder<(ins "Value":$value, "Value":$addr), [{
+      $_state.addOperands({value, addr});
+    }]>
+  ];
+
   let arguments = (ins CIR_AnyType:$value,
                        Arg<CIR_PointerType, "the address to store the value",
                            [MemWrite]>:$addr,

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -70,6 +70,7 @@ struct MissingFeatures {
   // ObjC
   static bool setObjCGCLValueClass() { return false; }
   static bool objCLifetime() { return false; }
+  static bool objCIvarDecls() { return false; }
 
   // Debug info
   static bool generateDebugInfo() { return false; }
@@ -205,18 +206,38 @@ struct MissingFeatures {
 
   //-- Missing AST queries
 
-  static bool recordDeclCanPassInRegisters() { return false; }
-  static bool recordDeclIsCXXDecl() { return false; }
+  static bool CXXRecordDeclIsEmptyCXX11() { return false; }
+  static bool CXXRecordDeclIsPOD() { return false; }
+  static bool CXXRecordIsDynamicClass() { return false; }
+  static bool astContextGetExternalSource() { return false; }
+  static bool declGetMaxAlignment() { return false; }
+  static bool declHasAlignMac68kAttr() { return false; }
+  static bool declHasAlignNaturalAttr() { return false; }
+  static bool declHasMaxFieldAlignmentAttr() { return false; }
+  static bool fieldDeclIsBitfield() { return false; }
+  static bool fieldDeclIsPotentiallyOverlapping() { return false; }
+  static bool fieldDeclGetMaxFieldAlignment() { return false; }
+  static bool fieldDeclisUnnamedBitField() { return false; }
   static bool funcDeclIsCXXConstructorDecl() { return false; }
   static bool funcDeclIsCXXDestructorDecl() { return false; }
   static bool funcDeclIsCXXMethodDecl() { return false; }
   static bool funcDeclIsInlineBuiltinDeclaration() { return false; }
   static bool funcDeclIsReplaceableGlobalAllocationFunction() { return false; }
+  static bool isCXXRecordDecl() { return false; }
   static bool qualTypeIsReferenceType() { return false; }
-  static bool typeGetAsEnumType() { return false; }
+  static bool recordDeclCanPassInRegisters() { return false; }
+  static bool recordDeclHasFlexibleArrayMember() { return false; }
+  static bool recordDeclIsCXXDecl() { return false; }
+  static bool recordDeclIsMSStruct() { return false; }
+  static bool recordDeclIsPacked() { return false; }
+  static bool recordDeclMayInsertExtraPadding() { return false; }
   static bool typeGetAsBuiltinType() { return false; }
+  static bool typeGetAsEnumType() { return false; }
   static bool typeIsCXXRecordDecl() { return false; }
   static bool varDeclIsKNRPromoted() { return false; }
+
+  // We need to track parent (base) classes to determine the layout of a class.
+  static bool getCXXRecordBases() { return false; }
 
   //-- Missing types
 
@@ -233,6 +254,14 @@ struct MissingFeatures {
   static bool noFPClass() { return false; }
 
   //-- Other missing features
+
+  // We need to track the parent record types that represent a field
+  // declaration. This is necessary to determine the layout of a class.
+  static bool fieldDeclAbstraction() { return false; }
+
+  // There are some padding diagnostic features for Itanium ABI that we might
+  // wanna add later.
+  static bool bitFieldPaddingDiagnostics() { return false; }
 
   // Empty values might be passed as arguments to serve as padding, ensuring
   // alignment and compliance (e.g. MIPS). We do not yet support this.
@@ -283,6 +312,7 @@ struct MissingFeatures {
   // If a store op is guaranteed to execute before the retun value load op, we
   // can optimize away the store and load ops. Seems like an early optimization.
   static bool returnValueDominatingStoreOptmiization() { return false; }
+
   // Globals (vars and functions) may have attributes that are target depedent.
   static bool setTargetAttributes() { return false; }
 

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -234,6 +234,7 @@ struct MissingFeatures {
   static bool typeGetAsBuiltinType() { return false; }
   static bool typeGetAsEnumType() { return false; }
   static bool typeIsCXXRecordDecl() { return false; }
+  static bool typeIsSized() { return false; }
   static bool varDeclIsKNRPromoted() { return false; }
 
   // We need to track parent (base) classes to determine the layout of a class.

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -206,6 +206,7 @@ struct MissingFeatures {
   //-- Missing AST queries
 
   static bool recordDeclCanPassInRegisters() { return false; }
+  static bool recordDeclIsCXXDecl() { return false; }
   static bool funcDeclIsCXXConstructorDecl() { return false; }
   static bool funcDeclIsCXXDestructorDecl() { return false; }
   static bool funcDeclIsCXXMethodDecl() { return false; }
@@ -214,6 +215,7 @@ struct MissingFeatures {
   static bool qualTypeIsReferenceType() { return false; }
   static bool typeGetAsEnumType() { return false; }
   static bool typeGetAsBuiltinType() { return false; }
+  static bool typeIsCXXRecordDecl() { return false; }
   static bool varDeclIsKNRPromoted() { return false; }
 
   //-- Missing types

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -234,6 +234,7 @@ struct MissingFeatures {
   static bool typeGetAsBuiltinType() { return false; }
   static bool typeGetAsEnumType() { return false; }
   static bool typeIsCXXRecordDecl() { return false; }
+  static bool typeIsScalableType() { return false; }
   static bool typeIsSized() { return false; }
   static bool varDeclIsKNRPromoted() { return false; }
 

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -226,6 +226,7 @@ struct MissingFeatures {
   static bool isCXXRecordDecl() { return false; }
   static bool qualTypeIsReferenceType() { return false; }
   static bool recordDeclCanPassInRegisters() { return false; }
+  static bool recordDeclHasAlignmentAttr() { return false; }
   static bool recordDeclHasFlexibleArrayMember() { return false; }
   static bool recordDeclIsCXXDecl() { return false; }
   static bool recordDeclIsMSStruct() { return false; }
@@ -265,6 +266,10 @@ struct MissingFeatures {
   // wanna add later.
   static bool bitFieldPaddingDiagnostics() { return false; }
 
+  // Clang considers both enums and records as tag types. We don't have a way to
+  // transparently handle both these types yet. Might need an interface here.
+  static bool tagTypeClassAbstraction() { return false; }
+
   // Empty values might be passed as arguments to serve as padding, ensuring
   // alignment and compliance (e.g. MIPS). We do not yet support this.
   static bool argumentPadding() { return false; }
@@ -301,7 +306,7 @@ struct MissingFeatures {
   // evaluating ABI-specific lowering.
   static bool qualifiedTypes() { return false; }
 
-  // We're ignoring several details regarding ABI-halding for Swift.
+  // We're ignoring several details regarding ABI-handling for Swift.
   static bool swift() { return false; }
 
   // The AppleARM64 is using ItaniumCXXABI, which is not quite right.

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -878,7 +878,7 @@ public:
       unsigned Pos = 0;
       for (size_t I = 0; I < Elts.size(); ++I) {
         auto EltSize = Layout.getTypeAllocSize(Elts[I]);
-        unsigned AlignMask = Layout.getABITypeAlign(Elts[I]) - 1;
+        unsigned AlignMask = Layout.getABITypeAlign(Elts[I]).value() - 1;
         Pos = (Pos + AlignMask) & ~AlignMask;
         if (Offset < Pos + EltSize) {
           Indices.push_back(I);

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -1,22 +1,159 @@
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/MissingFeatures.h"
+
+using namespace cir;
+
+//===----------------------------------------------------------------------===//
+// Support for StructLayout
+//===----------------------------------------------------------------------===//
+
+StructLayout::StructLayout(mlir::cir::StructType ST, const CIRDataLayout &DL)
+    : StructSize(llvm::TypeSize::getFixed(0)) {
+  assert(!ST.isIncomplete() && "Cannot get layout of opaque structs");
+  IsPadded = false;
+  NumElements = ST.getNumElements();
+
+  // Loop over each of the elements, placing them in memory.
+  for (unsigned i = 0, e = NumElements; i != e; ++i) {
+    mlir::Type Ty = ST.getMembers()[i];
+    if (i == 0 && ::cir::MissingFeatures::typeIsScalableType())
+      llvm_unreachable("Scalable types are not yet supported in CIR");
+
+    assert(!::cir::MissingFeatures::recordDeclIsPacked() &&
+           "Cannot identify packed structs");
+    const llvm::Align TyAlign = DL.getABITypeAlign(Ty);
+
+    // Add padding if necessary to align the data element properly.
+    // Currently the only structure with scalable size will be the homogeneous
+    // scalable vector types. Homogeneous scalable vector types have members of
+    // the same data type so no alignment issue will happen. The condition here
+    // assumes so and needs to be adjusted if this assumption changes (e.g. we
+    // support structures with arbitrary scalable data type, or structure that
+    // contains both fixed size and scalable size data type members).
+    if (!StructSize.isScalable() && !isAligned(TyAlign, StructSize)) {
+      IsPadded = true;
+      StructSize = llvm::TypeSize::getFixed(alignTo(StructSize, TyAlign));
+    }
+
+    // Keep track of maximum alignment constraint.
+    StructAlignment = std::max(TyAlign, StructAlignment);
+
+    getMemberOffsets()[i] = StructSize;
+    // Consume space for this data item
+    StructSize += DL.getTypeAllocSize(Ty);
+  }
+
+  // Add padding to the end of the struct so that it could be put in an array
+  // and all array elements would be aligned correctly.
+  if (!StructSize.isScalable() && !isAligned(StructAlignment, StructSize)) {
+    IsPadded = true;
+    StructSize = llvm::TypeSize::getFixed(alignTo(StructSize, StructAlignment));
+  }
+}
+
+/// getElementContainingOffset - Given a valid offset into the structure,
+/// return the structure index that contains it.
+unsigned StructLayout::getElementContainingOffset(uint64_t FixedOffset) const {
+  assert(!StructSize.isScalable() &&
+         "Cannot get element at offset for structure containing scalable "
+         "vector types");
+  llvm::TypeSize Offset = llvm::TypeSize::getFixed(FixedOffset);
+  llvm::ArrayRef<llvm::TypeSize> MemberOffsets = getMemberOffsets();
+
+  const auto *SI =
+      std::upper_bound(MemberOffsets.begin(), MemberOffsets.end(), Offset,
+                       [](llvm::TypeSize LHS, llvm::TypeSize RHS) -> bool {
+                         return llvm::TypeSize::isKnownLT(LHS, RHS);
+                       });
+  assert(SI != MemberOffsets.begin() && "Offset not in structure type!");
+  --SI;
+  assert(llvm::TypeSize::isKnownLE(*SI, Offset) && "upper_bound didn't work");
+  assert((SI == MemberOffsets.begin() ||
+          llvm::TypeSize::isKnownLE(*(SI - 1), Offset)) &&
+         (SI + 1 == MemberOffsets.end() ||
+          llvm::TypeSize::isKnownGT(*(SI + 1), Offset)) &&
+         "Upper bound didn't work!");
+
+  // Multiple fields can have the same offset if any of them are zero sized.
+  // For example, in { i32, [0 x i32], i32 }, searching for offset 4 will stop
+  // at the i32 element, because it is the last element at that offset.  This is
+  // the right one to return, because anything after it will have a higher
+  // offset, implying that this element is non-empty.
+  return SI - MemberOffsets.begin();
+}
 
 //===----------------------------------------------------------------------===//
 //                       DataLayout Class Implementation
 //===----------------------------------------------------------------------===//
 
-using namespace cir;
+namespace {
+
+class StructLayoutMap {
+  using LayoutInfoTy = llvm::DenseMap<mlir::cir::StructType, StructLayout *>;
+  LayoutInfoTy LayoutInfo;
+
+public:
+  ~StructLayoutMap() {
+    // Remove any layouts.
+    for (const auto &I : LayoutInfo) {
+      StructLayout *Value = I.second;
+      Value->~StructLayout();
+      free(Value);
+    }
+  }
+
+  StructLayout *&operator[](mlir::cir::StructType STy) {
+    return LayoutInfo[STy];
+  }
+};
+
+} // namespace
 
 CIRDataLayout::CIRDataLayout(mlir::ModuleOp modOp) : layout{modOp} { reset(); }
 
 void CIRDataLayout::reset() {
   clear();
 
+  LayoutMap = nullptr;
+  bigEndian = false;
+  // ManglingMode = MM_None;
+  // NonIntegralAddressSpaces.clear();
+  StructAlignment =
+      llvm::LayoutAlignElem::get(llvm::Align(1), llvm::Align(8), 0);
+
   // NOTE(cir): Alignment setter functions are skipped as these should already
   // be set in MLIR's data layout.
 }
 
-void CIRDataLayout::clear() {}
+void CIRDataLayout::clear() {
+  delete static_cast<StructLayoutMap *>(LayoutMap);
+  LayoutMap = nullptr;
+}
+
+const StructLayout *
+CIRDataLayout::getStructLayout(mlir::cir::StructType Ty) const {
+  if (!LayoutMap)
+    LayoutMap = new StructLayoutMap();
+
+  StructLayoutMap *STM = static_cast<StructLayoutMap *>(LayoutMap);
+  StructLayout *&SL = (*STM)[Ty];
+  if (SL)
+    return SL;
+
+  // Otherwise, create the struct layout.  Because it is variable length, we
+  // malloc it, then use placement new.
+  StructLayout *L = (StructLayout *)llvm::safe_malloc(
+      StructLayout::totalSizeToAlloc<llvm::TypeSize>(Ty.getNumElements()));
+
+  // Set SL before calling StructLayout's ctor.  The ctor could cause other
+  // entries to be added to TheMap, invalidating our reference.
+  SL = L;
+
+  new (L) StructLayout(Ty, *this);
+
+  return L;
+}
 
 /*!
   \param abi_or_pref Flag that determines which alignment is returned. true
@@ -27,6 +164,19 @@ void CIRDataLayout::clear() {}
   == false) for the requested type \a Ty.
  */
 llvm::Align CIRDataLayout::getAlignment(mlir::Type Ty, bool abi_or_pref) const {
+
+  if (llvm::isa<mlir::cir::StructType>(Ty)) {
+    // Packed structure types always have an ABI alignment of one.
+    if (::cir::MissingFeatures::recordDeclIsPacked() && abi_or_pref)
+      llvm_unreachable("NYI");
+
+    // Get the layout annotation... which is lazily created on demand.
+    const StructLayout *Layout =
+        getStructLayout(llvm::cast<mlir::cir::StructType>(Ty));
+    const llvm::Align Align =
+        abi_or_pref ? StructAlignment.ABIAlign : StructAlignment.PrefAlign;
+    return std::max(Align, Layout->getAlignment());
+  }
 
   // FIXME(cir): This does not account for differnt address spaces, and relies
   // on CIR's data layout to give the proper alignment.
@@ -43,6 +193,22 @@ llvm::Align CIRDataLayout::getAlignment(mlir::Type Ty, bool abi_or_pref) const {
 llvm::TypeSize CIRDataLayout::getTypeSizeInBits(mlir::Type Ty) const {
   assert(!::cir::MissingFeatures::typeIsSized() &&
          "Cannot getTypeInfo() on a type that is unsized!");
+
+  if (auto structTy = llvm::dyn_cast<mlir::cir::StructType>(Ty)) {
+
+    // FIXME(cir): CIR struct's data layout implementation doesn't do a good job
+    // of handling unions particularities. We should have a separate union type.
+    if (structTy.isUnion()) {
+      auto largestMember = structTy.getLargestMember(layout);
+      return llvm::TypeSize::getFixed(layout.getTypeSizeInBits(largestMember));
+    }
+
+    // FIXME(cir): We should be able to query the size of a struct directly to
+    // its data layout implementation instead of requiring a separate
+    // StructLayout object.
+    // Get the layout annotation... which is lazily created on demand.
+    return getStructLayout(structTy)->getSizeInBits();
+  }
 
   // FIXME(cir): This does not account for different address spaces, and relies
   // on CIR's data layout to give the proper ABI-specific type width.

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -30,7 +30,7 @@ CIRDataLayout::CIRDataLayout(mlir::ModuleOp modOp) : layout{modOp} {
   }
 }
 
-void CIRDataLayout::reset(llvm::StringRef Desc) { clear(); }
+void CIRDataLayout::reset() { clear(); }
 
 void CIRDataLayout::clear() {}
 

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -1,4 +1,5 @@
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace cir {

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -183,8 +183,8 @@ llvm::Align CIRDataLayout::getAlignment(mlir::Type Ty, bool abi_or_pref) const {
   assert(!::cir::MissingFeatures::addressSpace());
 
   // Fetch type alignment from MLIR's data layout.
-  uint align = abi_or_pref ? layout.getTypeABIAlignment(Ty)
-                           : layout.getTypePreferredAlignment(Ty);
+  unsigned align = abi_or_pref ? layout.getTypeABIAlignment(Ty)
+                               : layout.getTypePreferredAlignment(Ty);
   return llvm::Align(align);
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -458,6 +458,10 @@ LogicalResult CastOp::verify() {
     return success();
   }
   case cir::CastKind::bitcast: {
+    // Allow bitcast of structs for calling conventions.
+    if (isa<StructType>(srcType) || isa<StructType>(resType))
+      return success();
+
     // This is the only cast kind where we don't want vector types to decay
     // into the element type.
     if ((!mlir::isa<mlir::cir::PointerType>(getSrc().getType()) ||

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -32,6 +32,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MathExtras.h"
 #include <optional>
 
 using cir::MissingFeatures;
@@ -448,13 +449,13 @@ llvm::TypeSize mlir::cir::VectorType::getTypeSizeInBits(
 uint64_t mlir::cir::VectorType::getABIAlignment(
     const ::mlir::DataLayout &dataLayout,
     ::mlir::DataLayoutEntryListRef params) const {
-  return getSize() * dataLayout.getTypeABIAlignment(getEltType());
+  return llvm::NextPowerOf2(dataLayout.getTypeSizeInBits(*this));
 }
 
 uint64_t mlir::cir::VectorType::getPreferredAlignment(
     const ::mlir::DataLayout &dataLayout,
     ::mlir::DataLayoutEntryListRef params) const {
-  return getSize() * dataLayout.getTypePreferredAlignment(getEltType());
+  return llvm::NextPowerOf2(dataLayout.getTypeSizeInBits(*this));
 }
 
 llvm::TypeSize

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.cpp
@@ -27,6 +27,8 @@ CIRCXXABI &ABIInfo::getCXXABI() const { return LT.getCXXABI(); }
 
 CIRLowerContext &ABIInfo::getContext() const { return LT.getContext(); }
 
+const clang::TargetInfo &ABIInfo::getTarget() const { return LT.getTarget(); }
+
 const ::cir::CIRDataLayout &ABIInfo::getDataLayout() const {
   return LT.getDataLayout();
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.h
@@ -41,6 +41,8 @@ public:
 
   CIRLowerContext &getContext() const;
 
+  const clang::TargetInfo &getTarget() const;
+
   const ::cir::CIRDataLayout &getDataLayout() const;
 
   virtual void computeInfo(LowerFunctionInfo &FI) const = 0;

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -26,7 +26,7 @@ bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
   Type Ty = FI.getReturnType();
 
   if (const auto RT = dyn_cast<StructType>(Ty)) {
-    llvm_unreachable("NYI");
+    assert(!::cir::MissingFeatures::isCXXRecordDecl());
   }
 
   return CXXABI.classifyReturnType(FI);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -45,5 +45,13 @@ Type useFirstFieldIfTransparentUnion(Type Ty) {
   return Ty;
 }
 
+CIRCXXABI::RecordArgABI getRecordArgABI(const StructType RT,
+                                        CIRCXXABI &CXXABI) {
+  if (::cir::MissingFeatures::typeIsCXXRecordDecl()) {
+    llvm_unreachable("NYI");
+  }
+  return CXXABI.getRecordArgABI(RT);
+}
+
 } // namespace cir
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.h
@@ -30,6 +30,8 @@ bool isAggregateTypeForABI(Type T);
 /// should ensure that all elements of the union have the same "machine type".
 Type useFirstFieldIfTransparentUnion(Type Ty);
 
+CIRCXXABI::RecordArgABI getRecordArgABI(const StructType RT, CIRCXXABI &CXXABI);
+
 } // namespace cir
 } // namespace mlir
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -40,6 +40,26 @@ public:
   /// If the C++ ABI requires the given type be returned in a particular way,
   /// this method sets RetAI and returns true.
   virtual bool classifyReturnType(LowerFunctionInfo &FI) const = 0;
+
+  /// Specify how one should pass an argument of a record type.
+  enum RecordArgABI {
+    /// Pass it using the normal C aggregate rules for the ABI, potentially
+    /// introducing extra copies and passing some or all of it in registers.
+    RAA_Default = 0,
+
+    /// Pass it on the stack using its defined layout.  The argument must be
+    /// evaluated directly into the correct stack position in the arguments
+    /// area,
+    /// and the call machinery must not move it or introduce extra copies.
+    RAA_DirectInMemory,
+
+    /// Pass it as a pointer to temporary memory.
+    RAA_Indirect
+  };
+
+  /// Returns how an argument of the given record type should be passed.
+  /// FIXME(cir): This expects a CXXRecordDecl! Not any record type.
+  virtual RecordArgABI getRecordArgABI(const StructType RD) const = 0;
 };
 
 /// Creates an Itanium-family ABI.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -23,7 +23,7 @@
 namespace mlir {
 namespace cir {
 
-CIRLowerContext::CIRLowerContext(ModuleOp module, clang::LangOptions &LOpts)
+CIRLowerContext::CIRLowerContext(ModuleOp module, clang::LangOptions LOpts)
     : MLIRCtx(module.getContext()), LangOpts(LOpts) {}
 
 CIRLowerContext::~CIRLowerContext() {}

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -136,6 +136,11 @@ clang::CharUnits CIRLowerContext::toCharUnitsFromBits(int64_t BitSize) const {
   return clang::CharUnits::fromQuantity(BitSize / getCharWidth());
 }
 
+/// Convert a size in characters to a size in characters.
+int64_t CIRLowerContext::toBits(clang::CharUnits CharSize) const {
+  return CharSize.getQuantity() * getCharWidth();
+}
+
 clang::TypeInfoChars CIRLowerContext::getTypeInfoInChars(Type T) const {
   if (auto arrTy = dyn_cast<ArrayType>(T))
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.h
@@ -42,7 +42,7 @@ private:
 
   /// The language options used to create the AST associated with
   /// this ASTContext object.
-  clang::LangOptions &LangOpts;
+  clang::LangOptions LangOpts;
 
   //===--------------------------------------------------------------------===//
   //                         Built-in Types
@@ -51,7 +51,7 @@ private:
   Type CharTy;
 
 public:
-  CIRLowerContext(ModuleOp module, clang::LangOptions &LOpts);
+  CIRLowerContext(ModuleOp module, clang::LangOptions LOpts);
   CIRLowerContext(const CIRLowerContext &) = delete;
   CIRLowerContext &operator=(const CIRLowerContext &) = delete;
   ~CIRLowerContext();

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_CIRLowerContext_H
 #define LLVM_CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_CIRLowerContext_H
 
+#include "CIRRecordLayout.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
@@ -69,6 +70,10 @@ private:
   Type initBuiltinType(clang::BuiltinType::Kind K);
 
 public:
+  const clang::TargetInfo &getTargetInfo() const { return *Target; }
+
+  const clang::LangOptions &getLangOpts() const { return LangOpts; }
+
   MLIRContext *getMLIRContext() const { return MLIRCtx; }
 
   //===--------------------------------------------------------------------===//
@@ -88,6 +93,9 @@ public:
 
   /// Convert a size in bits to a size in characters.
   clang::CharUnits toCharUnitsFromBits(int64_t BitSize) const;
+
+  /// Convert a size in characters to a size in bits.
+  int64_t toBits(clang::CharUnits CharSize) const;
 
   clang::CharUnits getTypeSizeInChars(Type T) const {
     // FIXME(cir): We should query MLIR's Datalayout here instead.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.h
@@ -110,6 +110,11 @@ public:
 
   /// More type predicates useful for type checking/promotion
   bool isPromotableIntegerType(Type T) const; // C99 6.3.1.1p2
+
+  /// Get or compute information about the layout of the specified
+  /// record (struct/union/class) \p D, which indicates its size and field
+  /// position information.
+  const CIRRecordLayout &getCIRRecordLayout(const Type D) const;
 };
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRRecordLayout.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRRecordLayout.cpp
@@ -16,7 +16,47 @@
 namespace mlir {
 namespace cir {
 
-CIRRecordLayout::CIRRecordLayout() {}
+// Constructor for C++ records.
+CIRRecordLayout::CIRRecordLayout(
+    const CIRLowerContext &Ctx, clang::CharUnits size,
+    clang::CharUnits alignment, clang::CharUnits preferredAlignment,
+    clang::CharUnits unadjustedAlignment, clang::CharUnits requiredAlignment,
+    bool hasOwnVFPtr, bool hasExtendableVFPtr, clang::CharUnits vbptroffset,
+    clang::CharUnits datasize, ArrayRef<uint64_t> fieldoffsets,
+    clang::CharUnits nonvirtualsize, clang::CharUnits nonvirtualalignment,
+    clang::CharUnits preferrednvalignment,
+    clang::CharUnits SizeOfLargestEmptySubobject, const Type PrimaryBase,
+    bool IsPrimaryBaseVirtual, const Type BaseSharingVBPtr,
+    bool EndsWithZeroSizedObject, bool LeadsWithZeroSizedBase)
+    : Size(size), DataSize(datasize), Alignment(alignment),
+      PreferredAlignment(preferredAlignment),
+      UnadjustedAlignment(unadjustedAlignment),
+      RequiredAlignment(requiredAlignment), CXXInfo(new CXXRecordLayoutInfo) {
+  // NOTE(cir): Clang does a far more elaborate append here by leveraging the
+  // custom ASTVector class. For now, we'll do a simple append.
+  FieldOffsets.insert(FieldOffsets.end(), fieldoffsets.begin(),
+                      fieldoffsets.end());
+
+  assert(!PrimaryBase && "Layout for class with inheritance is NYI");
+  // CXXInfo->PrimaryBase.setPointer(PrimaryBase);
+  assert(!IsPrimaryBaseVirtual && "Layout for virtual base class is NYI");
+  // CXXInfo->PrimaryBase.setInt(IsPrimaryBaseVirtual);
+  CXXInfo->NonVirtualSize = nonvirtualsize;
+  CXXInfo->NonVirtualAlignment = nonvirtualalignment;
+  CXXInfo->PreferredNVAlignment = preferrednvalignment;
+  CXXInfo->SizeOfLargestEmptySubobject = SizeOfLargestEmptySubobject;
+  // FIXME(cir): I'm assuming that since we are not dealing with inherited
+  // classes yet, removing the following lines will be ok.
+  // CXXInfo->BaseOffsets = BaseOffsets;
+  // CXXInfo->VBaseOffsets = VBaseOffsets;
+  CXXInfo->HasOwnVFPtr = hasOwnVFPtr;
+  CXXInfo->VBPtrOffset = vbptroffset;
+  CXXInfo->HasExtendableVFPtr = hasExtendableVFPtr;
+  // FIXME(cir): Probably not necessary for now.
+  // CXXInfo->BaseSharingVBPtr = BaseSharingVBPtr;
+  CXXInfo->EndsWithZeroSizedObject = EndsWithZeroSizedObject;
+  CXXInfo->LeadsWithZeroSizedBase = LeadsWithZeroSizedBase;
+}
 
 } // namespace cir
 } // namespace mlir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRRecordLayout.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRRecordLayout.h
@@ -14,17 +14,122 @@
 #ifndef LLVM_CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_CIRRECORDLAYOUT_H
 #define LLVM_CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_CIRRECORDLAYOUT_H
 
+#include "mlir/IR/Types.h"
+#include "mlir/Support/LLVM.h"
+#include "clang/AST/CharUnits.h"
+#include <cstdint>
+#include <vector>
+
 namespace mlir {
 namespace cir {
 
 class CIRLowerContext;
+
+// FIXME(cir): Perhaps this logic can be moved to the CIR dialect, specifically
+// the data layout abstractions.
 
 /// This class contains layout information for one RecordDecl, which is a
 /// struct/union/class.  The decl represented must be a definition, not a
 /// forward declaration. This class is also used to contain layout information
 /// for one ObjCInterfaceDecl.
 class CIRRecordLayout {
-  CIRRecordLayout();
+
+private:
+  friend class CIRLowerContext;
+
+  /// Size of record in characters.
+  clang::CharUnits Size;
+
+  /// Size of record in characters without tail padding.
+  clang::CharUnits DataSize;
+
+  // Alignment of record in characters.
+  clang::CharUnits Alignment;
+
+  // Preferred alignment of record in characters. This can be different than
+  // Alignment in cases where it is beneficial for performance or backwards
+  // compatibility preserving (e.g. AIX-ABI).
+  clang::CharUnits PreferredAlignment;
+
+  // Maximum of the alignments of the record members in characters.
+  clang::CharUnits UnadjustedAlignment;
+
+  /// The required alignment of the object. In the MS-ABI the
+  /// __declspec(align()) trumps #pramga pack and must always be obeyed.
+  clang::CharUnits RequiredAlignment;
+
+  /// Array of field offsets in bits.
+  /// FIXME(cir): Create a custom CIRVector instead?
+  std::vector<uint64_t> FieldOffsets;
+
+  struct CXXRecordLayoutInfo {
+    /// The non-virtual size (in chars) of an object, which is the size of the
+    /// object without virtual bases.
+    clang::CharUnits NonVirtualSize;
+
+    /// The non-virtual alignment (in chars) of an object, which is the
+    /// alignment of the object without virtual bases.
+    clang::CharUnits NonVirtualAlignment;
+
+    /// The preferred non-virtual alignment (in chars) of an object, which is
+    /// the preferred alignment of the object without virtual bases.
+    clang::CharUnits PreferredNVAlignment;
+
+    /// The size of the largest empty subobject (either a base or a member).
+    /// Will be zero if the class doesn't contain any empty subobjects.
+    clang::CharUnits SizeOfLargestEmptySubobject;
+
+    /// Virtual base table offset (Microsoft-only).
+    clang::CharUnits VBPtrOffset;
+
+    /// Does this class provide a virtual function table (vtable in Itanium,
+    /// vftbl in Microsoft) that is independent from its base classes?
+    bool HasOwnVFPtr : 1;
+
+    /// Does this class have a vftable that could be extended by a derived
+    /// class.  The class may have inherited this pointer from a primary base
+    /// class.
+    bool HasExtendableVFPtr : 1;
+
+    /// True if this class contains a zero sized member or base or a base with a
+    /// zero sized member or base. Only used for MS-ABI.
+    bool EndsWithZeroSizedObject : 1;
+
+    /// True if this class is zero sized or first base is zero sized or has this
+    /// property.  Only used for MS-ABI.
+    bool LeadsWithZeroSizedBase : 1;
+  };
+
+  /// CXXInfo - If the record layout is for a C++ record, this will have
+  /// C++ specific information about the record.
+  CXXRecordLayoutInfo *CXXInfo = nullptr;
+
+  // Constructor for C++ records.
+  CIRRecordLayout(
+      const CIRLowerContext &Ctx, clang::CharUnits size,
+      clang::CharUnits alignment, clang::CharUnits preferredAlignment,
+      clang::CharUnits unadjustedAlignment, clang::CharUnits requiredAlignment,
+      bool hasOwnVFPtr, bool hasExtendableVFPtr, clang::CharUnits vbptroffset,
+      clang::CharUnits datasize, ArrayRef<uint64_t> fieldoffsets,
+      clang::CharUnits nonvirtualsize, clang::CharUnits nonvirtualalignment,
+      clang::CharUnits preferrednvalignment,
+      clang::CharUnits SizeOfLargestEmptySubobject, const Type PrimaryBase,
+      bool IsPrimaryBaseVirtual, const Type BaseSharingVBPtr,
+      bool EndsWithZeroSizedObject, bool LeadsWithZeroSizedBase);
+
+  ~CIRRecordLayout() = default;
+
+public:
+  /// Get the record alignment in characters.
+  clang::CharUnits getAlignment() const { return Alignment; }
+
+  /// Get the record size in characters.
+  clang::CharUnits getSize() const { return Size; }
+
+  /// Get the offset of the given field index, in bits.
+  uint64_t getFieldOffset(unsigned FieldNo) const {
+    return FieldOffsets[FieldNo];
+  }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -43,6 +43,14 @@ public:
         UseARMGuardVarABI(UseARMGuardVarABI), Use32BitVTableOffsetABI(false) {}
 
   bool classifyReturnType(LowerFunctionInfo &FI) const override;
+
+  // FIXME(cir): This expects a CXXRecordDecl! Not any record type.
+  RecordArgABI getRecordArgABI(const StructType RD) const override {
+    assert(!::cir::MissingFeatures::recordDeclIsCXXDecl());
+    // If C++ prohibits us from making a copy, pass by address.
+    assert(!::cir::MissingFeatures::recordDeclCanPassInRegisters());
+    return RAA_Default;
+  }
 };
 
 } // namespace

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.h
@@ -71,6 +71,15 @@ public:
   LogicalResult generateCode(FuncOp oldFn, FuncOp newFn,
                              const LowerFunctionInfo &FnInfo);
 
+  // Emit the most simple cir.store possible (e.g. a store for a whole
+  // struct), which can later be broken down in other CIR levels (or prior
+  // to dialect codegen).
+  void buildAggregateStore(Value Val, Value Dest, bool DestIsVolatile);
+
+  // Emit a simple bitcast for a coerced aggregate type to convert it from an
+  // ABI-agnostic to an ABI-aware type.
+  Value buildAggregateBitcast(Value Val, Type DestTy);
+
   /// Rewrite a call operation to abide to the ABI calling convention.
   LogicalResult rewriteCallOp(CallOp op,
                               ReturnValueSlot retValSlot = ReturnValueSlot());

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -23,6 +23,7 @@
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/TargetInfo.h"
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/MissingFeatures.h"
 #include <memory>
@@ -54,6 +55,10 @@ public:
   const clang::TargetInfo &getTarget() const { return *Target; }
   MLIRContext *getMLIRContext() { return module.getContext(); }
   ModuleOp &getModule() { return module; }
+
+  const ::cir::CIRDataLayout &getDataLayout() const {
+    return types.getDataLayout();
+  }
 
   const TargetLoweringInfo &getTargetLoweringInfo();
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
@@ -37,7 +37,7 @@ LowerTypes::LowerTypes(LowerModule &LM, StringRef DLString)
     : LM(LM), context(LM.getContext()), Target(LM.getTarget()),
       CXXABI(LM.getCXXABI()),
       TheABIInfo(LM.getTargetLoweringInfo().getABIInfo()),
-      mlirContext(LM.getMLIRContext()), DL(DLString, LM.getModule()) {}
+      mlirContext(LM.getMLIRContext()), DL(LM.getModule()) {}
 
 /// Return the ABI-specific function type for a CIR function type.
 FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.h
@@ -60,6 +60,7 @@ public:
   LowerModule &getLM() const { return LM; }
   CIRCXXABI &getCXXABI() const { return CXXABI; }
   CIRLowerContext &getContext() { return context; }
+  const clang::TargetInfo &getTarget() const { return Target; }
   MLIRContext *getMLIRContext() { return mlirContext; }
 
   /// Convert clang calling convention to LLVM callilng convention.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/RecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/RecordLayoutBuilder.cpp
@@ -10,3 +10,640 @@
 // queries are adapted to operate on the CIR dialect, however.
 //
 //===----------------------------------------------------------------------===//
+
+#include "CIRLowerContext.h"
+#include "CIRRecordLayout.h"
+#include "mlir/IR/Types.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "clang/CIR/MissingFeatures.h"
+
+using namespace mlir;
+using namespace mlir::cir;
+
+namespace {
+
+//===-----------------------------------------------------------------------==//
+// EmptySubobjectMap Implementation
+//===----------------------------------------------------------------------===//
+
+/// Keeps track of which empty subobjects exist at different offsets while
+/// laying out a C++ class.
+class EmptySubobjectMap {
+  const CIRLowerContext &Context;
+  uint64_t CharWidth;
+
+  /// The class whose empty entries we're keeping track of.
+  const StructType Class;
+
+  /// The highest offset known to contain an empty base subobject.
+  clang::CharUnits MaxEmptyClassOffset;
+
+  /// Compute the size of the largest base or member subobject that is empty.
+  void ComputeEmptySubobjectSizes();
+
+public:
+  /// This holds the size of the largest empty subobject (either a base
+  /// or a member). Will be zero if the record being built doesn't contain
+  /// any empty classes.
+  clang::CharUnits SizeOfLargestEmptySubobject;
+
+  EmptySubobjectMap(const CIRLowerContext &Context, const StructType Class)
+      : Context(Context), CharWidth(Context.getCharWidth()), Class(Class) {
+    ComputeEmptySubobjectSizes();
+  }
+
+  /// Return whether a field can be placed at the given offset.
+  bool canPlaceFieldAtOffset(const Type Ty, clang::CharUnits Offset);
+};
+
+void EmptySubobjectMap::ComputeEmptySubobjectSizes() {
+  // Check the bases.
+  assert(!::cir::MissingFeatures::getCXXRecordBases());
+
+  // Check the fields.
+  for (const auto FT : Class.getMembers()) {
+    assert(!::cir::MissingFeatures::qualifiedTypes());
+    const auto RT = dyn_cast<StructType>(FT);
+
+    // We only care about record types.
+    if (!RT)
+      continue;
+
+    // TODO(cir): Handle nested record types.
+    llvm_unreachable("NYI");
+  }
+}
+
+bool EmptySubobjectMap::canPlaceFieldAtOffset(const Type Ty,
+                                              clang::CharUnits Offset) {
+  llvm_unreachable("NYI");
+}
+
+//===-----------------------------------------------------------------------==//
+// ItaniumRecordLayoutBuilder Implementation
+//===----------------------------------------------------------------------===//
+
+class ItaniumRecordLayoutBuilder {
+protected:
+  // FIXME(cir):  Remove this and make the appropriate fields public.
+  friend class mlir::cir::CIRLowerContext;
+
+  const CIRLowerContext &Context;
+
+  EmptySubobjectMap *EmptySubobjects;
+
+  /// Size - The current size of the record layout.
+  uint64_t Size;
+
+  /// Alignment - The current alignment of the record layout.
+  clang::CharUnits Alignment;
+
+  /// PreferredAlignment - The preferred alignment of the record layout.
+  clang::CharUnits PreferredAlignment;
+
+  /// The alignment if attribute packed is not used.
+  clang::CharUnits UnpackedAlignment;
+
+  /// \brief The maximum of the alignments of top-level members.
+  clang::CharUnits UnadjustedAlignment;
+
+  SmallVector<uint64_t, 16> FieldOffsets;
+
+  /// Whether the external AST source has provided a layout for this
+  /// record.
+  unsigned UseExternalLayout : 1;
+
+  /// Whether we need to infer alignment, even when we have an
+  /// externally-provided layout.
+  unsigned InferAlignment : 1;
+
+  /// Packed - Whether the record is packed or not.
+  unsigned Packed : 1;
+
+  unsigned IsUnion : 1;
+
+  unsigned IsMac68kAlign : 1;
+
+  unsigned IsNaturalAlign : 1;
+
+  unsigned IsMsStruct : 1;
+
+  /// UnfilledBitsInLastUnit - If the last field laid out was a bitfield,
+  /// this contains the number of bits in the last unit that can be used for
+  /// an adjacent bitfield if necessary.  The unit in question is usually
+  /// a byte, but larger units are used if IsMsStruct.
+  unsigned char UnfilledBitsInLastUnit;
+
+  /// LastBitfieldStorageUnitSize - If IsMsStruct, represents the size of the
+  /// storage unit of the previous field if it was a bitfield.
+  unsigned char LastBitfieldStorageUnitSize;
+
+  /// MaxFieldAlignment - The maximum allowed field alignment. This is set by
+  /// #pragma pack.
+  clang::CharUnits MaxFieldAlignment;
+
+  /// DataSize - The data size of the record being laid out.
+  uint64_t DataSize;
+
+  clang::CharUnits NonVirtualSize;
+  clang::CharUnits NonVirtualAlignment;
+  clang::CharUnits PreferredNVAlignment;
+
+  /// If we've laid out a field but not included its tail padding in Size yet,
+  /// this is the size up to the end of that field.
+  clang::CharUnits PaddedFieldSize;
+
+  /// The primary base class (if one exists) of the class we're laying out.
+  const StructType PrimaryBase;
+
+  /// Whether the primary base of the class we're laying out is virtual.
+  bool PrimaryBaseIsVirtual;
+
+  /// Whether the class provides its own vtable/vftbl pointer, as opposed to
+  /// inheriting one from a primary base class.
+  bool HasOwnVFPtr;
+
+  /// the flag of field offset changing due to packed attribute.
+  bool HasPackedField;
+
+  /// An auxiliary field used for AIX. When there are OverlappingEmptyFields
+  /// existing in the aggregate, the flag shows if the following first non-empty
+  /// or empty-but-non-overlapping field has been handled, if any.
+  bool HandledFirstNonOverlappingEmptyField;
+
+public:
+  ItaniumRecordLayoutBuilder(const CIRLowerContext &Context,
+                             EmptySubobjectMap *EmptySubobjects)
+      : Context(Context), EmptySubobjects(EmptySubobjects), Size(0),
+        Alignment(clang::CharUnits::One()),
+        PreferredAlignment(clang::CharUnits::One()),
+        UnpackedAlignment(clang::CharUnits::One()),
+        UnadjustedAlignment(clang::CharUnits::One()), UseExternalLayout(false),
+        InferAlignment(false), Packed(false), IsUnion(false),
+        IsMac68kAlign(false),
+        IsNaturalAlign(!Context.getTargetInfo().getTriple().isOSAIX()),
+        IsMsStruct(false), UnfilledBitsInLastUnit(0),
+        LastBitfieldStorageUnitSize(0),
+        MaxFieldAlignment(clang::CharUnits::Zero()), DataSize(0),
+        NonVirtualSize(clang::CharUnits::Zero()),
+        NonVirtualAlignment(clang::CharUnits::One()),
+        PreferredNVAlignment(clang::CharUnits::One()),
+        PaddedFieldSize(clang::CharUnits::Zero()), PrimaryBaseIsVirtual(false),
+        HasOwnVFPtr(false), HasPackedField(false),
+        HandledFirstNonOverlappingEmptyField(false) {}
+
+  void layout(const StructType D);
+
+  void layoutFields(const StructType D);
+  void layoutField(const Type Ty, bool InsertExtraPadding);
+
+  void UpdateAlignment(clang::CharUnits NewAlignment,
+                       clang::CharUnits UnpackedNewAlignment,
+                       clang::CharUnits PreferredAlignment);
+
+  void checkFieldPadding(uint64_t Offset, uint64_t UnpaddedOffset,
+                         uint64_t UnpackedOffset, unsigned UnpackedAlign,
+                         bool isPacked, const Type Ty);
+
+  clang::CharUnits getSize() const {
+    assert(Size % Context.getCharWidth() == 0);
+    return Context.toCharUnitsFromBits(Size);
+  }
+  uint64_t getSizeInBits() const { return Size; }
+
+  void setSize(clang::CharUnits NewSize) { Size = Context.toBits(NewSize); }
+  void setSize(uint64_t NewSize) { Size = NewSize; }
+
+  clang::CharUnits getDataSize() const {
+    assert(DataSize % Context.getCharWidth() == 0);
+    return Context.toCharUnitsFromBits(DataSize);
+  }
+
+  /// Initialize record layout for the given record decl.
+  void initializeLayout(const Type Ty);
+
+  uint64_t getDataSizeInBits() const { return DataSize; }
+
+  void setDataSize(clang::CharUnits NewSize) {
+    DataSize = Context.toBits(NewSize);
+  }
+  void setDataSize(uint64_t NewSize) { DataSize = NewSize; }
+};
+
+void ItaniumRecordLayoutBuilder::layout(const StructType RT) {
+  initializeLayout(RT);
+
+  // Lay out the vtable and the non-virtual bases.
+  assert(!::cir::MissingFeatures::isCXXRecordDecl() &&
+         !::cir::MissingFeatures::CXXRecordIsDynamicClass());
+
+  layoutFields(RT);
+
+  // NonVirtualSize = Context.toCharUnitsFromBits(
+  //     llvm::alignTo(getSizeInBits(),
+  //     Context.getTargetInfo().getCharAlign()));
+  // NonVirtualAlignment = Alignment;
+  // PreferredNVAlignment = PreferredAlignment;
+
+  // // Lay out the virtual bases and add the primary virtual base offsets.
+  // LayoutVirtualBases(RD, RD);
+
+  // // Finally, round the size of the total struct up to the alignment
+  // // of the struct itself.
+  // FinishLayout(RD);
+}
+
+void ItaniumRecordLayoutBuilder::initializeLayout(const mlir::Type Ty) {
+  if (const auto RT = dyn_cast<StructType>(Ty)) {
+    IsUnion = RT.isUnion();
+    assert(!::cir::MissingFeatures::recordDeclIsMSStruct());
+  }
+
+  assert(!::cir::MissingFeatures::recordDeclIsPacked());
+
+  // Honor the default struct packing maximum alignment flag.
+  if (unsigned DefaultMaxFieldAlignment = Context.getLangOpts().PackStruct) {
+    llvm_unreachable("NYI");
+  }
+
+  // mac68k alignment supersedes maximum field alignment and attribute aligned,
+  // and forces all structures to have 2-byte alignment. The IBM docs on it
+  // allude to additional (more complicated) semantics, especially with regard
+  // to bit-fields, but gcc appears not to follow that.
+  if (::cir::MissingFeatures::declHasAlignMac68kAttr()) {
+    llvm_unreachable("NYI");
+  } else {
+    if (::cir::MissingFeatures::declHasAlignNaturalAttr())
+      llvm_unreachable("NYI");
+
+    if (::cir::MissingFeatures::declHasMaxFieldAlignmentAttr())
+      llvm_unreachable("NYI");
+
+    if (::cir::MissingFeatures::declGetMaxAlignment())
+      llvm_unreachable("NYI");
+  }
+
+  HandledFirstNonOverlappingEmptyField =
+      !Context.getTargetInfo().defaultsToAIXPowerAlignment() || IsNaturalAlign;
+
+  // If there is an external AST source, ask it for the various offsets.
+  if (const auto RT = dyn_cast<StructType>(Ty)) {
+    if (::cir::MissingFeatures::astContextGetExternalSource()) {
+      llvm_unreachable("NYI");
+    }
+  }
+}
+
+void ItaniumRecordLayoutBuilder::layoutField(const Type D,
+                                             bool InsertExtraPadding) {
+  // auto FieldClass = D.dyn_cast<StructType>();
+  assert(!::cir::MissingFeatures::fieldDeclIsPotentiallyOverlapping() &&
+         !::cir::MissingFeatures::CXXRecordDeclIsEmptyCXX11());
+  bool IsOverlappingEmptyField = false; // FIXME(cir): Needs more features.
+
+  clang::CharUnits FieldOffset = (IsUnion || IsOverlappingEmptyField)
+                                     ? clang::CharUnits::Zero()
+                                     : getDataSize();
+
+  const bool DefaultsToAIXPowerAlignment =
+      Context.getTargetInfo().defaultsToAIXPowerAlignment();
+  bool FoundFirstNonOverlappingEmptyFieldForAIX = false;
+  if (DefaultsToAIXPowerAlignment && !HandledFirstNonOverlappingEmptyField) {
+    llvm_unreachable("NYI");
+  }
+
+  assert(!::cir::MissingFeatures::fieldDeclIsBitfield());
+
+  uint64_t UnpaddedFieldOffset = getDataSizeInBits() - UnfilledBitsInLastUnit;
+  // Reset the unfilled bits.
+  UnfilledBitsInLastUnit = 0;
+  LastBitfieldStorageUnitSize = 0;
+
+  llvm::Triple Target = Context.getTargetInfo().getTriple();
+
+  clang::AlignRequirementKind AlignRequirement =
+      clang::AlignRequirementKind::None;
+  clang::CharUnits FieldSize;
+  clang::CharUnits FieldAlign;
+  // The amount of this class's dsize occupied by the field.
+  // This is equal to FieldSize unless we're permitted to pack
+  // into the field's tail padding.
+  clang::CharUnits EffectiveFieldSize;
+
+  auto setDeclInfo = [&](bool IsIncompleteArrayType) {
+    auto TI = Context.getTypeInfoInChars(D);
+    FieldAlign = TI.Align;
+    // Flexible array members don't have any size, but they have to be
+    // aligned appropriately for their element type.
+    EffectiveFieldSize = FieldSize =
+        IsIncompleteArrayType ? clang::CharUnits::Zero() : TI.Width;
+    AlignRequirement = TI.AlignRequirement;
+  };
+
+  if (isa<ArrayType>(D) && cast<ArrayType>(D).getSize() == 0) {
+    llvm_unreachable("NYI");
+  } else {
+    setDeclInfo(false /* IsIncompleteArrayType */);
+
+    if (::cir::MissingFeatures::fieldDeclIsPotentiallyOverlapping())
+      llvm_unreachable("NYI");
+
+    if (IsMsStruct)
+      llvm_unreachable("NYI");
+  }
+
+  assert(!::cir::MissingFeatures::recordDeclIsPacked() &&
+         !::cir::MissingFeatures::CXXRecordDeclIsPOD());
+  bool FieldPacked = false; // FIXME(cir): Needs more features.
+
+  // When used as part of a typedef, or together with a 'packed' attribute, the
+  // 'aligned' attribute can be used to decrease alignment. In that case, it
+  // overrides any computed alignment we have, and there is no need to upgrade
+  // the alignment.
+  auto alignedAttrCanDecreaseAIXAlignment = [AlignRequirement, FieldPacked] {
+    // Enum alignment sources can be safely ignored here, because this only
+    // helps decide whether we need the AIX alignment upgrade, which only
+    // applies to floating-point types.
+    return AlignRequirement == clang::AlignRequirementKind::RequiredByTypedef ||
+           (AlignRequirement == clang::AlignRequirementKind::RequiredByRecord &&
+            FieldPacked);
+  };
+
+  // The AIX `power` alignment rules apply the natural alignment of the
+  // "first member" if it is of a floating-point data type (or is an aggregate
+  // whose recursively "first" member or element is such a type). The alignment
+  // associated with these types for subsequent members use an alignment value
+  // where the floating-point data type is considered to have 4-byte alignment.
+  //
+  // For the purposes of the foregoing: vtable pointers, non-empty base classes,
+  // and zero-width bit-fields count as prior members; members of empty class
+  // types marked `no_unique_address` are not considered to be prior members.
+  clang::CharUnits PreferredAlign = FieldAlign;
+  if (DefaultsToAIXPowerAlignment && !alignedAttrCanDecreaseAIXAlignment() &&
+      (FoundFirstNonOverlappingEmptyFieldForAIX || IsNaturalAlign)) {
+    llvm_unreachable("NYI");
+  }
+
+  // The align if the field is not packed. This is to check if the attribute
+  // was unnecessary (-Wpacked).
+  clang::CharUnits UnpackedFieldAlign = FieldAlign;
+  clang::CharUnits PackedFieldAlign = clang::CharUnits::One();
+  clang::CharUnits UnpackedFieldOffset = FieldOffset;
+  // clang::CharUnits OriginalFieldAlign = UnpackedFieldAlign;
+
+  assert(!::cir::MissingFeatures::fieldDeclGetMaxFieldAlignment());
+  clang::CharUnits MaxAlignmentInChars = clang::CharUnits::Zero();
+  PackedFieldAlign = std::max(PackedFieldAlign, MaxAlignmentInChars);
+  PreferredAlign = std::max(PreferredAlign, MaxAlignmentInChars);
+  UnpackedFieldAlign = std::max(UnpackedFieldAlign, MaxAlignmentInChars);
+
+  // The maximum field alignment overrides the aligned attribute.
+  if (!MaxFieldAlignment.isZero()) {
+    llvm_unreachable("NYI");
+  }
+
+  if (!FieldPacked)
+    FieldAlign = UnpackedFieldAlign;
+  if (DefaultsToAIXPowerAlignment)
+    llvm_unreachable("NYI");
+  if (FieldPacked) {
+    llvm_unreachable("NYI");
+  }
+
+  clang::CharUnits AlignTo =
+      !DefaultsToAIXPowerAlignment ? FieldAlign : PreferredAlign;
+  // Round up the current record size to the field's alignment boundary.
+  FieldOffset = FieldOffset.alignTo(AlignTo);
+  UnpackedFieldOffset = UnpackedFieldOffset.alignTo(UnpackedFieldAlign);
+
+  if (UseExternalLayout) {
+    llvm_unreachable("NYI");
+  } else {
+    if (!IsUnion && EmptySubobjects) {
+      // Check if we can place the field at this offset.
+      while (/*!EmptySubobjects->CanPlaceFieldAtOffset(D, FieldOffset)*/
+             false) {
+        llvm_unreachable("NYI");
+      }
+    }
+  }
+
+  // Place this field at the current location.
+  FieldOffsets.push_back(Context.toBits(FieldOffset));
+
+  if (!UseExternalLayout)
+    checkFieldPadding(Context.toBits(FieldOffset), UnpaddedFieldOffset,
+                      Context.toBits(UnpackedFieldOffset),
+                      Context.toBits(UnpackedFieldAlign), FieldPacked, D);
+
+  if (InsertExtraPadding) {
+    llvm_unreachable("NYI");
+  }
+
+  // Reserve space for this field.
+  if (!IsOverlappingEmptyField) {
+    // uint64_t EffectiveFieldSizeInBits = Context.toBits(EffectiveFieldSize);
+    if (IsUnion)
+      llvm_unreachable("NYI");
+    else
+      setDataSize(FieldOffset + EffectiveFieldSize);
+
+    PaddedFieldSize = std::max(PaddedFieldSize, FieldOffset + FieldSize);
+    setSize(std::max(getSizeInBits(), getDataSizeInBits()));
+  } else {
+    llvm_unreachable("NYI");
+  }
+
+  // Remember max struct/class ABI-specified alignment.
+  UnadjustedAlignment = std::max(UnadjustedAlignment, FieldAlign);
+  UpdateAlignment(FieldAlign, UnpackedFieldAlign, PreferredAlign);
+
+  // For checking the alignment of inner fields against
+  // the alignment of its parent record.
+  // FIXME(cir): We need to track the parent record of the current type being
+  // laid out. A regular mlir::Type has not way of doing this. In fact, we will
+  // likely need an external abstraction, as I don't think this is possible with
+  // just the field type.
+  assert(!::cir::MissingFeatures::fieldDeclAbstraction());
+
+  if (Packed && !FieldPacked && PackedFieldAlign < FieldAlign)
+    llvm_unreachable("NYI");
+}
+
+void ItaniumRecordLayoutBuilder::layoutFields(const StructType D) {
+  // Layout each field, for now, just sequentially, respecting alignment.  In
+  // the future, this will need to be tweakable by targets.
+  assert(!::cir::MissingFeatures::recordDeclMayInsertExtraPadding() &&
+         !Context.getLangOpts().SanitizeAddressFieldPadding);
+  bool InsertExtraPadding = false;
+  assert(!::cir::MissingFeatures::recordDeclHasFlexibleArrayMember());
+  bool HasFlexibleArrayMember = false;
+  for (const auto FT : D.getMembers()) {
+    layoutField(FT, InsertExtraPadding && (FT != D.getMembers().back() ||
+                                           !HasFlexibleArrayMember));
+  }
+}
+
+void ItaniumRecordLayoutBuilder::UpdateAlignment(
+    clang::CharUnits NewAlignment, clang::CharUnits UnpackedNewAlignment,
+    clang::CharUnits PreferredNewAlignment) {
+  // The alignment is not modified when using 'mac68k' alignment or when
+  // we have an externally-supplied layout that also provides overall alignment.
+  if (IsMac68kAlign || (UseExternalLayout && !InferAlignment))
+    return;
+
+  if (NewAlignment > Alignment) {
+    assert(llvm::isPowerOf2_64(NewAlignment.getQuantity()) &&
+           "Alignment not a power of 2");
+    Alignment = NewAlignment;
+  }
+
+  if (UnpackedNewAlignment > UnpackedAlignment) {
+    assert(llvm::isPowerOf2_64(UnpackedNewAlignment.getQuantity()) &&
+           "Alignment not a power of 2");
+    UnpackedAlignment = UnpackedNewAlignment;
+  }
+
+  if (PreferredNewAlignment > PreferredAlignment) {
+    assert(llvm::isPowerOf2_64(PreferredNewAlignment.getQuantity()) &&
+           "Alignment not a power of 2");
+    PreferredAlignment = PreferredNewAlignment;
+  }
+}
+
+void ItaniumRecordLayoutBuilder::checkFieldPadding(
+    uint64_t Offset, uint64_t UnpaddedOffset, uint64_t UnpackedOffset,
+    unsigned UnpackedAlign, bool isPacked, const Type Ty) {
+  // We let objc ivars without warning, objc interfaces generally are not used
+  // for padding tricks.
+  if (::cir::MissingFeatures::objCIvarDecls())
+    llvm_unreachable("NYI");
+
+  // FIXME(cir): Should the following be skiped in CIR?
+  // Don't warn about structs created without a SourceLocation.  This can
+  // be done by clients of the AST, such as codegen.
+
+  unsigned CharBitNum = Context.getTargetInfo().getCharWidth();
+
+  // Warn if padding was introduced to the struct/class.
+  if (!IsUnion && Offset > UnpaddedOffset) {
+    unsigned PadSize = Offset - UnpaddedOffset;
+    // bool InBits = true;
+    if (PadSize % CharBitNum == 0) {
+      PadSize = PadSize / CharBitNum;
+      // InBits = false;
+    }
+    assert(::cir::MissingFeatures::bitFieldPaddingDiagnostics());
+  }
+  if (isPacked && Offset != UnpackedOffset) {
+    HasPackedField = true;
+  }
+}
+
+//===-----------------------------------------------------------------------==//
+// Misc. Helper Functions
+//===----------------------------------------------------------------------===//
+
+bool isMsLayout(const CIRLowerContext &Context) {
+  return Context.getTargetInfo().getCXXABI().isMicrosoft();
+}
+
+/// Does the target C++ ABI require us to skip over the tail-padding
+/// of the given class (considering it as a base class) when allocating
+/// objects?
+static bool mustSkipTailPadding(clang::TargetCXXABI ABI, const StructType RD) {
+  assert(!::cir::MissingFeatures::recordDeclIsCXXDecl());
+  switch (ABI.getTailPaddingUseRules()) {
+  case clang::TargetCXXABI::AlwaysUseTailPadding:
+    return false;
+
+  case clang::TargetCXXABI::UseTailPaddingUnlessPOD03:
+    // FIXME: To the extent that this is meant to cover the Itanium ABI
+    // rules, we should implement the restrictions about over-sized
+    // bitfields:
+    //
+    // http://itanium-cxx-abi.github.io/cxx-abi/abi.html#POD :
+    //   In general, a type is considered a POD for the purposes of
+    //   layout if it is a POD type (in the sense of ISO C++
+    //   [basic.types]). However, a POD-struct or POD-union (in the
+    //   sense of ISO C++ [class]) with a bitfield member whose
+    //   declared width is wider than the declared type of the
+    //   bitfield is not a POD for the purpose of layout.  Similarly,
+    //   an array type is not a POD for the purpose of layout if the
+    //   element type of the array is not a POD for the purpose of
+    //   layout.
+    //
+    //   Where references to the ISO C++ are made in this paragraph,
+    //   the Technical Corrigendum 1 version of the standard is
+    //   intended.
+    // FIXME(cir): This always returns true since we can't check if a CIR record
+    // is a POD type.
+    assert(!::cir::MissingFeatures::CXXRecordDeclIsPOD());
+    return true;
+
+  case clang::TargetCXXABI::UseTailPaddingUnlessPOD11:
+    // This is equivalent to RD->getTypeForDecl().isCXX11PODType(),
+    // but with a lot of abstraction penalty stripped off.  This does
+    // assume that these properties are set correctly even in C++98
+    // mode; fortunately, that is true because we want to assign
+    // consistently semantics to the type-traits intrinsics (or at
+    // least as many of them as possible).
+    llvm_unreachable("NYI");
+  }
+
+  llvm_unreachable("bad tail-padding use kind");
+}
+
+} // namespace
+
+/// Get or compute information about the layout of the specified record
+/// (struct/union/class), which indicates its size and field position
+/// information.
+const CIRRecordLayout &CIRLowerContext::getCIRRecordLayout(const Type D) const {
+  assert(isa<StructType>(D) && "Not a record type");
+  auto RT = dyn_cast<StructType>(D);
+
+  assert(RT.isComplete() && "Cannot get layout of forward declarations!");
+
+  // FIXME(cir): Cache the layout. Also, use a more MLIR-based approach.
+
+  const CIRRecordLayout *NewEntry = nullptr;
+
+  if (isMsLayout(*this)) {
+    llvm_unreachable("NYI");
+  } else {
+    // FIXME(cir): Add if-else separating C and C++ records.
+    assert(!::cir::MissingFeatures::isCXXRecordDecl());
+    EmptySubobjectMap EmptySubobjects(*this, RT);
+    ItaniumRecordLayoutBuilder Builder(*this, &EmptySubobjects);
+    Builder.layout(RT);
+
+    // In certain situations, we are allowed to lay out objects in the
+    // tail-padding of base classes.  This is ABI-dependent.
+    // FIXME: this should be stored in the record layout.
+    bool skipTailPadding = mustSkipTailPadding(getTargetInfo().getCXXABI(), RT);
+
+    // FIXME: This should be done in FinalizeLayout.
+    clang::CharUnits DataSize =
+        skipTailPadding ? Builder.getSize() : Builder.getDataSize();
+    clang::CharUnits NonVirtualSize =
+        skipTailPadding ? DataSize : Builder.NonVirtualSize;
+    assert(!::cir::MissingFeatures::CXXRecordIsDynamicClass());
+    // FIXME(cir): Whose responsible for freeing the allocation below?
+    NewEntry = new CIRRecordLayout(
+        *this, Builder.getSize(), Builder.Alignment, Builder.PreferredAlignment,
+        Builder.UnadjustedAlignment,
+        /*RequiredAlignment : used by MS-ABI)*/
+        Builder.Alignment, Builder.HasOwnVFPtr, /*RD->isDynamicClass()=*/false,
+        clang::CharUnits::fromQuantity(-1), DataSize, Builder.FieldOffsets,
+        NonVirtualSize, Builder.NonVirtualAlignment,
+        Builder.PreferredNVAlignment,
+        EmptySubobjects.SizeOfLargestEmptySubobject, Builder.PrimaryBase,
+        Builder.PrimaryBaseIsVirtual, nullptr, false, false);
+  }
+
+  // TODO(cir): Cache the layout.
+  // TODO(cir): Add option to dump the layouts.
+
+  return *NewEntry;
+}

--- a/clang/test/CIR/Lowering/address-space.cir
+++ b/clang/test/CIR/Lowering/address-space.cir
@@ -5,7 +5,8 @@
 
 module attributes {
   cir.triple = "spirv64-unknown-unknown",
-  llvm.data_layout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+  llvm.data_layout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1",
+  dlti.dl_spec = #dlti.dl_spec<> // Avoid assert errors.
 } {
   // LLVM: define void @foo(ptr %0)
   cir.func @foo(%arg0: !cir.ptr<!s32i>) {

--- a/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
@@ -87,3 +87,32 @@ double Double(double d) {
   // cir.call @_Z6Doubled(%{{.+}}) : (!cir.double) -> !cir.double
   return Double(d);
 }
+
+
+/// Test call conv lowering for struct type coercion scenarios. ///
+
+struct S1 {
+  int a, b;
+};
+
+
+/// Validate coerced argument and cast it to the expected type.
+
+/// Cast arguments to the expected type.
+// CHECK: cir.func @_Z2s12S1(%arg0: !u64i loc({{.+}})) -> !u64i
+// CHECK: %[[#V0:]] = cir.alloca !ty_22S122, !cir.ptr<!ty_22S122>
+// CHECK: %[[#V1:]] = cir.cast(bitcast, %arg0 : !u64i), !ty_22S122
+// CHECK: cir.store %[[#V1]], %[[#V0]] : !ty_22S122, !cir.ptr<!ty_22S122>
+S1 s1(S1 arg) {
+
+  /// Cast argument and result of the function call to the expected types.
+  // CHECK: %[[#V9:]] = cir.cast(bitcast, %{{.+}} : !ty_22S122), !u64i
+  // CHECK: %[[#V10:]] = cir.call @_Z2s12S1(%[[#V9]]) : (!u64i) -> !u64i
+  // CHECK: %[[#V11:]] = cir.cast(bitcast, %[[#V10]] : !u64i), !ty_22S122
+  s1({1, 2});
+
+  // CHECK: %[[#V12:]] = cir.load %{{.+}} : !cir.ptr<!ty_22S122>, !ty_22S122
+  // CHECK: %[[#V13:]] = cir.cast(bitcast, %[[#V12]] : !ty_22S122), !u64i
+  // CHECK: cir.return %[[#V13]] : !u64i
+  return {1, 2};
+}


### PR DESCRIPTION
This patch adds the necessary bits for unraveling struct arguments and
return values for the x86_64 calling convention.
