### PR TITLE
[CIR][ABI] Fix use after free from erasing while iterating

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -386,14 +386,11 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
       // the argument is used only to be stored in a alloca.
       Value arg = SrcFn.getArgument(ArgNo);
       assert(arg.hasOneUse());
-      for (auto *firstStore : arg.getUsers()) {
-        assert(isa<StoreOp>(firstStore));
-        auto argAlloca = cast<StoreOp>(firstStore).getAddr();
-        rewriter.replaceAllUsesWith(argAlloca, Alloca);
-        rewriter.eraseOp(firstStore);
-        rewriter.eraseOp(argAlloca.getDefiningOp());
-      }
-
+      auto *firstStore = *arg.user_begin();
+      auto argAlloca = cast<StoreOp>(firstStore).getAddr();
+      rewriter.replaceAllUsesWith(argAlloca, Alloca);
+      rewriter.eraseOp(firstStore);
+      rewriter.eraseOp(argAlloca.getDefiningOp());
       break;
     }
     default:


### PR DESCRIPTION
The loop was erasing the user of a value while iterating on the value's
users, which results in a use after free. We're already assuming (and
asserting) that there's only one user, so we can just access it directly
instead. CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
was failing with ASAN before this change. We're now ASAN-clean except
for https://github.com/llvm/clangir/issues/829 (which is also in
progress).
