### PR TITLE
[CIR][CodeGen] Fix address space of result pointer type of array decay cast op

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -19,9 +19,8 @@ mlir::Value CIRGenBuilderTy::maybeBuildArrayDecay(mlir::Location loc,
       ::mlir::dyn_cast<::mlir::cir::ArrayType>(arrayPtrTy.getPointee());
 
   if (arrayTy) {
-    mlir::cir::AddressSpaceAttr addrSpace =
-        ::mlir::cast_if_present<::mlir::cir::AddressSpaceAttr>(
-            arrayPtrTy.getAddrSpace());
+    auto addrSpace = ::mlir::cast_if_present<::mlir::cir::AddressSpaceAttr>(
+        arrayPtrTy.getAddrSpace());
     mlir::cir::PointerType flatPtrTy =
         getPointerTo(arrayTy.getEltType(), addrSpace);
     return create<mlir::cir::CastOp>(

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -19,8 +19,11 @@ mlir::Value CIRGenBuilderTy::maybeBuildArrayDecay(mlir::Location loc,
       ::mlir::dyn_cast<::mlir::cir::ArrayType>(arrayPtrTy.getPointee());
 
   if (arrayTy) {
+    mlir::cir::AddressSpaceAttr addrSpace =
+        ::mlir::cast_if_present<::mlir::cir::AddressSpaceAttr>(
+            arrayPtrTy.getAddrSpace());
     mlir::cir::PointerType flatPtrTy =
-        mlir::cir::PointerType::get(getContext(), arrayTy.getEltType());
+        getPointerTo(arrayTy.getEltType(), addrSpace);
     return create<mlir::cir::CastOp>(
         loc, flatPtrTy, mlir::cir::CastKind::array_to_ptrdecay, arrayPtr);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -488,8 +488,10 @@ void AggExprEmitter::buildArrayInit(Address DestPtr, mlir::cir::ArrayType AType,
   QualType elementPtrType = CGF.getContext().getPointerType(elementType);
 
   auto cirElementType = CGF.convertType(elementType);
-  auto cirElementPtrType = mlir::cir::PointerType::get(
-      CGF.getBuilder().getContext(), cirElementType);
+  auto cirAddrSpace = mlir::cast_if_present<mlir::cir::AddressSpaceAttr>(
+      DestPtr.getType().getAddrSpace());
+  auto cirElementPtrType =
+      CGF.getBuilder().getPointerTo(cirElementType, cirAddrSpace);
   auto loc = CGF.getLoc(ExprToVisit->getSourceRange());
 
   // Cast from cir.ptr<cir.array<elementType> to cir.ptr<elementType>

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -490,6 +490,11 @@ LogicalResult CastOp::verify() {
     if (!arrayPtrTy || !flatPtrTy)
       return emitOpError() << "requires !cir.ptr type for source and result";
 
+    if (arrayPtrTy.getAddrSpace() != flatPtrTy.getAddrSpace()) {
+      return emitOpError()
+             << "requires same address space for source and result";
+    }
+
     auto arrayTy =
         mlir::dyn_cast<mlir::cir::ArrayType>(arrayPtrTy.getPointee());
     if (!arrayTy)

--- a/clang/test/CIR/CodeGen/OpenCL/array-decay.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/array-decay.cl
@@ -3,12 +3,23 @@
 // RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
-// CIR: @func
-// LLVM: @func
-kernel void func(global int *data) {
+// CIR: @func1
+// LLVM: @func1
+kernel void func1(global int *data) {
     local int arr[32];
+
     local int *ptr = arr;
     // CIR:      cir.cast(array_to_ptrdecay, %{{[0-9]+}} : !cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_local)>), !cir.ptr<!s32i, addrspace(offload_local)>
     // CIR-NEXT: cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(offload_local)>, !cir.ptr<!cir.ptr<!s32i, addrspace(offload_local)>, addrspace(offload_private)>
-    // LLVM: store ptr addrspace(3) @func.arr, ptr %{{[0-9]+}}
+
+    // LLVM: store ptr addrspace(3) @func1.arr, ptr %{{[0-9]+}}
+}
+
+// CIR: @func2
+// LLVM: @func2
+kernel void func2(global int *data) {
+    private int arr[32] = {data[2]};
+    // CIR: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %{{[0-9]+}} : !cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_private)>), !cir.ptr<!s32i, addrspace(offload_private)>
+
+    // LLVM: %{{[0-9]+}} = getelementptr i32, ptr %3, i32 0
 }

--- a/clang/test/CIR/CodeGen/OpenCL/array-decay.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/array-decay.cl
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+
+// CIR: @func
+// LLVM: @func
+kernel void func(global int *data) {
+    local int arr[32];
+    local int *ptr = arr;
+    // CIR:      cir.cast(array_to_ptrdecay, %{{[0-9]+}} : !cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_local)>), !cir.ptr<!s32i, addrspace(offload_local)>
+    // CIR-NEXT: cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!s32i, addrspace(offload_local)>, !cir.ptr<!cir.ptr<!s32i, addrspace(offload_local)>, addrspace(offload_private)>
+    // LLVM: store ptr addrspace(3) @func.arr, ptr %{{[0-9]+}}
+}

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1285,3 +1285,16 @@ module {
     cir.return
   }
 }
+
+// -----
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.func @array_to_ptrdecay_addrspace() {
+    %0 = cir.alloca !cir.array<!s32i x 32>, !cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_private)>, ["x", init]
+    // expected-error@+1 {{requires same address space for source and result}}
+    %1 = cir.cast(array_to_ptrdecay, %0 : !cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_private)>), !cir.ptr<!s32i>
+    cir.return
+  }
+}


### PR DESCRIPTION
There are two occurrences of `cir.cast(array_to_ptrdecay, ...)` that drop address spaces unexpectedly for its result pointer type. This PR fixes them with the source address space.

```mlir
// Before
%1 = cir.cast(array_to_ptrdecay, %0 : !cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_local)>), !cir.ptr<!s32i>
// After
%1 = cir.cast(array_to_ptrdecay, %0 : !cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_local)>), !cir.ptr<!s32i, addrspace(offload_local)>
```