### PR TITLE
[CIR][Bugfix] renames minor/major parameters of the OpenCLVersionAttr

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -153,7 +153,7 @@ def OpenCLKernelArgMetadataAttr
 
 def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
   let summary = "OpenCL version";
-  let parameters = (ins "int32_t":$major, "int32_t":$minor);
+  let parameters = (ins "int32_t":$major_version, "int32_t":$minor_version);
   let description = [{
     Represents the version of OpenCL.
 
@@ -165,7 +165,7 @@ def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
     module attributes {cir.cl.version = cir.cl.version<3, 0>} {}
     ```
   }];
-  let assemblyFormat = "`<` $major `,` $minor `>`";
+  let assemblyFormat = "`<` $major_version `,` $minor_version `>`";
 }
 
 #endif // MLIR_CIR_DIALECT_CIR_OPENCL_ATTRS

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -73,9 +73,9 @@ private:
       auto *int32Ty = llvm::IntegerType::get(llvmContext, 32);
       llvm::Metadata *oclVerElts[] = {
           llvm::ConstantAsMetadata::get(
-              llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMajor())),
+              llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMajorVersion())),
           llvm::ConstantAsMetadata::get(
-              llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMinor()))};
+              llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMinorVersion()))};
       llvm::NamedMDNode *oclVerMD =
           llvmModule->getOrInsertNamedMetadata("opencl.ocl.version");
       oclVerMD->addOperand(llvm::MDNode::get(llvmContext, oclVerElts));


### PR DESCRIPTION
Looks like certain names should not be used - I even could not build CIR on the Ubuntu with a relatively old glibc version.  
In this case `minor` and `major` are macroses and can not be used in this context.

You can take a look at the comments in the [mlir/test/lib/Dialect/Test/TestDialect.h](https://github.com/llvm/clangir/blob/main/mlir/test/lib/Dialect/Test/TestDialect.h#L70) reference as well

