### PR TITLE
[CIR][Transforms] Fix CallConv Function Lowering

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -522,7 +522,8 @@ void LowerFunction::buildAggregateStore(Value Val, Value Dest,
             LM.getDataLayout().getTypeSizeInBits(pointeeTy)) &&
            "Incompatible types");
     auto loc = Val.getLoc();
-    Val = rewriter.create<CastOp>(loc, pointeeTy, CastKind::bitcast, Val);
+    auto valPtrTy = PointerType::get(rewriter.getContext(), Val.getType());
+    Dest = rewriter.create<CastOp>(loc, valPtrTy, CastKind::bitcast, Dest);
   }
 
   rewriter.create<StoreOp>(Val.getLoc(), Val, Dest);

--- a/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
+++ b/clang/test/CIR/Transforms/Target/x86_64/x86_64-call-conv-lowering-pass.cpp
@@ -101,8 +101,8 @@ struct S1 {
 /// Cast arguments to the expected type.
 // CHECK: cir.func @_Z2s12S1(%arg0: !u64i loc({{.+}})) -> !u64i
 // CHECK: %[[#V0:]] = cir.alloca !ty_S1_, !cir.ptr<!ty_S1_>
-// CHECK: %[[#V1:]] = cir.cast(bitcast, %arg0 : !u64i), !ty_S1_
-// CHECK: cir.store %[[#V1]], %[[#V0]] : !ty_S1_, !cir.ptr<!ty_S1_>
+// CHECK: %[[#V1:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S1_>), !cir.ptr<!u64i>
+// CHECK: cir.store %arg0, %[[#V1]] : !u64i, !cir.ptr<!u64i>
 S1 s1(S1 arg) {
 
   /// Cast argument and result of the function call to the expected types.


### PR DESCRIPTION
Consider the following code snippet `tmp.c`: 
```
typedef struct {
  int a, b;
} S;

void foo(S s) {}
```
Running `bin/clang tmp.c -fclangir -Xclang -emit-llvm -Xclang -fclangir-call-conv-lowering -S -o -`, we get:
```
loc(fused["tmp.c":5:1, "tmp.c":5:16]): error: 'llvm.bitcast' op result #0 must be LLVM-compatible non-aggregate type, but got '!llvm.struct<"struct.S", (i32, i32)>'
```

I've traced the error back to `lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp` in `LowerFunction::buildAggregateStore`. 

So, for example the original codegen gives such llvm: 
```
void @foo(i64 %0) #0 {
  %2 = alloca %struct.S, align 4
  %3 = bitcast %struct.S* %2 to i64*
  store i64 %0, i64* %3, align 4
  ret void
}
```
but ours will give something like (CIR because we can't generate LLVM due to the error):
```
@foo(%arg0: !cir.int<u, 64>) {
  %0 = cir.alloca !cir.struct<struct "S"
  %1 = cir.cast(bitcast, %arg0 : !cir.int<u, 64>), !cir.struct<struct "S"
  cir.store %1, %0 : !cir.struct<struct "S"
  cir.return
}
```
We try to cast the integer to a struct! It should be the other way around, from struct to an integer. 

`Dst.withElementType(SrcTy)` is currently commented out in `LowerFunction.cpp`, but it is important. In the original codegen `lib/CodeGen/CGCall.cpp` it looks like: `Builder.CreateStore(Src, Dst.withElementType(SrcTy)`.

This PR adds/fixes this, and updates one test for `call-conv-lowering` under transforms.