### PR TITLE
[CIR][NFC] Extend simple lowering to unary fp2int ops and binary fp2fp ops

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3796,7 +3796,8 @@ def IterEndOp : CIR_Op<"iterator_end"> {
 // Floating Point Ops
 //===----------------------------------------------------------------------===//
 
-class UnaryFPToIntBuiltinOp<string mnemonic> : CIR_Op<mnemonic, [Pure]> {
+class UnaryFPToIntBuiltinOp<string mnemonic, string llvmOpName>
+    : CIR_Op<mnemonic, [Pure]> {
   let arguments = (ins CIR_AnyFloat:$src);
   let results = (outs CIR_IntType:$result);
 
@@ -3808,12 +3809,14 @@ class UnaryFPToIntBuiltinOp<string mnemonic> : CIR_Op<mnemonic, [Pure]> {
   let assemblyFormat = [{
     $src `:` type($src) `->` type($result) attr-dict
   }];
+
+  let llvmOp = llvmOpName;
 }
 
-def LroundOp : UnaryFPToIntBuiltinOp<"lround">;
-def LLroundOp : UnaryFPToIntBuiltinOp<"llround">;
-def LrintOp : UnaryFPToIntBuiltinOp<"lrint">;
-def LLrintOp : UnaryFPToIntBuiltinOp<"llrint">;
+def LroundOp : UnaryFPToIntBuiltinOp<"lround", "LroundOp">;
+def LLroundOp : UnaryFPToIntBuiltinOp<"llround", "LlroundOp">;
+def LrintOp : UnaryFPToIntBuiltinOp<"lrint", "LrintOp">;
+def LLrintOp : UnaryFPToIntBuiltinOp<"llrint", "LlrintOp">;
 
 class UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
     : CIR_Op<mnemonic, [Pure, SameOperandsAndResultType]> {
@@ -3842,7 +3845,7 @@ def SinOp : UnaryFPToFPBuiltinOp<"sin", "SinOp">;
 def SqrtOp : UnaryFPToFPBuiltinOp<"sqrt", "SqrtOp">;
 def TruncOp : UnaryFPToFPBuiltinOp<"trunc", "FTruncOp">;
 
-class BinaryFPToFPBuiltinOp<string mnemonic>
+class BinaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
     : CIR_Op<mnemonic, [Pure, SameOperandsAndResultType]> {
   let summary = [{
     libc builtin equivalent ignoring floating-point exceptions and errno.
@@ -3854,13 +3857,15 @@ class BinaryFPToFPBuiltinOp<string mnemonic>
   let assemblyFormat = [{
     $lhs `,` $rhs `:` qualified(type($lhs)) attr-dict
   }];
+
+  let llvmOp = llvmOpName;
 }
 
-def CopysignOp : BinaryFPToFPBuiltinOp<"copysign">;
-def FMaxOp : BinaryFPToFPBuiltinOp<"fmax">;
-def FMinOp : BinaryFPToFPBuiltinOp<"fmin">;
-def FModOp : BinaryFPToFPBuiltinOp<"fmod">;
-def PowOp : BinaryFPToFPBuiltinOp<"pow">;
+def CopysignOp : BinaryFPToFPBuiltinOp<"copysign", "CopySignOp">;
+def FMaxOp : BinaryFPToFPBuiltinOp<"fmax", "MaxNumOp">;
+def FMinOp : BinaryFPToFPBuiltinOp<"fmin", "MinNumOp">;
+def FModOp : BinaryFPToFPBuiltinOp<"fmod", "FRemOp">;
+def PowOp : BinaryFPToFPBuiltinOp<"pow", "PowOp">;
 
 //===----------------------------------------------------------------------===//
 // Branch Probability Operations

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3539,73 +3539,6 @@ private:
   }
 };
 
-template <typename CIROp, typename LLVMOp>
-class CIRUnaryFPBuiltinOpLowering : public mlir::OpConversionPattern<CIROp> {
-public:
-  using mlir::OpConversionPattern<CIROp>::OpConversionPattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(CIROp op,
-                  typename mlir::OpConversionPattern<CIROp>::OpAdaptor adaptor,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    auto resTy = this->getTypeConverter()->convertType(op.getType());
-    rewriter.replaceOpWithNewOp<LLVMOp>(op, resTy, adaptor.getSrc());
-    return mlir::success();
-  }
-};
-
-using CIRLroundOpLowering =
-    CIRUnaryFPBuiltinOpLowering<mlir::cir::LroundOp, mlir::LLVM::LroundOp>;
-using CIRLLroundOpLowering =
-    CIRUnaryFPBuiltinOpLowering<mlir::cir::LLroundOp, mlir::LLVM::LlroundOp>;
-using CIRLrintOpLowering =
-    CIRUnaryFPBuiltinOpLowering<mlir::cir::LrintOp, mlir::LLVM::LrintOp>;
-using CIRLLrintOpLowering =
-    CIRUnaryFPBuiltinOpLowering<mlir::cir::LLrintOp, mlir::LLVM::LlrintOp>;
-
-template <typename CIROp, typename LLVMOp>
-class CIRBinaryFPToFPBuiltinOpLowering
-    : public mlir::OpConversionPattern<CIROp> {
-public:
-  using mlir::OpConversionPattern<CIROp>::OpConversionPattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(CIROp op,
-                  typename mlir::OpConversionPattern<CIROp>::OpAdaptor adaptor,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    auto resTy = this->getTypeConverter()->convertType(op.getType());
-    rewriter.replaceOpWithNewOp<LLVMOp>(op, resTy, adaptor.getLhs(),
-                                        adaptor.getRhs());
-    return mlir::success();
-  }
-};
-
-using CIRCopysignOpLowering =
-    CIRBinaryFPToFPBuiltinOpLowering<mlir::cir::CopysignOp,
-                                     mlir::LLVM::CopySignOp>;
-using CIRFMaxOpLowering =
-    CIRBinaryFPToFPBuiltinOpLowering<mlir::cir::FMaxOp, mlir::LLVM::MaxNumOp>;
-using CIRFMinOpLowering =
-    CIRBinaryFPToFPBuiltinOpLowering<mlir::cir::FMinOp, mlir::LLVM::MinNumOp>;
-using CIRPowOpLowering =
-    CIRBinaryFPToFPBuiltinOpLowering<mlir::cir::PowOp, mlir::LLVM::PowOp>;
-
-// cir.fmod is special. Instead of lowering it to an intrinsic call, lower it to
-// the frem LLVM instruction.
-class CIRFModOpLowering : public mlir::OpConversionPattern<mlir::cir::FModOp> {
-public:
-  using mlir::OpConversionPattern<mlir::cir::FModOp>::OpConversionPattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(mlir::cir::FModOp op, OpAdaptor adaptor,
-                  mlir::ConversionPatternRewriter &rewriter) const override {
-    auto resTy = this->getTypeConverter()->convertType(op.getType());
-    rewriter.replaceOpWithNewOp<mlir::LLVM::FRemOp>(op, resTy, adaptor.getLhs(),
-                                                    adaptor.getRhs());
-    return mlir::success();
-  }
-};
-
 class CIRClearCacheOpLowering
     : public mlir::OpConversionPattern<mlir::cir::ClearCacheOp> {
 public:
@@ -3832,12 +3765,9 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRStackSaveLowering, CIRUnreachableLowering, CIRTrapLowering,
       CIRInlineAsmOpLowering, CIRSetBitfieldLowering, CIRGetBitfieldLowering,
       CIRPrefetchLowering, CIRObjSizeOpLowering, CIRIsConstantOpLowering,
-      CIRCmpThreeWayOpLowering, CIRLroundOpLowering, CIRLLroundOpLowering,
-      CIRLrintOpLowering, CIRLLrintOpLowering, CIRCopysignOpLowering,
-      CIRFModOpLowering, CIRFMaxOpLowering, CIRFMinOpLowering, CIRPowOpLowering,
-      CIRClearCacheOpLowering, CIRUndefOpLowering, CIREhTypeIdOpLowering,
-      CIRCatchParamOpLowering, CIRResumeOpLowering, CIRAllocExceptionOpLowering,
-      CIRThrowOpLowering
+      CIRCmpThreeWayOpLowering, CIRClearCacheOpLowering, CIRUndefOpLowering,
+      CIREhTypeIdOpLowering, CIRCatchParamOpLowering, CIRResumeOpLowering,
+      CIRAllocExceptionOpLowering, CIRThrowOpLowering
 #define GET_BUILTIN_LOWERING_LIST
 #include "clang/CIR/Dialect/IR/CIRBuiltinsLowering.inc"
 #undef GET_BUILTIN_LOWERING_LIST


### PR DESCRIPTION
This PR makes simple lowering generate the result type lowering logic and make it suitable for unary fp2int operations and binary fp2fp operations.