### PR TITLE
[CIR][CIRGen][Lowering] Get alignment from frontend and pass it to LLVM

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -921,10 +921,9 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef MangledName, mlir::Type Ty,
 
     // FIXME: This code is overly simple and should be merged with other global
     // handling.
-
+    GV.setAlignmentAttr(getSize(astCtx.getDeclAlign(D)));
     // TODO(cir):
     //   GV->setConstant(isTypeConstant(D->getType(), false));
-    //   GV->setAlignment(getContext().getDeclAlign(D).getAsAlign());
     //   setLinkageForGV(GV, D);
 
     if (D->getTLSKind()) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1893,7 +1893,9 @@ public:
     SmallVector<mlir::NamedAttribute> attributes;
     auto newGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
         op, llvmType, op.getConstant(), convertLinkage(op.getLinkage()),
-        op.getSymName(), nullptr, /*alignment*/ 0,
+        op.getSymName(), nullptr,
+        /*alignment*/ op.getAlignment().has_value() ? op.getAlignment().value()
+                                                    : 0,
         /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
         /*dsoLocal*/ false, /*threadLocal*/ (bool)op.getTlsModelAttr(),
         /*comdat*/ mlir::SymbolRefAttr(), attributes);
@@ -2017,7 +2019,9 @@ public:
     // Rewrite op.
     auto llvmGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
         op, llvmType, isConst, linkage, symbol, init.value(),
-        /*alignment*/ 0, /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
+        /*alignment*/ op.getAlignment().has_value() ? op.getAlignment().value()
+                                                    : 0,
+        /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
         /*dsoLocal*/ false, /*threadLocal*/ (bool)op.getTlsModelAttr(),
         /*comdat*/ mlir::SymbolRefAttr(), attributes);
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1894,8 +1894,7 @@ public:
     auto newGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
         op, llvmType, op.getConstant(), convertLinkage(op.getLinkage()),
         op.getSymName(), nullptr,
-        /*alignment*/ op.getAlignment().has_value() ? op.getAlignment().value()
-                                                    : 0,
+        /*alignment*/ op.getAlignment().value_or(0),
         /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
         /*dsoLocal*/ false, /*threadLocal*/ (bool)op.getTlsModelAttr(),
         /*comdat*/ mlir::SymbolRefAttr(), attributes);
@@ -2019,8 +2018,7 @@ public:
     // Rewrite op.
     auto llvmGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
         op, llvmType, isConst, linkage, symbol, init.value(),
-        /*alignment*/ op.getAlignment().has_value() ? op.getAlignment().value()
-                                                    : 0,
+        /*alignment*/op.getAlignment().value_or(0),
         /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
         /*dsoLocal*/ false, /*threadLocal*/ (bool)op.getTlsModelAttr(),
         /*comdat*/ mlir::SymbolRefAttr(), attributes);

--- a/clang/test/CIR/CodeGen/attributes.c
+++ b/clang/test/CIR/CodeGen/attributes.c
@@ -5,11 +5,11 @@ extern int __attribute__((section(".shared"))) ext;
 int getExt() {
   return ext;
 }
-// CIR:   cir.global "private" external @ext : !s32i {section = ".shared"}
+// CIR:   cir.global "private" external @ext : !s32i {alignment = 4 : i64, section = ".shared"}
 // LLVM:  @ext = external global i32, section ".shared"
 
 int __attribute__((section(".shared"))) glob = 42;
-// CIR:   cir.global external @glob = #cir.int<42> : !s32i {section = ".shared"}
+// CIR:   cir.global external @glob = #cir.int<42> : !s32i {alignment = 4 : i64, section = ".shared"}
 // LLVM:   @glob = global i32 42, section ".shared"
 
 

--- a/clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
+++ b/clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
@@ -26,19 +26,18 @@ const int &compat_use_after_redecl1 = compat::c;
 const int &compat_use_after_redecl2 = compat::d;
 const int &compat_use_after_redecl3 = compat::g;
 
