### PR TITLE
[CIR][CIRGen] Correct isSized predicate for vector type

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -61,11 +61,9 @@ public:
     RecordNames["anon"] = 0; // in order to start from the name "anon.0"
   }
 
-  std::string getUniqueAnonRecordName() {
-    return getUniqueRecordName("anon");
-  }
+  std::string getUniqueAnonRecordName() { return getUniqueRecordName("anon"); }
 
-  std::string getUniqueRecordName(const std::string& baseName) {
+  std::string getUniqueRecordName(const std::string &baseName) {
     auto it = RecordNames.find(baseName);
     if (it == RecordNames.end()) {
       RecordNames[baseName] = 0;
@@ -500,6 +498,9 @@ public:
                   mlir::cir::ArrayType, mlir::cir::BoolType, mlir::cir::IntType,
                   mlir::cir::CIRFPTypeInterface>(ty))
       return true;
+    if (mlir::isa<mlir::cir::VectorType>(ty)) {
+      return isSized(mlir::cast<mlir::cir::VectorType>(ty).getEltType());
+    }
     assert(0 && "Unimplemented size for type");
     return false;
   }

--- a/clang/test/CIR/CodeGen/vectype-issized.c
+++ b/clang/test/CIR/CodeGen/vectype-issized.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android24  -fclangir -emit-cir -target-feature +neon %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple aarch64-none-linux-android24  -fclangir -emit-llvm -target-feature +neon %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+typedef __attribute__((neon_vector_type(8))) short  c;
+void d() { c a[8]; }
+
+// CIR-LABEL: d
+// CIR: {{%.*}} = cir.alloca !cir.array<!cir.vector<!s16i x 8> x 8>,
+// CIR-SAME: !cir.ptr<!cir.array<!cir.vector<!s16i x 8> x 8>>, ["a"]
+// CIR-SAME: {alignment = 16 : i64}
+
+// LLVM-LABEL: d
+// LLVM: {{%.*}} = alloca [8 x <8 x i16>], i64 1, align 16


### PR DESCRIPTION
As title, if element type of vector type is sized, then the vector type should be deemed sized.
This would enable us generate code for neon without triggering assertion