### PR TITLE
[CIR][CodeGen][NFCI] Unify attribute list handling of func / call by `constructAttributeList`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2422,9 +2422,14 @@ void CIRGenModule::setCIRFunctionAttributes(GlobalDecl GD,
                                             mlir::cir::FuncOp func,
                                             bool isThunk) {
   // TODO(cir): More logic of constructAttributeList is needed.
-  // NOTE(cir): Here we only need CallConv, so a call to constructAttributeList
-  // is omitted for simplicity.
-  mlir::cir::CallingConv callingConv = info.getEffectiveCallingConvention();
+  mlir::cir::CallingConv callingConv;
+
+  // Initialize PAL with existing attributes to merge attributes.
+  mlir::NamedAttrList PAL{func.getExtraAttrs().getElements().getValue()};
+  constructAttributeList(func.getName(), info, GD, PAL, callingConv,
+                         /*AttrOnCallSite=*/false, isThunk);
+  func.setExtraAttrsAttr(mlir::cir::ExtraFuncAttributesAttr::get(
+      builder.getContext(), PAL.getDictionary(builder.getContext())));
 
   // TODO(cir): Check X86_VectorCall incompatibility with WinARM64EC
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -274,10 +274,11 @@ public:
   /// constructed for. If valid, the attributes applied to this decl may
   /// contribute to the function attributes and calling convention.
   /// \param Attrs [out] - On return, the attribute list to use.
-  void ConstructAttributeList(StringRef Name, const CIRGenFunctionInfo &Info,
+  void constructAttributeList(StringRef Name, const CIRGenFunctionInfo &Info,
                               CIRGenCalleeInfo CalleeInfo,
-                              mlir::DictionaryAttr &Attrs, bool AttrOnCallSite,
-                              bool IsThunk);
+                              mlir::NamedAttrList &Attrs,
+                              mlir::cir::CallingConv &callingConv,
+                              bool AttrOnCallSite, bool IsThunk);
 
   /// Will return a global variable of the given type. If a variable with a
   /// different type already exists then a new variable with the right type

--- a/clang/test/CIR/CodeGen/delegating-ctor.cpp
+++ b/clang/test/CIR/CodeGen/delegating-ctor.cpp
@@ -38,7 +38,7 @@ DelegatingWithZeroing::DelegatingWithZeroing(int) : DelegatingWithZeroing() {}
 // CHECK-NEXT:    %2 = cir.load %0 : !cir.ptr<!cir.ptr<!ty_DelegatingWithZeroing>>, !cir.ptr<!ty_DelegatingWithZeroing>
 // CHECK-NEXT:    %3 = cir.const #cir.zero : !ty_DelegatingWithZeroing
 // CHECK-NEXT:    cir.store %3, %2 : !ty_DelegatingWithZeroing, !cir.ptr<!ty_DelegatingWithZeroing>
-// CHECK-NEXT:    cir.call @_ZN21DelegatingWithZeroingC2Ev(%2) : (!cir.ptr<!ty_DelegatingWithZeroing>) -> () extra(#fn_attr1)
+// CHECK-NEXT:    cir.call @_ZN21DelegatingWithZeroingC2Ev(%2) : (!cir.ptr<!ty_DelegatingWithZeroing>) -> () extra(#fn_attr{{[0-9]*}})
 // CHECK-NEXT:    cir.return
 // CHECK-NEXT:  }
 


### PR DESCRIPTION
Similar to #830 , this PR completes the `setCIRFunctionAttributes` part with the call to `constructAttributeList` method, so that func op and call op share the logic of handling these kinds of attributes, which is the design of OG CodeGen.

It also includes other refactors. The function `constructAttributeList` now use `mlir::NamedAttrList &` rather than immutable attribute `mlir::DictionaryAttr &` as the inout result parameter, which benefits the additive merging of attributes.