-// CIR: cir.global  weak_odr @_ZN6compat1bE = #cir.int<2> : !s32i
-// CIR: cir.global  weak_odr @_ZN6compat1aE = #cir.int<1> : !s32i
-// CIR: cir.global  weak_odr @_ZN6compat1cE = #cir.int<3> : !s32i
-// CIR: cir.global  external @_ZN6compat1eE = #cir.int<5> : !s32i
-// CIR: cir.global  weak_odr @_ZN6compat1fE = #cir.int<6> : !s32i
-// CIR: cir.global  linkonce_odr @_ZN6compat1dE = #cir.int<4> : !s32i
-// CIR: cir.global  linkonce_odr @_ZN6compat1gE = #cir.int<7> : !s32i
+// CIR: cir.global  weak_odr @_ZN6compat1bE = #cir.int<2> : !s32i {alignment = 4 : i64}
+// CIR: cir.global  weak_odr @_ZN6compat1aE = #cir.int<1> : !s32i {alignment = 4 : i64}
+// CIR: cir.global  weak_odr @_ZN6compat1cE = #cir.int<3> : !s32i {alignment = 4 : i64}
+// CIR: cir.global  external @_ZN6compat1eE = #cir.int<5> : !s32i {alignment = 4 : i64}
+// CIR: cir.global  weak_odr @_ZN6compat1fE = #cir.int<6> : !s32i {alignment = 4 : i64}
+// CIR: cir.global  linkonce_odr @_ZN6compat1dE = #cir.int<4> : !s32i {alignment = 4 : i64}
+// CIR: cir.global  linkonce_odr @_ZN6compat1gE = #cir.int<7> : !s32i {alignment = 4 : i64}
 
-// LLVM: @_ZN6compat1bE = weak_odr global i32 2
-// LLVM: @_ZN6compat1aE = weak_odr global i32 1
-// LLVM: @_ZN6compat1cE = weak_odr global i32 3
-// LLVM: @_ZN6compat1eE = global i32 5
-// LLVM: @_ZN6compat1fE = weak_odr global i32 6
-// LLVM: @_ZN6compat1dE = linkonce_odr global i32 4
-// LLVM: @_ZN6compat1gE = linkonce_odr global i32 7
-
+// LLVM: @_ZN6compat1bE = weak_odr global i32 2, align 4
+// LLVM: @_ZN6compat1aE = weak_odr global i32 1, align 4
+// LLVM: @_ZN6compat1cE = weak_odr global i32 3, align 4
+// LLVM: @_ZN6compat1eE = global i32 5, align 4
+// LLVM: @_ZN6compat1fE = weak_odr global i32 6, align 4
+// LLVM: @_ZN6compat1dE = linkonce_odr global i32 4, align 4
+// LLVM: @_ZN6compat1gE = linkonce_odr global i32 7, align 4

--- a/clang/test/CIR/CodeGen/globals-neg-index-array.c
+++ b/clang/test/CIR/CodeGen/globals-neg-index-array.c
@@ -14,7 +14,7 @@ struct __attribute__((packed)) PackedStruct {
 };
 struct PackedStruct packed[10];
 char *packed_element = &(packed[-2].a3);
-// CHECK: cir.global  external @packed = #cir.zero : !cir.array<!ty_22PackedStruct22 x 10> loc(#loc5)
+// CHECK: cir.global  external @packed = #cir.zero : !cir.array<!ty_22PackedStruct22 x 10> {alignment = 16 : i64} loc(#loc5)
 // CHECK: cir.global  external @packed_element = #cir.global_view<@packed, [-2 : i32, 2 : i32]>
 // LLVM: @packed = global [10 x %struct.PackedStruct] zeroinitializer
 // LLVM: @packed_element = global ptr getelementptr inbounds ([10 x %struct.PackedStruct], ptr @packed, i32 -2, i32 2)

--- a/clang/test/CIR/CodeGen/static.cpp
+++ b/clang/test/CIR/CodeGen/static.cpp
@@ -26,7 +26,7 @@ static Init __ioinit2(false);
 // BEFORE-NEXT:   } dtor {
 // BEFORE-NEXT:      %0 = cir.get_global @_ZL8__ioinit : !cir.ptr<!ty_22Init22>
 // BEFORE-NEXT:      cir.call @_ZN4InitD1Ev(%0) : (!cir.ptr<!ty_22Init22>) -> ()
