### PR TITLE
[CIR][NFC] Fix mismatch of argument type in IR tests

### DIFF
--- a/clang/test/CIR/IR/call-op-call-conv.cir
+++ b/clang/test/CIR/IR/call-op-call-conv.cir
@@ -2,7 +2,7 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 !s32i = !cir.int<s, 32>
-!fnptr = !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
+!fnptr = !cir.ptr<!cir.func<!s32i (!s32i)>>
 
 module {
   cir.func @my_add(%a: !s32i, %b: !s32i) -> !s32i cc(spir_function) {
@@ -22,6 +22,6 @@ module {
   }
 }
 
-// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !s32i) -> !s32i cc(spir_kernel)
-// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !s32i) -> !s32i cc(spir_function)
+// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i cc(spir_kernel)
+// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i cc(spir_function)
 // CHECK: %{{[0-9]+}} = cir.try_call @my_add(%{{[0-9]+}}, %{{[0-9]+}}) ^{{.+}}, ^{{.+}} : (!s32i, !s32i) -> !s32i cc(spir_function)

--- a/clang/test/CIR/IR/call.cir
+++ b/clang/test/CIR/IR/call.cir
@@ -1,7 +1,7 @@
 // RUN: cir-opt %s | FileCheck %s
 
 !s32i = !cir.int<s, 32>
-!fnptr = !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
+!fnptr = !cir.ptr<!cir.func<!s32i (!s32i)>>
 
 #fn_attr = #cir<extra({inline = #cir.inline<no>, optnone = #cir.optnone})>
 #fn_attr1 = #cir<extra({nothrow = #cir.nothrow})>
@@ -20,5 +20,5 @@ module {
   }
 }
 
-// CHECK: %0 = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !s32i) -> !s32i
+// CHECK: %0 = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
 // CHECK: %1 = cir.call @_ZNSt5arrayIiLm8192EEixEm(%arg1) : (!s32i) -> !s32i extra(#fn_attr1)


### PR DESCRIPTION
There is a typo in `call.cir` that uses a wrong function argument type, leading to failure in the final LLVM IR translation.

CIR verification does not reject it, because it skips indirect calls at the beginning. It's `verifySymbolUses` after all.

https://github.com/llvm/clangir/blob/bde154cf1243cc4f938339c4dc15b1576d3025ab/clang/lib/CIR/Dialect/IR/CIRDialect.cpp#L2672-L2679

The typo was copied to another IR test. Here we fix them all.
