### PR TITLE
[CIR][CodeGen] kr-style for function arguments

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -970,7 +970,7 @@ static bool matchesStlAllocatorFn(const Decl *D, const ASTContext &Ctx) {
   return true;
 }
 
-// TODO: this should live in `buildFunctionProlog
+/// TODO: this should live in `buildFunctionProlog`
 /// An argument came in as a promoted argument; demote it back to its
 /// declared type.
 static mlir::Value emitArgumentDemotion(CIRGenFunction &CGF, const VarDecl *var,
@@ -1275,7 +1275,7 @@ void CIRGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
       auto address = Address(addr, alignment);
       setAddrOfLocalVar(paramVar, address);
 
-      // TODO: this should live in `buildFunctionProlog
+      // TODO: this should live in `buildFunctionProlog`
       bool isPromoted = isa<ParmVarDecl>(paramVar) &&
                         cast<ParmVarDecl>(paramVar)->isKNRPromoted();
       assert(!MissingFeatures::constructABIArgDirectExtend());

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -1252,15 +1252,15 @@ void CIRGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
       auto address = Address(addr, alignment);
       setAddrOfLocalVar(paramVar, address);
 
-      bool isPromoted =
-        isa<ParmVarDecl>(paramVar) && cast<ParmVarDecl>(paramVar)->isKNRPromoted();
+      bool isPromoted = isa<ParmVarDecl>(paramVar) &&
+                        cast<ParmVarDecl>(paramVar)->isKNRPromoted();
       if (isPromoted) {
         auto ty = getCIRType(paramVar->getType());
         if (isa<mlir::cir::IntType>(ty))
           paramVal = builder.CIRBaseBuilderTy::createIntCast(paramVal, ty);
         else if (mlir::cir::isAnyFloatingPointType(ty)) {
-          paramVal = builder.CIRBaseBuilderTy::createCast(mlir::cir::CastKind::floating,
-                                                          paramVal, ty);
+          paramVal = builder.CIRBaseBuilderTy::createCast(
+              mlir::cir::CastKind::floating, paramVal, ty);
         }
       }
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -973,23 +973,24 @@ static bool matchesStlAllocatorFn(const Decl *D, const ASTContext &Ctx) {
 // TODO: this should live in `buildFunctionProlog
 /// An argument came in as a promoted argument; demote it back to its
 /// declared type.
-static mlir::Value emitArgumentDemotion(CIRGenFunction &CGF,
-                                        const VarDecl *var,
+static mlir::Value emitArgumentDemotion(CIRGenFunction &CGF, const VarDecl *var,
                                         mlir::Value value) {
   mlir::Type ty = CGF.ConvertType(var->getType());
 
   // This can happen with promotions that actually don't change the
   // underlying type, like the enum promotions.
-  if (value.getType() == ty) return value;
+  if (value.getType() == ty)
+    return value;
 
-  assert((isa<mlir::cir::IntType>(ty) || mlir::cir::isAnyFloatingPointType(ty))
-         && "unexpected promotion type");
+  assert(
+      (isa<mlir::cir::IntType>(ty) || mlir::cir::isAnyFloatingPointType(ty)) &&
+      "unexpected promotion type");
 
   if (isa<mlir::cir::IntType>(ty))
     return CGF.getBuilder().CIRBaseBuilderTy::createIntCast(value, ty);
 
   return CGF.getBuilder().CIRBaseBuilderTy::createCast(
-              mlir::cir::CastKind::floating, value, ty);
+      mlir::cir::CastKind::floating, value, ty);
 }
 
 void CIRGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
@@ -1277,9 +1278,10 @@ void CIRGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
       // TODO: this should live in `buildFunctionProlog
       bool isPromoted = isa<ParmVarDecl>(paramVar) &&
                         cast<ParmVarDecl>(paramVar)->isKNRPromoted();
+      assert(!MissingFeatures::constructABIArgDirectExtend());
       if (isPromoted)
         paramVal = emitArgumentDemotion(*this, paramVar, paramVal);
-      
+
       // Location of the store to the param storage tracked as beginning of
       // the function body.
       auto fnBodyBegin = getLoc(FD->getBody()->getBeginLoc());

--- a/clang/test/CIR/CodeGen/kr-func-promote.c
+++ b/clang/test/CIR/CodeGen/kr-func-promote.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - | FileCheck %s
+
+// CHECK: cir.func {{.*}}@foo(%arg0: !s32i
+// CHECK:   %0 = cir.alloca !s16i, !cir.ptr<!s16i>, ["x", init]
+// CHECK:   %1 = cir.cast(integral, %arg0 : !s32i)
+// CHECK:   cir.store %1, %0 : !s16i, !cir.ptr<!s16i>
+void foo(x) short x; {}
+
+// CHECK: cir.func no_proto  @bar(%arg0: !cir.double 
+// CHECK:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]
+// CHECK:   %1 = cir.cast(floating, %arg0 : !cir.double), !cir.float
+// CHECK:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>
+void bar(f) float f; {}


### PR DESCRIPTION
I tried to run llvm-test-suite and turned out that there are many tests fail with segfault due to old C style (let's remember Kernighan and Ritchie) . This PR fix it by the usual copy-pasta from the original codegen :)

So let's take a look at the code:
```
void foo(x) short x; {}
int main() {
  foo(4); 
  return 0;
}
```
and CIR for `foo` function is:
```
cir.func  @foo(%arg0: !s32i) {
    %0 = cir.alloca !s16i, !cir.ptr<!s16i>, ["x", init] 
    %1 = cir.cast(bitcast, %0 : !cir.ptr<!s16i>), !cir.ptr<!s32i>
    cir.store %arg0, %1 : !s32i, !cir.ptr<!s32i>
    cir.return
}
```
We bitcast the **address** (!!!) and store a value of a bigger size there.

And now everything looks fine:
```
cir.func no_proto  @foo(%arg0: !s32i) {
    %0 = cir.alloca !s16i, !cir.ptr<!s16i>, ["x", init] 
    %1 = cir.cast(integral, %arg0 : !s32i), !s16i
    cir.store %1, %0 : !s16i, !cir.ptr<!s16i> 
    cir.return 
} 
```
We truncate an argument and store it. 

P.S.
The `bitcast` that was there before looks a little bit suspicious and dangerous. Are we sure we can do this unconditional cast while we create `StoreOp` ? 





