### PR TITLE
[CIR][driver] Forward -fno-clangir-direct-lowering option to cc1

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4972,12 +4972,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       Args.hasArg(options::OPT_emit_cir_flat))
     CmdArgs.push_back("-fclangir");
 
-  if (Args.hasArg(options::OPT_fclangir_direct_lowering))
-    CmdArgs.push_back("-fclangir-direct-lowering");
-
-  if (Args.hasArg(options::OPT_fno_clangir_direct_lowering))
-    CmdArgs.push_back("-fno-clangir-direct-lowering");
-
+  Args.addOptOutFlag(CmdArgs, options::OPT_fclangir_direct_lowering, options::OPT_fno_clangir_direct_lowering)
   if (Args.hasArg(options::OPT_clangir_disable_passes))
     CmdArgs.push_back("-clangir-disable-passes");
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4972,7 +4972,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       Args.hasArg(options::OPT_emit_cir_flat))
     CmdArgs.push_back("-fclangir");
 
-  Args.addOptOutFlag(CmdArgs, options::OPT_fclangir_direct_lowering, options::OPT_fno_clangir_direct_lowering)
+  Args.addOptOutFlag(CmdArgs, options::OPT_fclangir_direct_lowering,
+                     options::OPT_fno_clangir_direct_lowering);
+
   if (Args.hasArg(options::OPT_clangir_disable_passes))
     CmdArgs.push_back("-clangir-disable-passes");
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4975,12 +4975,15 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_fclangir_direct_lowering))
     CmdArgs.push_back("-fclangir-direct-lowering");
 
+  if (Args.hasArg(options::OPT_fno_clangir_direct_lowering))
+    CmdArgs.push_back("-fno-clangir-direct-lowering");
+
   if (Args.hasArg(options::OPT_clangir_disable_passes))
     CmdArgs.push_back("-clangir-disable-passes");
 
   if (Args.hasArg(options::OPT_fclangir_call_conv_lowering))
     CmdArgs.push_back("-fclangir-call-conv-lowering");
-  
+
   if (Args.hasArg(options::OPT_fclangir_mem2reg))
     CmdArgs.push_back("-fclangir-mem2reg");
 

--- a/clang/test/CIR/driver.c
+++ b/clang/test/CIR/driver.c
@@ -4,9 +4,14 @@
 // RUN: FileCheck --input-file=%t2.cir %s -check-prefix=CIR
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fclangir-direct-lowering -S -emit-llvm %s -o %t1.ll
 // RUN: FileCheck --input-file=%t1.ll %s -check-prefix=LLVM
-// RUN %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -S -emit-llvm %s -o %t2.ll
-// RUN FileCheck --input-file=%t2.ll %s -check-prefix=CIR_STD_LLVM
-// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fclangir-direct-lowering -c -emit-llvm %s -o %t1.bc
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -S -emit-llvm %s -o %t2.ll
+// RUN: FileCheck --input-file=%t2.ll %s -check-prefix=CIR_STD_LLVM
+// Test also the cases for both -fclangir-direct-lowering and -fno-clangir-direct-lowering,
+// with -fno-clangir-direct-lowering having the preference
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fclangir-direct-lowering -fno-clangir-direct-lowering -S -emit-llvm %s -o %t2.ll
+// RUN: FileCheck --input-file=%t2.ll %s -check-prefix=CIR_STD_LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -fclangir-direct-lowering -c -emit-llvm %s -o %t1.bc
+// RUN: FileCheck --input-file=%t2.ll %s -check-prefix=CIR_STD_LLVM
 // RUN: llvm-dis %t1.bc -o %t1.bc.ll
 // RUN: FileCheck --input-file=%t1.bc.ll %s -check-prefix=LLVM
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -c -emit-llvm %s -o %t2.bc

--- a/clang/test/CIR/driver.c
+++ b/clang/test/CIR/driver.c
@@ -4,14 +4,14 @@
 // RUN: FileCheck --input-file=%t2.cir %s -check-prefix=CIR
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fclangir-direct-lowering -S -emit-llvm %s -o %t1.ll
 // RUN: FileCheck --input-file=%t1.ll %s -check-prefix=LLVM
-// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -S -emit-llvm %s -o %t2.ll
-// RUN: FileCheck --input-file=%t2.ll %s -check-prefix=LLVM
+// RUN %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -S -emit-llvm %s -o %t2.ll
+// RUN FileCheck --input-file=%t2.ll %s -check-prefix=CIR_STD_LLVM
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fclangir-direct-lowering -c -emit-llvm %s -o %t1.bc
 // RUN: llvm-dis %t1.bc -o %t1.bc.ll
 // RUN: FileCheck --input-file=%t1.bc.ll %s -check-prefix=LLVM
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -c -emit-llvm %s -o %t2.bc
 // RUN: llvm-dis %t2.bc -o %t2.bc.ll
-// RUN: FileCheck --input-file=%t2.bc.ll %s -check-prefix=LLVM
+// RUN: FileCheck --input-file=%t2.bc.ll %s -check-prefix=CIR_STD_LLVM
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -c %s -o %t.o
 // RUN: llvm-objdump -d %t.o | FileCheck %s -check-prefix=OBJ
 // RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -clangir-disable-passes -S -Xclang -emit-cir %s -o %t.cir
@@ -38,6 +38,10 @@ void foo(void) {}
 //      LLVM: define dso_local void @foo()
 // LLVM-NEXT:   ret void
 // LLVM-NEXT: }
+
+//      CIR_STD_LLVM: define void @foo()
+// CIR_STD_LLVM-NEXT:   ret void
+// CIR_STD_LLVM-NEXT: }
 
 //      LLVM_MACOS: define void @foo()
 // LLVM_MACOS-NEXT:   ret void


### PR DESCRIPTION
Allow from the clang driver the use of lowering from CIR to MLIR standard dialect.
Update the test to match the real output when
`-fno-clangir-direct-lowering` is used, or with a combination of both `-fclangir-direct-lowering` and `-fno-clangir-direct-lowering`.