### PR TITLE
[CIR] [CodeGen] Remove NYI in buildPointerWithAlignment

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -128,10 +128,6 @@ static Address buildPointerWithAlignment(const Expr *expr,
       cgf.CGM.buildExplicitCastExprType(ECE, &cgf);
 
     switch (CE->getCastKind()) {
-    default: {
-      llvm::errs() << CE->getCastKindName() << "\n";
-      assert(0 && "not implemented");
-    }
     // Non-converting casts (but not C's implicit conversion from void*).
     case CK_BitCast:
     case CK_NoOp:
@@ -183,12 +179,6 @@ static Address buildPointerWithAlignment(const Expr *expr,
       }
       break;
 
-    // Nothing to do here...
-    case CK_LValueToRValue:
-    case CK_NullToPointer:
-    case CK_IntegralToPointer:
-      break;
-
     // Array-to-pointer decay. TODO(cir): BaseInfo and TBAAInfo.
     case CK_ArrayToPointerDecay:
       return cgf.buildArrayToPointerDecay(CE->getSubExpr());
@@ -205,6 +195,11 @@ static Address buildPointerWithAlignment(const Expr *expr,
           Addr, Derived, CE->path_begin(), CE->path_end(),
           cgf.shouldNullCheckClassCastValue(CE), CE->getExprLoc());
     }
+
+    // TODO: Is there any reason to treat base-to-derived conversions
+    // specially?
+    default:
+      break;
     }
   }
 

--- a/clang/test/CIR/CodeGen/function-to-pointer-decay.c
+++ b/clang/test/CIR/CodeGen/function-to-pointer-decay.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - | FileCheck %s
+
+void f(void);
+
+void test_call_lvalue_cast() {
+  (*(void (*)(int))f)(42);
+}
+
+// CHECK: cir.func {{.*}}@test_call_lvalue_cast()
+// CHECK: [[F:%.+]] = cir.get_global @f
+// CHECK: [[CASTED:%.+]] = cir.cast(bitcast, [[F]]
+// CHECK: [[CONST:%.+]] = cir.const #cir.int<42>
+// CHECK: cir.call [[CASTED]]([[CONST]])


### PR DESCRIPTION
See the test for the reproducer. It would crash due the NYI.

See https://github.com/llvm/llvm-project/blob/327124ece7d59de56ca0f9faa2cd82af68c011b9/clang/lib/CodeGen/CGExpr.cpp#L1295-L1373, I found we've implemented all the cases in CGExpr.cpp. IIUC, I think we can remove the NYI. 