### PR TITLE
[CIR][NFC] Change default LLVM output file extension

### DIFF
--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -355,7 +355,7 @@ getOutputStream(CompilerInstance &ci, StringRef inFile,
   case CIRGenAction::OutputType::EmitMLIR:
     return ci.createDefaultOutputFile(false, inFile, "mlir");
   case CIRGenAction::OutputType::EmitLLVM:
-    return ci.createDefaultOutputFile(false, inFile, "llvm");
+    return ci.createDefaultOutputFile(false, inFile, "ll");
   case CIRGenAction::OutputType::EmitBC:
     return ci.createDefaultOutputFile(true, inFile, "bc");
   case CIRGenAction::OutputType::EmitObj:


### PR DESCRIPTION
When the output file name is not specified via `-o`, the upstream clang uses `.ll` as the extension of the default output file name. This PR makes ClangIR follow this behavior.