### PR TITLE
[CIR][CIRGen] Initialize more CGF member variables to nullptr

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -463,8 +463,8 @@ public:
   // Holds the Decl for the current outermost non-closure context
   const clang::Decl *CurFuncDecl = nullptr;
   /// This is the inner-most code context, which includes blocks.
-  const clang::Decl *CurCodeDecl;
-  const CIRGenFunctionInfo *CurFnInfo;
+  const clang::Decl *CurCodeDecl = nullptr;
+  const CIRGenFunctionInfo *CurFnInfo = nullptr;
   clang::QualType FnRetTy;
 
   /// This is the current function or global initializer that is generated code


### PR DESCRIPTION
These were uninitialized, which led to intermittent test failures from
the use of uninitialized variables. Initialize them to `nullptr` as is
done with other member variables that are pointers to fix this.

I did a quick spot-check and didn't find other uninitialized variables
in the main CGF class itself. Lots of subclasses have uninitialized
member variables, but those are presumably expected to be initialized at
all points of construction, so we can leave them alone until they cause
any issues.

`ninja check-clang-cir` now passes with ASan+UBSan and MSan.

Fixes https://github.com/llvm/clangir/issues/829
