### PR TITLE
[CIR][CodeGen] Refactor `setExtraAttributesForFunc` to better align with OG

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -287,7 +287,7 @@ mlir::cir::FuncOp CIRGenModule::codegenCXXStructor(GlobalDecl GD) {
   CurCGF = nullptr;
 
   setNonAliasAttributes(GD, Fn);
-  // TODO: SetLLVMFunctionAttributesForDefinition
+  setCIRFunctionAttributesForDefinition(cast<CXXMethodDecl>(GD.getDecl()), Fn);
   return Fn;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -572,7 +572,12 @@ public:
 
   /// Set the CIR function attributes (sext, zext, etc).
   void setCIRFunctionAttributes(GlobalDecl GD, const CIRGenFunctionInfo &info,
-                                 mlir::cir::FuncOp func, bool isThunk);
+                                mlir::cir::FuncOp func, bool isThunk);
+
+  /// Set the CIR function attributes which only apply to a function
+  /// definition.
+  void setCIRFunctionAttributesForDefinition(const Decl *decl,
+                                             mlir::cir::FuncOp func);
 
   void buildGlobalDefinition(clang::GlobalDecl D,
                              mlir::Operation *Op = nullptr);
@@ -664,9 +669,6 @@ public:
 
   void ReplaceUsesOfNonProtoTypeWithRealFunction(mlir::Operation *Old,
                                                  mlir::cir::FuncOp NewFn);
-
-  void setExtraAttributesForFunc(mlir::cir::FuncOp f,
-                                 const clang::FunctionDecl *FD);
 
   // TODO: CodeGen also passes an AttributeList here. We'll have to match that
   // in CIR

--- a/clang/test/CIR/CodeGen/attributes.c
+++ b/clang/test/CIR/CodeGen/attributes.c
@@ -14,7 +14,7 @@ int __attribute__((section(".shared"))) glob = 42;
 
 
 void __attribute__((__visibility__("hidden"))) foo();
-// CIR: cir.func no_proto private hidden @foo(...) extra(#fn_attr)
+// CIR: cir.func no_proto private hidden @foo(...)
 int bah()
 {
   foo();

--- a/clang/test/CIR/CodeGen/visibility-attribute.c
+++ b/clang/test/CIR/CodeGen/visibility-attribute.c
@@ -19,15 +19,15 @@ int call_glob()
 }
 
 void foo_default();
-// CIR: cir.func no_proto private @foo_default(...) extra(#fn_attr)
+// CIR: cir.func no_proto private @foo_default(...)
 // LLVM: declare {{.*}} void @foo_default(...)
 
 void __attribute__((__visibility__("hidden"))) foo_hidden();
-// CIR: cir.func no_proto private hidden @foo_hidden(...) extra(#fn_attr)
+// CIR: cir.func no_proto private hidden @foo_hidden(...)
 // LLVM: declare {{.*}} hidden void @foo_hidden(...)
 
 void __attribute__((__visibility__("protected"))) foo_protected();
-// CIR: cir.func no_proto private protected @foo_protected(...) extra(#fn_attr)
+// CIR: cir.func no_proto private protected @foo_protected(...)
 // LLVM: declare {{.*}} protected void @foo_protected(...)
 
 void call_foo()


### PR DESCRIPTION
Previously the body of `setExtraAttributesForFunc` corresponds to `SetLLVMFunctionAttributesForDefinition`, but the callsite of it does not reside at the right position. This PR rename it and adjust the calls to it following OG CodeGen.

To be specific, `setExtraAttributesForFunc` is called right after the initialization of `FuncOp`. But in OG CodeGen, the list of attributes is constructed by several more functions: `SetLLVMFunctionAttributes` and `SetLLVMFunctionAttributesForDefinition`.

This results in diff in attributes of function declarations, which is reflected by the changes of test files. Apart from them, there is no functional change. In other words, the two code path calling `setCIRFunctionAttributesForDefinition` are tested by existing tests:

* Caller `buildGlobalFunctionDefinition`: tested by `CIR/CodeGen/function-attrs.cpp`, ...
* Caller `codegenCXXStructor`: tested by `CIR/CodeGen/delegating-ctor.cpp`, `defined-pure-virtual-func.cpp`, ...
