### PR TITLE
[CIR][CodeGen] Set address space for OpenCL static and local-qualified variables

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -165,6 +165,10 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
       builder.getContext(), astCtx.getTargetInfo().getMaxPointerWidth(),
       /*isSigned=*/true);
 
+  if (langOpts.OpenCL) {
+    createOpenCLRuntime();
+  }
+
   mlir::cir::sob::SignedOverflowBehavior sob;
   switch (langOpts.getSignedOverflowBehavior()) {
   case clang::LangOptions::SignedOverflowBehaviorTy::SOB_Defined:

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -15,6 +15,7 @@
 
 #include "CIRGenBuilder.h"
 #include "CIRGenCall.h"
+#include "CIRGenOpenCLRuntime.h"
 #include "CIRGenTypeCache.h"
 #include "CIRGenTypes.h"
 #include "CIRGenVTables.h"
@@ -101,6 +102,9 @@ private:
 
   /// Holds information about C++ vtables.
   CIRGenVTables VTables;
+
+  /// Holds the OpenCL runtime
+  std::unique_ptr<CIRGenOpenCLRuntime> openCLRuntime;
 
   /// Holds the OpenMP runtime
   std::unique_ptr<CIRGenOpenMPRuntime> openMPRuntime;
@@ -696,6 +700,16 @@ public:
 
   /// Print out an error that codegen doesn't support the specified decl yet.
   void ErrorUnsupported(const Decl *D, const char *Type);
+
+  /// Return a reference to the configured OpenMP runtime.
+  CIRGenOpenCLRuntime &getOpenCLRuntime() {
+    assert(openCLRuntime != nullptr);
+    return *openCLRuntime;
+  }
+
+  void createOpenCLRuntime() {
+    openCLRuntime.reset(new CIRGenOpenCLRuntime(*this));
+  }
 
   /// Return a reference to the configured OpenMP runtime.
   CIRGenOpenMPRuntime &getOpenMPRuntime() {

--- a/clang/lib/CIR/CodeGen/CIRGenOpenCLRuntime.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenCLRuntime.cpp
@@ -1,0 +1,29 @@
+//===-- CIRGenOpenCLRuntime.cpp - Interface to OpenCL Runtimes ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This provides an abstract class for OpenCL CIR generation. Concrete
+// subclasses of this implement code generation for specific OpenCL
+// runtime libraries.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenOpenCLRuntime.h"
+#include "CIRGenFunction.h"
+
+#include "clang/CIR/Dialect/IR/CIROpsEnums.h"
+
+using namespace clang;
+using namespace cir;
+
+CIRGenOpenCLRuntime::~CIRGenOpenCLRuntime() {}
+
+void CIRGenOpenCLRuntime::buildWorkGroupLocalVarDecl(CIRGenFunction &CGF,
+                                                     const VarDecl &D) {
+  return CGF.buildStaticVarDecl(D,
+                                mlir::cir::GlobalLinkageKind::InternalLinkage);
+}

--- a/clang/lib/CIR/CodeGen/CIRGenOpenCLRuntime.h
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenCLRuntime.h
@@ -1,0 +1,46 @@
+//===-- CIRGenOpenCLRuntime.h - Interface to OpenCL Runtimes -----*- C++ -*-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This provides an abstract class for OpenCL CIR generation. Concrete
+// subclasses of this implement code generation for specific OpenCL
+// runtime libraries.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_CIR_CIRGENOPENCLRUNTIME_H
+#define LLVM_CLANG_LIB_CIR_CIRGENOPENCLRUNTIME_H
+
+namespace clang {
+
+class VarDecl;
+
+} // namespace clang
+
+namespace cir {
+
+class CIRGenFunction;
+class CIRGenModule;
+
+class CIRGenOpenCLRuntime {
+protected:
+  CIRGenModule &CGM;
+
+public:
+  CIRGenOpenCLRuntime(CIRGenModule &CGM) : CGM(CGM) {}
+  virtual ~CIRGenOpenCLRuntime();
+
+  /// Emit the IR required for a work-group-local variable declaration, and add
+  /// an entry to CGF's LocalDeclMap for D.  The base class does this using
+  /// CIRGenFunction::EmitStaticVarDecl to emit an internal global for D.
+  virtual void buildWorkGroupLocalVarDecl(CIRGenFunction &CGF,
+                                          const clang::VarDecl &D);
+};
+
+} // namespace cir
+
+#endif // LLVM_CLANG_LIB_CIR_CIRGENOPENCLRUNTIME_H

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -31,6 +31,7 @@ add_clang_library(clangCIR
   CIRGenFunction.cpp
   CIRGenItaniumCXXABI.cpp
   CIRGenModule.cpp
+  CIRGenOpenCLRuntime.cpp
   CIRGenOpenCL.cpp
   CIRGenOpenMPRuntime.cpp
   CIRGenStmt.cpp

--- a/clang/test/CIR/CodeGen/OpenCL/global.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/global.cl
@@ -21,32 +21,3 @@ kernel void test_get_global() {
   // LLVM:      %[[#LOADB:]] = load i32, ptr addrspace(1) @b, align 4
   // LLVM-NEXT: store i32 %[[#LOADB]], ptr addrspace(1) @a, align 4
 }
-
-kernel void test_static(int i) {
-  static global int b = 15;
-  // CIR-DAG: cir.global "private" internal dsolocal addrspace(offload_global) @func.b = #cir.int<15> : !s32i {alignment = 4 : i64}
-  // LLVM-DAG: @func.b = internal addrspace(1) global i32 15
-
-  local int c;
-  // CIR-DAG: cir.global "private" internal dsolocal addrspace(offload_local) @func.c : !s32i {alignment = 4 : i64}
-  // LLVM-DAG: @func.c = internal addrspace(3) global i32 undef
-
-  // CIR-DAG: %[[#ADDRA:]] = cir.get_global @a : !cir.ptr<!s32i, addrspace(offload_global)>
-  // CIR-DAG: %[[#ADDRB:]] = cir.get_global @func.b : !cir.ptr<!s32i, addrspace(offload_global)>
-  // CIR-DAG: %[[#ADDRC:]] = cir.get_global @func.c : !cir.ptr<!s32i, addrspace(offload_local)>
-
-  c = a;
-  // CIR:      %[[#LOADA:]] = cir.load %[[#ADDRA]] : !cir.ptr<!s32i, addrspace(offload_global)>, !s32i
-  // CIR-NEXT: cir.store %[[#LOADA]], %[[#ADDRC]] : !s32i, !cir.ptr<!s32i, addrspace(offload_local)>
-
-  // LLVM:     %[[#LOADA:]] = load i32, ptr addrspace(1) @a, align 4
-  // LLVM-NEXT: store i32 %[[#LOADA]], ptr addrspace(3) @func.c, align 4
-
-  a = b;
-  // CIR: %[[#LOADB:]] = cir.load %[[#ADDRB]] : !cir.ptr<!s32i, addrspace(offload_global)>, !s32i
-  // CIR-NEXT: %[[#ADDRA:]] = cir.get_global @a : !cir.ptr<!s32i, addrspace(offload_global)>
-  // CIR-NEXT: cir.store %[[#LOADB]], %[[#ADDRA]] : !s32i, !cir.ptr<!s32i, addrspace(offload_global)>
-
-  // LLVM:      %[[#LOADB:]] = load i32, ptr addrspace(1) @func.b, align 4
-  // LLVM-NEXT: store i32 %[[#LOADB]], ptr addrspace(1) @a, align 4
-}

--- a/clang/test/CIR/CodeGen/OpenCL/global.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/global.cl
@@ -21,3 +21,13 @@ kernel void test_get_global() {
   // LLVM:      %[[#LOADB:]] = load i32, ptr addrspace(1) @b, align 4
   // LLVM-NEXT: store i32 %[[#LOADB]], ptr addrspace(1) @a, align 4
 }
+
+kernel void test_static(int i) {
+  static global int b = 15;
+  // CIR-DAG: cir.global "private" internal dsolocal addrspace(offload_global) @func.b = #cir.int<15> : !s32i {alignment = 4 : i64}
+  a = b;
+  // CIR: %[[#ADDRB:]] = cir.get_global @func.b : !cir.ptr<!s32i, addrspace(offload_global)>
+  // CIR-NEXT: %[[#LOADB:]] = cir.load %[[#ADDRB]] : !cir.ptr<!s32i, addrspace(offload_global)>, !s32i
+  // CIR-NEXT: %[[#ADDRA:]] = cir.get_global @a : !cir.ptr<!s32i, addrspace(offload_global)>
+  // CIR-NEXT: cir.store %[[#LOADB]], %[[#ADDRA]] : !s32i, !cir.ptr<!s32i, addrspace(offload_global)>
+}

--- a/clang/test/CIR/CodeGen/OpenCL/global.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/global.cl
@@ -25,9 +25,28 @@ kernel void test_get_global() {
 kernel void test_static(int i) {
   static global int b = 15;
   // CIR-DAG: cir.global "private" internal dsolocal addrspace(offload_global) @func.b = #cir.int<15> : !s32i {alignment = 4 : i64}
+  // LLVM-DAG: @func.b = internal addrspace(1) global i32 15
+
+  local int c;
+  // CIR-DAG: cir.global "private" internal dsolocal addrspace(offload_local) @func.c : !s32i {alignment = 4 : i64}
+  // LLVM-DAG: @func.c = internal addrspace(3) global i32 undef
+
+  // CIR-DAG: %[[#ADDRA:]] = cir.get_global @a : !cir.ptr<!s32i, addrspace(offload_global)>
+  // CIR-DAG: %[[#ADDRB:]] = cir.get_global @func.b : !cir.ptr<!s32i, addrspace(offload_global)>
+  // CIR-DAG: %[[#ADDRC:]] = cir.get_global @func.c : !cir.ptr<!s32i, addrspace(offload_local)>
+
+  c = a;
+  // CIR:      %[[#LOADA:]] = cir.load %[[#ADDRA]] : !cir.ptr<!s32i, addrspace(offload_global)>, !s32i
+  // CIR-NEXT: cir.store %[[#LOADA]], %[[#ADDRC]] : !s32i, !cir.ptr<!s32i, addrspace(offload_local)>
+
+  // LLVM:     %[[#LOADA:]] = load i32, ptr addrspace(1) @a, align 4
+  // LLVM-NEXT: store i32 %[[#LOADA]], ptr addrspace(3) @func.c, align 4
+
   a = b;
-  // CIR: %[[#ADDRB:]] = cir.get_global @func.b : !cir.ptr<!s32i, addrspace(offload_global)>
-  // CIR-NEXT: %[[#LOADB:]] = cir.load %[[#ADDRB]] : !cir.ptr<!s32i, addrspace(offload_global)>, !s32i
+  // CIR: %[[#LOADB:]] = cir.load %[[#ADDRB]] : !cir.ptr<!s32i, addrspace(offload_global)>, !s32i
   // CIR-NEXT: %[[#ADDRA:]] = cir.get_global @a : !cir.ptr<!s32i, addrspace(offload_global)>
   // CIR-NEXT: cir.store %[[#LOADB]], %[[#ADDRA]] : !s32i, !cir.ptr<!s32i, addrspace(offload_global)>
+
+  // LLVM:      %[[#LOADB:]] = load i32, ptr addrspace(1) @func.b, align 4
+  // LLVM-NEXT: store i32 %[[#LOADB]], ptr addrspace(1) @a, align 4
 }

--- a/clang/test/CIR/CodeGen/OpenCL/static-vardecl.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/static-vardecl.cl
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+
+kernel void test_static(int i) {
+  static global int b = 15;
+  // CIR-DAG: cir.global "private" internal dsolocal addrspace(offload_global) @test_static.b = #cir.int<15> : !s32i {alignment = 4 : i64}
+  // LLVM-DAG: @test_static.b = internal addrspace(1) global i32 15
+
+  local int c;
+  // CIR-DAG: cir.global "private" internal dsolocal addrspace(offload_local) @test_static.c : !s32i {alignment = 4 : i64}
+  // LLVM-DAG: @test_static.c = internal addrspace(3) global i32 undef
+
+  // CIR-DAG: %[[#ADDRB:]] = cir.get_global @test_static.b : !cir.ptr<!s32i, addrspace(offload_global)>
+  // CIR-DAG: %[[#ADDRC:]] = cir.get_global @test_static.c : !cir.ptr<!s32i, addrspace(offload_local)>
+
+  c = b;
+  // CIR:      %[[#LOADB:]] = cir.load %[[#ADDRB]] : !cir.ptr<!s32i, addrspace(offload_global)>, !s32i
+  // CIR-NEXT: cir.store %[[#LOADB]], %[[#ADDRC]] : !s32i, !cir.ptr<!s32i, addrspace(offload_local)>
+
+  // LLVM:     %[[#LOADB:]] = load i32, ptr addrspace(1) @test_static.b, align 4
+  // LLVM-NEXT: store i32 %[[#LOADB]], ptr addrspace(3) @test_static.c, align 4
+}


### PR DESCRIPTION
In OpenCL, `local`-qualified variables are implicitly considered as static. In order to support it, this PR unblocks code paths related to OpenCL static declarations in `CIRGenDecl.cpp`.

Following the approach of LLVM CodeGen, a new class `CIRGenOpenCLRuntime` is added to handle the language hook of creating `local`-qualified variables. The default behavior of this hook is quite simple. It forwards the call to `CGF.buildStaticVarDecl`.

So in CIR, the OpenCL local memory representation is equivalent to the one defined by SPIR-LLVM convention: a `cir.global` with `addrspace(local)` and *without initializer*, which corresponds to LLVM `undef` initializer. See check lines in test for more details.

A `static global`-qualified variable is also added in the test to exercise the static code path itself.