### PR TITLE
[CIR] Derived-to-base conversions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2960,23 +2960,37 @@ def BaseClassAddrOp : CIR_Op<"base_class_addr"> {
   let summary = "Get the base class address for a class/struct";
   let description = [{
     The `cir.base_class_addr` operaration gets the address of a particular
-    base class given a derived class pointer.
+    non-virtual base class given a derived class pointer. The offset in bytes
+    of the base class must be passed in, since it is easier for the front end
+    to calculate that than the MLIR passes. The operation contains a flag for
+    whether or not the operand may be nullptr. That depends on the context and
+    cannot be known by the operation, and that information affects how the
+    operation is lowered.
 
     Example:
+    ```c++
+    struct Base { };
+    struct Derived : Base { };
+    Derived d;
+    Base& b = d;
+    ```
+    will generate
     ```mlir
-    TBD
+    %3 = cir.base_class_addr (%1 : !cir.ptr<!ty_Derived> nonnull) [0] -> !cir.ptr<!ty_Base>
     ```
   }];
 
   let arguments = (ins
-    Arg<CIR_PointerType, "derived class pointer", [MemRead]>:$derived_addr);
+    Arg<CIR_PointerType, "derived class pointer", [MemRead]>:$derived_addr,
+    IndexAttr:$offset, UnitAttr:$assume_not_null);
 
   let results = (outs Res<CIR_PointerType, "">:$base_addr);
 
   let assemblyFormat = [{
     `(`
       $derived_addr `:` qualified(type($derived_addr))
-    `)` `->` qualified(type($base_addr)) attr-dict
+      (`nonnull` $assume_not_null^)?
+    `)` `[` $offset `]` `->` qualified(type($base_addr)) attr-dict
   }];
 
   // FIXME: add verifier.

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -684,14 +684,14 @@ public:
   }
 
   cir::Address createBaseClassAddr(mlir::Location loc, cir::Address addr,
-                                   mlir::Type destType) {
+                                   mlir::Type destType, unsigned offset,
+                                   bool assumeNotNull) {
     if (destType == addr.getElementType())
       return addr;
 
     auto ptrTy = getPointerTo(destType);
-    auto baseAddr =
-        create<mlir::cir::BaseClassAddrOp>(loc, ptrTy, addr.getPointer());
-
+    auto baseAddr = create<mlir::cir::BaseClassAddrOp>(
+        loc, ptrTy, addr.getPointer(), mlir::APInt(64, offset), assumeNotNull);
     return Address(baseAddr, ptrTy, addr.getAlignment());
   }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -624,6 +624,39 @@ public:
   }
 };
 
