### PR TITLE
[CIR][Transform] Add simplify transformation for select op

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1395,11 +1395,20 @@ void TernaryOp::build(OpBuilder &builder, OperationState &result, Value cond,
 
 OpFoldResult SelectOp::fold(FoldAdaptor adaptor) {
   auto condition = adaptor.getCondition();
-  if (!condition)
-    return nullptr;
+  if (condition) {
+    auto conditionValue = mlir::cast<mlir::cir::BoolAttr>(condition).getValue();
+    return conditionValue ? getTrueValue() : getFalseValue();
+  }
 
-  auto conditionValue = mlir::cast<mlir::cir::BoolAttr>(condition).getValue();
-  return conditionValue ? getTrueValue() : getFalseValue();
+  // cir.select if %0 then x else x -> x
+  auto trueValue = adaptor.getTrueValue();
+  auto falseValue = adaptor.getFalseValue();
+  if (trueValue && trueValue == falseValue)
+    return trueValue;
+  if (getTrueValue() == getFalseValue())
+    return getTrueValue();
+
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/test/CIR/Transforms/select.cir
+++ b/clang/test/CIR/Transforms/select.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt --canonicalize -o %t.cir %s
+// RUN: cir-opt -cir-simplify -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir %s
 
 !s32i = !cir.int<s, 32>
@@ -22,5 +22,39 @@ module {
 
   //      CHECK: cir.func @fold_false(%[[ARG0:.+]]: !s32i, %[[ARG1:.+]]: !s32i) -> !s32i {
   // CHECK-NEXT:   cir.return %[[ARG1]] : !s32i
+  // CHECK-NEXT: }
+
+  cir.func @fold_to_const(%arg0 : !cir.bool) -> !s32i {
+    %0 = cir.const #cir.int<42> : !s32i
+    %1 = cir.select if %arg0 then %0 else %0 : (!cir.bool, !s32i, !s32i) -> !s32i
+    cir.return %1 : !s32i
+  }
+
+  //      CHECK: cir.func @fold_to_const(%{{.+}}: !cir.bool) -> !s32i {
+  // CHECK-NEXT:   %[[#A:]] = cir.const #cir.int<42> : !s32i
+  // CHECK-NEXT:   cir.return %[[#A]] : !s32i
+  // CHECK-NEXT: }
+
+  cir.func @simplify_1(%arg0 : !cir.bool) -> !cir.bool {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    %1 = cir.const #cir.bool<false> : !cir.bool
+    %2 = cir.select if %arg0 then %0 else %1 : (!cir.bool, !cir.bool, !cir.bool) -> !cir.bool
+    cir.return %2 : !cir.bool
+  }
+
+  //      CHECK: cir.func @simplify_1(%[[ARG0:.+]]: !cir.bool) -> !cir.bool {
+  // CHECK-NEXT:   cir.return %[[ARG0]] : !cir.bool
+  // CHECK-NEXT: }
+
+  cir.func @simplify_2(%arg0 : !cir.bool) -> !cir.bool {
+    %0 = cir.const #cir.bool<false> : !cir.bool
+    %1 = cir.const #cir.bool<true> : !cir.bool
+    %2 = cir.select if %arg0 then %0 else %1 : (!cir.bool, !cir.bool, !cir.bool) -> !cir.bool
+    cir.return %2 : !cir.bool
+  }
+
+  //      CHECK: cir.func @simplify_2(%[[ARG0:.+]]: !cir.bool) -> !cir.bool {
+  // CHECK-NEXT:   %[[#A:]] = cir.unary(not, %[[ARG0]]) : !cir.bool, !cir.bool
+  // CHECK-NEXT:   cir.return %[[#A]] : !cir.bool
   // CHECK-NEXT: }
 }


### PR DESCRIPTION
As mentioned at https://github.com/llvm/clangir/pull/809#discussion_r1734972785 , this PR adds more simplify transformations for select op:

- `cir.select if %0 then x else x` -> `x`
- `cir.select if %0 then #true else #false` -> `%0`
- `cir.select if %0 then #false else #true` -> `cir.unary not %0`