### PR TITLE
fixup! [CIR][CIRGen] Support mutable and recursive named records

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -78,7 +78,7 @@ class StructType
 public:
   using Base::Base;
   using Base::getChecked;
-  // using Base::verify;
+  using Base::verifyInvariants;
 
   static constexpr StringLiteral name = "cir.struct";
 
@@ -109,11 +109,11 @@ public:
                                ASTRecordDeclInterface ast = {});
 
   /// Validate the struct about to be constructed.
-  static LogicalResult verify(function_ref<InFlightDiagnostic()> emitError,
-                              ArrayRef<Type> members, StringAttr name,
-                              bool incomplete, bool packed,
-                              StructType::RecordKind kind,
-                              ASTRecordDeclInterface ast);
+  static LogicalResult
+  verifyInvariants(function_ref<InFlightDiagnostic()> emitError,
+                   ArrayRef<Type> members, StringAttr name, bool incomplete,
+                   bool packed, StructType::RecordKind kind,
+                   ASTRecordDeclInterface ast);
 
   // Parse/print methods.
   static constexpr StringLiteral getMnemonic() { return {"struct"}; }

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -261,12 +261,11 @@ void StructType::print(mlir::AsmPrinter &printer) const {
   printer << '>';
 }
 
-mlir::LogicalResult
-StructType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
-                   llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                   bool incomplete, bool packed,
-                   mlir::cir::StructType::RecordKind kind,
-                   ASTRecordDeclInterface ast) {
+mlir::LogicalResult StructType::verifyInvariants(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+    llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name, bool incomplete,
+    bool packed, mlir::cir::StructType::RecordKind kind,
+    ASTRecordDeclInterface ast) {
   if (name && name.getValue().empty()) {
     emitError() << "identified structs cannot have an empty name";
     return mlir::failure();

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1,6 +1,5 @@
 // Test attempts to build bogus CIR
 // RUN: cir-opt %s -verify-diagnostics -split-input-file
-// XFAIL: *
 
 !u32i = !cir.int<u, 32>
 


### PR DESCRIPTION
After 7359a6b7996f92e6659418d3d2e5b57c44d65e37, we need to rename verify
to verifyInvariants.

Fixes https://github.com/llvm/clangir/issues/923
