### PR TITLE
fixup! [CIR][ABI] Implement basic struct CC lowering for x86_64

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -133,7 +133,7 @@ void CIRDataLayout::reset(mlir::DataLayoutSpecInterface spec) {
   // ManglingMode = MM_None;
   // NonIntegralAddressSpaces.clear();
   StructAlignment =
-      llvm::DataLayout::PrimitiveSpec{0, llvm::Align(8), llvm::Align(1)};
+      llvm::DataLayout::PrimitiveSpec{0, llvm::Align(1), llvm::Align(8)};
 
   // NOTE(cir): Alignment setter functions are skipped as these should already
   // be set in MLIR's data layout.

--- a/clang/test/CIR/CodeGen/array.c
+++ b/clang/test/CIR/CodeGen/array.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
 // Should implicitly zero-initialize global array elements.
 struct S {

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -Wno-return-stack-address -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
 void a0() {
   int a[10];

--- a/clang/test/CIR/CodeGen/bool.c
+++ b/clang/test/CIR/CodeGen/bool.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
 #include <stdbool.h>
 

--- a/clang/test/CIR/CodeGen/c11atomic.c
+++ b/clang/test/CIR/CodeGen/c11atomic.c
@@ -2,7 +2,6 @@
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 %s -triple aarch64-none-linux-android21 -fclangir -emit-llvm -std=c11 -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// XFAIL: *
 
 // CIR-DAG: ![[PS:.*]] = !cir.struct<struct "PS" {!cir.int<s, 16>, !cir.int<s, 16>, !cir.int<s, 16>}
 // CIR-DAG: ![[ANON:.*]] = !cir.struct<struct  {!cir.struct<struct "PS" {!cir.int<s, 16>, !cir.int<s, 16>, !cir.int<s, 16>} {{.*}}>, !cir.array<!cir.int<u, 8> x 2>}>

--- a/clang/test/CIR/CodeGen/evaluate-expr.c
+++ b/clang/test/CIR/CodeGen/evaluate-expr.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
 static const int g = 1;
 void foo() {

--- a/clang/test/CIR/CodeGen/globals-neg-index-array.c
+++ b/clang/test/CIR/CodeGen/globals-neg-index-array.c
@@ -6,7 +6,6 @@
 // RUN: FileCheck --input-file=%t.cir %s
 // RUN: %clang_cc1 -x c++ -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// XFAIL: *
 
 struct __attribute__((packed)) PackedStruct {
     char a1;

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -5,7 +5,6 @@
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
 char string[] = "whatnow";
 // CHECK: cir.global external @string = #cir.const_array<"whatnow\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8>

--- a/clang/test/CIR/CodeGen/packed-structs.c
+++ b/clang/test/CIR/CodeGen/packed-structs.c
@@ -2,7 +2,6 @@
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// XFAIL: *
 
 #pragma pack(1)
 

--- a/clang/test/CIR/CodeGen/stmtexpr-init.c
+++ b/clang/test/CIR/CodeGen/stmtexpr-init.c
@@ -2,7 +2,6 @@
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// XFAIL: *
 
 // CIR: ![[annon_struct:.*]] = !cir.struct<struct  {!cir.int<s, 32>, !cir.array<!cir.int<s, 32> x 2>}>
 // CIR: ![[sized_array:.*]] = !cir.struct<struct "sized_array" {!cir.int<s, 32>, !cir.array<!cir.int<s, 32> x 0>}

--- a/clang/test/CIR/CodeGen/string-literals.c
+++ b/clang/test/CIR/CodeGen/string-literals.c
@@ -2,7 +2,6 @@
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// XFAIL: *
 
 struct {
   char x[10];

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
 struct Bar {
   int a;

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// XFAIL: *
 
 struct Bar {
   int a;

--- a/clang/test/CIR/CodeGen/union-init.c
+++ b/clang/test/CIR/CodeGen/union-init.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s
-// XFAIL: *
 
 typedef union {
   int value;

--- a/clang/test/CIR/Lowering/struct-init.c
+++ b/clang/test/CIR/Lowering/struct-init.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
-// XFAIL: *
 
 struct S {
     int x;


### PR DESCRIPTION
The ABI alignment and preferred alignment fields were swapped (per [1],
the ABI alignment should be 1 and the preferred alignment should be 8),
leading to incorrect struct size calculations.

Fixes https://github.com/llvm/clangir/issues/911
Fixes https://github.com/llvm/clangir/issues/915
Fixes https://github.com/llvm/clangir/issues/916
Fixes https://github.com/llvm/clangir/issues/917
Fixes https://github.com/llvm/clangir/issues/918
Fixes https://github.com/llvm/clangir/issues/919
Fixes https://github.com/llvm/clangir/issues/920
Fixes https://github.com/llvm/clangir/issues/921
Fixes https://github.com/llvm/clangir/issues/922
Fixes https://github.com/llvm/clangir/issues/925
Fixes https://github.com/llvm/clangir/issues/926
Fixes https://github.com/llvm/clangir/issues/929
Fixes https://github.com/llvm/clangir/issues/930

[1] https://github.com/llvm/llvm-project/commit/8eadf21004ecfa78fa3c6da385c5b2f2f44458fa