+class CIRBaseClassAddrOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::BaseClassAddrOp> {
+public:
+  using mlir::OpConversionPattern<
+      mlir::cir::BaseClassAddrOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::BaseClassAddrOp baseClassOp, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    const auto resultType =
+        getTypeConverter()->convertType(baseClassOp.getType());
+    mlir::Value derivedAddr = adaptor.getDerivedAddr();
+    llvm::SmallVector<mlir::LLVM::GEPArg, 1> offset = {
+        adaptor.getOffset().getZExtValue()};
+    mlir::Type byteType = mlir::IntegerType::get(resultType.getContext(), 8,
+                                                 mlir::IntegerType::Signless);
+    if (baseClassOp.getAssumeNotNull()) {
+      rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
+          baseClassOp, resultType, byteType, derivedAddr, offset);
+    } else {
+      auto loc = baseClassOp.getLoc();
+      mlir::Value isNull = rewriter.create<mlir::LLVM::ICmpOp>(
+          loc, mlir::LLVM::ICmpPredicate::eq, derivedAddr,
+          rewriter.create<mlir::LLVM::ZeroOp>(loc, derivedAddr.getType()));
+      mlir::Value adjusted = rewriter.create<mlir::LLVM::GEPOp>(
+          loc, resultType, byteType, derivedAddr, offset);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::SelectOp>(baseClassOp, isNull,
+                                                        derivedAddr, adjusted);
+    }
+    return mlir::success();
+  }
+};
+
 class CIRBrCondOpLowering
     : public mlir::OpConversionPattern<mlir::cir::BrCondOp> {
 public:
@@ -3823,7 +3856,8 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIRPrefetchLowering, CIRObjSizeOpLowering, CIRIsConstantOpLowering,
       CIRCmpThreeWayOpLowering, CIRClearCacheOpLowering, CIRUndefOpLowering,
       CIREhTypeIdOpLowering, CIRCatchParamOpLowering, CIRResumeOpLowering,
-      CIRAllocExceptionOpLowering, CIRThrowOpLowering, CIRIntrinsicCallLowering
+      CIRAllocExceptionOpLowering, CIRThrowOpLowering, CIRIntrinsicCallLowering,
+      CIRBaseClassAddrOpLowering
 #define GET_BUILTIN_LOWERING_LIST
 #include "clang/CIR/Dialect/IR/CIRBuiltinsLowering.inc"
 #undef GET_BUILTIN_LOWERING_LIST

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -56,8 +56,10 @@ int main() {
 // CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
 // CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, vtable_index = 1, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
 // CIR:   %{{[0-9]+}} = cir.const #cir.int<8> : !s64i
-// CIR:   %{{[0-9]+}} = cir.ptr_stride(%{{[0-9]+}} : !cir.ptr<!ty_Child>, %{{[0-9]+}} : !s64i), !cir.ptr<!ty_Child>
-// CIR:   %11 = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_Child>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_Child>), !cir.ptr<!u8i>
+// CIR:   %{{[0-9]+}} = cir.ptr_stride(%{{[0-9]+}} : !cir.ptr<!u8i>, %{{[0-9]+}} : !s64i), !cir.ptr<!u8i>
+// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!u8i>), !cir.ptr<!ty_Child>
+// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_Child>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
 // CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
 // CIR:   cir.return
 // CIR: }
@@ -68,7 +70,7 @@ int main() {
 
 // LLVM-DAG: define linkonce_odr void @_ZN5ChildC2Ev(ptr %0)
 // LLVM-DAG:  store ptr getelementptr inbounds ({ [4 x ptr], [3 x ptr] }, ptr @_ZTV5Child, i32 0, i32 0, i32 2), ptr %{{[0-9]+}}, align 8
-// LLVM-DAG:  %{{[0-9]+}} = getelementptr %class.Child, ptr %3, i64 8
+// LLVM-DAG:  %{{[0-9]+}} = getelementptr i8, ptr %3, i64 8
 // LLVM-DAG:  store ptr getelementptr inbounds ({ [4 x ptr], [3 x ptr] }, ptr @_ZTV5Child, i32 0, i32 1, i32 2), ptr %{{[0-9]+}}, align 8
 // LLVM-DAG:  ret void
 // }

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -42,7 +42,7 @@ public:
 // CHECK:   %0 = cir.alloca !cir.ptr<![[ClassB]]>, !cir.ptr<!cir.ptr<![[ClassB]]>>, ["this", init] {alignment = 8 : i64}
 // CHECK:   cir.store %arg0, %0 : !cir.ptr<![[ClassB]]>, !cir.ptr<!cir.ptr<![[ClassB]]>>
 // CHECK:   %1 = cir.load %0 : !cir.ptr<!cir.ptr<![[ClassB]]>>, !cir.ptr<![[ClassB]]>
-// CHECK:   %2 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassB]]>), !cir.ptr<![[ClassA]]>
+// CHECK:   %2 = cir.base_class_addr(%1 : !cir.ptr<![[ClassB]]> nonnull) [0] -> !cir.ptr<![[ClassA]]>
 // CHECK:   cir.call @_ZN1AC2Ev(%2) : (!cir.ptr<![[ClassA]]>) -> ()
 // CHECK:   %3 = cir.vtable.address_point(@_ZTV1B, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
 // CHECK:   %4 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassB]]>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>

--- a/clang/test/CIR/Lowering/derived-to-base.cpp
+++ b/clang/test/CIR/Lowering/derived-to-base.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+struct Base1 { int a; };
+struct Base2 { int b; };
+struct Derived : Base1, Base2 { int c; };
+void test_multi_base() {
+  Derived d;
+
+  Base2& bref = d; // no null check needed
+  // LLVM: %7 = getelementptr i8, ptr %1, i32 4
+
+  Base2* bptr = &d; // has null pointer check
+  // LLVM: %8 = icmp eq ptr %1, null
+  // LLVM: %9 = getelementptr i8, ptr %1, i32 4
+  // LLVM: %10 = select i1 %8, ptr %1, ptr %9
+
+  int a = d.a;
+  // LLVM: %11 = getelementptr i8, ptr %1, i32 0
+  // LLVM: %12 = getelementptr %struct.Base1, ptr %11, i32 0, i32 0
+
+  int b = d.b;
+  // LLVM: %14 = getelementptr i8, ptr %1, i32 4
+  // LLVM: %15 = getelementptr %struct.Base2, ptr %14, i32 0, i32 0
+
+  int c = d.c;
+  // LLVM: %17 = getelementptr %struct.Derived, ptr %1, i32 0, i32 2
+}


### PR DESCRIPTION
Implement derived-to-base address conversions for non-virtual base classes.  The code gen for this situation was only implemented when the offset was zero, and it simply created a `cir.base_class_addr` op for which no lowering or other transformation existed.

Conversion to a virtual base class is not yet implemented.

Two new fields are added to the `cir.base_class_addr` operation: the byte offset of the necessary adjustment, and a boolean flag indicating whether the source operand may be null.  The offset is easy to compute in the front end while the entire path of intermediate classes is still available.  It would be difficult for the back end to recompute the offset.  So it is best to store it in the operation.  The null-pointer check is best done late in the lowering process.  But whether or not the null-pointer check is needed is only known by the front end; the back end can't figure that out.  So that flag needs to be stored in the operation.

`CIRGenFunction::getAddressOfBaseClass` was largely rewritten.  The code path no longer matches the equivalent function in the LLVM IR code gen, because the generated ClangIR is quite different from the generated LLVM IR.

`cir.base_class_addr` is lowered to LLVM IR as a `getelementptr` operation.  If a null-pointer check is needed, then that is wrapped in a `select` operation.

When generating code for a constructor or destructor, an incorrect `cir.ptr_stride` op was used to convert the pointer to a base class. The code was assuming that the operand of `cir.ptr_stride` was measured in bytes; the operand is the number elements, not the number of bytes. So the base class constructor was being called on the wrong chunk of memory.  Fix this by using a `cir.base_class_addr` op instead of `cir.ptr_stride` in this scenario.

The use of `cir.ptr_stride` in `ApplyNonVirtualAndVirtualOffset` had the same problem.  Continue using `cir.ptr_stride` here, but temporarily convert the pointer to type `char*` so the pointer is adjusted correctly.

Adjust the expected results of three existing tests in response to these changes.

Add two new tests, one code gen and one lowering, to cover the case where a base class is at a non-zero offset.