### PR TITLE
[CIR][CodeGen] Implement union cast

### DIFF
--- a/clang/test/CIR/CodeGen/union-init.c
+++ b/clang/test/CIR/CodeGen/union-init.c
@@ -46,3 +46,18 @@ unsigned is_little(void) {
 // CHECK: %[[VAL_1:.*]] = cir.get_global @is_little.one : !cir.ptr<![[anon0]]>
 // CHECK: %[[VAL_2:.*]] = cir.cast(bitcast, %[[VAL_1]] : !cir.ptr<![[anon0]]>), !cir.ptr<![[anon1]]>
 // CHECK: %[[VAL_3:.*]] = cir.get_member %[[VAL_2]][1] {name = "c"} : !cir.ptr<![[anon1]]> -> !cir.ptr<!cir.array<!u8i x 4>>
+
+typedef union {
+	int x;
+} U;
+
+// CHECK: %[[VAL_0:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
+// CHECK: %[[VAL_1:.*]] = cir.alloca !ty_U, !cir.ptr<!ty_U>, ["u", init] {alignment = 4 : i64}
+// CHECK: cir.store %arg0, %[[VAL_0]] : !s32i, !cir.ptr<!s32i>
+// CHECK: %[[VAL_2:.*]] = cir.load %[[VAL_0]] : !cir.ptr<!s32i>, !s32i
+// CHECK: %[[VAL_3:.*]] = cir.cast(bitcast, %[[VAL_1]] : !cir.ptr<!ty_U>), !cir.ptr<!s32i>
+// CHECK: cir.store %[[VAL_2]], %[[VAL_3]] : !s32i, !cir.ptr<!s32i>
+
+void union_cast(int x) {
+	U u = (U) x;
+}

--- a/clang/test/CIR/CodeGen/union-init.c
+++ b/clang/test/CIR/CodeGen/union-init.c
@@ -48,7 +48,7 @@ unsigned is_little(void) {
 // CHECK: %[[VAL_3:.*]] = cir.get_member %[[VAL_2]][1] {name = "c"} : !cir.ptr<![[anon1]]> -> !cir.ptr<!cir.array<!u8i x 4>>
 
 typedef union {
-	int x;
+  int x;
 } U;
 
 // CHECK: %[[VAL_0:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
@@ -59,5 +59,5 @@ typedef union {
 // CHECK: cir.store %[[VAL_2]], %[[VAL_3]] : !s32i, !cir.ptr<!s32i>
 
 void union_cast(int x) {
-	U u = (U) x;
+  U u = (U) x;
 }


### PR DESCRIPTION
Currently the C style cast is not implemented/supported for unions. 

This PR adds support for union casts as done in `CGExprAgg.cpp`. I have also added an extra test in `union-init.c`.