### PR TITLE
[CIR][Lowering] Fix static array lowering

### DIFF
--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -91,7 +91,7 @@ void convertToDenseElementsAttrImpl(mlir::cir::ConstArrayAttr attr,
 
     auto nestTy = localArrayTy.getEltType();
     if (!mlir::isa<mlir::cir::ArrayType>(nestTy))
-      values.insert(values.end(), localArrayTy.getSize() - numTrailingZeros,
+      values.insert(values.end(), numTrailingZeros,
                     getZeroInitFromType<StorageTy>(nestTy));
   }
 }

--- a/clang/test/CIR/Lowering/static-array.c
+++ b/clang/test/CIR/Lowering/static-array.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+int test(int x) {
+  static int arr[10] = {0, 1, 0, 0};
+  return arr[x];
+}
+// LLVM: internal global [10 x i32] [i32 0, i32 1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]


### PR DESCRIPTION
Consider the following code snippet `test.c`: 

```
int test(int x) {
  static int arr[10] = {0, 1, 0, 0};
  return arr[x];
}
```

When lowering from CIR to LLVM using `bin/clang test.c -Xclang -fclangir -Xclang -emit-llvm -S -o -` It produces: 
```
clangir/mlir/lib/IR/BuiltinAttributes.cpp:1015: static mlir::DenseElementsAttr mlir::DenseElementsAttr::get(mlir::ShapedType, llvm::ArrayRef<llvm::APInt>): Assertion `hasSameElementsOrSplat(type, values)' failed.
```

I traced the bug back to `Lowering/LoweringHelpers.cpp` where we fill trailing zeros, and I believe this PR does it the right way. I have also added a very simple test for verification.