### PR TITLE
[CIR][CIRGen] Support pure and deleted virtual functions

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -235,6 +235,12 @@ public:
                                   BaseSubobject Base,
                                   const CXXRecordDecl *NearestVBase) = 0;
 
+  /// Gets the pure virtual member call function.
+  virtual StringRef getPureVirtualCallName() = 0;
+
+  /// Gets the deleted virtual member call name.
+  virtual StringRef getDeletedVirtualCallName() = 0;
+
   /// Specify how one should pass an argument of a record type.
   enum class RecordArgABI {
     /// Pass it using the normal C aggregate rules for the ABI, potentially

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -215,6 +215,11 @@ public:
     return false;
   }
 
+  StringRef getPureVirtualCallName() override { return "__cxa_pure_virtual"; }
+  StringRef getDeletedVirtualCallName() override {
+    return "__cxa_deleted_virtual";
+  }
+
   /// TODO(cir): seems like could be shared between LLVM IR and CIR codegen.
   bool mayNeedDestruction(const VarDecl *VD) const {
     if (VD->needsDestruction(getContext()))

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.h
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.h
@@ -19,6 +19,7 @@
 #include "clang/AST/GlobalDecl.h"
 #include "clang/AST/VTableBuilder.h"
 #include "clang/Basic/ABI.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "llvm/ADT/DenseMap.h"
 
 namespace clang {
@@ -52,11 +53,11 @@ class CIRGenVTables {
   /// indices.
   SecondaryVirtualPointerIndicesMapTy SecondaryVirtualPointerIndices;
 
-  //   /// Cache for the pure virtual member call function.
-  //   llvm::Constant *PureVirtualFn = nullptr;
+  /// Cache for the pure virtual member call function.
+  mlir::cir::FuncOp PureVirtualFn = nullptr;
 
-  //   /// Cache for the deleted virtual member call function.
-  //   llvm::Constant *DeletedVirtualFn = nullptr;
+  /// Cache for the deleted virtual member call function.
+  mlir::cir::FuncOp DeletedVirtualFn = nullptr;
 
   //   /// Get the address of a thunk and emit it if necessary.
   //   llvm::Constant *maybeEmitThunk(GlobalDecl GD,

--- a/clang/test/CIR/CodeGen/special-virtual-func.cpp
+++ b/clang/test/CIR/CodeGen/special-virtual-func.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// Check that pure and deleted virtual functions are correctly emitted in the
+// vtable.
+class A {
+  A();
+  virtual void pure() = 0;
+  virtual void deleted() = delete;
+};
+
+A::A() = default;
+
+// CHECK: @_ZTV1A = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1A> : !cir.ptr<!u8i>, #cir.global_view<@__cxa_pure_virtual> : !cir.ptr<!u8i>, #cir.global_view<@__cxa_deleted_virtual> : !cir.ptr<!u8i>]>
+// CHECK: cir.func private @__cxa_pure_virtual()
+// CHECK: cir.func private @__cxa_deleted_virtual()


### PR DESCRIPTION
This is a straightforward adaption of existing CodeGen logic. While I'm
here, move block comments inside their blocks, so that they look nicer.
