### PR TITLE
[CIR][CIRGen] Allow constant evaluation of int annotation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3337,7 +3337,7 @@ mlir::ArrayAttr CIRGenModule::buildAnnotationArgs(AnnotateAttr *attr) {
       // Add trailing null character as StringLiteral->getString() does not
       args.push_back(builder.getStringAttr(strE->getString()));
     } else if (ce.hasAPValueResult()) {
-      // Handle case which can be evaluated to some numbers, not only litterals
+      // Handle case which can be evaluated to some numbers, not only literals
       const auto &ap = ce.getAPValueResult();
       if (ap.isInt()) {
         args.push_back(mlir::IntegerAttr::get(

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -33,6 +33,8 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Verifier.h"
+#include "clang/AST/Expr.h"
+#include "clang/Basic/Cuda.h"
 #include "clang/CIR/MissingFeatures.h"
 
 #include "clang/AST/ASTConsumer.h"
@@ -3329,16 +3331,22 @@ mlir::ArrayAttr CIRGenModule::buildAnnotationArgs(AnnotateAttr *attr) {
   llvm::SmallVector<mlir::Attribute, 4> args;
   args.reserve(exprs.size());
   for (Expr *e : exprs) {
+    auto &ce = *cast<clang::ConstantExpr>(e);
     if (auto *const strE =
-            ::clang::dyn_cast<clang::StringLiteral>(e->IgnoreParenCasts())) {
+            clang::dyn_cast<clang::StringLiteral>(ce.IgnoreParenCasts())) {
       // Add trailing null character as StringLiteral->getString() does not
       args.push_back(builder.getStringAttr(strE->getString()));
-    } else if (auto *const intE = ::clang::dyn_cast<clang::IntegerLiteral>(
-                   e->IgnoreParenCasts())) {
-      args.push_back(mlir::IntegerAttr::get(
-          mlir::IntegerType::get(builder.getContext(),
-                                 intE->getValue().getBitWidth()),
-          intE->getValue()));
+    } else if (ce.hasAPValueResult()) {
+      // Handle case which can be evaluated to some numbers, not only litterals
+      const auto &ap = ce.getAPValueResult();
+      if (ap.isInt()) {
+        args.push_back(mlir::IntegerAttr::get(
+            mlir::IntegerType::get(builder.getContext(),
+                                   ap.getInt().getBitWidth()),
+            ap.getInt()));
+      } else {
+        llvm_unreachable("NYI like float, fixed-point, array...");
+      }
     } else {
       llvm_unreachable("NYI");
     }

--- a/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
+++ b/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
@@ -5,6 +5,10 @@
 double *a __attribute__((annotate("withargs", "21", 12 )));
 int *b __attribute__((annotate("withargs", "21", 12 )));
 void *c __attribute__((annotate("noargvar")));
+
+enum : char { npu1 = 42};
+int tile __attribute__((annotate("cir.aie.device.tile", npu1))) = 7;
+
 void foo(int i) __attribute__((annotate("noargfunc"))) {
 }
 // redeclare with more annotate
@@ -20,6 +24,8 @@ void bar() __attribute__((annotate("withargfunc", "os", 22))) {
 // BEFORE-SAME: [#cir.annotation<name = "withargs", args = ["21", 12 : i32]>]
 // BEFORE: cir.global  external @c = #cir.ptr<null> : !cir.ptr<!void>
 // BEFORE-SAME: [#cir.annotation<name = "noargvar", args = []>]
+// BEFORE: cir.global external @tile = #cir.int<7> : !s32i
+// BEFORE-SAME: #cir.annotation<name = "cir.aie.device.tile", args = [42 : i8]>]
 
 // BEFORE: cir.func  @_Z3fooi(%arg0: !s32i) [#cir.annotation<name = "noargfunc", args = []>,
 // BEFORE-SAME: #cir.annotation<name = "withargfunc", args = ["os", 23 : i32]>]
@@ -31,6 +37,7 @@ void bar() __attribute__((annotate("withargfunc", "os", 22))) {
 // AFTER-SAME: ["a", #cir.annotation<name = "withargs", args = ["21", 12 : i32]>],
 // AFTER-SAME: ["b", #cir.annotation<name = "withargs", args = ["21", 12 : i32]>],
 // AFTER-SAME: ["c", #cir.annotation<name = "noargvar", args = []>],
+// AFTER-SAME: ["tile", #cir.annotation<name = "cir.aie.device.tile", args = [42 : i8]>],
 // AFTER-SAME: ["_Z3fooi", #cir.annotation<name = "noargfunc", args = []>],
 // AFTER-SAME: ["_Z3fooi", #cir.annotation<name = "withargfunc", args = ["os", 23 : i32]>],
 // AFTER-SAME: ["_Z3barv", #cir.annotation<name = "withargfunc", args = ["os", 22 : i32]>]]>,
@@ -39,20 +46,23 @@ void bar() __attribute__((annotate("withargfunc", "os", 22))) {
 // LLVM: @a = global ptr null
 // LLVM: @b = global ptr null
 // LLVM: @c = global ptr null
+// LLVM: @tile = global i32 7
 // LLVM: @.str.annotation = private unnamed_addr constant [9 x i8] c"withargs\00", section "llvm.metadata"
 // LLVM: @.str.1.annotation = private unnamed_addr constant [{{[0-9]+}} x i8] c"{{.*}}attribute-annotate-multiple.cpp\00", section "llvm.metadata"
 // LLVM: @.str.annotation.arg = private unnamed_addr constant [3 x i8] c"21\00", align 1
 // LLVM: @.args.annotation = private unnamed_addr constant { ptr, i32 } { ptr @.str.annotation.arg, i32 12 }, section "llvm.metadata"
 // LLVM: @.str.2.annotation = private unnamed_addr constant [9 x i8] c"noargvar\00", section "llvm.metadata"
-// LLVM: @.str.3.annotation = private unnamed_addr constant [10 x i8] c"noargfunc\00", section "llvm.metadata"
-// LLVM: @.str.4.annotation = private unnamed_addr constant [12 x i8] c"withargfunc\00", section "llvm.metadata"
+// LLVM: @.str.3.annotation = private unnamed_addr constant [20 x i8] c"cir.aie.device.tile\00", section "llvm.metadata"
+// LLVM: @.args.1.annotation = private unnamed_addr constant { i8 } { i8 42 }, section "llvm.metadata"
+// LLVM: @.str.4.annotation = private unnamed_addr constant [10 x i8] c"noargfunc\00", section "llvm.metadata"
+// LLVM: @.str.5.annotation = private unnamed_addr constant [12 x i8] c"withargfunc\00", section "llvm.metadata"
 // LLVM: @.str.1.annotation.arg = private unnamed_addr constant [3 x i8] c"os\00", align 1
-// LLVM: @.args.1.annotation = private unnamed_addr constant { ptr, i32 } 
-// LLVM-SAME: { ptr @.str.1.annotation.arg, i32 23 }, section "llvm.metadata"
 // LLVM: @.args.2.annotation = private unnamed_addr constant { ptr, i32 } 
+// LLVM-SAME: { ptr @.str.1.annotation.arg, i32 23 }, section "llvm.metadata"
+// LLVM: @.args.3.annotation = private unnamed_addr constant { ptr, i32 } 
 // LLVM-SAME: { ptr @.str.1.annotation.arg, i32 22 }, section "llvm.metadata"
 
-// LLVM: @llvm.global.annotations = appending global [6 x { ptr, ptr, ptr, i32, ptr }]
+// LLVM: @llvm.global.annotations = appending global [7 x { ptr, ptr, ptr, i32, ptr }]
 // LLVM-SAME: [{ ptr, ptr, ptr, i32, ptr }
 // LLVM-SAME: { ptr @a, ptr @.str.annotation, ptr @.str.1.annotation, i32 5, ptr @.args.annotation },
 // LLVM-SAME: { ptr, ptr, ptr, i32, ptr }
@@ -60,11 +70,13 @@ void bar() __attribute__((annotate("withargfunc", "os", 22))) {
 // LLVM-SAME: { ptr, ptr, ptr, i32, ptr }
 // LLVM-SAME: { ptr @c, ptr @.str.2.annotation, ptr @.str.1.annotation, i32 7, ptr null },
 // LLVM-SAME: { ptr, ptr, ptr, i32, ptr }
-// LLVM-SAME: { ptr @_Z3fooi, ptr @.str.3.annotation, ptr @.str.1.annotation, i32 8, ptr null },
+// LLVM-SAME: { ptr @tile, ptr @.str.3.annotation, ptr @.str.1.annotation, i32 10, ptr @.args.1.annotation },
 // LLVM-SAME: { ptr, ptr, ptr, i32, ptr }
-// LLVM-SAME: { ptr @_Z3fooi, ptr @.str.4.annotation, ptr @.str.1.annotation, i32 8, ptr @.args.1.annotation },
+// LLVM-SAME: { ptr @_Z3fooi, ptr @.str.4.annotation, ptr @.str.1.annotation, i32 12, ptr null },
 // LLVM-SAME: { ptr, ptr, ptr, i32, ptr }
-// LLVM-SAME: { ptr @_Z3barv, ptr @.str.4.annotation, ptr @.str.1.annotation, i32 12, ptr @.args.2.annotation }],
+// LLVM-SAME: { ptr @_Z3fooi, ptr @.str.5.annotation, ptr @.str.1.annotation, i32 12, ptr @.args.2.annotation },
+// LLVM-SAME: { ptr, ptr, ptr, i32, ptr }
+// LLVM-SAME: { ptr @_Z3barv, ptr @.str.5.annotation, ptr @.str.1.annotation, i32 16, ptr @.args.3.annotation }],
 // LLVM-SAME: section "llvm.metadata"
 
 // LLVM: define dso_local void @_Z3fooi(i32 %0)


### PR DESCRIPTION
__attribute__((annotate()) was only accepting integer literals, preventing some meta-programming usage for example.
This should be extended to some other kinds of types.