### PR TITLE
[CIR][Dialect][CodeGen] Add a unit attribute for OpenCL kernels

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -168,4 +168,19 @@ def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
   let assemblyFormat = "`<` $major_version `,` $minor_version `>`";
 }
 
+
+//===----------------------------------------------------------------------===//
+// OpenCLKernelAttr
+//===----------------------------------------------------------------------===//
+
+def OpenCLKernelAttr : CIRUnitAttr<
+    "OpenCLKernel", "cl.kernel"> {
+  let summary = "OpenCL kernel";
+  let description = [{
+    Indicate the function is a OpenCL kernel.
+  }];
+
+  let storageType = [{ OpenCLKernelAttr }];
+}
+
 #endif // MLIR_CIR_DIALECT_CIR_OPENCL_ATTRS

--- a/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROpenCLAttrs.td
@@ -173,6 +173,8 @@ def OpenCLVersionAttr : CIR_Attr<"OpenCLVersion", "cl.version"> {
 // OpenCLKernelAttr
 //===----------------------------------------------------------------------===//
 
+// TODO: It might be worthwhile to introduce a generic attribute applicable to
+// all offloading languages.
 def OpenCLKernelAttr : CIRUnitAttr<
     "OpenCLKernel", "cl.kernel"> {
   let summary = "OpenCL kernel";

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -430,6 +430,9 @@ void CIRGenModule::constructAttributeList(StringRef Name,
     }
 
     if (TargetDecl->hasAttr<OpenCLKernelAttr>()) {
+      auto cirKernelAttr =
+          mlir::cir::OpenCLKernelAttr::get(builder.getContext());
+      funcAttrs.set(cirKernelAttr.getMnemonic(), cirKernelAttr);
       assert(!MissingFeatures::openCL());
     }
 

--- a/clang/test/CIR/CodeGen/OpenCL/kernel-unit-attr.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/kernel-unit-attr.cl
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
+
+
+// CIR: #fn_attr[[KERNEL1:[0-9]*]] = {{.+}}cl.kernel = #cir.cl.kernel
+// CIR-NEXT: #fn_attr[[FUNC1:[0-9]*]] =
+// CIR-NOT: cl.kernel = #cir.cl.kernel
+
+kernel void kernel1() {}
+// CIR: cir.func @kernel1{{.+}} extra(#fn_attr[[KERNEL1]])
+
+void func1() {}
+
+// CIR: cir.func @func1{{.+}} extra(#fn_attr[[FUNC1]])


### PR DESCRIPTION
We need a target-independent way to distinguish OpenCL kernels in ClangIR. This PR adds a unit attribute `OpenCLKernelAttr` similar to the one in Clang AST.

This attribute is attached to the extra attribute dictionary of `cir.func` operations only. (Not for `cir.call`.)
