### PR TITLE
fixup! [CIR][LowerToLLVM] Fix crash in PtrStrideOp lowering

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -761,8 +761,8 @@ public:
       // before it. To achieve that, look at unary minus, which already got
       // lowered to "sub 0, x".
       auto sub = dyn_cast<mlir::LLVM::SubOp>(indexOp);
-      auto unary =
-          dyn_cast<mlir::cir::UnaryOp>(ptrStrideOp.getStride().getDefiningOp());
+      auto unary = dyn_cast_if_present<mlir::cir::UnaryOp>(
+          ptrStrideOp.getStride().getDefiningOp());
       bool rewriteSub =
           unary && unary.getKind() == mlir::cir::UnaryOpKind::Minus && sub;
       if (rewriteSub)

--- a/clang/test/CIR/Lowering/ptrstride.cir
+++ b/clang/test/CIR/Lowering/ptrstride.cir
@@ -1,6 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir -check-prefix=MLIR
-// XFAIL:* 
 
 !s32i = !cir.int<s, 32>
 module {
@@ -31,4 +30,5 @@ module {
 // MLIR:   llvm.return
 
 // MLIR-LABEL: @g
-// MLIR: llvm.getelementptr %arg0[%arg1] : (!llvm.ptr, i32) -> !llvm.ptr, i32
+// MLIR:      %0 = llvm.sext %arg1 : i32 to i64
+// MLIR-NEXT: llvm.getelementptr %arg0[%0] : (!llvm.ptr, i64) -> !llvm.ptr, i32


### PR DESCRIPTION
After recent rebases (likely as a result of [1]), the LLVMIR stride
operand can be generated by an unrealized_conversion_cast whereas the
CIR operand is coming directly from a block argument (and thus has no
defining op), so we need to separately check the CIR operand for the
existence of a defining op.

[1] https://github.com/llvm/llvm-project/commit/2d50029f986da1fdc9cb88cd8a1070aa086dc6b6