-// BEFORE-NEXT:   } {ast = #cir.var.decl.ast}
+// BEFORE-NEXT:   } {alignment = 1 : i64, ast = #cir.var.decl.ast}
 // BEFORE:        cir.global "private" internal dsolocal @_ZL9__ioinit2 = ctor : !ty_22Init22 {
 // BEFORE-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : !cir.ptr<!ty_22Init22>
 // BEFORE-NEXT:     %1 = cir.const #false
@@ -34,7 +34,7 @@ static Init __ioinit2(false);
 // BEFORE-NEXT:   } dtor  {
 // BEFORE-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : !cir.ptr<!ty_22Init22>
 // BEFORE-NEXT:     cir.call @_ZN4InitD1Ev(%0) : (!cir.ptr<!ty_22Init22>) -> ()
-// BEFORE-NEXT:   } {ast = #cir.var.decl.ast}
+// BEFORE-NEXT:   } {alignment = 1 : i64, ast = #cir.var.decl.ast}
 // BEFORE-NEXT: }
 
 
@@ -43,7 +43,7 @@ static Init __ioinit2(false);
 // AFTER-NEXT:   cir.func private @__cxa_atexit(!cir.ptr<!cir.func<!void (!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>)
 // AFTER-NEXT:   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_22Init22>, !cir.bool)
 // AFTER-NEXT:   cir.func private @_ZN4InitD1Ev(!cir.ptr<!ty_22Init22>)
-// AFTER-NEXT:   cir.global "private" internal dsolocal @_ZL8__ioinit =  #cir.zero : !ty_22Init22 {ast = #cir.var.decl.ast}
+// AFTER-NEXT:   cir.global "private" internal dsolocal @_ZL8__ioinit =  #cir.zero : !ty_22Init22 {alignment = 1 : i64, ast = #cir.var.decl.ast}
 // AFTER-NEXT:   cir.func internal private @__cxx_global_var_init()
 // AFTER-NEXT:     %0 = cir.get_global @_ZL8__ioinit : !cir.ptr<!ty_22Init22>
 // AFTER-NEXT:     %1 = cir.const #true
@@ -55,7 +55,7 @@ static Init __ioinit2(false);
 // AFTER-NEXT:     %6 = cir.get_global @__dso_handle : !cir.ptr<i8>
 // AFTER-NEXT:     cir.call @__cxa_atexit(%4, %5, %6) : (!cir.ptr<!cir.func<!void (!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
 // AFTER-NEXT:     cir.return
-// AFTER:        cir.global "private" internal dsolocal @_ZL9__ioinit2 =  #cir.zero : !ty_22Init22 {ast = #cir.var.decl.ast}
+// AFTER:        cir.global "private" internal dsolocal @_ZL9__ioinit2 =  #cir.zero : !ty_22Init22 {alignment = 1 : i64, ast = #cir.var.decl.ast}
 // AFTER-NEXT:   cir.func internal private @__cxx_global_var_init.1()
 // AFTER-NEXT:     %0 = cir.get_global @_ZL9__ioinit2 : !cir.ptr<!ty_22Init22>
 // AFTER-NEXT:     %1 = cir.const #false

