### PR TITLE
[CIR][Asm] Fix parsing of extra(...) attributes in cir.call

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2827,6 +2827,18 @@ static ::mlir::ParseResult parseCallCommon(::mlir::OpAsmParser &parser,
             .failed())
       return ::mlir::failure();
 
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return ::mlir::failure();
+  if (parser.parseColon())
+    return ::mlir::failure();
+
+  ::mlir::FunctionType opsFnTy;
+  if (parser.parseType(opsFnTy))
+    return ::mlir::failure();
+  operandsTypes = opsFnTy.getInputs();
+  allResultTypes = opsFnTy.getResults();
+  result.addTypes(allResultTypes);
+
   auto &builder = parser.getBuilder();
   Attribute extraAttrs;
   if (::mlir::succeeded(parser.parseOptionalKeyword("extra"))) {
@@ -2842,18 +2854,6 @@ static ::mlir::ParseResult parseCallCommon(::mlir::OpAsmParser &parser,
         builder.getContext(), empty.getDictionary(builder.getContext()));
   }
   result.addAttribute(extraAttrsAttrName, extraAttrs);
-
-  if (parser.parseOptionalAttrDict(result.attributes))
-    return ::mlir::failure();
-  if (parser.parseColon())
-    return ::mlir::failure();
-
-  ::mlir::FunctionType opsFnTy;
-  if (parser.parseType(opsFnTy))
-    return ::mlir::failure();
-  operandsTypes = opsFnTy.getInputs();
-  allResultTypes = opsFnTy.getResults();
-  result.addTypes(allResultTypes);
 
   if (parser.resolveOperands(ops, operandsTypes, opsLoc, result.operands))
     return ::mlir::failure();

--- a/clang/test/CIR/IR/call.cir
+++ b/clang/test/CIR/IR/call.cir
@@ -3,11 +3,22 @@
 !s32i = !cir.int<s, 32>
 !fnptr = !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
 
+#fn_attr = #cir<extra({inline = #cir.inline<no>, optnone = #cir.optnone})>
+#fn_attr1 = #cir<extra({nothrow = #cir.nothrow})>
+
 module {
+  // Excerpt of std::array<int, 8192ul>::operator[](unsigned long)
+  cir.func linkonce_odr @_ZNSt5arrayIiLm8192EEixEm(%arg0: !s32i) -> !s32i extra(#fn_attr) {
+    cir.return %arg0 : !s32i
+  }
+
   cir.func @ind(%fnptr: !fnptr, %a : !s32i) {
     %r = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i
+    // Check parse->pretty-print round-trip on extra() attribute
+    %7 = cir.call @_ZNSt5arrayIiLm8192EEixEm(%a) : (!s32i) -> !s32i extra(#fn_attr1)
     cir.return
   }
 }
 
 // CHECK: %0 = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !s32i) -> !s32i
+// CHECK: %1 = cir.call @_ZNSt5arrayIiLm8192EEixEm(%arg1) : (!s32i) -> !s32i extra(#fn_attr1)


### PR DESCRIPTION
The parser was looking for extra(...) before the return type while the pretty-printer put it after the return type.
This was breaking the LSP-server for example.
Change the parser behavior accordingly.