### PR TITLE
[CIR] Check CLANG_ENABLE_CIR is actually enabled when using CIR

### DIFF
--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -56,6 +56,12 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
   auto CIRAnalysisOnly = CI.getFrontendOpts().ClangIRAnalysisOnly;
   auto EmitsCIR = Act == EmitCIR || Act == EmitCIRFlat || Act == EmitCIROnly;
 
+#if !CLANG_ENABLE_CIR
+  if (UseCIR)
+    llvm::report_fatal_error(
+        "CIR is not supported by this build of Clang");
+#endif
+
   if (!UseCIR && EmitsCIR)
     llvm::report_fatal_error(
         "-emit-cir and -emit-cir-only only valid when using -fclangir");


### PR DESCRIPTION
When the CMake option `CLANG_ENABLE_CIR` is *not* enabled the `-fclangir` option was being silently ignored and LLVM IR would not be produced through the ClangIR pipeline. This new check errors out in that condition, preventing people from thinking CIR is enabled when it actually is not.

This also helps the `llvm_unreachable("CIR suppport not built into clang");` statement below to not actually be reached.