### PR TITLE
[CIR][NFC] Replace ternary ops after lowering prepare to select ops

### DIFF
--- a/clang/test/CIR/CodeGen/complex-cast.c
+++ b/clang/test/CIR/CodeGen/complex-cast.c
@@ -173,41 +173,16 @@ void complex_to_bool() {
 // CIR-AFTER-NEXT: %[[#IMAG:]] = cir.complex.imag %{{.+}} : !cir.complex<!cir.double> -> !cir.double
 // CIR-AFTER-NEXT: %[[#RB:]] = cir.cast(float_to_bool, %[[#REAL]] : !cir.double), !cir.bool
 // CIR-AFTER-NEXT: %[[#IB:]] = cir.cast(float_to_bool, %[[#IMAG]] : !cir.double), !cir.bool
-// CIR-AFTER-NEXT: %{{.+}} = cir.ternary(%[[#RB]], true {
-// CIR-AFTER-NEXT:   %[[#A:]] = cir.const #true
-// CIR-AFTER-NEXT:   cir.yield %[[#A]] : !cir.bool
-// CIR-AFTER-NEXT: }, false {
-// CIR-AFTER-NEXT:   %[[#B:]] = cir.ternary(%[[#IB]], true {
-// CIR-AFTER-NEXT:     %[[#C:]] = cir.const #true
-// CIR-AFTER-NEXT:     cir.yield %[[#C]] : !cir.bool
-// CIR-AFTER-NEXT:   }, false {
-// CIR-AFTER-NEXT:     %[[#D:]] = cir.const #false
-// CIR-AFTER-NEXT:     cir.yield %[[#D]] : !cir.bool
-// CIR-AFTER-NEXT:   }) : (!cir.bool) -> !cir.bool
-// CIR-AFTER-NEXT:   cir.yield %[[#B]] : !cir.bool
-// CIR-AFTER-NEXT: }) : (!cir.bool) -> !cir.bool
+// CIR-AFTER-NEXT: %[[#A:]] = cir.const #true
+// CIR-AFTER-NEXT: %{{.+}} = cir.select if %[[#RB]] then %[[#A]] else %[[#IB]] : (!cir.bool, !cir.bool, !cir.bool) -> !cir.bool
 
 //      LLVM:   %[[#REAL:]] = extractvalue { double, double } %{{.+}}, 0
 // LLVM-NEXT:   %[[#IMAG:]] = extractvalue { double, double } %{{.+}}, 1
 // LLVM-NEXT:   %[[#RB:]] = fcmp une double %[[#REAL]], 0.000000e+00
+// LLVM-NEXT:   %[[#RB2:]] = zext i1 %[[#RB]] to i8
 // LLVM-NEXT:   %[[#IB:]] = fcmp une double %[[#IMAG]], 0.000000e+00
-// LLVM-NEXT:   br i1 %[[#RB]], label %[[#LABEL_RB:]], label %[[#LABEL_RB_NOT:]]
-//      LLVM: [[#LABEL_RB]]:
-// LLVM-NEXT:   br label %[[#LABEL_EXIT:]]
-//      LLVM: [[#LABEL_RB_NOT]]:
-// LLVM-NEXT:   br i1 %[[#IB]], label %[[#LABEL_IB:]], label %[[#LABEL_IB_NOT:]]
-//      LLVM: [[#LABEL_IB]]:
-// LLVM-NEXT:   br label %[[#LABEL_A:]]
-//      LLVM: [[#LABEL_IB_NOT]]:
-// LLVM-NEXT:   br label %[[#LABEL_A]]
-//      LLVM: [[#LABEL_A]]:
-// LLVM-NEXT:   %[[#A:]] = phi i8 [ 0, %[[#LABEL_IB_NOT]] ], [ 1, %[[#LABEL_IB]] ]
-// LLVM-NEXT:   br label %[[#LABEL_B:]]
-//      LLVM: [[#LABEL_B]]:
-// LLVM-NEXT:   br label %[[#LABEL_EXIT]]
-//      LLVM: [[#LABEL_EXIT]]:
-// LLVM-NEXT:   %{{.+}} = phi i8 [ %[[#A]], %[[#LABEL_B]] ], [ 1, %[[#LABEL_RB]] ]
-// LLVM-NEXT:   br label %{{.+}}
+// LLVM-NEXT:   %[[#IB2:]] = zext i1 %[[#IB]] to i8
+// LLVM-NEXT:   %{{.+}} = or i8 %[[#RB2]], %[[#IB2]]
 
 // CIR-BEFORE: %{{.+}} = cir.cast(int_complex_to_bool, %{{.+}} : !cir.complex<!s32i>), !cir.bool
 
@@ -215,41 +190,16 @@ void complex_to_bool() {
 // CIR-AFTER-NEXT: %[[#IMAG:]] = cir.complex.imag %{{.+}} : !cir.complex<!s32i> -> !s32i
 // CIR-AFTER-NEXT: %[[#RB:]] = cir.cast(int_to_bool, %[[#REAL]] : !s32i), !cir.bool
 // CIR-AFTER-NEXT: %[[#IB:]] = cir.cast(int_to_bool, %[[#IMAG]] : !s32i), !cir.bool
-// CIR-AFTER-NEXT: %{{.+}} = cir.ternary(%[[#RB]], true {
-// CIR-AFTER-NEXT:   %[[#A:]] = cir.const #true
-// CIR-AFTER-NEXT:   cir.yield %[[#A]] : !cir.bool
-// CIR-AFTER-NEXT: }, false {
-// CIR-AFTER-NEXT:   %[[#B:]] = cir.ternary(%[[#IB]], true {
-// CIR-AFTER-NEXT:     %[[#C:]] = cir.const #true
-// CIR-AFTER-NEXT:     cir.yield %[[#C]] : !cir.bool
-// CIR-AFTER-NEXT:   }, false {
-// CIR-AFTER-NEXT:     %[[#D:]] = cir.const #false
-// CIR-AFTER-NEXT:     cir.yield %[[#D]] : !cir.bool
-// CIR-AFTER-NEXT:   }) : (!cir.bool) -> !cir.bool
-// CIR-AFTER-NEXT:   cir.yield %[[#B]] : !cir.bool
-// CIR-AFTER-NEXT: }) : (!cir.bool) -> !cir.bool
+// CIR-AFTER-NEXT: %[[#A:]] = cir.const #true
+// CIR-AFTER-NEXT: %{{.+}} = cir.select if %[[#RB]] then %[[#A]] else %[[#IB]] : (!cir.bool, !cir.bool, !cir.bool) -> !cir.bool
 
 //      LLVM:   %[[#REAL:]] = extractvalue { i32, i32 } %{{.+}}, 0
 // LLVM-NEXT:   %[[#IMAG:]] = extractvalue { i32, i32 } %{{.+}}, 1
 // LLVM-NEXT:   %[[#RB:]] = icmp ne i32 %[[#REAL]], 0
+// LLVM-NEXT:   %[[#RB2:]] = zext i1 %[[#RB]] to i8
 // LLVM-NEXT:   %[[#IB:]] = icmp ne i32 %[[#IMAG]], 0
-// LLVM-NEXT:   br i1 %[[#RB]], label %[[#LABEL_RB:]], label %[[#LABEL_RB_NOT:]]
-//      LLVM: [[#LABEL_RB]]:
-// LLVM-NEXT:   br label %[[#LABEL_EXIT:]]
-//      LLVM: [[#LABEL_RB_NOT]]:
-// LLVM-NEXT:   br i1 %[[#IB]], label %[[#LABEL_IB:]], label %[[#LABEL_IB_NOT:]]
-//      LLVM: [[#LABEL_IB]]:
-// LLVM-NEXT:   br label %[[#LABEL_A:]]
-//      LLVM: [[#LABEL_IB_NOT]]:
-// LLVM-NEXT:   br label %[[#LABEL_A]]
-//      LLVM: [[#LABEL_A]]:
-// LLVM-NEXT:   %[[#A:]] = phi i8 [ 0, %[[#LABEL_IB_NOT]] ], [ 1, %[[#LABEL_IB]] ]
-// LLVM-NEXT:   br label %[[#LABEL_B:]]
-//      LLVM: [[#LABEL_B]]:
-// LLVM-NEXT:   br label %[[#LABEL_EXIT]]
-//      LLVM: [[#LABEL_EXIT]]:
-// LLVM-NEXT:   %{{.+}} = phi i8 [ %[[#A]], %[[#LABEL_B]] ], [ 1, %[[#LABEL_RB]] ]
-// LLVM-NEXT:   br label %{{.+}}
+// LLVM-NEXT:   %[[#IB2:]] = zext i1 %[[#IB]] to i8
+// LLVM-NEXT:   %{{.+}} = or i8 %[[#RB2]], %[[#IB2]]
 
 // CHECK: }
 

--- a/clang/test/CIR/CodeGen/three-way-comparison.cpp
+++ b/clang/test/CIR/CodeGen/three-way-comparison.cpp
@@ -33,27 +33,15 @@ auto three_way_strong(int x, int y) {
 // NONCANONICAL-AFTER-NEXT:   %[[#NEGONE:]] = cir.const #cir.int<-1> : !s8i
 // NONCANONICAL-AFTER-NEXT:   %[[#ONE:]] = cir.const #cir.int<1> : !s8i
 // NONCANONICAL-AFTER-NEXT:   %[[#CMP_TO_NEGONE:]] = cir.cmp(eq, %[[#CMP3WAY_RESULT]], %[[#NEGONE]]) : !s8i, !cir.bool
-// NONCANONICAL-AFTER-NEXT:   %[[#A:]] = cir.ternary(%[[#CMP_TO_NEGONE]], true {
-// NONCANONICAL-AFTER-NEXT:     cir.yield %[[#ONE]] : !s8i
-// NONCANONICAL-AFTER-NEXT:   }, false {
-// NONCANONICAL-AFTER-NEXT:     cir.yield %[[#CMP3WAY_RESULT]] : !s8i
-// NONCANONICAL-AFTER-NEXT:   }) : (!cir.bool) -> !s8i
+// NONCANONICAL-AFTER-NEXT:   %[[#A:]] = cir.select if %[[#CMP_TO_NEGONE]] then %[[#ONE]] else %[[#CMP3WAY_RESULT]] : (!cir.bool, !s8i, !s8i) -> !s8i
 // NONCANONICAL-AFTER-NEXT:   %[[#ZERO:]] = cir.const #cir.int<0> : !s8i
 // NONCANONICAL-AFTER-NEXT:   %[[#TWO:]] = cir.const #cir.int<2> : !s8i
 // NONCANONICAL-AFTER-NEXT:   %[[#CMP_TO_ZERO:]] = cir.cmp(eq, %[[#A]], %[[#ZERO]]) : !s8i, !cir.bool
-// NONCANONICAL-AFTER-NEXT:   %[[#B:]] = cir.ternary(%[[#CMP_TO_ZERO]], true {
-// NONCANONICAL-AFTER-NEXT:     cir.yield %[[#TWO]] : !s8i
-// NONCANONICAL-AFTER-NEXT:   }, false {
-// NONCANONICAL-AFTER-NEXT:     cir.yield %[[#A]] : !s8i
-// NONCANONICAL-AFTER-NEXT:   }) : (!cir.bool) -> !s8i
+// NONCANONICAL-AFTER-NEXT:   %[[#B:]] = cir.select if %[[#CMP_TO_ZERO]] then %[[#TWO]] else %[[#A]] : (!cir.bool, !s8i, !s8i) -> !s8i
 // NONCANONICAL-AFTER-NEXT:   %[[#ONE2:]] = cir.const #cir.int<1> : !s8i
 // NONCANONICAL-AFTER-NEXT:   %[[#THREE:]] = cir.const #cir.int<3> : !s8i
 // NONCANONICAL-AFTER-NEXT:   %[[#CMP_TO_ONE:]] = cir.cmp(eq, %[[#B]], %[[#ONE2]]) : !s8i, !cir.bool
-// NONCANONICAL-AFTER-NEXT:   %{{.+}} = cir.ternary(%[[#CMP_TO_ONE]], true {
-// NONCANONICAL-AFTER-NEXT:     cir.yield %[[#THREE]] : !s8i
-// NONCANONICAL-AFTER-NEXT:   }, false {
-// NONCANONICAL-AFTER-NEXT:     cir.yield %[[#B]] : !s8i
-// NONCANONICAL-AFTER-NEXT:   }) : (!cir.bool) -> !s8i
+// NONCANONICAL-AFTER-NEXT:   %{{.+}} = cir.select if %[[#CMP_TO_ONE]] then %[[#THREE]] else %[[#B]] : (!cir.bool, !s8i, !s8i) -> !s8i
 //      NONCANONICAL-AFTER: }
 
 auto three_way_weak(float x, float y) {
@@ -74,19 +62,7 @@ auto three_way_weak(float x, float y) {
 // AFTER-NEXT:   %[[#CMP_LT:]] = cir.cmp(lt, %[[#LHS]], %[[#RHS]]) : !cir.float, !cir.bool
 // AFTER-NEXT:   %[[#CMP_EQ:]] = cir.cmp(eq, %[[#LHS]], %[[#RHS]]) : !cir.float, !cir.bool
 // AFTER-NEXT:   %[[#CMP_GT:]] = cir.cmp(gt, %[[#LHS]], %[[#RHS]]) : !cir.float, !cir.bool
-// AFTER-NEXT:   %[[#CMP_EQ_RES:]] = cir.ternary(%[[#CMP_EQ]], true {
-// AFTER-NEXT:     cir.yield %[[#EQ]] : !s8i
-// AFTER-NEXT:   }, false {
-// AFTER-NEXT:     cir.yield %[[#UNORDERED]] : !s8i
-// AFTER-NEXT:   }) : (!cir.bool) -> !s8i
-// AFTER-NEXT:   %[[#CMP_GT_RES:]] = cir.ternary(%[[#CMP_GT]], true {
-// AFTER-NEXT:     cir.yield %[[#GT]] : !s8i
-// AFTER-NEXT:   }, false {
-// AFTER-NEXT:     cir.yield %[[#CMP_EQ_RES]] : !s8i
-// AFTER-NEXT:   }) : (!cir.bool) -> !s8i
-// AFTER-NEXT:   %{{.+}} = cir.ternary(%[[#CMP_LT]], true {
-// AFTER-NEXT:     cir.yield %[[#LT]] : !s8i
-// AFTER-NEXT:   }, false {
-// AFTER-NEXT:     cir.yield %[[#CMP_GT_RES]] : !s8i
-// AFTER-NEXT:   }) : (!cir.bool) -> !s8i
+// AFTER-NEXT:   %[[#CMP_EQ_RES:]] = cir.select if %[[#CMP_EQ]] then %[[#EQ]] else %[[#UNORDERED]] : (!cir.bool, !s8i, !s8i) -> !s8i
+// AFTER-NEXT:   %[[#CMP_GT_RES:]] = cir.select if %[[#CMP_GT]] then %[[#GT]] else %[[#CMP_EQ_RES]] : (!cir.bool, !s8i, !s8i) -> !s8i
+// AFTER-NEXT:   %{{.+}} = cir.select if %[[#CMP_LT]] then %[[#LT]] else %[[#CMP_GT_RES]] : (!cir.bool, !s8i, !s8i) -> !s8i
 //      AFTER: }


### PR DESCRIPTION
This PR refactors the LoweringPrepare pass and replaces various ternary ops generated by LoweringPrepare with semantically equivalent select ops.