--- a/clang/test/CIR/Lowering/ThroughMLIR/vtable.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/vtable.cir
@@ -18,56 +18,57 @@
 !ty_22Child22 = !cir.struct<class "Child" {!cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>, !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>} #cir.record.decl.ast>
 
 module {
-  cir.func linkonce_odr @_ZN6Mother6simpleEv(%arg0: !cir.ptr<!ty_22Mother22>) { 
+  cir.func linkonce_odr @_ZN6Mother6simpleEv(%arg0: !cir.ptr<!ty_22Mother22>) {
     %0 = cir.alloca !cir.ptr<!ty_22Mother22>, !cir.ptr<!cir.ptr<!ty_22Mother22>>, ["this", init] {alignment = 8 : i64}
     cir.store %arg0, %0 : !cir.ptr<!ty_22Mother22>, !cir.ptr<!cir.ptr<!ty_22Mother22>>
     %1 = cir.load %0 : !cir.ptr<!cir.ptr<!ty_22Mother22>>, !cir.ptr<!ty_22Mother22>
-    cir.return 
+    cir.return
   }
   cir.func private @_ZN5ChildC2Ev(%arg0: !cir.ptr<!ty_22Child22>) { cir.return }
-  cir.global linkonce_odr @_ZTV6Mother = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother9MotherFooEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother10MotherFoo2Ev> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>}> : !ty_anon_struct2 {alignment = 8 : i64} 
-  cir.global "private" external @_ZTVN10__cxxabiv117__class_type_infoE : !cir.ptr<!cir.ptr<!u8i>> 
-  cir.global linkonce_odr @_ZTS6Mother = #cir.const_array<"6Mother" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7> {alignment = 1 : i64} 
-  cir.global constant external @_ZTI6Mother = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Mother> : !cir.ptr<!u8i>}> : !ty_anon_struct {alignment = 8 : i64} 
+  cir.global linkonce_odr @_ZTV6Mother = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother9MotherFooEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother10MotherFoo2Ev> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>}> : !ty_anon_struct2 {alignment = 8 : i64}
+  cir.global "private" external @_ZTVN10__cxxabiv117__class_type_infoE : !cir.ptr<!cir.ptr<!u8i>>
+  cir.global linkonce_odr @_ZTS6Mother = #cir.const_array<"6Mother" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7> {alignment = 1 : i64}
+  cir.global constant external @_ZTI6Mother = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Mother> : !cir.ptr<!u8i>}> : !ty_anon_struct {alignment = 8 : i64}
   cir.func linkonce_odr @_ZN6Mother9MotherFooEv(%arg0: !cir.ptr<!ty_22Mother22> ) { cir.return }
   cir.func linkonce_odr @_ZN6Mother10MotherFoo2Ev(%arg0: !cir.ptr<!ty_22Mother22> ) { cir.return }
-  cir.global linkonce_odr @_ZTV6Father = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : !ty_anon_struct3 {alignment = 8 : i64} 
+  cir.global linkonce_odr @_ZTV6Father = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : !ty_anon_struct3 {alignment = 8 : i64}
   cir.func linkonce_odr @_ZN6FatherC2Ev(%arg0: !cir.ptr<!ty_22Father22> ) { cir.return }
-  cir.global linkonce_odr @_ZTV5Child = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI5Child> : !cir.ptr<!u8i>, #cir.global_view<@_ZN5Child9MotherFooEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother10MotherFoo2Ev> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>, #cir.const_array<[#cir.ptr<-8 : i64> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI5Child> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : !ty_anon_struct4 {alignment = 8 : i64} 
-  cir.global "private" external @_ZTVN10__cxxabiv121__vmi_class_type_infoE : !cir.ptr<!cir.ptr<!u8i>> 
-  cir.global linkonce_odr @_ZTS5Child = #cir.const_array<"5Child" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6> {alignment = 1 : i64} 
-  cir.global linkonce_odr @_ZTS6Father = #cir.const_array<"6Father" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7> {alignment = 1 : i64} 
-  cir.global constant external @_ZTI6Father = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Father> : !cir.ptr<!u8i>}> : !ty_anon_struct {alignment = 8 : i64} 
-  cir.global constant external @_ZTI5Child = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv121__vmi_class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS5Child> : !cir.ptr<!u8i>, #cir.int<0> : !u32i, #cir.int<2> : !u32i, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.int<2> : !s64i, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.int<2050> : !s64i}> : !ty_anon_struct1 {alignment = 8 : i64} 
+  cir.global linkonce_odr @_ZTV5Child = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI5Child> : !cir.ptr<!u8i>, #cir.global_view<@_ZN5Child9MotherFooEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother10MotherFoo2Ev> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>, #cir.const_array<[#cir.ptr<-8 : i64> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI5Child> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : !ty_anon_struct4 {alignment = 8 : i64}
+  cir.global "private" external @_ZTVN10__cxxabiv121__vmi_class_type_infoE : !cir.ptr<!cir.ptr<!u8i>>
+  cir.global linkonce_odr @_ZTS5Child = #cir.const_array<"5Child" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6> {alignment = 1 : i64}
+  cir.global linkonce_odr @_ZTS6Father = #cir.const_array<"6Father" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7> {alignment = 1 : i64}
+  cir.global constant external @_ZTI6Father = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Father> : !cir.ptr<!u8i>}> : !ty_anon_struct {alignment = 8 : i64}
+  cir.global constant external @_ZTI5Child = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv121__vmi_class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS5Child> : !cir.ptr<!u8i>, #cir.int<0> : !u32i, #cir.int<2> : !u32i, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.int<2> : !s64i, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.int<2050> : !s64i}> : !ty_anon_struct1 {alignment = 8 : i64}
   cir.func linkonce_odr @_ZN5Child9MotherFooEv(%arg0: !cir.ptr<!ty_22Child22> ) { cir.return }
   cir.func linkonce_odr @_ZN6Father9FatherFooEv(%arg0: !cir.ptr<!ty_22Father22> ) { cir.return }
