### PR TITLE
[CIR][FlattenCFG] Fix use after free when flattening terminator

### DIFF
--- a/clang/include/clang/CIR/Interfaces/CIRLoopOpInterface.td
+++ b/clang/include/clang/CIR/Interfaces/CIRLoopOpInterface.td
@@ -71,14 +71,13 @@ def LoopOpInterface : OpInterface<"LoopOpInterface", [
       }],
       /*retTy=*/"mlir::WalkResult",
       /*methodName=*/"walkBodySkippingNestedLoops",
-      /*args=*/(ins "::llvm::function_ref<void (Operation *)>":$callback),
+      /*args=*/(ins "::llvm::function_ref<mlir::WalkResult (Operation *)>":$callback),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return $_op.getBody().template walk<WalkOrder::PreOrder>([&](Operation *op) {
           if (isa<LoopOpInterface>(op))
             return mlir::WalkResult::skip();
-          callback(op);
-          return mlir::WalkResult::advance();
+          return callback(op);
         });
       }]
     >


### PR DESCRIPTION
Per the operation walking documentation [1]:

> A callback on a block or operation is allowed to erase that block or
> operation if either:
>   * the walk is in post-order, or
>   * the walk is in pre-order and the walk is skipped after the erasure.

We were doing neither when erasing terminator operations and replacing
them with a branch, leading to a use after free and ASAN errors. This
fixes the following tests with ASAN:

```
  Clang :: CIR/CodeGen/switch-gnurange.cpp
  Clang :: CIR/Lowering/atomic-runtime.cpp
  Clang :: CIR/Lowering/loop.cir
  Clang :: CIR/Lowering/loops-with-break.cir
  Clang :: CIR/Lowering/loops-with-continue.cir
  Clang :: CIR/Lowering/switch.cir
  Clang :: CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
  Clang :: CIR/Transforms/loop.cir
  Clang :: CIR/Transforms/switch.cir
```

These two tests still fail with ASAN after this, which I'm looking into:
```
  Clang :: CIR/CodeGen/pointer-arith-ext.c
  Clang :: CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
```

`CIR/CodeGen/global-new.cpp` is failing even on a non-ASAN Release build
for me on the parent commit, so it's unrelated.

[1] https://github.com/llvm/llvm-project/blob/0c55ad11ab3857056bb3917fdf087c4aa811b790/mlir/include/mlir/IR/Operation.h#L767-L770
