### PR TITLE
[CIR][CodeGen][NFC] Rename the confusing `buildGlobal` overload

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -988,8 +988,9 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef MangledName, mlir::Type Ty,
   return GV;
 }
 
-mlir::cir::GlobalOp CIRGenModule::buildGlobal(const VarDecl *D, mlir::Type Ty,
-                                              ForDefinition_t IsForDefinition) {
+mlir::cir::GlobalOp
+CIRGenModule::getOrCreateCIRGlobal(const VarDecl *D, mlir::Type Ty,
+                                   ForDefinition_t IsForDefinition) {
   assert(D->hasGlobalStorage() && "Not a global variable");
   QualType ASTTy = D->getType();
   if (!Ty)
@@ -1014,7 +1015,7 @@ mlir::Value CIRGenModule::getAddrOfGlobalVar(const VarDecl *D, mlir::Type Ty,
     Ty = getTypes().convertTypeForMem(ASTTy);
 
   bool tlsAccess = D->getTLSKind() != VarDecl::TLS_None;
-  auto g = buildGlobal(D, Ty, IsForDefinition);
+  auto g = getOrCreateCIRGlobal(D, Ty, IsForDefinition);
   auto ptrTy = builder.getPointerTo(g.getSymType(), g.getAddrSpaceAttr());
   return builder.create<mlir::cir::GetGlobalOp>(
       getLoc(D->getSourceRange()), ptrTy, g.getSymName(), tlsAccess);
@@ -1028,7 +1029,7 @@ CIRGenModule::getAddrOfGlobalVarAttr(const VarDecl *D, mlir::Type Ty,
   if (!Ty)
     Ty = getTypes().convertTypeForMem(ASTTy);
 
-  auto globalOp = buildGlobal(D, Ty, IsForDefinition);
+  auto globalOp = getOrCreateCIRGlobal(D, Ty, IsForDefinition);
   return builder.getGlobalViewAttr(builder.getPointerTo(Ty), globalOp);
 }
 
@@ -1217,7 +1218,7 @@ void CIRGenModule::buildGlobalVarDefinition(const clang::VarDecl *D,
   }
   assert(!mlir::isa<mlir::NoneType>(InitType) && "Should have a type by now");
 
-  auto Entry = buildGlobal(D, InitType, ForDefinition_t(!IsTentative));
+  auto Entry = getOrCreateCIRGlobal(D, InitType, ForDefinition_t(!IsTentative));
   // TODO(cir): Strip off pointer casts from Entry if we get them?
 
   // TODO(cir): use GlobalValue interface

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -234,7 +234,7 @@ public:
   getOrCreateStaticVarDecl(const VarDecl &D,
                            mlir::cir::GlobalLinkageKind Linkage);
 
-  mlir::cir::GlobalOp buildGlobal(const VarDecl *D, mlir::Type Ty,
+  mlir::cir::GlobalOp getOrCreateCIRGlobal(const VarDecl *D, mlir::Type Ty,
                                   ForDefinition_t IsForDefinition);
 
   /// TODO(cir): once we have cir.module, add this as a convenience method


### PR DESCRIPTION
`CIRGenModule::buildGlobal` --[rename]--> `CIRGenModule::getOrCreateCIRGlobal`

We already have `CIRGenModule::buildGlobal` that corresponds to `CodeGenModule::EmitGlobal`. But there is an overload of `buildGlobal` used by `getAddrOfGlobalVar`. Since this name is confusing, this PR rename it to `getOrCreateCIRGlobal`.

Note that `getOrCreateCIRGlobal` already exists. It is intentional to make the renamed function an overload to it. The reason here is that the renamed function is basically a wrapper of the original `getOrCreateCIRGlobal` with more specific parameters:

`getOrCreateCIRGlobal(decl, type, isDef)` --[call]--> `getOrCreateCIRGlobal(getMangledName(decl), type, decl->getType()->getAS(), decl, isDef)`