### PR TITLE
[CIR][Lowering] Fix Global Attr Lowering

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -407,6 +407,11 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
 
   if (globalAttr.getIndices()) {
     llvm::SmallVector<mlir::LLVM::GEPArg> indices;
+
+    if (auto stTy = dyn_cast<mlir::LLVM::LLVMStructType>(sourceType))
+      if (stTy.isIdentified())
+        indices.push_back(0);
+
     for (auto idx : globalAttr.getIndices()) {
       auto intAttr = dyn_cast<mlir::IntegerAttr>(idx);
       assert(intAttr && "index must be integers");

--- a/clang/test/CIR/Lowering/global-ptr.c
+++ b/clang/test/CIR/Lowering/global-ptr.c
@@ -1,0 +1,54 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+// LLVM: %struct.S1 = type { [3200 x double], [3200 x double] }
+// LLVM: %struct.S2 = type { [10 x ptr] }
+// LLVM: %struct.S3 = type { [2000 x i32], [2000 x i32], [2000 x i32] }
+// LLVM: %struct.S4 = type { i32, i32, i32 }
+// LLVM: %union.U1 = type { [2000 x i32] }
+
+// LLVM: @s1 = global %struct.S1 zeroinitializer, align 8
+// LLVM: @b1 = global ptr getelementptr inbounds (%struct.S1, ptr @s1, i32 0, i32 1), align 8
+// LLVM: @s2 = global %struct.S2 zeroinitializer, align 8
+// LLVM: @b2 = global ptr @s2, align 8
+// LLVM: @s3 = global %struct.S3 zeroinitializer, align 4
+// LLVM: @b3 = global ptr getelementptr inbounds (%struct.S3, ptr @s3, i32 0, i32 2), align 8
+// LLVM: @s4 = global %struct.S4 zeroinitializer, align 4
+// LLVM: @b4 = global ptr getelementptr inbounds (%struct.S4, ptr @s4, i32 0, i32 2), align 8
+// LLVM: @u1 = global %union.U1 zeroinitializer, align 4
+// LLVM: @b5 = global ptr @u1, align 8
+
+struct S1 {
+  double a[3200];
+  double b[3200];
+} s1;
+
+double *b1 = s1.b;
+
+struct S2 {
+  double* a[10];
+} s2;
+
+double **b2 = s2.a;
+
+struct S3 {
+  int a[2000];
+  int b[2000];
+  int c[2000];
+} s3;
+
+double *b3 = s3.c;
+
+struct S4 {
+    int a, b, c;
+} s4;
+
+int* b4 = &s4.c;
+
+union U1 {
+  int a[2000];
+  int b[2000];
+  int c[2000];
+} u1;
+
+double *b5 = u1.a;


### PR DESCRIPTION
Consider the following code snippet `tmp.c`: 
```
#define N 3200

struct S {
  double a[N];
  double b[N];
} s;

double *b = s.b;

void foo() {
  double x = 0;
  for (int i = 0; i < N; i++)
    x += b[i];
}

int main() {
  foo();
  return 0;
}
```
Running `bin/clang tmp.c -fclangir -o tmp && ./tmp` causes a segmentation fault.

I compared the LLVM IR with and without CIR and noticed a difference which causes this: 
`@b = global ptr getelementptr inbounds (%struct.S, ptr @s, i32 0, i32 1)` // no CIR 
`@b = global ptr getelementptr inbounds (%struct.S, ptr @s, i32 1)` // with CIR 

It seems there is a missing index when creating global pointers from structs. I have updated `Lowering/DirectToLLVM/LowerToLLVM.cpp`, and added a few tests. 