### PR TITLE
[CIR][CodeGen] Add `nothrow` for functions in OpenCL languages

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -1591,6 +1591,16 @@ static void getTrivialDefaultFunctionAttributes(
     auto convgt = mlir::cir::ConvergentAttr::get(CGM.getBuilder().getContext());
     funcAttrs.set(convgt.getMnemonic(), convgt);
   }
+
+  // TODO: NoThrow attribute should be added for other GPU modes CUDA, SYCL,
+  // HIP, OpenMP offload.
+  // AFAIK, neither of them support exceptions in device code.
+  if ((langOpts.CUDA && langOpts.CUDAIsDevice) || langOpts.SYCLIsDevice)
+    llvm_unreachable("NYI");
+  if (langOpts.OpenCL) {
+    auto noThrow = mlir::cir::NoThrowAttr::get(CGM.getBuilder().getContext());
+    funcAttrs.set(noThrow.getMnemonic(), noThrow);
+  }
 }
 
 void CIRGenModule::getTrivialDefaultFunctionAttributes(

--- a/clang/test/CIR/CodeGen/OpenCL/convergent.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/convergent.cl
@@ -8,7 +8,6 @@
 
 // CIR:      #fn_attr[[CONV_NOINLINE_ATTR:[0-9]*]] = #cir<extra({convergent = #cir.convergent, inline = #cir.inline<no>
 // CIR-NEXT: #fn_attr[[CONV_DECL_ATTR:[0-9]*]] = #cir<extra({convergent = #cir.convergent
-// CIR-NEXT: #fn_attr[[CONV_NOTHROW_ATTR:[0-9]*]] = #cir<extra({convergent = #cir.convergent, nothrow = #cir.nothrow
 
 __attribute__((noinline))
 void non_convfun(void) {
@@ -37,7 +36,7 @@ void test_merge_if(int a) {
     g();
   }
 }
-// CIR: cir.func @test_merge_if{{.*}} extra(#fn_attr[[CONV_NOTHROW_ATTR]])
+// CIR: cir.func @test_merge_if{{.*}} extra(#fn_attr[[CONV_DECL_ATTR]])
 
 // The LLVM IR below is equivalent to:
 //    if (a) {
@@ -81,7 +80,7 @@ void test_no_merge_if(int a) {
     g();
   }
 }
-// CIR: cir.func @test_no_merge_if{{.*}} extra(#fn_attr[[CONV_NOTHROW_ATTR]])
+// CIR: cir.func @test_no_merge_if{{.*}} extra(#fn_attr[[CONV_DECL_ATTR]])
 
 // LLVM-LABEL: define{{.*}} spir_func void @test_no_merge_if
 // LLVM:         %[[tobool:.+]] = icmp eq i32 %[[ARG:.+]], 0

--- a/clang/test/CIR/CodeGen/OpenCL/nothrow.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/nothrow.cl
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -o %t.cir %s
+// RUN: FileCheck %s -input-file=%t.cir -check-prefixes CIR
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -o %t.ll %s
+// RUN: FileCheck %s -input-file=%t.ll -check-prefixes LLVM
+
+// CIR-LABEL: #fn_attr =
+// CIR: cl.kernel = #cir.cl.kernel
+// CIR: nothrow = #cir.nothrow
+
+// CIR-LABEL: #fn_attr1 =
+// CIR-NOT: cl.kernel = #cir.cl.kernel
+// CIR: nothrow = #cir.nothrow
+
+kernel void ker() {};
+// CIR: cir.func @ker{{.*}} extra(#fn_attr) {
+// LLVM: define{{.*}}@ker(){{.*}} #0
+
+void foo() {};
+// CIR: cir.func @foo{{.*}} extra(#fn_attr1) {
+// LLVM: define{{.*}}@foo(){{.*}} #1
+
+// LLVM-LABEL: attributes #0
+// LLVM: nounwind
+
+// LLVM-LABEL: attributes #1
+// LLVM: nounwind


### PR DESCRIPTION
Heterogeneous languages do not support exceptions, which corresponds to `nothrow` in ClangIR and `nounwind` in LLVM IR.

This PR adds nothrow attributes for all functions for OpenCL languages in CIRGen. The Lowering for it is already supported previously.