### PR TITLE
[CIR][CodeGen][LowerToLLVM] Set calling convention for call ops

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2704,6 +2704,12 @@ verifyCallCommInSymbolUses(Operation *op, SymbolTableCollection &symbolTable) {
                << op->getOperand(i).getType() << " for operand number " << i;
   }
 
+  // Calling convention must match.
+  if (callIf.getCallingConv() != fn.getCallingConv())
+    return op->emitOpError("calling convention mismatch: expected ")
+           << stringifyCallingConv(fn.getCallingConv()) << ", but provided "
+           << stringifyCallingConv(callIf.getCallingConv());
+
   // Void function must not return any results.
   if (fnType.isVoid() && op->getNumResults() != 0)
     return op->emitOpError("callee returns void but call has results");

--- a/clang/test/CIR/CodeGen/OpenCL/spir-calling-conv.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/spir-calling-conv.cl
@@ -15,6 +15,10 @@ kernel void bar(global int *A);
 // LLVM-DAG: define{{.*}} spir_kernel void @foo(
 kernel void foo(global int *A) {
   int id = get_dummy_id(0);
+  // CIR: %{{[0-9]+}} = cir.call @get_dummy_id(%2) : (!s32i) -> !s32i cc(spir_function)
+  // LLVM: %{{[a-z0-9_]+}} = call spir_func i32 @get_dummy_id(
   A[id] = id;
   bar(A);
+  // CIR: cir.call @bar(%8) : (!cir.ptr<!s32i, addrspace(offload_global)>) -> () cc(spir_kernel)
+  // LLVM: call spir_kernel void @bar(ptr addrspace(1)
 }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1304,7 +1304,22 @@ module {
 !s32i = !cir.int<s, 32>
 
 module {
+  cir.func @subroutine() cc(spir_function) {
+    cir.return
+  }
 
+  cir.func @call_conv_match() {
+    // expected-error@+1 {{'cir.call' op calling convention mismatch: expected spir_function, but provided spir_kernel}}
+    cir.call @subroutine(): () -> !cir.void cc(spir_kernel)
+    cir.return
+  }
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+
+module {
   cir.func @test_bitcast_addrspace() {
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["tmp"] {alignment = 4 : i64}
     // expected-error@+1 {{'cir.cast' op result type address space does not match the address space of the operand}}

--- a/clang/test/CIR/Lowering/call-op-call-conv.cir
+++ b/clang/test/CIR/Lowering/call-op-call-conv.cir
@@ -1,0 +1,22 @@
+// RUN: cir-translate -cir-to-llvmir %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+
+!s32i = !cir.int<s, 32>
+!fnptr = !cir.ptr<!cir.func<!s32i (!s32i)>>
+
+module {
+  cir.func private @my_add(%a: !s32i, %b: !s32i) -> !s32i cc(spir_function)
+
+  cir.func @ind(%fnptr: !fnptr, %a : !s32i) {
+    %1 = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i cc(spir_kernel)
+    // LLVM: %{{[0-9]+}} = call spir_kernel i32 %{{[0-9]+}}(i32 %{{[0-9]+}})
+
+    %2 = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i cc(spir_function)
+    // LLVM: %{{[0-9]+}} = call spir_func i32 %{{[0-9]+}}(i32 %{{[0-9]+}})
+
+    %3 = cir.call @my_add(%1, %2) : (!s32i, !s32i) -> !s32i cc(spir_function)
+    // LLVM: %{{[0-9]+}} = call spir_func i32 @my_add(i32 %{{[0-9]+}}, i32 %{{[0-9]+}})
+
+    cir.return
+  }
+}


### PR DESCRIPTION
This PR implements the CIRGen and Lowering part of calling convention attribute of `cir.call`-like operations. Here we have **4 kinds of operations**: (direct or indirect) x (`call` or `try_call`).

According to our need and feasibility of constructing a test case, this PR includes:

* For CIRGen, only direct `call`. Until now, the only extra calling conventions are SPIR ones, which cannot be set from source code manually using attributes. Meanwhile, OpenCL C *does not allow* function pointers or exceptions, therefore the only case remaining is direct call.
* For Lowering, direct and indirect `call`, but not any `try_call`. Although it's possible to write all 4 kinds of calls with calling convention in ClangIR assembly, exceptions is quite hard to write and read. I prefer source-code-level test for it when it's available in the future. For example, possibly C++ `thiscall` with exceptions.
* Extra: the verification of calling convention consistency for direct `call` and direct `try_call`.

All unsupported cases are guarded by assertions or MLIR diags.