-} 
+}
 
-// MLIR:  llvm.mlir.global linkonce_odr @_ZTV5Child() {addr_space = 0 : i32} : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)> {
+// MLIR:  llvm.mlir.global linkonce_odr @_ZTV5Child() {addr_space = 0 : i32, alignment = 8 : i64} :
+// MLIR-SAME: !llvm.struct<(array<4 x ptr>, array<3 x ptr>)> {
 // MLIR:    %{{[0-9]+}} = llvm.mlir.undef : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.undef : !llvm.array<4 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.zero : !llvm.ptr
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.array<4 x ptr> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.array<4 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZTI5Child : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.array<4 x ptr> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.array<4 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZN5Child9MotherFooEv : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[2] : !llvm.array<4 x ptr> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[2] : !llvm.array<4 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZN6Mother10MotherFoo2Ev : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[3] : !llvm.array<4 x ptr> 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[3] : !llvm.array<4 x ptr>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.undef : !llvm.array<3 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.constant(-8 : i64) : i64
 // MLIR:    %{{[0-9]+}} = llvm.inttoptr %{{[0-9]+}} : i64 to !llvm.ptr
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.array<3 x ptr> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.array<3 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZTI5Child : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.array<3 x ptr> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.array<3 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZN6Father9FatherFooEv : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[2] : !llvm.array<3 x ptr> 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[2] : !llvm.array<3 x ptr>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)>
 // MLIR:    llvm.return %{{[0-9]+}} : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)>
 // MLIR:  }

--- a/clang/test/CIR/Lowering/ThroughMLIR/vtable.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/vtable.cir
@@ -18,57 +18,56 @@
 !ty_22Child22 = !cir.struct<class "Child" {!cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>, !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>} #cir.record.decl.ast>
 
 module {
-  cir.func linkonce_odr @_ZN6Mother6simpleEv(%arg0: !cir.ptr<!ty_22Mother22>) {
+  cir.func linkonce_odr @_ZN6Mother6simpleEv(%arg0: !cir.ptr<!ty_22Mother22>) { 
     %0 = cir.alloca !cir.ptr<!ty_22Mother22>, !cir.ptr<!cir.ptr<!ty_22Mother22>>, ["this", init] {alignment = 8 : i64}
     cir.store %arg0, %0 : !cir.ptr<!ty_22Mother22>, !cir.ptr<!cir.ptr<!ty_22Mother22>>
     %1 = cir.load %0 : !cir.ptr<!cir.ptr<!ty_22Mother22>>, !cir.ptr<!ty_22Mother22>
-    cir.return
+    cir.return 
   }
   cir.func private @_ZN5ChildC2Ev(%arg0: !cir.ptr<!ty_22Child22>) { cir.return }
-  cir.global linkonce_odr @_ZTV6Mother = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother9MotherFooEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother10MotherFoo2Ev> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>}> : !ty_anon_struct2 {alignment = 8 : i64}
-  cir.global "private" external @_ZTVN10__cxxabiv117__class_type_infoE : !cir.ptr<!cir.ptr<!u8i>>
-  cir.global linkonce_odr @_ZTS6Mother = #cir.const_array<"6Mother" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7> {alignment = 1 : i64}
-  cir.global constant external @_ZTI6Mother = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Mother> : !cir.ptr<!u8i>}> : !ty_anon_struct {alignment = 8 : i64}
+  cir.global linkonce_odr @_ZTV6Mother = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother9MotherFooEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother10MotherFoo2Ev> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>}> : !ty_anon_struct2 {alignment = 8 : i64} 
+  cir.global "private" external @_ZTVN10__cxxabiv117__class_type_infoE : !cir.ptr<!cir.ptr<!u8i>> 
+  cir.global linkonce_odr @_ZTS6Mother = #cir.const_array<"6Mother" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7> {alignment = 1 : i64} 
+  cir.global constant external @_ZTI6Mother = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Mother> : !cir.ptr<!u8i>}> : !ty_anon_struct {alignment = 8 : i64} 
   cir.func linkonce_odr @_ZN6Mother9MotherFooEv(%arg0: !cir.ptr<!ty_22Mother22> ) { cir.return }
   cir.func linkonce_odr @_ZN6Mother10MotherFoo2Ev(%arg0: !cir.ptr<!ty_22Mother22> ) { cir.return }
