### PR TITLE
[CIR][clang] Inline variables processing

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -510,12 +510,11 @@ void CIRGenModule::buildGlobal(GlobalDecl GD) {
           assert(0 && "OMPDeclareTargetDeclAttr NYI");
         }
       }
-      // If this declaration may have caused an inline variable definition
-      // to change linkage, make sure that it's emitted.
-      // TODO(cir): probably use GetAddrOfGlobalVar(VD) below?
-      assert((astCtx.getInlineVariableDefinitionKind(VD) !=
-              ASTContext::InlineVariableDefinitionKind::Strong) &&
-             "not implemented");
+      // If this declaration may have caused an inline variable definition to
+      // change linkage, make sure that it's emitted.
+      if (astCtx.getInlineVariableDefinitionKind(VD) ==
+          ASTContext::InlineVariableDefinitionKind::Strong)
+        getAddrOfGlobalVar(VD);
       return;
     }
   }

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -184,7 +184,7 @@ llvm::Align CIRDataLayout::getAlignment(mlir::Type Ty, bool abiOrPref) const {
 
   // Fetch type alignment from MLIR's data layout.
   unsigned align = abiOrPref ? layout.getTypeABIAlignment(Ty)
-                               : layout.getTypePreferredAlignment(Ty);
+                             : layout.getTypePreferredAlignment(Ty);
   return llvm::Align(align);
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -235,8 +235,9 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
     } else if (isa<IntType>(Ty)) {
 
       // FIXME(cir): Clang's BuiltinType::Kind allow comparisons (GT, LT, etc).
-      // We should implement this in CIR to simplify the conditions below. Hence,
-      // Comparisons below might not be truly equivalent to the ones in Clang.
+      // We should implement this in CIR to simplify the conditions below.
+      // Hence, Comparisons below might not be truly equivalent to the ones in
+      // Clang.
       if (isa<IntType>(Ty)) {
         Current = Class::Integer;
       }

--- a/clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
+++ b/clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck -check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// For compatibility with C++11 and C++14, an out-of-line declaration of a
+// static constexpr local variable promotes the variable to weak_odr.
+struct compat {
+  static constexpr int a = 1;
+  static constexpr int b = 2;
+  static constexpr int c = 3;
+  static inline constexpr int d = 4;
+  static const int e = 5;
+  static const int f = 6;
+  static const int g = 7;
+};
+const int &compat_use_before_redecl = compat::b;
+const int compat::a;
+const int compat::b;
+const int compat::c;
+const int compat::d;
+const int compat::e;
+constexpr int compat::f;
+constexpr inline int compat::g;
+const int &compat_use_after_redecl1 = compat::c;
+const int &compat_use_after_redecl2 = compat::d;
+const int &compat_use_after_redecl3 = compat::g;
+
+// CIR: cir.global  weak_odr @_ZN6compat1bE = #cir.int<2> : !s32i
+// CIR: cir.global  weak_odr @_ZN6compat1aE = #cir.int<1> : !s32i
+// CIR: cir.global  weak_odr @_ZN6compat1cE = #cir.int<3> : !s32i
+// CIR: cir.global  external @_ZN6compat1eE = #cir.int<5> : !s32i
+// CIR: cir.global  weak_odr @_ZN6compat1fE = #cir.int<6> : !s32i
+// CIR: cir.global  linkonce_odr @_ZN6compat1dE = #cir.int<4> : !s32i
+// CIR: cir.global  linkonce_odr @_ZN6compat1gE = #cir.int<7> : !s32i
+
+// LLVM: @_ZN6compat1bE = weak_odr global i32 2
+// LLVM: @_ZN6compat1aE = weak_odr global i32 1
+// LLVM: @_ZN6compat1cE = weak_odr global i32 3
+// LLVM: @_ZN6compat1eE = global i32 5
+// LLVM: @_ZN6compat1fE = weak_odr global i32 6
+// LLVM: @_ZN6compat1dE = linkonce_odr global i32 4
+// LLVM: @_ZN6compat1gE = linkonce_odr global i32 7
+


### PR DESCRIPTION
There is an implementation for inline variables processing at CIR. The LIT test was taken from clang's cxx1z-inline-variables.cpp where the same functionality is tested for Clang Code generation. The test can be run as follows
```
bin/llvm-lit -v ../clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
```

Note: the pull request also contains a formatting change for two files:
- `clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp`
- `clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp`