### PR TITLE
Reapply and patch "[CIR][ABI] Apply CC lowering pass by default (#842)"

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -43,7 +43,7 @@ std::unique_ptr<Pass> createGotoSolverPass();
 /// Create a pass to lower ABI-independent function definitions/calls.
 std::unique_ptr<Pass> createCallConvLoweringPass();
 
-void populateCIRPreLoweringPasses(mlir::OpPassManager &pm);
+void populateCIRPreLoweringPasses(mlir::OpPassManager &pm, bool useCCLowering);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/clang/include/clang/CIR/LowerToLLVM.h
+++ b/clang/include/clang/CIR/LowerToLLVM.h
@@ -29,10 +29,9 @@ class ModuleOp;
 namespace cir {
 
 namespace direct {
-std::unique_ptr<llvm::Module>
-lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule,
-                             llvm::LLVMContext &llvmCtx,
-                             bool disableVerifier = false);
+std::unique_ptr<llvm::Module> lowerDirectlyFromCIRToLLVMIR(
+    mlir::ModuleOp theModule, llvm::LLVMContext &llvmCtx,
+    bool disableVerifier = false, bool disableCCLowering = false);
 }
 
 // Lower directly from pristine CIR to LLVMIR.

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -15,6 +15,27 @@
 #ifndef CLANG_CIR_MISSINGFEATURES_H
 #define CLANG_CIR_MISSINGFEATURES_H
 