-  cir.global linkonce_odr @_ZTV6Father = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : !ty_anon_struct3 {alignment = 8 : i64}
+  cir.global linkonce_odr @_ZTV6Father = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : !ty_anon_struct3 {alignment = 8 : i64} 
   cir.func linkonce_odr @_ZN6FatherC2Ev(%arg0: !cir.ptr<!ty_22Father22> ) { cir.return }
-  cir.global linkonce_odr @_ZTV5Child = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI5Child> : !cir.ptr<!u8i>, #cir.global_view<@_ZN5Child9MotherFooEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother10MotherFoo2Ev> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>, #cir.const_array<[#cir.ptr<-8 : i64> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI5Child> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : !ty_anon_struct4 {alignment = 8 : i64}
-  cir.global "private" external @_ZTVN10__cxxabiv121__vmi_class_type_infoE : !cir.ptr<!cir.ptr<!u8i>>
-  cir.global linkonce_odr @_ZTS5Child = #cir.const_array<"5Child" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6> {alignment = 1 : i64}
-  cir.global linkonce_odr @_ZTS6Father = #cir.const_array<"6Father" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7> {alignment = 1 : i64}
-  cir.global constant external @_ZTI6Father = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Father> : !cir.ptr<!u8i>}> : !ty_anon_struct {alignment = 8 : i64}
-  cir.global constant external @_ZTI5Child = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv121__vmi_class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS5Child> : !cir.ptr<!u8i>, #cir.int<0> : !u32i, #cir.int<2> : !u32i, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.int<2> : !s64i, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.int<2050> : !s64i}> : !ty_anon_struct1 {alignment = 8 : i64}
+  cir.global linkonce_odr @_ZTV5Child = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI5Child> : !cir.ptr<!u8i>, #cir.global_view<@_ZN5Child9MotherFooEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Mother10MotherFoo2Ev> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>, #cir.const_array<[#cir.ptr<-8 : i64> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI5Child> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : !ty_anon_struct4 {alignment = 8 : i64} 
+  cir.global "private" external @_ZTVN10__cxxabiv121__vmi_class_type_infoE : !cir.ptr<!cir.ptr<!u8i>> 
+  cir.global linkonce_odr @_ZTS5Child = #cir.const_array<"5Child" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6> {alignment = 1 : i64} 
+  cir.global linkonce_odr @_ZTS6Father = #cir.const_array<"6Father" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7> {alignment = 1 : i64} 
+  cir.global constant external @_ZTI6Father = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Father> : !cir.ptr<!u8i>}> : !ty_anon_struct {alignment = 8 : i64} 
+  cir.global constant external @_ZTI5Child = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv121__vmi_class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS5Child> : !cir.ptr<!u8i>, #cir.int<0> : !u32i, #cir.int<2> : !u32i, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.int<2> : !s64i, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.int<2050> : !s64i}> : !ty_anon_struct1 {alignment = 8 : i64} 
   cir.func linkonce_odr @_ZN5Child9MotherFooEv(%arg0: !cir.ptr<!ty_22Child22> ) { cir.return }
   cir.func linkonce_odr @_ZN6Father9FatherFooEv(%arg0: !cir.ptr<!ty_22Father22> ) { cir.return }
-}
+} 
 
