### PR TITLE
[CIR][CIRGen][Builtin] Support unsigned type for _sync_(bool/val)_compare_and_swap 

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -269,7 +269,10 @@ static mlir::Value MakeAtomicCmpXchgValue(CIRGenFunction &cgf,
   Address destAddr = checkAtomicAlignment(cgf, expr);
   auto &builder = cgf.getBuilder();
 
-  auto intType = builder.getSIntNTy(cgf.getContext().getTypeSize(typ));
+  auto intType =
+      expr->getArg(0)->getType()->getPointeeType()->isUnsignedIntegerType()
+          ? builder.getUIntNTy(cgf.getContext().getTypeSize(typ))
+          : builder.getSIntNTy(cgf.getContext().getTypeSize(typ));
   auto cmpVal = cgf.buildScalarExpr(expr->getArg(1));
   cmpVal = buildToInt(cgf, cmpVal, typ, intType);
   auto newVal =


### PR DESCRIPTION
as title. 
Actually just follow the way in `makeBinaryAtomicValue` in the same file which did the right thing by creating SInt or UInt based on first argument's signess. 