+constexpr bool cirMissingFeatureAssertionMode =
+    true; // Change to `false` to use llvm_unreachable
+
+#define NOTE                                                                   \
+  " Target lowering is now required. Disable it with "                         \
+  "-fno-clangir-call-conv-lowering."
+
+// Special assertion to be used in the target lowering library.
+#define cir_tl_assert(cond) assert((cond) && NOTE);
+
+// Some assertions knowingly generate incorrect code. This macro allows us to
+// switch between using `assert` and `llvm_unreachable` for these cases.
+#define cir_assert_or_abort(cond, msg)                                         \
+  do {                                                                         \
+    if (cirMissingFeatureAssertionMode) {                                      \
+      assert((cond) && msg NOTE);                                              \
+    } else {                                                                   \
+      llvm_unreachable(msg NOTE);                                              \
+    }                                                                          \
+  } while (0)
+
 namespace cir {
 
 struct MissingFeatures {
@@ -211,6 +232,26 @@ struct MissingFeatures {
   static bool supportisAggregateTypeForABIAArch64() { return false; }
 
   //===--- ABI lowering --===//
+
+  static bool SPIRVABI() { return false; }
+
+  static bool AArch64TypeClassification() { return false; }
+
+  static bool X86ArgTypeClassification() { return false; }
+  static bool X86DefaultABITypeConvertion() { return false; }
+  static bool X86GetFPTypeAtOffset() { return false; }
+  static bool X86RetTypeClassification() { return false; }
+  static bool X86TypeClassification() { return false; }
+
+  static bool ABIClangTypeKind() { return false; }
+  static bool ABIEnterStructForCoercedAccess() { return false; }
+  static bool ABIFuncPtr() { return false; }
+  static bool ABIInRegAttribute() { return false; }
+  static bool ABINestedRecordLayout() { return false; }
+  static bool ABINoProtoFunctions() { return false; }
+  static bool ABIParameterCoercion() { return false; }
+  static bool ABIPointerParameterAttrs() { return false; }
+  static bool ABITransparentUnionHandling() { return false; }
 
   //-- Missing AST queries
 

--- a/clang/include/clang/CIR/Passes.h
+++ b/clang/include/clang/CIR/Passes.h
@@ -30,7 +30,7 @@ namespace direct {
 std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass();
 
 /// Adds passes that fully lower CIR to the LLVMIR dialect.
-void populateCIRToLLVMPasses(mlir::OpPassManager &pm);
+void populateCIRToLLVMPasses(mlir::OpPassManager &pm, bool useCCLowering);
 
 } // namespace direct
 } // end namespace cir

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3037,10 +3037,6 @@ def fclangir_lib_opt : Flag<["-"], "fclangir-lib-opt">,
   Visibility<[ClangOption, CC1Option]>, Group<f_Group>,
   Alias<fclangir_lib_opt_EQ>,
   HelpText<"Enable C/C++ library based optimizations">;
-def fclangir_call_conv_lowering : Flag<["-"], "fclangir-call-conv-lowering">,
-  Visibility<[ClangOption, CC1Option]>, Group<f_Group>,
-  HelpText<"Enable ClangIR calling convention lowering">,
-  MarshallingInfoFlag<FrontendOpts<"ClangIREnableCallConvLowering">>;
 def fclangir_mem2reg : Flag<["-"], "fclangir-mem2reg">,
   Visibility<[ClangOption, CC1Option]>, Group<f_Group>,
   HelpText<"Enable mem2reg on the flat ClangIR">,
@@ -3071,6 +3067,13 @@ defm clangir_analysis_only : BoolFOption<"clangir-analysis-only",
   PosFlag<SetTrue, [], [ClangOption, CC1Option],
     "Enable CIR analysis but keep traditional LLVM codegen (not through CIR)">,
   NegFlag<SetFalse, [], [ClangOption, CC1Option],  "">>;
+// FIXME(cir): Remove this option once all pre-existing tests are compatible with
+// the calling convention lowering pass.
+defm clangir_call_conv_lowering : BoolFOption<"clangir-call-conv-lowering",
+  FrontendOpts<"ClangIRCallConvLowering">, DefaultTrue,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option], "Transform CIR to abide to calling convetions during lowering">,
+  NegFlag<SetFalse, [], [ClangOption, CC1Option], "Ignore calling convetion during lowering">,
+  BothFlags<[], [ClangOption, CC1Option], "">>;
 
 def emit_cir : Flag<["-"], "emit-cir">, Visibility<[CC1Option]>,
   Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR, emit the .cir file">;

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -449,7 +449,7 @@ public:
   unsigned ClangIRLibOpt : 1;
 
   // Enable Clang IR call conv lowering pass.
-  unsigned ClangIREnableCallConvLowering : 1;
+  unsigned ClangIRCallConvLowering : 1;
 
   // Enable Clang IR mem2reg pass on the flat CIR.
   unsigned ClangIREnableMem2Reg : 1;

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -75,13 +75,8 @@ mlir::LogicalResult runCIRToCIRPasses(
 
   pm.addPass(mlir::createLoweringPreparePass(&astCtx));
 
-  // FIXME(cir): This pass should run by default, but it is lacking support for
-  // several code bits. Once it's more mature, we should fix this.
-  if (enableCallConvLowering)
-    pm.addPass(mlir::createCallConvLoweringPass());
-
   if (flattenCIR || enableMem2Reg)
-    mlir::populateCIRPreLoweringPasses(pm);
+    mlir::populateCIRPreLoweringPasses(pm, enableCallConvLowering);
 
   if (enableMem2Reg)
     pm.addPass(mlir::createMem2Reg());
@@ -101,7 +96,9 @@ mlir::LogicalResult runCIRToCIRPasses(
 
 namespace mlir {
 
-void populateCIRPreLoweringPasses(OpPassManager &pm) {
+void populateCIRPreLoweringPasses(OpPassManager &pm, bool useCCLowering) {
+  if (useCCLowering)
+    pm.addPass(createCallConvLoweringPass());
   pm.addPass(createHoistAllocasPass());
   pm.addPass(createFlattenCFGPass());
   pm.addPass(createGotoSolverPass());

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -36,9 +36,6 @@ struct CallConvLoweringPattern : public OpRewritePattern<FuncOp> {
 
     const auto module = op->getParentOfType<mlir::ModuleOp>();
 
-    if (!op.getAst())
-      return op.emitError("function has no AST information");
-
     auto modOp = op->getParentOfType<ModuleOp>();
     std::unique_ptr<LowerModule> lowerModule =
         createLowerModule(modOp, rewriter);

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "TargetLowering/LowerModule.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -14,6 +13,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/MissingFeatures.h"
 
 #define GEN_PASS_DEF_CALLCONVLOWERING
 #include "clang/CIR/Dialect/Passes.h.inc"
@@ -48,6 +48,12 @@ struct CallConvLoweringPattern : public OpRewritePattern<FuncOp> {
     auto calls = op.getSymbolUses(module);
     if (calls.has_value()) {
       for (auto call : calls.value()) {
+        // FIXME(cir): Function pointers are ignored.
+        if (isa<GetGlobalOp>(call.getUser())) {
+          cir_assert_or_abort(!::cir::MissingFeatures::ABIFuncPtr(), "NYI");
+          continue;
+        }
+
         auto callOp = cast<CallOp>(call.getUser());
         if (lowerModule->rewriteFunctionCall(callOp, op).failed())
           return failure();

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfo.cpp
@@ -37,7 +37,7 @@ bool ABIInfo::isPromotableIntegerTypeForABI(Type Ty) const {
   if (getContext().isPromotableIntegerType(Ty))
     return true;
 
-  assert(!::cir::MissingFeatures::fixedWidthIntegers());
+  cir_tl_assert(!::cir::MissingFeatures::fixedWidthIntegers());
 
   return false;
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -26,21 +26,22 @@ bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
   Type Ty = FI.getReturnType();
 
   if (const auto RT = dyn_cast<StructType>(Ty)) {
-    assert(!::cir::MissingFeatures::isCXXRecordDecl());
+    cir_tl_assert(!::cir::MissingFeatures::isCXXRecordDecl());
   }
 
   return CXXABI.classifyReturnType(FI);
 }
 
 bool isAggregateTypeForABI(Type T) {
-  assert(!::cir::MissingFeatures::functionMemberPointerType());
+  cir_tl_assert(!::cir::MissingFeatures::functionMemberPointerType());
   return !LowerFunction::hasScalarEvaluationKind(T);
 }
 
 Type useFirstFieldIfTransparentUnion(Type Ty) {
   if (auto RT = dyn_cast<StructType>(Ty)) {
     if (RT.isUnion())
-      llvm_unreachable("NYI");
+      cir_assert_or_abort(
+          !::cir::MissingFeatures::ABITransparentUnionHandling(), "NYI");
   }
   return Ty;
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -55,7 +55,10 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const Type T) const {
   } else if (isa<StructType>(T)) {
     typeKind = clang::Type::Record;
   } else {
-    llvm_unreachable("Unhandled type class");
+    cir_assert_or_abort(!::cir::MissingFeatures::ABIClangTypeKind(),
+                        "Unhandled type class");
+    // FIXME(cir): Completely wrong. Just here to make it non-blocking.
+    typeKind = clang::Type::Builtin;
   }
 
   // FIXME(cir): Here we fetch the width and alignment of a type considering the
@@ -96,10 +99,10 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const Type T) const {
   }
   case clang::Type::Record: {
     const auto RT = dyn_cast<StructType>(T);
-    assert(!::cir::MissingFeatures::tagTypeClassAbstraction());
+    cir_tl_assert(!::cir::MissingFeatures::tagTypeClassAbstraction());
 
     // Only handle TagTypes (names types) for now.
-    assert(RT.getName() && "Anonymous record is NYI");
+    cir_tl_assert(RT.getName() && "Anonymous record is NYI");
 
     // NOTE(cir): Clang does some hanlding of invalid tagged declarations here.
     // Not sure if this is necessary in CIR.
@@ -111,14 +114,14 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const Type T) const {
     const CIRRecordLayout &Layout = getCIRRecordLayout(RT);
     Width = toBits(Layout.getSize());
     Align = toBits(Layout.getAlignment());
-    assert(!::cir::MissingFeatures::recordDeclHasAlignmentAttr());
+    cir_tl_assert(!::cir::MissingFeatures::recordDeclHasAlignmentAttr());
     break;
   }
   default:
     llvm_unreachable("Unhandled type class");
   }
 
-  assert(llvm::isPowerOf2_32(Align) && "Alignment must be power of 2");
+  cir_tl_assert(llvm::isPowerOf2_32(Align) && "Alignment must be power of 2");
   return clang::TypeInfo(Width, Align, AlignRequirement);
 }
 
@@ -126,7 +129,7 @@ Type CIRLowerContext::initBuiltinType(clang::BuiltinType::Kind K) {
   Type Ty;
 
   // NOTE(cir): Clang does more stuff here. Not sure if we need to do the same.
-  assert(!::cir::MissingFeatures::qualifiedTypes());
+  cir_tl_assert(!::cir::MissingFeatures::qualifiedTypes());
   switch (K) {
   case clang::BuiltinType::Char_S:
     Ty = IntType::get(getMLIRContext(), 8, true);
@@ -141,7 +144,7 @@ Type CIRLowerContext::initBuiltinType(clang::BuiltinType::Kind K) {
 
 void CIRLowerContext::initBuiltinTypes(const clang::TargetInfo &Target,
                                        const clang::TargetInfo *AuxTarget) {
-  assert((!this->Target || this->Target == &Target) &&
+  cir_tl_assert((!this->Target || this->Target == &Target) &&
          "Incorrect target reinitialization");
   this->Target = &Target;
   this->AuxTarget = AuxTarget;

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -145,7 +145,7 @@ Type CIRLowerContext::initBuiltinType(clang::BuiltinType::Kind K) {
 void CIRLowerContext::initBuiltinTypes(const clang::TargetInfo &Target,
                                        const clang::TargetInfo *AuxTarget) {
   cir_tl_assert((!this->Target || this->Target == &Target) &&
-         "Incorrect target reinitialization");
+                "Incorrect target reinitialization");
   this->Target = &Target;
   this->AuxTarget = AuxTarget;
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRRecordLayout.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRRecordLayout.cpp
@@ -38,16 +38,16 @@ CIRRecordLayout::CIRRecordLayout(
   FieldOffsets.insert(FieldOffsets.end(), fieldoffsets.begin(),
                       fieldoffsets.end());
 
-  assert(!PrimaryBase && "Layout for class with inheritance is NYI");
+  cir_tl_assert(!PrimaryBase && "Layout for class with inheritance is NYI");
   // CXXInfo->PrimaryBase.setPointer(PrimaryBase);
-  assert(!IsPrimaryBaseVirtual && "Layout for virtual base class is NYI");
+  cir_tl_assert(!IsPrimaryBaseVirtual && "Layout for virtual base class is NYI");
   // CXXInfo->PrimaryBase.setInt(IsPrimaryBaseVirtual);
   CXXInfo->NonVirtualSize = nonvirtualsize;
   CXXInfo->NonVirtualAlignment = nonvirtualalignment;
   CXXInfo->PreferredNVAlignment = preferrednvalignment;
   CXXInfo->SizeOfLargestEmptySubobject = SizeOfLargestEmptySubobject;
   // FIXME(cir): Initialize base classes offsets.
-  assert(!::cir::MissingFeatures::getCXXRecordBases());
+  cir_tl_assert(!::cir::MissingFeatures::getCXXRecordBases());
   CXXInfo->HasOwnVFPtr = hasOwnVFPtr;
   CXXInfo->VBPtrOffset = vbptroffset;
   CXXInfo->HasExtendableVFPtr = hasExtendableVFPtr;

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRRecordLayout.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRRecordLayout.cpp
@@ -40,7 +40,8 @@ CIRRecordLayout::CIRRecordLayout(
 
   cir_tl_assert(!PrimaryBase && "Layout for class with inheritance is NYI");
   // CXXInfo->PrimaryBase.setPointer(PrimaryBase);
-  cir_tl_assert(!IsPrimaryBaseVirtual && "Layout for virtual base class is NYI");
+  cir_tl_assert(!IsPrimaryBaseVirtual &&
+                "Layout for virtual base class is NYI");
   // CXXInfo->PrimaryBase.setInt(IsPrimaryBaseVirtual);
   CXXInfo->NonVirtualSize = nonvirtualsize;
   CXXInfo->NonVirtualAlignment = nonvirtualalignment;

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRToCIRArgMapping.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRToCIRArgMapping.h
@@ -58,7 +58,7 @@ public:
   unsigned totalIRArgs() const { return TotalIRArgs; }
 
   bool hasPaddingArg(unsigned ArgNo) const {
-    assert(ArgNo < ArgInfo.size());
+    cir_tl_assert(ArgNo < ArgInfo.size());
     return ArgInfo[ArgNo].PaddingArgIndex != InvalidIndex;
   }
 
@@ -77,7 +77,7 @@ public:
         onlyRequiredArgs ? FI.getNumRequiredArgs() : FI.arg_size();
     for (LowerFunctionInfo::const_arg_iterator I = FI.arg_begin();
          ArgNo < NumArgs; ++I, ++ArgNo) {
-      assert(I != FI.arg_end());
+      cir_tl_assert(I != FI.arg_end());
       // Type ArgType = I->type;
       const ::cir::ABIArgInfo &AI = I->info;
       // Collect data about IR arguments corresponding to Clang argument ArgNo.
@@ -91,7 +91,7 @@ public:
       case ::cir::ABIArgInfo::Extend:
       case ::cir::ABIArgInfo::Direct: {
         // FIXME(cir): handle sseregparm someday...
-        assert(AI.getCoerceToType() && "Missing coerced type!!");
+        cir_tl_assert(AI.getCoerceToType() && "Missing coerced type!!");
         StructType STy = dyn_cast<StructType>(AI.getCoerceToType());
         if (AI.isDirect() && AI.getCanBeFlattened() && STy) {
           llvm_unreachable("NYI");
@@ -114,7 +114,7 @@ public:
       if (IRArgNo == 1 && SwapThisWithSRet)
         IRArgNo++;
     }
-    assert(ArgNo == ArgInfo.size());
+    cir_tl_assert(ArgNo == ArgInfo.size());
 
     if (::cir::MissingFeatures::inallocaArgs()) {
       llvm_unreachable("NYI");
@@ -126,7 +126,7 @@ public:
   /// Returns index of first IR argument corresponding to ArgNo, and their
   /// quantity.
   std::pair<unsigned, unsigned> getIRArgs(unsigned ArgNo) const {
-    assert(ArgNo < ArgInfo.size());
+    cir_tl_assert(ArgNo < ArgInfo.size());
     return std::make_pair(ArgInfo[ArgNo].FirstArgIndex,
                           ArgInfo[ArgNo].NumberOfArgs);
   }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -46,9 +46,9 @@ public:
 
   // FIXME(cir): This expects a CXXRecordDecl! Not any record type.
   RecordArgABI getRecordArgABI(const StructType RD) const override {
-    assert(!::cir::MissingFeatures::recordDeclIsCXXDecl());
+    cir_tl_assert(!::cir::MissingFeatures::recordDeclIsCXXDecl());
     // If C++ prohibits us from making a copy, pass by address.
-    assert(!::cir::MissingFeatures::recordDeclCanPassInRegisters());
+    cir_tl_assert(!::cir::MissingFeatures::recordDeclCanPassInRegisters());
     return RAA_Default;
   }
 };
@@ -76,7 +76,7 @@ CIRCXXABI *CreateItaniumCXXABI(LowerModule &LM) {
   case clang::TargetCXXABI::AppleARM64:
     // TODO: this isn't quite right, clang uses AppleARM64CXXABI which inherits
     // from ARMCXXABI. We'll have to follow suit.
-    assert(!::cir::MissingFeatures::appleArm64CXXABI());
+    cir_tl_assert(!::cir::MissingFeatures::appleArm64CXXABI());
     return new ItaniumCXXABI(LM, /*UseARMMethodPtrABI=*/true,
                              /*UseARMGuardVarABI=*/true);
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
@@ -23,9 +23,9 @@ const LowerFunctionInfo &
 arrangeFreeFunctionLikeCall(LowerTypes &LT, LowerModule &LM,
                             const OperandRange &args, const FuncType fnType,
                             unsigned numExtraRequiredArgs, bool chainCall) {
-  assert(args.size() >= numExtraRequiredArgs);
+  cir_tl_assert(args.size() >= numExtraRequiredArgs);
 
-  assert(!::cir::MissingFeatures::extParamInfo());
+  cir_tl_assert(!::cir::MissingFeatures::extParamInfo());
 
   // In most cases, there are no optional arguments.
   RequiredArgs required = RequiredArgs::All;
@@ -35,7 +35,7 @@ arrangeFreeFunctionLikeCall(LowerTypes &LT, LowerModule &LM,
   // FIXME(cir): Properly check if function is no-proto.
   if (/*IsPrototypedFunction=*/true) {
     if (fnType.isVarArg())
-      llvm_unreachable("NYI");
+      cir_assert_or_abort(!::cir::MissingFeatures::isVarArg(), "NYI");
 
     if (::cir::MissingFeatures::extParamInfo())
       llvm_unreachable("NYI");
@@ -45,7 +45,7 @@ arrangeFreeFunctionLikeCall(LowerTypes &LT, LowerModule &LM,
   // its skipped here since it requires CodeGen info. Maybe this information
   // could be embbed  in the FuncOp during CIRGen.
 
-  assert(!::cir::MissingFeatures::chainCall() && !chainCall && "NYI");
+  cir_tl_assert(!::cir::MissingFeatures::chainCall() && !chainCall && "NYI");
   FnInfoOpts opts = chainCall ? FnInfoOpts::IsChainCall : FnInfoOpts::None;
   return LT.arrangeLLVMFunctionInfo(fnType.getReturnType(), opts,
                                     fnType.getInputs(), required);
@@ -60,7 +60,7 @@ static void appendParameterTypes(SmallVectorImpl<Type> &prefix, FuncType fnTy) {
     return;
   }
 
-  assert(MissingFeatures::extParamInfo());
+  cir_tl_assert(MissingFeatures::extParamInfo());
   llvm_unreachable("NYI");
 }
 
@@ -74,11 +74,11 @@ static void appendParameterTypes(SmallVectorImpl<Type> &prefix, FuncType fnTy) {
 static const LowerFunctionInfo &
 arrangeCIRFunctionInfo(LowerTypes &CGT, bool instanceMethod,
                        SmallVectorImpl<mlir::Type> &prefix, FuncType fnTy) {
-  assert(!MissingFeatures::extParamInfo());
+  cir_tl_assert(!MissingFeatures::extParamInfo());
   RequiredArgs Required = RequiredArgs::forPrototypePlus(fnTy, prefix.size());
   // FIXME: Kill copy.
   appendParameterTypes(prefix, fnTy);
-  assert(!MissingFeatures::qualifiedTypes());
+  cir_tl_assert(!MissingFeatures::qualifiedTypes());
   Type resultType = fnTy.getReturnType();
 
   FnInfoOpts opts =
@@ -110,7 +110,7 @@ void LowerModule::constructAttributeList(StringRef Name,
 
   // TODO(cir): Implement AddAttributesFromFunctionProtoType here.
   // TODO(cir): Implement AddAttributesFromOMPAssumes here.
-  assert(!MissingFeatures::openMP());
+  cir_tl_assert(!MissingFeatures::openMP());
 
   // TODO(cir): Skipping a bunch of AST queries here. We will need to partially
   // implement some of them as this section sets target-specific attributes
@@ -147,8 +147,8 @@ void LowerModule::constructAttributeList(StringRef Name,
     [[fallthrough]];
   case ABIArgInfo::Direct:
     if (RetAI.getInReg())
-      llvm_unreachable("InReg attribute is NYI");
-    assert(!::cir::MissingFeatures::noFPClass());
+      cir_assert_or_abort(!::cir::MissingFeatures::ABIInRegAttribute(), "NYI");
+    cir_tl_assert(!::cir::MissingFeatures::noFPClass());
     break;
   case ABIArgInfo::Ignore:
     break;
@@ -216,7 +216,7 @@ void LowerModule::constructAttributeList(StringRef Name,
       else if (AI.getInReg())
         llvm_unreachable("InReg attribute is NYI");
       // Attrs.addStackAlignmentAttr(llvm::MaybeAlign(AI.getDirectAlign()));
-      assert(!::cir::MissingFeatures::noFPClass());
+      cir_tl_assert(!::cir::MissingFeatures::noFPClass());
       break;
     default:
       llvm_unreachable("Missing ABIArgInfo::Kind");
@@ -227,7 +227,7 @@ void LowerModule::constructAttributeList(StringRef Name,
     }
 
     // TODO(cir): Missing some swift and nocapture stuff here.
-    assert(!::cir::MissingFeatures::extParamInfo());
+    cir_tl_assert(!::cir::MissingFeatures::extParamInfo());
 
     if (!Attrs.empty()) {
       unsigned FirstIRArg, NumIRArgs;
@@ -236,7 +236,7 @@ void LowerModule::constructAttributeList(StringRef Name,
         newFn.setArgAttrs(FirstIRArg + i, Attrs);
     }
   }
-  assert(ArgNo == FI.arg_size());
+  cir_tl_assert(ArgNo == FI.arg_size());
 }
 
 /// Arrange the argument and result information for the declaration or
@@ -245,15 +245,15 @@ const LowerFunctionInfo &LowerTypes::arrangeFunctionDeclaration(FuncOp fnOp) {
   if (MissingFeatures::funcDeclIsCXXMethodDecl())
     llvm_unreachable("NYI");
 
-  assert(!MissingFeatures::qualifiedTypes());
+  cir_tl_assert(!MissingFeatures::qualifiedTypes());
   FuncType FTy = fnOp.getFunctionType();
 
-  assert(!MissingFeatures::CUDA());
+  cir_tl_assert(!MissingFeatures::CUDA());
 
   // When declaring a function without a prototype, always use a
   // non-variadic type.
   if (fnOp.getNoProto()) {
-    llvm_unreachable("NYI");
+    cir_assert_or_abort(!::cir::MissingFeatures::ABINoProtoFunctions(), "NYI");
   }
 
   return arrangeFreeFunctionType(FTy);
@@ -300,12 +300,12 @@ const LowerFunctionInfo &
 LowerTypes::arrangeLLVMFunctionInfo(Type resultType, FnInfoOpts opts,
                                     ArrayRef<Type> argTypes,
                                     RequiredArgs required) {
-  assert(!::cir::MissingFeatures::qualifiedTypes());
+  cir_tl_assert(!::cir::MissingFeatures::qualifiedTypes());
 
   LowerFunctionInfo *FI = nullptr;
 
   // FIXME(cir): Allow user-defined CCs (e.g. __attribute__((vectorcall))).
-  assert(!::cir::MissingFeatures::extParamInfo());
+  cir_tl_assert(!::cir::MissingFeatures::extParamInfo());
   unsigned CC = clangCallConvToLLVMCallConv(clang::CallingConv::CC_C);
 
   // Construct the function info. We co-allocate the ArgInfos.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -63,7 +63,10 @@ Value enterStructPointerForCoercedAccess(Value SrcPtr, StructType SrcSTy,
       FirstEltSize < CGF.LM.getDataLayout().getTypeStoreSize(SrcSTy))
     return SrcPtr;
 
-  llvm_unreachable("NYI");
+  cir_assert_or_abort(!::cir::MissingFeatures::ABIEnterStructForCoercedAccess(),
+                      "NYI");
+  return SrcPtr; // FIXME: This is a temporary workaround for the assertion
+                 // above.
 }
 
 /// Create a store to \param Dst from \param Src where the source and
@@ -80,13 +83,13 @@ void createCoercedStore(Value Src, Value Dst, bool DstIsVolatile,
   }
 
   // FIXME(cir): We need a better way to handle datalayout queries.
-  assert(isa<IntType>(SrcTy));
+  cir_tl_assert(isa<IntType>(SrcTy));
   llvm::TypeSize SrcSize = CGF.LM.getDataLayout().getTypeAllocSize(SrcTy);
 
   if (StructType DstSTy = dyn_cast<StructType>(DstTy)) {
     Dst = enterStructPointerForCoercedAccess(Dst, DstSTy,
                                              SrcSize.getFixedValue(), CGF);
-    assert(isa<PointerType>(Dst.getType()));
+    cir_tl_assert(isa<PointerType>(Dst.getType()));
     DstTy = cast<PointerType>(Dst.getType()).getPointee();
   }
 
@@ -107,7 +110,7 @@ void createCoercedStore(Value Src, Value Dst, bool DstIsVolatile,
   llvm::TypeSize DstSize = CGF.LM.getDataLayout().getTypeAllocSize(DstTy);
 
   // If store is legal, just bitcast the src pointer.
-  assert(!::cir::MissingFeatures::vectorType());
+  cir_tl_assert(!::cir::MissingFeatures::vectorType());
   if (SrcSize.getFixedValue() <= DstSize.getFixedValue()) {
     // Dst = Dst.withElementType(SrcTy);
     CGF.buildAggregateStore(Src, Dst, DstIsVolatile);
@@ -257,14 +260,14 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
   // are dealt with in CIRGen.
 
   CIRToCIRArgMapping IRFunctionArgs(LM.getContext(), FI);
-  assert(Fn.getNumArguments() == IRFunctionArgs.totalIRArgs());
+  cir_tl_assert(Fn.getNumArguments() == IRFunctionArgs.totalIRArgs());
 
   // If we're using inalloca, all the memory arguments are GEPs off of the last
   // parameter, which is a pointer to the complete memory area.
-  assert(!::cir::MissingFeatures::inallocaArgs());
+  cir_tl_assert(!::cir::MissingFeatures::inallocaArgs());
 
   // Name the struct return parameter.
-  assert(!::cir::MissingFeatures::sretArgs());
+  cir_tl_assert(!::cir::MissingFeatures::sretArgs());
 
   // Track if we received the parameter as a pointer (indirect, byval, or
   // inalloca). If already have a pointer, EmitParmDecl doesn't need to copy it
@@ -272,11 +275,18 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
   SmallVector<Value, 8> ArgVals;
   ArgVals.reserve(Args.size());
 
+  // FIXME(cir): non-blocking workaround for argument types that are not yet
+  // properly handled by the ABI.
+  if (cirMissingFeatureAssertionMode && FI.arg_size() != Args.size()) {
+    cir_tl_assert(::cir::MissingFeatures::ABIParameterCoercion());
+    return success();
+  }
+
   // Create a pointer value for every parameter declaration. This usually
   // entails copying one or more LLVM IR arguments into an alloca. Don't push
   // any cleanups or do anything that might unwind. We do that separately, so
   // we can push the cleanups in the correct order for the ABI.
-  assert(FI.arg_size() == Args.size());
+  cir_tl_assert(FI.arg_size() == Args.size());
   unsigned ArgNo = 0;
   LowerFunctionInfo::const_arg_iterator info_it = FI.arg_begin();
   for (MutableArrayRef<BlockArgument>::const_iterator i = Args.begin(),
@@ -294,7 +304,7 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
       llvm_unreachable("NYI");
     else
       Ty = Arg.getType();
-    assert(!::cir::MissingFeatures::evaluationKind());
+    cir_tl_assert(!::cir::MissingFeatures::evaluationKind());
 
     unsigned FirstIRArg, NumIRArgs;
     std::tie(FirstIRArg, NumIRArgs) = IRFunctionArgs.getIRArgs(ArgNo);
@@ -310,14 +320,15 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
       // http://llvm.org/docs/LangRef.html#paramattrs.
       if (ArgI.getDirectOffset() == 0 && isa<PointerType>(LTy) &&
           isa<PointerType>(ArgI.getCoerceToType())) {
-        llvm_unreachable("NYI");
+        cir_assert_or_abort(!::cir::MissingFeatures::ABIPointerParameterAttrs(),
+                            "NYI");
       }
 
       // Prepare the argument value. If we have the trivial case, handle it
       // with no muss and fuss.
       if (!isa<StructType>(ArgI.getCoerceToType()) &&
           ArgI.getCoerceToType() == Ty && ArgI.getDirectOffset() == 0) {
-        assert(NumIRArgs == 1);
+        cir_tl_assert(NumIRArgs == 1);
 
         // LLVM expects swifterror parameters to be used in very restricted
         // ways. Copy the value into a less-restricted temporary.
@@ -344,7 +355,7 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
         break;
       }
 
-      assert(!::cir::MissingFeatures::vectorType());
+      cir_tl_assert(!::cir::MissingFeatures::vectorType());
 
       // Allocate original argument to be "uncoerced".
       // FIXME(cir): We should have a alloca op builder that does not required
@@ -366,7 +377,7 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
         llvm_unreachable("NYI");
       } else {
         // Simple case, just do a coerced store of the argument into the alloca.
-        assert(NumIRArgs == 1);
+        cir_tl_assert(NumIRArgs == 1);
         Value AI = Fn.getArgument(FirstIRArg);
         // TODO(cir): Set argument name in the new function.
         createCoercedStore(AI, Ptr, /*DstIsVolatile=*/false, *this);
@@ -385,7 +396,7 @@ LowerFunction::buildFunctionProlog(const LowerFunctionInfo &FI, FuncOp Fn,
       // RAUW the original argument alloca with the new one. This assumes that
       // the argument is used only to be stored in a alloca.
       Value arg = SrcFn.getArgument(ArgNo);
-      assert(arg.hasOneUse());
+      cir_tl_assert(arg.hasOneUse());
       auto *firstStore = *arg.user_begin();
       auto argAlloca = cast<StoreOp>(firstStore).getAddr();
       rewriter.replaceAllUsesWith(argAlloca, Alloca);
@@ -471,28 +482,33 @@ LogicalResult LowerFunction::buildFunctionEpilog(const LowerFunctionInfo &FI) {
 /// focuses on the ABI-specific details. So a lot of codegen stuff is removed.
 LogicalResult LowerFunction::generateCode(FuncOp oldFn, FuncOp newFn,
                                           const LowerFunctionInfo &FnInfo) {
-  assert(newFn && "generating code for null Function");
+  cir_tl_assert(newFn && "generating code for null Function");
   auto Args = oldFn.getArguments();
 
   // Emit the ABI-specific function prologue.
-  assert(newFn.empty() && "Function already has a body");
+  cir_tl_assert(newFn.empty() && "Function already has a body");
   rewriter.setInsertionPointToEnd(newFn.addEntryBlock());
   if (buildFunctionProlog(FnInfo, newFn, oldFn.getArguments()).failed())
     return failure();
 
   // Ensure that old ABI-agnostic arguments uses were replaced.
   const auto hasNoUses = [](Value val) { return val.getUses().empty(); };
-  assert(std::all_of(Args.begin(), Args.end(), hasNoUses) && "Missing RAUW?");
+  cir_tl_assert(std::all_of(Args.begin(), Args.end(), hasNoUses) && "Missing RAUW?");
+
+  // NOTE(cir): While the new function has the ABI-aware parameters, the old
+  // function still has the function logic. To complete the migration, we have
+  // to move the old function body to the new function.
+
+  // Backup references  to entry blocks.
+  Block *srcBlock = &oldFn.getBody().front();
+  Block *dstBlock = &newFn.getBody().front();
 
   // Migrate function body to new ABI-aware function.
-  assert(oldFn.getBody().hasOneBlock() &&
-         "Multiple blocks in original function not supported");
+  rewriter.inlineRegionBefore(oldFn.getBody(), newFn.getBody(),
+                              newFn.getBody().end());
 
-  // Move old function body to new function.
-  // FIXME(cir): The merge below is not very good: will not work if SrcFn has
-  // multiple blocks and it mixes the new and old prologues.
-  rewriter.mergeBlocks(&oldFn.getBody().front(), &newFn.getBody().front(),
-                       newFn.getArguments());
+  // Merge entry blocks to ensure correct branching.
+  rewriter.mergeBlocks(srcBlock, dstBlock, newFn.getArguments());
 
   // FIXME(cir): What about saving parameters for corotines? Should we do
   // something about it in this pass? If the change with the calling
@@ -511,14 +527,14 @@ void LowerFunction::buildAggregateStore(Value Val, Value Dest,
   // Function to store a first-class aggregate into memory. We prefer to
   // store the elements rather than the aggregate to be more friendly to
   // fast-isel.
-  assert(mlir::isa<PointerType>(Dest.getType()) && "Storing in a non-pointer!");
+  cir_tl_assert(mlir::isa<PointerType>(Dest.getType()) && "Storing in a non-pointer!");
   (void)DestIsVolatile;
 
   // Circumvent CIR's type checking.
   Type pointeeTy = mlir::cast<PointerType>(Dest.getType()).getPointee();
   if (Val.getType() != pointeeTy) {
     // NOTE(cir):  We only bitcast and store if the types have the same size.
-    assert((LM.getDataLayout().getTypeSizeInBits(Val.getType()) ==
+    cir_tl_assert((LM.getDataLayout().getTypeSizeInBits(Val.getType()) ==
             LM.getDataLayout().getTypeSizeInBits(pointeeTy)) &&
            "Incompatible types");
     auto loc = Val.getLoc();
@@ -552,7 +568,7 @@ LogicalResult LowerFunction::rewriteCallOp(CallOp op,
   // NOTE(cir): There is no direct way to fetch the function type from the
   // CallOp, so we fetch it from the source function. This assumes the
   // function definition has not yet been lowered.
-  assert(SrcFn && "No source function");
+  cir_tl_assert(SrcFn && "No source function");
   auto fnType = SrcFn.getFunctionType();
 
   // Rewrite the call operation to abide to the ABI calling convention.
@@ -610,10 +626,10 @@ Value LowerFunction::rewriteCallOp(FuncType calleeTy, FuncOp origCallee,
   // Chain calls use this same code path to add the invisible chain parameter
   // to the function type.
   if (origCallee.getNoProto() || Chain) {
-    llvm_unreachable("NYI");
+    cir_assert_or_abort(::cir::MissingFeatures::ABINoProtoFunctions(), "NYI");
   }
 
-  assert(!::cir::MissingFeatures::CUDA());
+  cir_tl_assert(!::cir::MissingFeatures::CUDA());
 
   // TODO(cir): LLVM IR has the concept of "CallBase", which is a base class
   // for all types of calls. Perhaps we should have a CIR interface to mimic
@@ -665,12 +681,12 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
     llvm_unreachable("NYI");
   }
 
-  assert(!::cir::MissingFeatures::swift());
+  cir_tl_assert(!::cir::MissingFeatures::swift());
 
   // NOTE(cir): Skipping lifetime markers here.
 
   // Translate all of the arguments as necessary to match the IR lowering.
-  assert(CallInfo.arg_size() == CallArgs.size() &&
+  cir_tl_assert(CallInfo.arg_size() == CallArgs.size() &&
          "Mismatch between function signature & arguments.");
   unsigned ArgNo = 0;
   LowerFunctionInfo::const_arg_iterator info_it = CallInfo.arg_begin();
@@ -696,7 +712,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
       if (!isa<StructType>(ArgInfo.getCoerceToType()) &&
           ArgInfo.getCoerceToType() == info_it->type &&
           ArgInfo.getDirectOffset() == 0) {
-        assert(NumIRArgs == 1);
+        cir_tl_assert(NumIRArgs == 1);
         Value V;
         if (!isa<StructType>(I->getType())) {
           V = *I;
@@ -742,11 +758,11 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
         llvm_unreachable("NYI");
       } else {
         // In the simple case, just pass the coerced loaded value.
-        assert(NumIRArgs == 1);
+        cir_tl_assert(NumIRArgs == 1);
         Value Load = createCoercedValue(Src, ArgInfo.getCoerceToType(), *this);
 
         // FIXME(cir): We should probably handle CMSE non-secure calls here
-        assert(!::cir::MissingFeatures::cmseNonSecureCallAttr());
+        cir_tl_assert(!::cir::MissingFeatures::cmseNonSecureCallAttr());
 
         // since they are a ARM-specific feature.
         if (::cir::MissingFeatures::undef())
@@ -771,7 +787,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
   // debugging stuff here.
 
   // Update the largest vector width if any arguments have vector types.
-  assert(!::cir::MissingFeatures::vectorType());
+  cir_tl_assert(!::cir::MissingFeatures::vectorType());
 
   // Compute the calling convention and attributes.
 
@@ -797,7 +813,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
       rewriter.getAttr<ExtraFuncAttributesAttr>(rewriter.getDictionaryAttr({}));
   newCallOp->setAttr("extra_attrs", extraAttrs);
 
-  assert(!::cir::MissingFeatures::vectorType());
+  cir_tl_assert(!::cir::MissingFeatures::vectorType());
 
   // NOTE(cir): Skipping some ObjC, tail-call, debug, and attribute stuff
   // here.
@@ -847,7 +863,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
       // FIXME(cir): Use return value slot here.
       Value RetVal = callOp.getResult();
       // TODO(cir): Check for volatile return values.
-      assert(!::cir::MissingFeatures::volatileTypes());
+      cir_tl_assert(!::cir::MissingFeatures::volatileTypes());
 
       // NOTE(cir): If the function returns, there should always be a valid
       // return value present. Instead of setting the return value here, we
@@ -855,7 +871,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
       if (!RetVal) {
         RetVal = callOp.getResult();
         // TODO(cir): Check for volatile return values.
-        assert(::cir::MissingFeatures::volatileTypes());
+        cir_tl_assert(::cir::MissingFeatures::volatileTypes());
       }
 
       // An empty record can overlap other data (if declared with
@@ -897,7 +913,8 @@ Value LowerFunction::getUndefRValue(Type Ty) {
   // FIXME(cir): Implement type classes for CIR types.
   if (isa<StructType>(type))
     return ::cir::TypeEvaluationKind::TEK_Aggregate;
-  if (isa<BoolType, IntType, SingleType, DoubleType>(type))
+  if (isa<BoolType, IntType, SingleType, DoubleType, LongDoubleType, VectorType,
+          PointerType>(type))
     return ::cir::TypeEvaluationKind::TEK_Scalar;
   llvm_unreachable("NYI");
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -493,7 +493,8 @@ LogicalResult LowerFunction::generateCode(FuncOp oldFn, FuncOp newFn,
 
   // Ensure that old ABI-agnostic arguments uses were replaced.
   const auto hasNoUses = [](Value val) { return val.getUses().empty(); };
-  cir_tl_assert(std::all_of(Args.begin(), Args.end(), hasNoUses) && "Missing RAUW?");
+  cir_tl_assert(std::all_of(Args.begin(), Args.end(), hasNoUses) &&
+                "Missing RAUW?");
 
   // NOTE(cir): While the new function has the ABI-aware parameters, the old
   // function still has the function logic. To complete the migration, we have
@@ -527,7 +528,8 @@ void LowerFunction::buildAggregateStore(Value Val, Value Dest,
   // Function to store a first-class aggregate into memory. We prefer to
   // store the elements rather than the aggregate to be more friendly to
   // fast-isel.
-  cir_tl_assert(mlir::isa<PointerType>(Dest.getType()) && "Storing in a non-pointer!");
+  cir_tl_assert(mlir::isa<PointerType>(Dest.getType()) &&
+                "Storing in a non-pointer!");
   (void)DestIsVolatile;
 
   // Circumvent CIR's type checking.
@@ -535,8 +537,8 @@ void LowerFunction::buildAggregateStore(Value Val, Value Dest,
   if (Val.getType() != pointeeTy) {
     // NOTE(cir):  We only bitcast and store if the types have the same size.
     cir_tl_assert((LM.getDataLayout().getTypeSizeInBits(Val.getType()) ==
-            LM.getDataLayout().getTypeSizeInBits(pointeeTy)) &&
-           "Incompatible types");
+                   LM.getDataLayout().getTypeSizeInBits(pointeeTy)) &&
+                  "Incompatible types");
     auto loc = Val.getLoc();
     Val = rewriter.create<CastOp>(loc, pointeeTy, CastKind::bitcast, Val);
   }
@@ -687,7 +689,7 @@ Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
 
   // Translate all of the arguments as necessary to match the IR lowering.
   cir_tl_assert(CallInfo.arg_size() == CallArgs.size() &&
-         "Mismatch between function signature & arguments.");
+                "Mismatch between function signature & arguments.");
   unsigned ArgNo = 0;
   LowerFunctionInfo::const_arg_iterator info_it = CallInfo.arg_begin();
   for (auto I = CallArgs.begin(), E = CallArgs.end(); I != E;

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunctionInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunctionInfo.h
@@ -35,7 +35,7 @@ public:
   enum All_t { All };
 
   RequiredArgs(All_t _) : NumRequired(~0U) {}
-  explicit RequiredArgs(unsigned n) : NumRequired(n) { assert(n != ~0U); }
+  explicit RequiredArgs(unsigned n) : NumRequired(n) { cir_tl_assert(n != ~0U); }
 
   /// Compute the arguments required by the given formal prototype,
   /// given that there may be some additional, non-formal arguments
@@ -47,7 +47,8 @@ public:
     if (!prototype.isVarArg())
       return All;
 
-    llvm_unreachable("Variadic function is NYI");
+    cir_assert_or_abort(!::cir::MissingFeatures::variadicFunctions(), "NYI");
+    return All; // FIXME(cir): Temporary workaround for the assertion above.
   }
 
   bool allowsOptionalArgs() const { return NumRequired != ~0U; }
@@ -105,7 +106,7 @@ public:
                                    ArrayRef<mlir::Type> argTypes,
                                    RequiredArgs required) {
     // TODO(cir): Add assertions?
-    assert(!::cir::MissingFeatures::extParamInfo());
+    cir_tl_assert(!::cir::MissingFeatures::extParamInfo());
     void *buffer = operator new(totalSizeToAlloc<ArgInfo>(argTypes.size() + 1));
 
     LowerFunctionInfo *FI = new (buffer) LowerFunctionInfo();
@@ -146,7 +147,7 @@ public:
   unsigned arg_size() const { return NumArgs; }
 
   bool isVariadic() const {
-    assert(!::cir::MissingFeatures::variadicFunctions());
+    cir_tl_assert(!::cir::MissingFeatures::variadicFunctions());
     return false;
   }
   unsigned getNumRequiredArgs() const {

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunctionInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunctionInfo.h
@@ -35,7 +35,9 @@ public:
   enum All_t { All };
 
   RequiredArgs(All_t _) : NumRequired(~0U) {}
-  explicit RequiredArgs(unsigned n) : NumRequired(n) { cir_tl_assert(n != ~0U); }
+  explicit RequiredArgs(unsigned n) : NumRequired(n) {
+    cir_tl_assert(n != ~0U);
+  }
 
   /// Compute the arguments required by the given formal prototype,
   /// given that there may be some additional, non-formal arguments

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -199,10 +199,13 @@ LogicalResult LowerModule::rewriteFunctionDefinition(FuncOp op) {
     llvm_unreachable("ExtraAttrs are NYI");
   }
 
-  if (LowerFunction(*this, rewriter, op, newFn)
-          .generateCode(op, newFn, FI)
-          .failed())
-    return failure();
+  // Is a function definition: handle the body.
+  if (!op.isDeclaration()) {
+    if (LowerFunction(*this, rewriter, op, newFn)
+            .generateCode(op, newFn, FI)
+            .failed())
+      return failure();
+  }
 
   // Erase original ABI-agnostic function.
   rewriter.eraseOp(op);
@@ -239,7 +242,7 @@ std::unique_ptr<LowerModule> createLowerModule(ModuleOp module,
   // FIXME(cir): This just uses the default language options. We need to account
   // for custom options.
   // Create context.
-  assert(!::cir::MissingFeatures::langOpts());
+  cir_tl_assert(!::cir::MissingFeatures::langOpts());
   clang::LangOptions langOpts;
 
   return std::make_unique<LowerModule>(langOpts, module, dataLayoutStr,

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -228,6 +228,9 @@ LogicalResult LowerModule::rewriteFunctionCall(CallOp callOp, FuncOp funcOp) {
 // TODO: not to create it every time
 std::unique_ptr<LowerModule> createLowerModule(ModuleOp module,
                                                PatternRewriter &rewriter) {
+  assert(module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName()) &&
+         "Missing data layout attribute");
+
   // Fetch the LLVM data layout string.
   auto dataLayoutStr = cast<StringAttr>(
       module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName()));

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -68,7 +68,7 @@ public:
   // FIXME(cir): This would be in ASTContext, not CodeGenModule.
   clang::TargetCXXABI::Kind getCXXABIKind() const {
     auto kind = getTarget().getCXXABI().getKind();
-    assert(!::cir::MissingFeatures::langOpts());
+    cir_tl_assert(!::cir::MissingFeatures::langOpts());
     return kind;
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
@@ -60,10 +60,10 @@ FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {
   SmallVector<Type, 8> ArgTypes(IRFunctionArgs.totalIRArgs());
 
   // Add type for sret argument.
-  assert(!::cir::MissingFeatures::sretArgs());
+  cir_tl_assert(!::cir::MissingFeatures::sretArgs());
 
   // Add type for inalloca argument.
-  assert(!::cir::MissingFeatures::inallocaArgs());
+  cir_tl_assert(!::cir::MissingFeatures::inallocaArgs());
 
   // Add in all of the required arguments.
   unsigned ArgNo = 0;
@@ -72,7 +72,7 @@ FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {
   for (; it != ie; ++it, ++ArgNo) {
     const ABIArgInfo &ArgInfo = it->info;
 
-    assert(!::cir::MissingFeatures::argumentPadding());
+    cir_tl_assert(!::cir::MissingFeatures::argumentPadding());
 
     unsigned FirstIRArg, NumIRArgs;
     std::tie(FirstIRArg, NumIRArgs) = IRFunctionArgs.getIRArgs(ArgNo);
@@ -85,11 +85,11 @@ FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {
       Type argType = ArgInfo.getCoerceToType();
       StructType st = dyn_cast<StructType>(argType);
       if (st && ArgInfo.isDirect() && ArgInfo.getCanBeFlattened()) {
-        assert(NumIRArgs == st.getNumElements());
+        cir_tl_assert(NumIRArgs == st.getNumElements());
         for (unsigned i = 0, e = st.getNumElements(); i != e; ++i)
           ArgTypes[FirstIRArg + i] = st.getMembers()[i];
       } else {
-        assert(NumIRArgs == 1);
+        cir_tl_assert(NumIRArgs == 1);
         ArgTypes[FirstIRArg] = argType;
       }
       break;
@@ -117,5 +117,7 @@ mlir::Type LowerTypes::convertType(Type T) {
   }
 
   llvm::outs() << "Missing default ABI-specific type for " << T << "\n";
-  llvm_unreachable("NYI");
+  cir_assert_or_abort(!::cir::MissingFeatures::X86DefaultABITypeConvertion(),
+                      "NYI");
+  return T;
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/RecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/RecordLayoutBuilder.cpp
@@ -236,14 +236,15 @@ void ItaniumRecordLayoutBuilder::layout(const StructType RT) {
 
   // Lay out the vtable and the non-virtual bases.
   cir_tl_assert(!::cir::MissingFeatures::isCXXRecordDecl() &&
-         !::cir::MissingFeatures::CXXRecordIsDynamicClass());
+                !::cir::MissingFeatures::CXXRecordIsDynamicClass());
 
   layoutFields(RT);
 
   // FIXME(cir): Handle virtual-related layouts.
   cir_tl_assert(!::cir::MissingFeatures::getCXXRecordBases());
 
-  cir_tl_assert(!::cir::MissingFeatures::itaniumRecordLayoutBuilderFinishLayout());
+  cir_tl_assert(
+      !::cir::MissingFeatures::itaniumRecordLayoutBuilderFinishLayout());
 }
 
 void ItaniumRecordLayoutBuilder::initializeLayout(const mlir::Type Ty) {
@@ -291,7 +292,7 @@ void ItaniumRecordLayoutBuilder::layoutField(const Type D,
                                              bool InsertExtraPadding) {
   // auto FieldClass = D.dyn_cast<StructType>();
   cir_tl_assert(!::cir::MissingFeatures::fieldDeclIsPotentiallyOverlapping() &&
-         !::cir::MissingFeatures::CXXRecordDeclIsEmptyCXX11());
+                !::cir::MissingFeatures::CXXRecordDeclIsEmptyCXX11());
   bool IsOverlappingEmptyField = false; // FIXME(cir): Needs more features.
 
   clang::CharUnits FieldOffset = (IsUnion || IsOverlappingEmptyField)
@@ -346,7 +347,7 @@ void ItaniumRecordLayoutBuilder::layoutField(const Type D,
   }
 
   cir_tl_assert(!::cir::MissingFeatures::recordDeclIsPacked() &&
-         !::cir::MissingFeatures::CXXRecordDeclIsPOD());
+                !::cir::MissingFeatures::CXXRecordDeclIsPOD());
   bool FieldPacked = false; // FIXME(cir): Needs more features.
 
   // When used as part of a typedef, or together with a 'packed' attribute, the
@@ -467,7 +468,7 @@ void ItaniumRecordLayoutBuilder::layoutFields(const StructType D) {
   // Layout each field, for now, just sequentially, respecting alignment.  In
   // the future, this will need to be tweakable by targets.
   cir_tl_assert(!::cir::MissingFeatures::recordDeclMayInsertExtraPadding() &&
-         !Context.getLangOpts().SanitizeAddressFieldPadding);
+                !Context.getLangOpts().SanitizeAddressFieldPadding);
   bool InsertExtraPadding = false;
   cir_tl_assert(!::cir::MissingFeatures::recordDeclHasFlexibleArrayMember());
   bool HasFlexibleArrayMember = false;
@@ -487,19 +488,19 @@ void ItaniumRecordLayoutBuilder::UpdateAlignment(
 
   if (NewAlignment > Alignment) {
     cir_tl_assert(llvm::isPowerOf2_64(NewAlignment.getQuantity()) &&
-           "Alignment not a power of 2");
+                  "Alignment not a power of 2");
     Alignment = NewAlignment;
   }
 
   if (UnpackedNewAlignment > UnpackedAlignment) {
     cir_tl_assert(llvm::isPowerOf2_64(UnpackedNewAlignment.getQuantity()) &&
-           "Alignment not a power of 2");
+                  "Alignment not a power of 2");
     UnpackedAlignment = UnpackedNewAlignment;
   }
 
   if (PreferredNewAlignment > PreferredAlignment) {
     cir_tl_assert(llvm::isPowerOf2_64(PreferredNewAlignment.getQuantity()) &&
-           "Alignment not a power of 2");
+                  "Alignment not a power of 2");
     PreferredAlignment = PreferredNewAlignment;
   }
 }
@@ -592,7 +593,8 @@ const CIRRecordLayout &CIRLowerContext::getCIRRecordLayout(const Type D) const {
   cir_tl_assert(isa<StructType>(D) && "Not a record type");
   auto RT = dyn_cast<StructType>(D);
 
-  cir_tl_assert(RT.isComplete() && "Cannot get layout of forward declarations!");
+  cir_tl_assert(RT.isComplete() &&
+                "Cannot get layout of forward declarations!");
 
   // FIXME(cir): Use a more MLIR-based approach by using it's buitin data layout
   // features, such as interfaces, cacheing, and the DLTI dialect.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -60,7 +60,7 @@ class AArch64TargetLoweringInfo : public TargetLoweringInfo {
 public:
   AArch64TargetLoweringInfo(LowerTypes &LT, AArch64ABIKind Kind)
       : TargetLoweringInfo(std::make_unique<AArch64ABIInfo>(LT, Kind)) {
-    assert(!MissingFeature::swift());
+    cir_tl_assert(!MissingFeature::swift());
   }
 
   unsigned getTargetAddrSpaceFromCIRAddrSpace(
@@ -87,7 +87,7 @@ ABIArgInfo AArch64ABIInfo::classifyReturnType(Type RetTy,
     return ABIArgInfo::getIgnore();
 
   if (const auto _ = dyn_cast<VectorType>(RetTy)) {
-    llvm_unreachable("NYI");
+    cir_assert_or_abort(!::cir::MissingFeatures::vectorType(), "NYI");
   }
 
   // Large vector types should be returned via memory.
@@ -128,7 +128,9 @@ AArch64ABIInfo::classifyArgumentType(Type Ty, bool IsVariadic,
                 : ABIArgInfo::getDirect());
   }
 
-  llvm_unreachable("NYI");
+  cir_assert_or_abort(!::cir::MissingFeatures::AArch64TypeClassification(),
+                      "NYI");
+  return {};
 }
 
 std::unique_ptr<TargetLoweringInfo>

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
@@ -70,13 +70,13 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // Homogenous Aggregate type not supported and indirect arg
   // passing not supported yet. And for these supported types,
   // we should not have alignment greater than 8 problem.
-  assert(isSupportedType);
-  assert(!cir::MissingFeatures::classifyArgumentTypeForAArch64());
+  cir_tl_assert(isSupportedType);
+  cir_tl_assert(!cir::MissingFeatures::classifyArgumentTypeForAArch64());
   // indirect arg passing would expect one more level of pointer dereference.
-  assert(!cir::MissingFeatures::handleAArch64Indirect());
+  cir_tl_assert(!cir::MissingFeatures::handleAArch64Indirect());
   // false as a place holder for now, as we don't have a way to query
   bool isIndirect = false;
-  assert(!cir::MissingFeatures::supportgetCoerceToTypeForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::supportgetCoerceToTypeForAArch64());
   // we don't convert to LLVM Type here as we are lowering to CIR here.
   // so baseTy is the just type of the result of va_arg.
   // but it depends on arg type indirectness and coercion defined by ABI.
@@ -120,8 +120,8 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // though anyone passing 2GB of arguments, each at most 16 bytes, deserves
   // whatever they get).
 
-  assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
-  assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
   // One is just place holder for now, as we don't have a way to query
   // type size and alignment.
   clang::CharUnits tySize =
@@ -132,7 +132,7 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // indirectness, type size and type alignment all
   // decide regSize, but they are all ABI defined
   // thus need ABI lowering query system.
-  assert(!cir::MissingFeatures::handleAArch64Indirect());
+  cir_tl_assert(!cir::MissingFeatures::handleAArch64Indirect());
   int regSize = isIndirect ? 8 : tySize.getQuantity();
   int regTopIndex;
   mlir::Value regOffsP;
@@ -187,8 +187,8 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // "struct { __int128 a; };" gets passed in x_2N, x_{2N+1}). In this case we
   // align __gr_offs to calculate the potential address.
   if (!IsFPR && !isIndirect && tyAlign.getQuantity() > 8) {
-    assert(!cir::MissingFeatures::handleAArch64Indirect());
-    assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+    cir_tl_assert(!cir::MissingFeatures::handleAArch64Indirect());
+    cir_tl_assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
     llvm_unreachable("register alignment correction NYI");
   }
 
@@ -224,19 +224,19 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
       loc, castRegTop.getType(), castRegTop, regOffs);
 
   if (isIndirect) {
-    assert(!cir::MissingFeatures::handleAArch64Indirect());
+    cir_tl_assert(!cir::MissingFeatures::handleAArch64Indirect());
     llvm_unreachable("indirect arg passing NYI");
   }
 
   // TODO: isHFA, numMembers and base should be query result from query
   uint64_t numMembers = 0;
-  assert(!cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
   bool isHFA = false;
   // though endianess can be known from datalayout, it might need an unified
   // ABI lowering query system to answer the question.
-  assert(!cir::MissingFeatures::supportisEndianQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::supportisEndianQueryForAArch64());
   bool isBigEndian = datalayout.isBigEndian();
-  assert(!cir::MissingFeatures::supportisAggregateTypeForABIAArch64());
+  cir_tl_assert(!cir::MissingFeatures::supportisAggregateTypeForABIAArch64());
   // TODO: isAggregateTypeForABI should be query result from ABI info
   bool isAggregateTypeForABI = false;
   if (isHFA && numMembers > 1) {
@@ -244,10 +244,10 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
     // and stored 16-bytes apart regardless of size (they're notionally in qN,
     // qN+1, ...). We reload and store into a temporary local variable
     // contiguously.
-    assert(!isIndirect && "Homogeneous aggregates should be passed directly");
+    cir_tl_assert(!isIndirect && "Homogeneous aggregates should be passed directly");
     llvm_unreachable("Homogeneous aggregates NYI");
   } else {
-    assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+    cir_tl_assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
     // TODO: slotSize should be query result about alignment.
     clang::CharUnits slotSize = clang::CharUnits::fromQuantity(8);
     if (isBigEndian && !isIndirect && (isHFA || isAggregateTypeForABI) &&
@@ -266,11 +266,11 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
 
   // On big-endian platforms, the value will be right-aligned in its stack slot.
   // and we also need to think about other ABI lowering concerns listed below.
-  assert(!cir::MissingFeatures::handleBigEndian());
-  assert(!cir::MissingFeatures::handleAArch64Indirect());
-  assert(!cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
-  assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
-  assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::handleBigEndian());
+  cir_tl_assert(!cir::MissingFeatures::handleAArch64Indirect());
+  cir_tl_assert(!cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
 
   builder.create<mlir::cir::BrOp>(loc, mlir::ValueRange{resAsVoidP}, contBlock);
 
@@ -284,8 +284,8 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   auto ptrDiffTy =
       mlir::cir::IntType::get(builder.getContext(), 64, /*signed=*/false);
 
-  assert(!cir::MissingFeatures::handleAArch64Indirect());
-  assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::handleAArch64Indirect());
+  cir_tl_assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
   // Again, stack arguments may need realignment. In this case both integer and
   // floating-point ones might be affected.
   if (!isIndirect && tyAlign.getQuantity() > 8) {
@@ -307,8 +307,8 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // which are all ABI defined thus need ABI lowering query system.
   // The implementation we have now supports most common cases which assumes
   // no indirectness, no alignment greater than 8, and little endian.
-  assert(!cir::MissingFeatures::handleBigEndian());
-  assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
+  cir_tl_assert(!cir::MissingFeatures::handleBigEndian());
+  cir_tl_assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
 
   auto stackSizeC = builder.create<mlir::cir::ConstantOp>(
       loc, ptrDiffTy,
@@ -340,12 +340,12 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   builder.setInsertionPoint(op);
   contBlock->addArgument(onStackPtr.getType(), loc);
   auto resP = contBlock->getArgument(0);
-  assert(mlir::isa<mlir::cir::PointerType>(resP.getType()));
+  cir_tl_assert(mlir::isa<mlir::cir::PointerType>(resP.getType()));
   auto opResPTy = mlir::cir::PointerType::get(builder.getContext(), opResTy);
   auto castResP = builder.createBitcast(resP, opResPTy);
   auto res = builder.create<mlir::cir::LoadOp>(loc, castResP);
   // there would be another level of ptr dereference if indirect arg passing
-  assert(!cir::MissingFeatures::handleAArch64Indirect());
+  cir_tl_assert(!cir::MissingFeatures::handleAArch64Indirect());
   if (isIndirect) {
     res = builder.create<mlir::cir::LoadOp>(loc, res.getResult());
   }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareAArch64CXXABI.cpp
@@ -230,7 +230,8 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
 
   // TODO: isHFA, numMembers and base should be query result from query
   uint64_t numMembers = 0;
-  cir_tl_assert(!cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
+  cir_tl_assert(
+      !cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
   bool isHFA = false;
   // though endianess can be known from datalayout, it might need an unified
   // ABI lowering query system to answer the question.
@@ -244,7 +245,8 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
     // and stored 16-bytes apart regardless of size (they're notionally in qN,
     // qN+1, ...). We reload and store into a temporary local variable
     // contiguously.
-    cir_tl_assert(!isIndirect && "Homogeneous aggregates should be passed directly");
+    cir_tl_assert(!isIndirect &&
+                  "Homogeneous aggregates should be passed directly");
     llvm_unreachable("Homogeneous aggregates NYI");
   } else {
     cir_tl_assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
@@ -268,7 +270,8 @@ mlir::Value LoweringPrepareAArch64CXXABI::lowerAAPCSVAArg(
   // and we also need to think about other ABI lowering concerns listed below.
   cir_tl_assert(!cir::MissingFeatures::handleBigEndian());
   cir_tl_assert(!cir::MissingFeatures::handleAArch64Indirect());
-  cir_tl_assert(!cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
+  cir_tl_assert(
+      !cir::MissingFeatures::supportisHomogeneousAggregateQueryForAArch64());
   cir_tl_assert(!cir::MissingFeatures::supportTySizeQueryForAArch64());
   cir_tl_assert(!cir::MissingFeatures::supportTyAlignQueryForAArch64());
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
@@ -34,7 +34,7 @@ cir::LoweringPrepareCXXABI *cir::LoweringPrepareCXXABI::createItaniumABI() {
 static void buildBadCastCall(CIRBaseBuilderTy &builder, mlir::Location loc,
                              mlir::FlatSymbolRefAttr badCastFuncRef) {
   // TODO(cir): set the calling convention to __cxa_bad_cast.
-  assert(!MissingFeatures::setCallingConv());
+  cir_tl_assert(!MissingFeatures::setCallingConv());
 
   builder.createCallOp(loc, badCastFuncRef, mlir::ValueRange{});
   builder.create<mlir::cir::UnreachableOp>(loc);
@@ -48,7 +48,7 @@ static mlir::Value buildDynamicCastAfterNullCheck(CIRBaseBuilderTy &builder,
   auto castInfo = op.getInfo().value();
 
   // TODO(cir): consider address space
-  assert(!MissingFeatures::addressSpace());
+  cir_tl_assert(!MissingFeatures::addressSpace());
 
   auto srcPtr = builder.createBitcast(srcValue, builder.getVoidPtrTy());
   auto srcRtti = builder.getConstant(loc, castInfo.getSrcRtti());
@@ -59,14 +59,14 @@ static mlir::Value buildDynamicCastAfterNullCheck(CIRBaseBuilderTy &builder,
   mlir::Value dynCastFuncArgs[4] = {srcPtr, srcRtti, destRtti, offsetHint};
 
   // TODO(cir): set the calling convention for __dynamic_cast.
-  assert(!MissingFeatures::setCallingConv());
+  cir_tl_assert(!MissingFeatures::setCallingConv());
   mlir::Value castedPtr =
       builder
           .createCallOp(loc, dynCastFuncRef, builder.getVoidPtrTy(),
                         dynCastFuncArgs)
           .getResult();
 
-  assert(mlir::isa<mlir::cir::PointerType>(castedPtr.getType()) &&
+  cir_tl_assert(mlir::isa<mlir::cir::PointerType>(castedPtr.getType()) &&
          "the return value of __dynamic_cast should be a ptr");
 
   /// C++ [expr.dynamic.cast]p9:
@@ -93,7 +93,7 @@ buildDynamicCastToVoidAfterNullCheck(CIRBaseBuilderTy &builder,
   bool vtableUsesRelativeLayout = op.getRelativeLayout();
 
   // TODO(cir): consider address space in this function.
-  assert(!MissingFeatures::addressSpace());
+  cir_tl_assert(!MissingFeatures::addressSpace());
 
   mlir::Type vtableElemTy;
   uint64_t vtableElemAlign;
@@ -141,7 +141,7 @@ LoweringPrepareItaniumCXXABI::lowerDynamicCast(CIRBaseBuilderTy &builder,
   auto loc = op->getLoc();
   auto srcValue = op.getSrc();
 
-  assert(!MissingFeatures::buildTypeCheck());
+  cir_tl_assert(!MissingFeatures::buildTypeCheck());
 
   if (op.isRefcast())
     return buildDynamicCastAfterNullCheck(builder, op);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
@@ -67,7 +67,7 @@ static mlir::Value buildDynamicCastAfterNullCheck(CIRBaseBuilderTy &builder,
           .getResult();
 
   cir_tl_assert(mlir::isa<mlir::cir::PointerType>(castedPtr.getType()) &&
-         "the return value of __dynamic_cast should be a ptr");
+                "the return value of __dynamic_cast should be a ptr");
 
   /// C++ [expr.dynamic.cast]p9:
   ///   A failed cast to reference type throws std::bad_cast

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/SPIR.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/SPIR.cpp
@@ -33,7 +33,7 @@ public:
 
 private:
   void computeInfo(LowerFunctionInfo &FI) const override {
-    llvm_unreachable("ABI NYI");
+    cir_assert_or_abort(!::cir::MissingFeatures::SPIRVABI(), "NYI");
   }
 };
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -275,7 +275,7 @@ void X86_64ABIInfo::classify(Type Ty, uint64_t OffsetBase, Class &Lo, Class &Hi,
 
       // If this is a C++ record, classify the bases first.
       cir_tl_assert(!::cir::MissingFeatures::isCXXRecordDecl() &&
-             !::cir::MissingFeatures::getCXXRecordBases());
+                    !::cir::MissingFeatures::getCXXRecordBases());
 
       // Classify the fields one at a time, merging the results.
       bool UseClang11Compat = getContext().getLangOpts().getClangABICompat() <=
@@ -463,9 +463,9 @@ Type X86_64ABIInfo::GetINTEGERTypeAtOffset(Type DestTy, unsigned IROffset,
 
   // Check some invariants.
   cir_tl_assert((Hi != Class::Memory || Lo == Class::Memory) &&
-         "Invalid memory classification.");
+                "Invalid memory classification.");
   cir_tl_assert((Hi != Class::SSEUp || Lo == Class::SSE) &&
-         "Invalid SSEUp classification.");
+                "Invalid SSEUp classification.");
 
   Type resType = {};
   switch (Lo) {
@@ -532,9 +532,9 @@ ABIArgInfo X86_64ABIInfo::classifyArgumentType(Type Ty, unsigned freeIntRegs,
   // Check some invariants.
   // FIXME: Enforce these by construction.
   cir_tl_assert((Hi != Class::Memory || Lo == Class::Memory) &&
-         "Invalid memory classification.");
+                "Invalid memory classification.");
   cir_tl_assert((Hi != Class::SSEUp || Lo == Class::SSE) &&
-         "Invalid SSEUp classification.");
+                "Invalid SSEUp classification.");
 
   neededInt = 0;
   neededSSE = 0;
@@ -677,7 +677,7 @@ X86_64ABIInfo::Class X86_64ABIInfo::merge(Class Accum, Class Field) {
   // Accum should never be memory (we should have returned) or
   // ComplexX87 (because this cannot be passed in a structure).
   cir_tl_assert((Accum != Class::Memory && Accum != Class::ComplexX87) &&
-         "Invalid accumulated classification during merge.");
+                "Invalid accumulated classification during merge.");
   if (Accum == Field || Field == Class::NoClass)
     return Accum;
   if (Field == Class::Memory)

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -198,6 +198,9 @@ public:
       if (feOptions.ClangIRLibOpt)
         libOptOpts = sanitizePassOptions(feOptions.ClangIRLibOptOpts);
 
+      bool enableCCLowering = feOptions.ClangIRCallConvLowering &&
+                              action == CIRGenAction::OutputType::EmitCIRFlat;
+
       // Setup and run CIR pipeline.
       std::string passOptParsingFailure;
       if (runCIRToCIRPasses(
@@ -207,8 +210,7 @@ public:
               feOptions.ClangIRLibOpt, libOptOpts, passOptParsingFailure,
               codeGenOptions.OptimizationLevel > 0,
               action == CIRGenAction::OutputType::EmitCIRFlat,
-              action == CIRGenAction::OutputType::EmitMLIR,
-              feOptions.ClangIREnableCallConvLowering,
+              action == CIRGenAction::OutputType::EmitMLIR, enableCCLowering,
               feOptions.ClangIREnableMem2Reg)
               .failed()) {
         if (!passOptParsingFailure.empty())

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -198,7 +198,7 @@ public:
         libOptOpts = sanitizePassOptions(feOptions.ClangIRLibOptOpts);
 
       bool enableCCLowering = feOptions.ClangIRCallConvLowering &&
-                              action == CIRGenAction::OutputType::EmitCIRFlat;
+                              action != CIRGenAction::OutputType::EmitCIR;
 
       // Setup and run CIR pipeline.
       std::string passOptParsingFailure;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4454,7 +4454,7 @@ std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass() {
 }
 
 void populateCIRToLLVMPasses(mlir::OpPassManager &pm) {
-  populateCIRPreLoweringPasses(pm);
+  populateCIRPreLoweringPasses(pm, true);
   pm.addPass(createConvertCIRToLLVMPass());
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4453,8 +4453,8 @@ std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass() {
   return std::make_unique<ConvertCIRToLLVMPass>();
 }
 
-void populateCIRToLLVMPasses(mlir::OpPassManager &pm) {
-  populateCIRPreLoweringPasses(pm, true);
+void populateCIRToLLVMPasses(mlir::OpPassManager &pm, bool useCCLowering) {
+  populateCIRPreLoweringPasses(pm, useCCLowering);
   pm.addPass(createConvertCIRToLLVMPass());
 }
 
@@ -4462,12 +4462,12 @@ extern void registerCIRDialectTranslation(mlir::MLIRContext &context);
 
 std::unique_ptr<llvm::Module>
 lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx,
-                             bool disableVerifier) {
+                             bool disableVerifier, bool disableCCLowering) {
   llvm::TimeTraceScope scope("lower from CIR to LLVM directly");
 
   mlir::MLIRContext *mlirCtx = theModule.getContext();
   mlir::PassManager pm(mlirCtx);
-  populateCIRToLLVMPasses(pm);
+  populateCIRToLLVMPasses(pm, !disableCCLowering);
 
   // This is necessary to have line tables emitted and basic
   // debugger working. In the future we will add proper debug information

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3057,7 +3057,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     Opts.ClangIRVerifyDiags = true;
 
   if (Args.hasArg(OPT_fclangir_call_conv_lowering))
-    Opts.ClangIREnableCallConvLowering = true;
+    Opts.ClangIRCallConvLowering = true;
 
   if (Args.hasArg(OPT_fclangir_analysis_only))
     Opts.ClangIRAnalysisOnly = true;

--- a/clang/test/CIR/CodeGen/AArch64/neon-arith.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-arith.c
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android24  -fclangir \
-// RUN:            -ffreestanding -emit-cir -target-feature +neon %s -o %t.cir
+// RUN:            -ffreestanding -emit-cir -fno-clangir-call-conv-lowering -target-feature +neon %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple aarch64-none-linux-android24  -fclangir \
-// RUN:            -ffreestanding -emit-llvm -target-feature +neon %s -o %t.ll
+// RUN:            -ffreestanding -emit-llvm -fno-clangir-call-conv-lowering -target-feature +neon %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 // REQUIRES: aarch64-registered-target || arm-registered-target

--- a/clang/test/CIR/CodeGen/AArch64/neon-ldst.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-ldst.c
@@ -1,11 +1,11 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android24 -target-feature +neon \
 // RUN:    -fclangir -disable-O0-optnone \
-// RUN:  -flax-vector-conversions=none -emit-cir -o %t.cir %s
+// RUN:  -flax-vector-conversions=none -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
 // RUN: %clang_cc1 -triple aarch64-none-linux-android24 -target-feature +neon \
 // RUN:    -fclangir -disable-O0-optnone \
-// RUN:  -flax-vector-conversions=none -emit-llvm -o - %s \
+// RUN:  -flax-vector-conversions=none -emit-llvm -fno-clangir-call-conv-lowering -o - %s \
 // RUN: | opt -S -passes=mem2reg,simplifycfg -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 

--- a/clang/test/CIR/CodeGen/AArch64/neon-misc.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-misc.c
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android24  -fclangir \
-// RUN:            -emit-cir -target-feature +neon %s -o %t.cir
+// RUN:            -emit-cir -fno-clangir-call-conv-lowering -target-feature +neon %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple aarch64-none-linux-android24  -fclangir \
-// RUN:            -emit-llvm -target-feature +neon %s -o %t.ll
+// RUN:            -emit-llvm -fno-clangir-call-conv-lowering -target-feature +neon %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 // This test file contains tests of AArch64 NEON intrinsics 

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -1,11 +1,11 @@
 // RUN: %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon \
 // RUN:    -fclangir -disable-O0-optnone \
-// RUN:  -flax-vector-conversions=none -emit-cir -o %t.cir %s
+// RUN:  -flax-vector-conversions=none -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 
 // RUN: %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon \
 // RUN:    -fclangir -disable-O0-optnone \
-// RUN:  -flax-vector-conversions=none -emit-llvm -o - %s \
+// RUN:  -flax-vector-conversions=none -emit-llvm -fno-clangir-call-conv-lowering -o - %s \
 // RUN: | opt -S -passes=mem2reg,simplifycfg -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 

--- a/clang/test/CIR/CodeGen/OpenCL/addrspace-alloca.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/addrspace-alloca.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 

--- a/clang/test/CIR/CodeGen/OpenCL/array-decay.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/array-decay.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 // CIR: @func1

--- a/clang/test/CIR/CodeGen/OpenCL/cl-uniform-wg-size.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/cl-uniform-wg-size.cl
@@ -1,19 +1,19 @@
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -O0 -cl-std=CL1.2 -o %t.cl12.cir %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -fno-clangir-call-conv-lowering -O0 -cl-std=CL1.2 -o %t.cl12.cir %s
 // RUN: FileCheck %s -input-file=%t.cl12.cir -check-prefixes CIR,CIR-UNIFORM
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -O0 -cl-std=CL2.0 -o %t.cl20.cir %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -fno-clangir-call-conv-lowering -O0 -cl-std=CL2.0 -o %t.cl20.cir %s
 // RUN: FileCheck %s -input-file=%t.cl20.cir -check-prefixes CIR,CIR-NONUNIFORM
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -O0 -cl-std=CL2.0 -cl-uniform-work-group-size -o %t.cl20.uniform1.cir %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -fno-clangir-call-conv-lowering -O0 -cl-std=CL2.0 -cl-uniform-work-group-size -o %t.cl20.uniform1.cir %s
 // RUN: FileCheck %s -input-file=%t.cl20.uniform1.cir -check-prefixes CIR,CIR-UNIFORM
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -O0 -cl-std=CL2.0 -foffload-uniform-block -o %t.cl20.uniform2.cir %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -fno-clangir-call-conv-lowering -O0 -cl-std=CL2.0 -foffload-uniform-block -o %t.cl20.uniform2.cir %s
 // RUN: FileCheck %s -input-file=%t.cl20.uniform2.cir -check-prefixes CIR,CIR-UNIFORM
 
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -O0 -cl-std=CL1.2 -o %t.cl12.ll %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -fno-clangir-call-conv-lowering -O0 -cl-std=CL1.2 -o %t.cl12.ll %s
 // RUN: FileCheck %s -input-file=%t.cl12.ll -check-prefixes LLVM,LLVM-UNIFORM
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -O0 -cl-std=CL2.0 -o %t.cl20.ll %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -fno-clangir-call-conv-lowering -O0 -cl-std=CL2.0 -o %t.cl20.ll %s
 // RUN: FileCheck %s -input-file=%t.cl20.ll -check-prefixes LLVM,LLVM-NONUNIFORM
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -O0 -cl-std=CL2.0 -cl-uniform-work-group-size -o %t.cl20.uniform1.ll %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -fno-clangir-call-conv-lowering -O0 -cl-std=CL2.0 -cl-uniform-work-group-size -o %t.cl20.uniform1.ll %s
 // RUN: FileCheck %s -input-file=%t.cl20.uniform1.ll -check-prefixes LLVM,LLVM-UNIFORM
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -O0 -cl-std=CL2.0 -foffload-uniform-block -o %t.cl20.uniform2.ll %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -fno-clangir-call-conv-lowering -O0 -cl-std=CL2.0 -foffload-uniform-block -o %t.cl20.uniform2.ll %s
 // RUN: FileCheck %s -input-file=%t.cl20.uniform2.ll -check-prefixes LLVM,LLVM-UNIFORM
 
 // CIR-LABEL: #fn_attr =

--- a/clang/test/CIR/CodeGen/OpenCL/convergent.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/convergent.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fclangir -triple spirv64-unknown-unknown -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -fclangir -triple spirv64-unknown-unknown -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
-// RUN: %clang_cc1 -fclangir -triple spirv64-unknown-unknown -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -fclangir -triple spirv64-unknown-unknown -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
 
 // In ClangIR for OpenCL, all functions should be marked convergent.

--- a/clang/test/CIR/CodeGen/OpenCL/global.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/global.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 global int a = 13;

--- a/clang/test/CIR/CodeGen/OpenCL/kernel-arg-info-single-as.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/kernel-arg-info-single-as.cl
@@ -1,9 +1,9 @@
 // Test that the kernel argument info always refers to SPIR address spaces,
 // even if the target has only one address space like x86_64 does.
-// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-cir -o - -triple x86_64-unknown-linux-gnu -o %t.cir
+// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-cir -fno-clangir-call-conv-lowering -o - -triple x86_64-unknown-linux-gnu -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
 
-// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-llvm -o - -triple x86_64-unknown-linux-gnu -o %t.ll
+// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-llvm -fno-clangir-call-conv-lowering -o - -triple x86_64-unknown-linux-gnu -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
 
 kernel void foo(__global int * G, __constant int *C, __local int *L) {

--- a/clang/test/CIR/CodeGen/OpenCL/kernel-arg-info.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/kernel-arg-info.cl
@@ -1,12 +1,12 @@
 // See also clang/test/CodeGenOpenCL/kernel-arg-info.cl
-// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-cir -o - -triple spirv64-unknown-unknown -o %t.cir
+// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-cir -fno-clangir-call-conv-lowering -o - -triple spirv64-unknown-unknown -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
-// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-cir -o - -triple spirv64-unknown-unknown -cl-kernel-arg-info -o %t.arginfo.cir
+// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-cir -fno-clangir-call-conv-lowering -o - -triple spirv64-unknown-unknown -cl-kernel-arg-info -o %t.arginfo.cir
 // RUN: FileCheck %s --input-file=%t.arginfo.cir --check-prefix=CIR-ARGINFO
 
-// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-llvm -o - -triple spirv64-unknown-unknown -o %t.ll
+// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-llvm -fno-clangir-call-conv-lowering -o - -triple spirv64-unknown-unknown -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
-// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-llvm -o - -triple spirv64-unknown-unknown -cl-kernel-arg-info -o %t.arginfo.ll
+// RUN: %clang_cc1 -fclangir %s -cl-std=CL2.0 -emit-llvm -fno-clangir-call-conv-lowering -o - -triple spirv64-unknown-unknown -cl-kernel-arg-info -o %t.arginfo.ll
 // RUN: FileCheck %s --input-file=%t.arginfo.ll --check-prefix=LLVM-ARGINFO
 
 kernel void foo(global int * globalintp, global int * restrict globalintrestrictp,

--- a/clang/test/CIR/CodeGen/OpenCL/kernel-arg-metadata.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/kernel-arg-metadata.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s -fclangir -triple spirv64-unknown-unknown -emit-cir -o %t.cir
+// RUN: %clang_cc1 %s -fclangir -triple spirv64-unknown-unknown -emit-cir -fno-clangir-call-conv-lowering -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
-// RUN: %clang_cc1 %s -fclangir -triple spirv64-unknown-unknown -emit-llvm -o %t.ll
+// RUN: %clang_cc1 %s -fclangir -triple spirv64-unknown-unknown -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
 
 __kernel void kernel_function() {}

--- a/clang/test/CIR/CodeGen/OpenCL/kernel-attributes.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/kernel-attributes.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
-// RUN: %clang_cc1 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: %clang_cc1 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
 
 typedef unsigned int uint4 __attribute__((ext_vector_type(4)));

--- a/clang/test/CIR/CodeGen/OpenCL/kernel-unit-attr.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/kernel-unit-attr.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
 
 

--- a/clang/test/CIR/CodeGen/OpenCL/nothrow.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/nothrow.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck %s -input-file=%t.cir -check-prefixes CIR
-// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -o %t.ll %s
+// RUN: %clang_cc1 -fclangir -triple=spirv64-unknown-unknown -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll %s
 // RUN: FileCheck %s -input-file=%t.ll -check-prefixes LLVM
 
 // CIR-LABEL: #fn_attr =

--- a/clang/test/CIR/CodeGen/OpenCL/opencl-c-lang.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/opencl-c-lang.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
 
 // CIR: module{{.*}} attributes {{{.*}}cir.lang = #cir.lang<opencl_c>

--- a/clang/test/CIR/CodeGen/OpenCL/opencl-version.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/opencl-version.cl
@@ -1,10 +1,10 @@
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR-CL30
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM-CL30
-// RUN: %clang_cc1 -cl-std=CL1.2 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -cl-std=CL1.2 -O0 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR-CL12
-// RUN: %clang_cc1 -cl-std=CL1.2 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: %clang_cc1 -cl-std=CL1.2 -O0 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM-CL12
 
 // CIR-CL30: module {{.*}} attributes {{{.*}}cir.cl.version = #cir.cl.version<3, 0>

--- a/clang/test/CIR/CodeGen/OpenCL/spir-calling-conv.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/spir-calling-conv.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fclangir %s -O0 -triple "spirv64-unknown-unknown" -emit-cir -o %t.cir
+// RUN: %clang_cc1 -fclangir %s -O0 -triple "spirv64-unknown-unknown" -emit-cir -fno-clangir-call-conv-lowering -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir --check-prefix=CIR
-// RUN: %clang_cc1 -fclangir %s -O0 -triple "spirv64-unknown-unknown" -emit-llvm -o %t.ll
+// RUN: %clang_cc1 -fclangir %s -O0 -triple "spirv64-unknown-unknown" -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
 
 // CIR: cir.func {{.*}}@get_dummy_id{{.*}} cc(spir_function)

--- a/clang/test/CIR/CodeGen/OpenCL/spirv-target.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/spirv-target.cl
@@ -1,7 +1,7 @@
 // See also: clang/test/CodeGenOpenCL/spirv_target.cl
-// RUN: %clang_cc1 -cl-std=CL3.0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t_64.cir
+// RUN: %clang_cc1 -cl-std=CL3.0 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t_64.cir
 // RUN: FileCheck --input-file=%t_64.cir %s --check-prefix=CIR-SPIRV64
-// RUN: %clang_cc1 -cl-std=CL3.0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t_64.ll
+// RUN: %clang_cc1 -cl-std=CL3.0 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t_64.ll
 // RUN: FileCheck --input-file=%t_64.ll %s --check-prefix=LLVM-SPIRV64
 
 

--- a/clang/test/CIR/CodeGen/OpenCL/static-vardecl.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/static-vardecl.cl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -triple spirv64-unknown-unknown %s -o %t.cir
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-cir -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -triple spirv64-unknown-unknown %s -o %t.ll
+// RUN: %clang_cc1 -cl-std=CL3.0 -O0 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -triple spirv64-unknown-unknown %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 kernel void test_static(int i) {

--- a/clang/test/CIR/CodeGen/abstract-cond.c
+++ b/clang/test/CIR/CodeGen/abstract-cond.c
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 // ?: in "lvalue"

--- a/clang/test/CIR/CodeGen/attributes.c
+++ b/clang/test/CIR/CodeGen/attributes.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o -  | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o - | FileCheck %s -check-prefix=LLVM
 
 extern int __attribute__((section(".shared"))) ext;
 int getExt() {

--- a/clang/test/CIR/CodeGen/builtin-bit-cast.cpp
+++ b/clang/test/CIR/CodeGen/builtin-bit-cast.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
 
 float test_scalar(int &oper) {

--- a/clang/test/CIR/CodeGen/complex-arithmetic.c
+++ b/clang/test/CIR/CodeGen/complex-arithmetic.c
@@ -1,46 +1,46 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=basic -fclangir -clangir-disable-passes -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=basic -fclangir -clangir-disable-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CLANG,CIRGEN,CIRGEN-BASIC,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=basic -fclangir -clangir-disable-passes -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=basic -fclangir -clangir-disable-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CPPLANG,CIRGEN,CIRGEN-BASIC,CHECK %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=improved -fclangir -clangir-disable-passes -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=improved -fclangir -clangir-disable-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CLANG,CIRGEN,CIRGEN-IMPROVED,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=improved -fclangir -clangir-disable-passes -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=improved -fclangir -clangir-disable-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CPPLANG,CIRGEN,CIRGEN-IMPROVED,CHECK %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=full -fclangir -clangir-disable-passes -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=full -fclangir -clangir-disable-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CLANG,CIRGEN,CIRGEN-FULL,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=full -fclangir -clangir-disable-passes -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=full -fclangir -clangir-disable-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CPPLANG,CIRGEN,CIRGEN-FULL,CHECK %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=basic -fclangir -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=basic -fclangir -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CLANG,CIR,CIR-BASIC,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=basic -fclangir -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=basic -fclangir -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CPPLANG,CIR,CIR-BASIC,CHECK %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=improved -fclangir -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=improved -fclangir -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CLANG,CIR,CIR-IMPROVED,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=improved -fclangir -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=improved -fclangir -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CPPLANG,CIR,CIR-IMPROVED,CHECK %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=full -fclangir -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=full -fclangir -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CLANG,CIR,CIR-FULL,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=full -fclangir -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=full -fclangir -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir --check-prefixes=CPPLANG,CIR,CIR-FULL,CHECK %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=basic -fclangir -emit-llvm -o %t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=basic -fclangir -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll --check-prefixes=CLANG,LLVM,LLVM-BASIC,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=basic -fclangir -emit-llvm -o %t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=basic -fclangir -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll --check-prefixes=CPPLANG,LLVM,LLVM-BASIC,CHECK %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=improved -fclangir -emit-llvm -o %t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=improved -fclangir -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll --check-prefixes=CLANG,LLVM,LLVM-IMPROVED,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=improved -fclangir -emit-llvm -o %t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=improved -fclangir -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll --check-prefixes=CPPLANG,LLVM,LLVM-IMPROVED,CHECK %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=full -fclangir -emit-llvm -o %t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -complex-range=full -fclangir -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll --check-prefixes=CLANG,LLVM,LLVM-FULL,CHECK %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=full -fclangir -emit-llvm -o %t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -complex-range=full -fclangir -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll --check-prefixes=CPPLANG,LLVM,LLVM-FULL,CHECK %s
 
 double _Complex cd1, cd2;

--- a/clang/test/CIR/CodeGen/compound-literal.c
+++ b/clang/test/CIR/CodeGen/compound-literal.c
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -Wno-unused-value -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -Wno-unused-value -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -Wno-unused-value -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-call-conv-lowering -Wno-unused-value -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 

--- a/clang/test/CIR/CodeGen/conditional-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/conditional-cleanup.cpp
@@ -2,7 +2,7 @@
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir %s -o %t.eh.cir
 // RUN: FileCheck --check-prefix=CIR_EH --input-file=%t.eh.cir %s
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir-flat %s -o %t.eh.flat.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir-flat -fno-clangir-call-conv-lowering %s -o %t.eh.flat.cir
 // RUN: FileCheck --check-prefix=CIR_FLAT_EH --input-file=%t.eh.flat.cir %s
 
 typedef __typeof(sizeof(0)) size_t;

--- a/clang/test/CIR/CodeGen/dynamic-cast-exact.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast-exact.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O1 -fclangir -clangir-disable-passes -emit-cir -o %t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O1 -fclangir -clangir-disable-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.cir %s
 // RUN: FileCheck --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O1 -fclangir -emit-llvm -o %t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O1 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
 
 struct Base1 {

--- a/clang/test/CIR/CodeGen/eh.cpp
+++ b/clang/test/CIR/CodeGen/eh.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -fcxx-exceptions -fexceptions -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -fcxx-exceptions -fexceptions -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -fcxx-exceptions -fexceptions -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 struct test1_D {

--- a/clang/test/CIR/CodeGen/global-new.cpp
+++ b/clang/test/CIR/CodeGen/global-new.cpp
@@ -4,7 +4,7 @@
 // RUN: FileCheck %s -check-prefix=LLVM --input-file=%t.ll
 // RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fexceptions -fcxx-exceptions %s -o %t.eh.cir
 // RUN: FileCheck %s -check-prefix=CIR_EH --input-file=%t.eh.cir
-// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-cir-flat -fexceptions -fcxx-exceptions %s -o %t.eh.flat.cir
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -fno-clangir-call-conv-lowering -emit-cir-flat -fexceptions -fcxx-exceptions %s -o %t.eh.flat.cir
 // RUN: FileCheck %s -check-prefix=CIR_FLAT_EH --input-file=%t.eh.flat.cir
 // RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fexceptions -fcxx-exceptions %s -o %t.eh.ll
 // RUN: FileCheck %s -check-prefix=LLVM_EH --input-file=%t.eh.ll

--- a/clang/test/CIR/CodeGen/global-new.cpp
+++ b/clang/test/CIR/CodeGen/global-new.cpp
@@ -1,12 +1,12 @@
-// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR_BEFORE
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fno-clangir-call-conv-lowering -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR_BEFORE
 // RUN: FileCheck %s -check-prefix=CIR_AFTER --input-file=%t.cir
 // RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck %s -check-prefix=LLVM --input-file=%t.ll
-// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fexceptions -fcxx-exceptions %s -o %t.eh.cir
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fno-clangir-call-conv-lowering -fexceptions -fcxx-exceptions %s -o %t.eh.cir
 // RUN: FileCheck %s -check-prefix=CIR_EH --input-file=%t.eh.cir
-// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -fno-clangir-call-conv-lowering -emit-cir-flat -fexceptions -fcxx-exceptions %s -o %t.eh.flat.cir
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -fno-clangir-call-conv-lowering -emit-cir-flat -fno-clangir-call-conv-lowering -fexceptions -fcxx-exceptions %s -o %t.eh.flat.cir
 // RUN: FileCheck %s -check-prefix=CIR_FLAT_EH --input-file=%t.eh.flat.cir
-// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fexceptions -fcxx-exceptions %s -o %t.eh.ll
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fno-clangir-call-conv-lowering -fexceptions -fcxx-exceptions %s -o %t.eh.ll
 // RUN: FileCheck %s -check-prefix=LLVM_EH --input-file=%t.eh.ll
 
 struct e { e(int); };

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-flat %s -o %t1.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-flat -fno-clangir-call-conv-lowering %s -o %t1.cir
 // RUN: FileCheck --input-file=%t1.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t2.cir
 // RUN: FileCheck --input-file=%t2.cir %s -check-prefix=NOFLAT

--- a/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
+++ b/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 namespace std {

--- a/clang/test/CIR/CodeGen/initlist-ptr-unsigned.cpp
+++ b/clang/test/CIR/CodeGen/initlist-ptr-unsigned.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 namespace std {

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 class Mother {

--- a/clang/test/CIR/CodeGen/temporaries.cpp
+++ b/clang/test/CIR/CodeGen/temporaries.cpp
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -fcxx-exceptions -fexceptions -emit-cir %s -o %t.eh.cir
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -fcxx-exceptions -fexceptions -emit-cir -fno-clangir-call-conv-lowering %s -o %t.eh.cir
 // RUN: FileCheck --input-file=%t.eh.cir %s -check-prefix=CIR_EH
-// RUN: cir-translate %t.cir -cir-to-llvmir -o %t.ll
+// RUN: cir-translate %t.cir -cir-to-llvmir --disable-cc-lowering -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 struct E {

--- a/clang/test/CIR/CodeGen/try-catch-dtors.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-dtors.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir-flat %s -o %t.flat.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -fno-clangir-call-conv-lowering -emit-cir-flat %s -o %t.flat.cir
 // RUN: FileCheck --input-file=%t.flat.cir --check-prefix=CIR_FLAT %s
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s

--- a/clang/test/CIR/CodeGen/try-catch-dtors.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-dtors.cpp
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -fno-clangir-call-conv-lowering -emit-cir-flat %s -o %t.flat.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir-flat -fno-clangir-call-conv-lowering %s -o %t.flat.cir
 // RUN: FileCheck --input-file=%t.flat.cir --check-prefix=CIR_FLAT %s
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 struct Vec {

--- a/clang/test/CIR/CodeGen/var-arg-float.c
+++ b/clang/test/CIR/CodeGen/var-arg-float.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=BEFORE
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fno-clangir-call-conv-lowering -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 #include <stdarg.h>

--- a/clang/test/CIR/CodeGen/var-arg-scope.c
+++ b/clang/test/CIR/CodeGen/var-arg-scope.c
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=BEFORE
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fno-clangir-call-conv-lowering -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=BEFORE
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -fno-clangir-call-conv-lowering -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 void f1(__builtin_va_list c) {

--- a/clang/test/CIR/CodeGen/var-arg.c
+++ b/clang/test/CIR/CodeGen/var-arg.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=BEFORE
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare -fno-clangir-call-conv-lowering %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 #include <stdarg.h>

--- a/clang/test/CIR/CodeGen/visibility-attribute.c
+++ b/clang/test/CIR/CodeGen/visibility-attribute.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o -  | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o - | FileCheck %s -check-prefix=LLVM
 
 extern int glob_default;
 // CIR: cir.global "private" external @glob_default : !s32i

--- a/clang/test/CIR/Lowering/OpenMP/barrier.cir
+++ b/clang/test/CIR/Lowering/OpenMP/barrier.cir
@@ -1,5 +1,5 @@
 
-// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
 
 
 module {

--- a/clang/test/CIR/Lowering/OpenMP/parallel.cir
+++ b/clang/test/CIR/Lowering/OpenMP/parallel.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 module {

--- a/clang/test/CIR/Lowering/OpenMP/taskwait.cir
+++ b/clang/test/CIR/Lowering/OpenMP/taskwait.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
 
 
 module {

--- a/clang/test/CIR/Lowering/OpenMP/taskyield.cir
+++ b/clang/test/CIR/Lowering/OpenMP/taskyield.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
 
 
 module {

--- a/clang/test/CIR/Lowering/address-space.cir
+++ b/clang/test/CIR/Lowering/address-space.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/array.cir
+++ b/clang/test/CIR/Lowering/array.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir -o -  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 !ty_S = !cir.struct<struct "S" {!s32i} #cir.record.decl.ast>

--- a/clang/test/CIR/Lowering/binop-fp.cir
+++ b/clang/test/CIR/Lowering/binop-fp.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 module {
   cir.func @foo() {

--- a/clang/test/CIR/Lowering/binop-overflow.cir
+++ b/clang/test/CIR/Lowering/binop-overflow.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir -o -  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !u32i = !cir.int<u, 32>
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/binop-unsigned-int.cir
+++ b/clang/test/CIR/Lowering/binop-unsigned-int.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !u32i = !cir.int<u, 32>
 
 module {

--- a/clang/test/CIR/Lowering/bitint.cir
+++ b/clang/test/CIR/Lowering/bitint.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 

--- a/clang/test/CIR/Lowering/bool-to-int.cir
+++ b/clang/test/CIR/Lowering/bool-to-int.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 #false = #cir.bool<false> : !cir.bool

--- a/clang/test/CIR/Lowering/bool.cir
+++ b/clang/test/CIR/Lowering/bool.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 #false = #cir.bool<false> : !cir.bool
 #true = #cir.bool<true> : !cir.bool

--- a/clang/test/CIR/Lowering/branch.cir
+++ b/clang/test/CIR/Lowering/branch.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 cir.func @foo(%arg0: !cir.bool) -> !s32i {

--- a/clang/test/CIR/Lowering/brcond.cir
+++ b/clang/test/CIR/Lowering/brcond.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 #fn_attr = #cir<extra({inline = #cir.inline<no>, nothrow = #cir.nothrow, optnone = #cir.optnone})>

--- a/clang/test/CIR/Lowering/bswap.cir
+++ b/clang/test/CIR/Lowering/bswap.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !u32i = !cir.int<u, 32>
 

--- a/clang/test/CIR/Lowering/call-op-call-conv.cir
+++ b/clang/test/CIR/Lowering/call-op-call-conv.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate -cir-to-llvmir %s -o %t.ll
+// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/call.cir
+++ b/clang/test/CIR/Lowering/call.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 module {

--- a/clang/test/CIR/Lowering/cmp3way.cir
+++ b/clang/test/CIR/Lowering/cmp3way.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s8i = !cir.int<s, 8>
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/complex.cir
+++ b/clang/test/CIR/Lowering/complex.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate -cir-to-llvmir -o %t.ll %s
+// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o %t.ll %s
 // RUN: FileCheck --input-file %t.ll -check-prefix=LLVM %s
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/const-array.cir
+++ b/clang/test/CIR/Lowering/const-array.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir -o -  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !u8i = !cir.int<u, 8>
 

--- a/clang/test/CIR/Lowering/data-member.cir
+++ b/clang/test/CIR/Lowering/data-member.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt -cir-to-llvm -o - %s | FileCheck -check-prefix=MLIR %s
-// RUN: cir-translate -cir-to-llvmir -o - %s  | FileCheck -check-prefix=LLVM %s
+// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o - %s  | FileCheck -check-prefix=LLVM %s
 
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>

--- a/clang/test/CIR/Lowering/exceptions.cir
+++ b/clang/test/CIR/Lowering/exceptions.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/expect.cir
+++ b/clang/test/CIR/Lowering/expect.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s64i = !cir.int<s, 64>
 module {

--- a/clang/test/CIR/Lowering/func-call-conv.cir
+++ b/clang/test/CIR/Lowering/func-call-conv.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-to-llvm -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir -o %t.ll
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 !void = !cir.void

--- a/clang/test/CIR/Lowering/if.cir
+++ b/clang/test/CIR/Lowering/if.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !s32i = !cir.int<s, 32>
 
 module {

--- a/clang/test/CIR/Lowering/int-wrap.cir
+++ b/clang/test/CIR/Lowering/int-wrap.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 module {

--- a/clang/test/CIR/Lowering/intrinsics.cir
+++ b/clang/test/CIR/Lowering/intrinsics.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 module {
   cir.func @test_unreachable() {

--- a/clang/test/CIR/Lowering/ptrdiff.cir
+++ b/clang/test/CIR/Lowering/ptrdiff.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 !u64i = !cir.int<u, 64>

--- a/clang/test/CIR/Lowering/region-simplify.cir
+++ b/clang/test/CIR/Lowering/region-simplify.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -canonicalize -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-opt %s -canonicalize -o - | cir-translate -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s -canonicalize -o - | cir-translate -cir-to-llvmir --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
 
 !u32i = !cir.int<u, 32>
 

--- a/clang/test/CIR/Lowering/scope.cir
+++ b/clang/test/CIR/Lowering/scope.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-to-llvm -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !u32i = !cir.int<u, 32>
 
 module {

--- a/clang/test/CIR/Lowering/select.cir
+++ b/clang/test/CIR/Lowering/select.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate -cir-to-llvmir -o %t.ll %s
+// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll -check-prefix=LLVM %s
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/try-catch.cpp
+++ b/clang/test/CIR/Lowering/try-catch.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-cir-flat %s -o %t.flat.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -fno-clangir-call-conv-lowering -emit-cir-flat %s -o %t.flat.cir
 // RUN: FileCheck --input-file=%t.flat.cir --check-prefix=CIR_FLAT %s
 // RUN_DISABLED: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fcxx-exceptions -fexceptions -mconstructor-aliases -fclangir -emit-llvm %s -o %t.ll
 // RUN_DISABLED: FileCheck --input-file=%t.flat.cir --check-prefix=CIR_LLVM %s

--- a/clang/test/CIR/Lowering/unary-inc-dec.cir
+++ b/clang/test/CIR/Lowering/unary-inc-dec.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !s32i = !cir.int<s, 32>
 module {
   cir.func @foo() {

--- a/clang/test/CIR/Lowering/unary-not.cir
+++ b/clang/test/CIR/Lowering/unary-not.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !s32i = !cir.int<s, 32>
 module {
     cir.func @foo() -> !s32i  {

--- a/clang/test/CIR/Transforms/Target/aarch64/aarch64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/aarch64/aarch64-call-conv-lowering-pass.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple aarch64-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-after=cir-call-conv-lowering %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple aarch64-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-cir-flat -mmlir --mlir-print-ir-after=cir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 // CHECK: @_Z4Voidv()

--- a/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-cir -mmlir --mlir-print-ir-after=cir-call-conv-lowering %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-cir-flat -mmlir --mlir-print-ir-after=cir-call-conv-lowering %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 // Test call conv lowering for trivial cases. //

--- a/clang/test/CodeGen/compound-literal.c
+++ b/clang/test/CodeGen/compound-literal.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm %s -o - | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-apple-darwin -fexperimental-new-constant-interpreter -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm -fno-clangir-call-conv-lowering %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -fexperimental-new-constant-interpreter -emit-llvm -fno-clangir-call-conv-lowering %s -o - | FileCheck %s
 
 // Capture the type and name so matching later is cleaner.
 struct CompoundTy { int a; };

--- a/clang/tools/cir-translate/cir-translate.cpp
+++ b/clang/tools/cir-translate/cir-translate.cpp
@@ -24,12 +24,11 @@
 namespace cir {
 namespace direct {
 extern void registerCIRDialectTranslation(mlir::DialectRegistry &registry);
-extern std::unique_ptr<llvm::Module>
-lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule,
-                             llvm::LLVMContext &llvmCtx,
-                             bool disableVerifier = false);
+extern std::unique_ptr<llvm::Module> lowerDirectlyFromCIRToLLVMIR(
+    mlir::ModuleOp theModule, llvm::LLVMContext &llvmCtx,
+    bool disableVerifier = false, bool disableCCLowering = false);
 } // namespace direct
-}
+} // namespace cir
 
 void registerToLLVMTranslation() {
   mlir::TranslateFromMLIRRegistration registration(


### PR DESCRIPTION
 This reverts commit 8f699fd and fixes some issues, namely:
 
  - CC lowering pass will no longer fail if the function has no AST information that won't be used.
  - Fixed CC lowering not disabling when running certain `cc1` compilation commands.
  - CC lowering can now be disabled when calling `cir-opt` and `cir-translate`.
  - Compilation commands that generate Object files should now invoke CC lowering by default.
 
 