### PR TITLE
[CIR][CodeGen] Handle the case of 'case' after label statement after  'case'

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -478,6 +478,13 @@ public:
   // applies to. nullptr if there is no 'musttail' on the current statement.
   const clang::CallExpr *MustTailCall = nullptr;
 
+  /// The attributes of cases collected during emitting the body of a switch
+  /// stmt.
+  llvm::SmallVector<llvm::SmallVector<mlir::Attribute, 4>, 2> caseAttrsStack;
+
+  /// The type of the condition for the emitting switch statement.
+  llvm::SmallVector<mlir::Type, 2> condTypeStack;
+
   clang::ASTContext &getContext() const;
 
   CIRGenBuilderTy &getBuilder() { return builder; }
@@ -1210,13 +1217,9 @@ public:
   buildDefaultStmt(const clang::DefaultStmt &S, mlir::Type condType,
                    SmallVector<mlir::Attribute, 4> &caseAttrs);
 
-  mlir::LogicalResult
-  buildSwitchCase(const clang::SwitchCase &S, mlir::Type condType,
-                  SmallVector<mlir::Attribute, 4> &caseAttrs);
+  mlir::LogicalResult buildSwitchCase(const clang::SwitchCase &S);
 
-  mlir::LogicalResult
-  buildSwitchBody(const clang::Stmt *S, mlir::Type condType,
-                  SmallVector<mlir::Attribute, 4> &caseAttrs);
+  mlir::LogicalResult buildSwitchBody(const clang::Stmt *S);
 
   mlir::cir::FuncOp generateCode(clang::GlobalDecl GD, mlir::cir::FuncOp Fn,
                                  const CIRGenFunctionInfo &FnInfo);

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -310,3 +310,28 @@ extern "C" void multiple_non_case(int v) {
 // NOFLAT: cir.label
 // NOFLAT: cir.call @action2()
 // NOFLAT: cir.break
+
+extern "C" void case_follow_label(int v) {
+  switch (v) {
+    case 1:
+    label:
+    case 2:
+      action1();
+      break;
+    default:
+      action2();
+      goto label;
+  }
+}
+
+// NOFLAT: cir.func  @case_follow_label
+// NOFLAT: cir.switch
+// NOFLAT: case (equal, 1)
+// NOFLAT: cir.label "label"
+// NOFLAT: cir.yield
+// NOFLAT: case (equal, 2)
+// NOFLAT: cir.call @action1()
+// NOFLAT: cir.break
+// NOFLAT: case (default)
+// NOFLAT: cir.call @action2()
+// NOFLAT: cir.goto "label"

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -335,3 +335,26 @@ extern "C" void case_follow_label(int v) {
 // NOFLAT: case (default)
 // NOFLAT: cir.call @action2()
 // NOFLAT: cir.goto "label"
+
+extern "C" void default_follow_label(int v) {
+  switch (v) {
+    case 1:
+    case 2:
+      action1();
+      break;
+    label:
+    default:
+      action2();
+      goto label;
+  }
+}
+
+// NOFLAT: cir.func  @default_follow_label
+// NOFLAT: cir.switch
+// NOFLAT: case (anyof, [1, 2] : !s32i)
+// NOFLAT: cir.call @action1()
+// NOFLAT: cir.break
+// NOFLAT: cir.label "label"
+// NOFLAT: case (default)
+// NOFLAT: cir.call @action2()
+// NOFLAT: cir.goto "label"


### PR DESCRIPTION
Motivation example:

```
extern "C" void action1();
extern "C" void action2();

extern "C" void case_follow_label(int v) {
  switch (v) {
    case 1:
    label:
    case 2:
      action1();
      break;
    default:
      action2();
      goto label;
  }
}
```

When we compile it, we will meet:

```
  case Stmt::CaseStmtClass:
  case Stmt::DefaultStmtClass:
    assert(0 &&
           "Should not get here, currently handled directly from SwitchStmt");
    break;
```

in `buildStmt`. The cause is clear. We call `buildStmt` when we build the label stmt. 

To solve this, I think we should be able to build case stmt in buildStmt. But the new problem is, we need to pass the information like caseAttr and condType. So I tried to add such informations in CIRGenFunction as data member.