-// MLIR:  llvm.mlir.global linkonce_odr @_ZTV5Child() {addr_space = 0 : i32, alignment = 8 : i64} :
-// MLIR-SAME: !llvm.struct<(array<4 x ptr>, array<3 x ptr>)> {
+// MLIR:  llvm.mlir.global linkonce_odr @_ZTV5Child() {addr_space = 0 : i32, alignment = 8 : i64} : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)> {
 // MLIR:    %{{[0-9]+}} = llvm.mlir.undef : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.undef : !llvm.array<4 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.zero : !llvm.ptr
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.array<4 x ptr>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.array<4 x ptr> 
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZTI5Child : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.array<4 x ptr>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.array<4 x ptr> 
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZN5Child9MotherFooEv : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[2] : !llvm.array<4 x ptr>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[2] : !llvm.array<4 x ptr> 
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZN6Mother10MotherFoo2Ev : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[3] : !llvm.array<4 x ptr>
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[3] : !llvm.array<4 x ptr> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)> 
 // MLIR:    %{{[0-9]+}} = llvm.mlir.undef : !llvm.array<3 x ptr>
 // MLIR:    %{{[0-9]+}} = llvm.mlir.constant(-8 : i64) : i64
 // MLIR:    %{{[0-9]+}} = llvm.inttoptr %{{[0-9]+}} : i64 to !llvm.ptr
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.array<3 x ptr>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[0] : !llvm.array<3 x ptr> 
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZTI5Child : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.array<3 x ptr>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.array<3 x ptr> 
 // MLIR:    %{{[0-9]+}} = llvm.mlir.addressof @_ZN6Father9FatherFooEv : !llvm.ptr
 
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[2] : !llvm.array<3 x ptr>
-// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)>
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[2] : !llvm.array<3 x ptr> 
+// MLIR:    %{{[0-9]+}} = llvm.insertvalue %{{[0-9]+}}, %{{[0-9]+}}[1] : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)> 
 // MLIR:    llvm.return %{{[0-9]+}} : !llvm.struct<(array<4 x ptr>, array<3 x ptr>)>
 // MLIR:  }

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -27,7 +27,8 @@ module {
   cir.global external @alpha = #cir.const_array<[#cir.int<97> : !s8i, #cir.int<98> : !s8i, #cir.int<99> : !s8i, #cir.int<0> : !s8i]> : !cir.array<!s8i x 4>
   cir.global "private" constant internal @".str" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global external @s = #cir.global_view<@".str"> : !cir.ptr<!s8i>
-  // MLIR: llvm.mlir.global internal constant @".str"("example\00") {addr_space = 0 : i32}
+  // MLIR: llvm.mlir.global internal constant @".str"("example\00")
+  // MLIR-SAME: {addr_space = 0 : i32, alignment = 1 : i64}
   // MLIR: llvm.mlir.global external @s() {addr_space = 0 : i32} : !llvm.ptr {
   // MLIR:   %0 = llvm.mlir.addressof @".str" : !llvm.ptr
   // MLIR:   %1 = llvm.bitcast %0 : !llvm.ptr to !llvm.ptr

--- a/clang/test/CIR/Lowering/hello.cir
+++ b/clang/test/CIR/Lowering/hello.cir
@@ -20,7 +20,8 @@ module @"/tmp/test.raw" attributes {cir.lang = #cir.lang<c>, cir.sob = #cir.sign
 }
 
 // CHECK:  llvm.func @printf(!llvm.ptr, ...) -> i32
-// CHECK:  llvm.mlir.global internal constant @".str"("Hello, world!\0A\00") {addr_space = 0 : i32}
+// CHECK:  llvm.mlir.global internal constant @".str"("Hello, world!\0A\00")
+// CHECK-SAME: {addr_space = 0 : i32, alignment = 1 : i64}
 // CHECK:  llvm.func @main() -> i32
 // CHECK:    %0 = llvm.mlir.constant(1 : index) : i64
 // CHECK:    %1 = llvm.alloca %0 x i32 {alignment = 4 : i64} : (i64) -> !llvm.ptr


### PR DESCRIPTION
As title.
Add setAlignmentAttr for GlobalOps created from AST.
LLVM Lowering should have LLVM GlobalOp's alignment attribute inherited from CIR::GlobalOp.

This PR is definitely needed to fix issue https://github.com/llvm/clangir/issues/801#issuecomment-2305692250, but the issue doesn't have alignment and comdat attribute for CIR Ops to begin with, so I'll keep investigating and fix CIR problem in another PR.


