### PR TITLE
[CIR][Dialect] Add calling convention attribute to cir.call op

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -622,10 +622,11 @@ public:
                mlir::SymbolRefAttr callee = mlir::SymbolRefAttr(),
                mlir::Type returnType = mlir::cir::VoidType(),
                mlir::ValueRange operands = mlir::ValueRange(),
+               mlir::cir::CallingConv callingConv = mlir::cir::CallingConv::C,
                mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
 
-    mlir::cir::CallOp callOp =
-        create<mlir::cir::CallOp>(loc, callee, returnType, operands);
+    mlir::cir::CallOp callOp = create<mlir::cir::CallOp>(
+        loc, callee, returnType, operands, callingConv);
 
     if (extraFnAttr) {
       callOp->setAttr("extra_attrs", extraFnAttr);
@@ -641,41 +642,44 @@ public:
   mlir::cir::CallOp
   createCallOp(mlir::Location loc, mlir::cir::FuncOp callee,
                mlir::ValueRange operands = mlir::ValueRange(),
+               mlir::cir::CallingConv callingConv = mlir::cir::CallingConv::C,
                mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
     return createCallOp(loc, mlir::SymbolRefAttr::get(callee),
                         callee.getFunctionType().getReturnType(), operands,
-                        extraFnAttr);
+                        callingConv, extraFnAttr);
   }
 
-  mlir::cir::CallOp
-  createIndirectCallOp(mlir::Location loc, mlir::Value ind_target,
-                       mlir::cir::FuncType fn_type,
-                       mlir::ValueRange operands = mlir::ValueRange(),
-                       mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
+  mlir::cir::CallOp createIndirectCallOp(
+      mlir::Location loc, mlir::Value ind_target, mlir::cir::FuncType fn_type,
+      mlir::ValueRange operands = mlir::ValueRange(),
+      mlir::cir::CallingConv callingConv = mlir::cir::CallingConv::C,
+      mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
 
     llvm::SmallVector<mlir::Value, 4> resOperands({ind_target});
     resOperands.append(operands.begin(), operands.end());
 
     return createCallOp(loc, mlir::SymbolRefAttr(), fn_type.getReturnType(),
-                        resOperands, extraFnAttr);
+                        resOperands, callingConv, extraFnAttr);
   }
 
   mlir::cir::CallOp
   createCallOp(mlir::Location loc, mlir::SymbolRefAttr callee,
                mlir::ValueRange operands = mlir::ValueRange(),
+               mlir::cir::CallingConv callingConv = mlir::cir::CallingConv::C,
                mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
     return createCallOp(loc, callee, mlir::cir::VoidType(), operands,
-                        extraFnAttr);
+                        callingConv, extraFnAttr);
   }
 
