### PR TITLE
[CIR][CodeGen][NFC] Break the missing feature flag for OpenCL into smaller pieces

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -154,7 +154,7 @@ struct MissingFeatures {
   static bool CGFPOptionsRAII() { return false; }
   static bool getFPFeaturesInEffect() { return false; }
   static bool cxxABI() { return false; }
-  static bool openCL() { return false; }
+  static bool openCLCXX() { return false; }
   static bool openCLBuiltinTypes() { return false; }
   static bool CUDA() { return false; }
   static bool openMP() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -253,7 +253,7 @@ static void buildDeclDestroy(CIRGenFunction &CGF, const VarDecl *D) {
   if (Record && (CanRegisterDestructor || UsingExternalHelper)) {
     assert(!D->getTLSKind() && "TLS NYI");
     assert(!Record->hasTrivialDestructor());
-    assert(!MissingFeatures::openCL());
+    assert(!MissingFeatures::openCLCXX());
     CXXDestructorDecl *Dtor = Record->getDestructor();
     // In LLVM OG codegen this is done in registerGlobalDtor, but CIRGen
     // relies on LoweringPrepare for further decoupling, so build the

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -36,7 +36,6 @@ CIRGenFunction::AutoVarEmission
 CIRGenFunction::buildAutoVarAlloca(const VarDecl &D,
                                    mlir::OpBuilder::InsertPoint ip) {
   QualType Ty = D.getType();
-  assert(!MissingFeatures::openCL());
   assert(
       Ty.getAddressSpace() == LangAS::Default ||
       (Ty.getAddressSpace() == LangAS::opencl_private && getLangOpts().OpenCL));


### PR DESCRIPTION
The missing feature flag for OpenCL has very few occurrences now. This PR rearranges them into proper pieces to better track them.