### PR TITLE
[CIR][CIRGen][Builtin] Allow CIRGen for builtin calls with math errorno override

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -337,7 +337,9 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   // '#pragma float_control(precise, on)'. This pragma disables fast-math,
   // which implies math-errno.
   if (E->hasStoredFPFeatures()) {
-    llvm_unreachable("NYI");
+    FPOptionsOverride OP = E->getFPFeatures();
+    if (OP.hasMathErrnoOverride())
+      ErrnoOverriden = OP.getMathErrnoOverride();
   }
   // True if 'atttibute__((optnone)) is used. This attibute overrides
   // fast-math which implies math-errno.

--- a/clang/test/CIR/CodeGen/builtin-abort.c
+++ b/clang/test/CIR/CodeGen/builtin-abort.c
@@ -6,6 +6,8 @@
 void abort();
 void test() { abort(); }
 
+// TODO: Add test to test unreachable when CIR support for NORETURN is added.
+
 // CIR-LABEL: test
 // CIR:  cir.call @abort() : () -> ()
 

--- a/clang/test/CIR/CodeGen/builtin-abort.c
+++ b/clang/test/CIR/CodeGen/builtin-abort.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+void abort();
+void test() { abort(); }
+
+// CIR-LABEL: test
+// CIR:  cir.call @abort() : () -> ()
+
+// LLVM-LABEL: test
+// LLVM:  call void @abort()


### PR DESCRIPTION
As title. 
The test case used is abort(), but it is from the real code. 
Notice: Since CIR implementation for NoReturn Call is pending to implement, the generated llvm code is like:
`define dso_local void @test() #1  {
  call void @abort(), !dbg !8
  ret void
}`
which is not right, right code should be like, 
`
`define dso_local void @test() #1  {
  call void @abort(), !dbg !8
  unreachable
}`
`
Still send this PR as Noreturn implementation is a separate issue.

