### PR TITLE
[CIR][Lowering] Erase op through rewriter instead of directly

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -592,7 +592,7 @@ public:
                 index.getLoc(), index.getType(),
                 mlir::IntegerAttr::get(index.getType(), 0)),
             index);
-        sub->erase();
+        rewriter.eraseOp(sub);
       }
     }
 


### PR DESCRIPTION
Directly erasing the op causes a use after free later on, presumably
because the lowering framework isn't aware of the op being deleted. This
fixes `clang/test/CIR/CodeGen/pointer-arith-ext.c` with ASAN.