-  mlir::cir::CallOp
-  createTryCallOp(mlir::Location loc,
-                  mlir::SymbolRefAttr callee = mlir::SymbolRefAttr(),
-                  mlir::Type returnType = mlir::cir::VoidType(),
-                  mlir::ValueRange operands = mlir::ValueRange(),
-                  mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
-    mlir::cir::CallOp tryCallOp = create<mlir::cir::CallOp>(
-        loc, callee, returnType, operands, getUnitAttr());
+  mlir::cir::CallOp createTryCallOp(
+      mlir::Location loc, mlir::SymbolRefAttr callee = mlir::SymbolRefAttr(),
+      mlir::Type returnType = mlir::cir::VoidType(),
+      mlir::ValueRange operands = mlir::ValueRange(),
+      mlir::cir::CallingConv callingConv = mlir::cir::CallingConv::C,
+      mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
+    mlir::cir::CallOp tryCallOp =
+        create<mlir::cir::CallOp>(loc, callee, returnType, operands,
+                                  callingConv, /*exception=*/getUnitAttr());
     if (extraFnAttr) {
       tryCallOp->setAttr("extra_attrs", extraFnAttr);
     } else {
@@ -687,13 +691,13 @@ public:
     return tryCallOp;
   }
 
-  mlir::cir::CallOp
-  createTryCallOp(mlir::Location loc, mlir::cir::FuncOp callee,
-                  mlir::ValueRange operands,
-                  mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
+  mlir::cir::CallOp createTryCallOp(
+      mlir::Location loc, mlir::cir::FuncOp callee, mlir::ValueRange operands,
+      mlir::cir::CallingConv callingConv = mlir::cir::CallingConv::C,
+      mlir::cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
     return createTryCallOp(loc, mlir::SymbolRefAttr::get(callee),
                            callee.getFunctionType().getReturnType(), operands,
-                           extraFnAttr);
+                           callingConv, extraFnAttr);
   }
 
   mlir::cir::CallOp createIndirectTryCallOp(mlir::Location loc,

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -700,14 +700,14 @@ public:
                            callingConv, extraFnAttr);
   }
 
-  mlir::cir::CallOp createIndirectTryCallOp(mlir::Location loc,
-                                            mlir::Value ind_target,
-                                            mlir::cir::FuncType fn_type,
-                                            mlir::ValueRange operands) {
+  mlir::cir::CallOp createIndirectTryCallOp(
+      mlir::Location loc, mlir::Value ind_target, mlir::cir::FuncType fn_type,
+      mlir::ValueRange operands,
+      mlir::cir::CallingConv callingConv = mlir::cir::CallingConv::C) {
     llvm::SmallVector<mlir::Value, 4> resOperands({ind_target});
     resOperands.append(operands.begin(), operands.end());
     return createTryCallOp(loc, mlir::SymbolRefAttr(), fn_type.getReturnType(),
-                           resOperands);
+                           resOperands, callingConv);
   }
 
   struct GetMethodResults {

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3208,8 +3208,7 @@ class CIR_CallOp<string mnemonic, list<Trait> extra_traits = []> :
   dag commonArgs = (ins
     OptionalAttr<FlatSymbolRefAttr>:$callee,
     Variadic<CIR_AnyType>:$arg_ops,
-    DefaultValuedAttr<CallingConv,
-                          "CallingConv::C">:$calling_conv,
+    DefaultValuedAttr<CallingConv, "CallingConv::C">:$calling_conv,
     ExtraFuncAttr:$extra_attrs,
     OptionalAttr<ASTCallExprInterface>:$ast
   );

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3208,6 +3208,8 @@ class CIR_CallOp<string mnemonic, list<Trait> extra_traits = []> :
   dag commonArgs = (ins
     OptionalAttr<FlatSymbolRefAttr>:$callee,
     Variadic<CIR_AnyType>:$arg_ops,
+    DefaultValuedAttr<CallingConv,
+                          "CallingConv::C">:$calling_conv,
     ExtraFuncAttr:$extra_attrs,
     OptionalAttr<ASTCallExprInterface>:$ast
   );
@@ -3251,10 +3253,13 @@ def CallOp : CIR_CallOp<"call"> {
   let builders = [
     OpBuilder<(ins "SymbolRefAttr":$callee, "mlir::Type":$resType,
               CArg<"ValueRange", "{}">:$operands,
+              CArg<"CallingConv", "CallingConv::C">:$callingConv,
               CArg<"UnitAttr", "{}">:$exception), [{
       $_state.addOperands(operands);
       if (callee)
         $_state.addAttribute("callee", callee);
+      $_state.addAttribute("calling_conv",
+        CallingConvAttr::get($_builder.getContext(), callingConv));
       if (exception)
         $_state.addAttribute("exception", exception);
       if (resType && !isa<VoidType>(resType))
@@ -3263,11 +3268,14 @@ def CallOp : CIR_CallOp<"call"> {
     OpBuilder<(ins "Value":$ind_target,
                "FuncType":$fn_type,
                CArg<"ValueRange", "{}">:$operands,
+               CArg<"CallingConv", "CallingConv::C">:$callingConv,
                CArg<"UnitAttr", "{}">:$exception), [{
       $_state.addOperands(ValueRange{ind_target});
       $_state.addOperands(operands);
       if (!fn_type.isVoid())
         $_state.addTypes(fn_type.getReturnType());
+      $_state.addAttribute("calling_conv",
+        CallingConvAttr::get($_builder.getContext(), callingConv));
       if (exception)
         $_state.addAttribute("exception", exception);
     }]>
@@ -3307,12 +3315,16 @@ def TryCallOp : CIR_CallOp<"try_call",
                "Block *":$cont, "Block *":$landing_pad,
                CArg<"ValueRange", "{}">:$operands,
                CArg<"ValueRange", "{}">:$contOperands,
-               CArg<"ValueRange", "{}">:$landingPadOperands), [{
+               CArg<"ValueRange", "{}">:$landingPadOperands,
+               CArg<"CallingConv", "CallingConv::C">:$callingConv), [{
       $_state.addOperands(operands);
       if (callee)
         $_state.addAttribute("callee", callee);
       if (resType && !isa<VoidType>(resType))
         $_state.addTypes(resType);
+
+      $_state.addAttribute("calling_conv",
+        CallingConvAttr::get($_builder.getContext(), callingConv));
 
       // Handle branches
       $_state.addOperands(contOperands);
@@ -3332,13 +3344,17 @@ def TryCallOp : CIR_CallOp<"try_call",
                "Block *":$cont, "Block *":$landing_pad,
                CArg<"ValueRange", "{}">:$operands,
                CArg<"ValueRange", "{}">:$contOperands,
-               CArg<"ValueRange", "{}">:$landingPadOperands), [{
+               CArg<"ValueRange", "{}">:$landingPadOperands,
+               CArg<"CallingConv", "CallingConv::C">:$callingConv), [{
       ::llvm::SmallVector<mlir::Value, 4> finalCallOperands({ind_target});
       finalCallOperands.append(operands.begin(), operands.end());
       $_state.addOperands(finalCallOperands);
 
       if (!fn_type.isVoid())
         $_state.addTypes(fn_type.getReturnType());
+
+      $_state.addAttribute("calling_conv",
+        CallingConvAttr::get($_builder.getContext(), callingConv));
 
       // Handle branches
       $_state.addOperands(contOperands);

--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
@@ -34,6 +34,9 @@ let cppNamespace = "::mlir::cir" in {
           "Return the number of operands, accounts for indirect call or "
           "exception info",
           "unsigned", "getNumArgOperands", (ins)>,
+      InterfaceMethod<
+          "Return the calling convention of the call operation",
+          "mlir::cir::CallingConv", "getCallingConv", (ins)>,
     ];
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -487,8 +487,10 @@ buildCallLikeOp(CIRGenFunction &CGF, mlir::Location callLoc,
   assert(builder.getInsertionBlock() && "expected valid basic block");
   if (indirectFuncTy)
     return builder.createIndirectCallOp(
-        callLoc, indirectFuncVal, indirectFuncTy, CIRCallArgs, extraFnAttrs);
-  return builder.createCallOp(callLoc, directFuncOp, CIRCallArgs, extraFnAttrs);
+        callLoc, indirectFuncVal, indirectFuncTy, CIRCallArgs,
+        mlir::cir::CallingConv::C, extraFnAttrs);
+  return builder.createCallOp(callLoc, directFuncOp, CIRCallArgs,
+                              mlir::cir::CallingConv::C, extraFnAttrs);
 }
 
 RValue CIRGenFunction::buildCall(const CIRGenFunctionInfo &CallInfo,

--- a/clang/test/CIR/IR/call-op-call-conv.cir
+++ b/clang/test/CIR/IR/call-op-call-conv.cir
@@ -1,0 +1,27 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+!s32i = !cir.int<s, 32>
+!fnptr = !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
+
+module {
+  cir.func @my_add(%a: !s32i, %b: !s32i) -> !s32i cc(spir_function) {
+    %c = cir.binop(add, %a, %b) : !s32i
+    cir.return %c : !s32i
+  }
+
+  cir.func @ind(%fnptr: !fnptr, %a : !s32i) {
+    %1 = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i cc(spir_kernel)
+    %2 = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i cc(spir_function)
+
+    %3 = cir.try_call @my_add(%1, %2) ^continue, ^landing_pad : (!s32i, !s32i) -> !s32i cc(spir_function)
+  ^continue:
+    cir.br ^landing_pad
+  ^landing_pad:
+    cir.return
+  }
+}
+
+// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !s32i) -> !s32i cc(spir_kernel)
+// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !s32i) -> !s32i cc(spir_function)
+// CHECK: %{{[0-9]+}} = cir.try_call @my_add(%{{[0-9]+}}, %{{[0-9]+}}) ^{{.+}}, ^{{.+}} : (!s32i, !s32i) -> !s32i cc(spir_function)


### PR DESCRIPTION
The first patch to fix #803 . This PR adds the calling convention attribute to CallOp directly, which is similar to LLVM, rather than adding the information to function type, which mimics Clang AST function type.

The syntax of it in CIR assembly is between the function type and extra attributes, as follows:

```mlir
%1 = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i cc(spir_kernel) extra(#fn_attr)
```

The verification of direct calls is not included. It will be included in the next patch extending CIRGen & Lowering.

---

For every builder method of Call Op, an optional parameter `callingConv` is inserted right before the parameter of extra attribute. However, apart from the parser / printer, this PR does not introduce any functional changes.
