### PR TITLE
[CIR][Asm] Parse extra attributes after calling convention

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2859,22 +2859,6 @@ static ::mlir::ParseResult parseCallCommon(::mlir::OpAsmParser &parser,
   allResultTypes = opsFnTy.getResults();
   result.addTypes(allResultTypes);
 
-  auto &builder = parser.getBuilder();
-  Attribute extraAttrs;
-  if (::mlir::succeeded(parser.parseOptionalKeyword("extra"))) {
-    if (parser.parseLParen().failed())
-      return failure();
-    if (parser.parseAttribute(extraAttrs).failed())
-      return failure();
-    if (parser.parseRParen().failed())
-      return failure();
-  } else {
-    NamedAttrList empty;
-    extraAttrs = mlir::cir::ExtraFuncAttributesAttr::get(
-        builder.getContext(), empty.getDictionary(builder.getContext()));
-  }
-  result.addAttribute(extraAttrsAttrName, extraAttrs);
-
   if (parser.resolveOperands(ops, operandsTypes, opsLoc, result.operands))
     return ::mlir::failure();
 
@@ -2894,6 +2878,7 @@ static ::mlir::ParseResult parseCallCommon(::mlir::OpAsmParser &parser,
       return ::mlir::failure();
   }
 
+  auto &builder = parser.getBuilder();
   if (parser.parseOptionalKeyword("cc").succeeded()) {
     if (parser.parseLParen().failed())
       return failure();
@@ -2905,6 +2890,21 @@ static ::mlir::ParseResult parseCallCommon(::mlir::OpAsmParser &parser,
     result.addAttribute("calling_conv", mlir::cir::CallingConvAttr::get(
                                             builder.getContext(), callingConv));
   }
+
+  Attribute extraAttrs;
+  if (::mlir::succeeded(parser.parseOptionalKeyword("extra"))) {
+    if (parser.parseLParen().failed())
+      return failure();
+    if (parser.parseAttribute(extraAttrs).failed())
+      return failure();
+    if (parser.parseRParen().failed())
+      return failure();
+  } else {
+    NamedAttrList empty;
+    extraAttrs = mlir::cir::ExtraFuncAttributesAttr::get(
+        builder.getContext(), empty.getDictionary(builder.getContext()));
+  }
+  result.addAttribute(extraAttrsAttrName, extraAttrs);
 
   // If exception is present and there are cleanups, this should be latest thing
   // present (after all attributes, etc).

--- a/clang/test/CIR/IR/call.cir
+++ b/clang/test/CIR/IR/call.cir
@@ -12,13 +12,20 @@ module {
     cir.return %arg0 : !s32i
   }
 
+  cir.func private @my_add(%a: !s32i, %b: !s32i) -> !s32i cc(spir_function) extra(#fn_attr)
+
   cir.func @ind(%fnptr: !fnptr, %a : !s32i) {
     %r = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i
+// CHECK: %0 = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
     // Check parse->pretty-print round-trip on extra() attribute
     %7 = cir.call @_ZNSt5arrayIiLm8192EEixEm(%a) : (!s32i) -> !s32i extra(#fn_attr1)
+// CHECK: %1 = cir.call @_ZNSt5arrayIiLm8192EEixEm(%arg1) : (!s32i) -> !s32i extra(#fn_attr1)
+    // Frankenstein's example from clang/test/CIR/Lowering/call-op-call-conv.cir
+    %3 = cir.try_call @my_add(%r, %7) ^continue, ^landing_pad : (!s32i, !s32i) -> !s32i cc(spir_function) extra(#fn_attr1)
+// CHECK: %2 = cir.try_call @my_add(%0, %1) ^bb1, ^bb2 : (!s32i, !s32i) -> !s32i cc(spir_function) extra(#fn_attr1)
+  ^continue:
+    cir.br ^landing_pad
+  ^landing_pad:
     cir.return
   }
 }
-
-// CHECK: %0 = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
-// CHECK: %1 = cir.call @_ZNSt5arrayIiLm8192EEixEm(%arg1) : (!s32i) -> !s32i extra(#fn_attr1)


### PR DESCRIPTION
Align parsing of cir.call with its pretty-printing.