### PR TITLE
[CIR][Lowering] VecCreateOp and VecSplatOp lowering choose LLVM:PoisonOp

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1564,7 +1564,7 @@ public:
     assert(vecTy && "result type of cir.vec.create op is not VectorType");
     auto llvmTy = typeConverter->convertType(vecTy);
     auto loc = op.getLoc();
-    mlir::Value result = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
+    mlir::Value result = rewriter.create<mlir::LLVM::PoisonOp>(loc, llvmTy);
     assert(vecTy.getSize() == op.getElements().size() &&
            "cir.vec.create op count doesn't match vector type elements count");
     for (uint64_t i = 0; i < vecTy.getSize(); ++i) {
@@ -1629,7 +1629,7 @@ public:
     assert(vecTy && "result type of cir.vec.splat op is not VectorType");
     auto llvmTy = typeConverter->convertType(vecTy);
     auto loc = op.getLoc();
-    mlir::Value undef = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmTy);
+    mlir::Value undef = rewriter.create<mlir::LLVM::PoisonOp>(loc, llvmTy);
     mlir::Value indexValue =
         rewriter.create<mlir::LLVM::ConstantOp>(loc, rewriter.getI64Type(), 0);
     mlir::Value elementValue = adaptor.getValue();

--- a/clang/test/CIR/CodeGen/vectype-ext.cpp
+++ b/clang/test/CIR/CodeGen/vectype-ext.cpp
@@ -25,7 +25,7 @@ void vector_int_test(int x) {
   // LLVM:      %[[#X1:]] = load i32, ptr %{{[0-9]+}}, align 4
   // LLVM-NEXT: %[[#X2:]] = load i32, ptr %{{[0-9]+}}, align 4
   // LLVM-NEXT: %[[#SUM:]] = add nsw i32 %[[#X2]], 1
-  // LLVM-NEXT: %[[#VEC1:]] = insertelement <4 x i32> undef, i32 %[[#X1]], i64 0
+  // LLVM-NEXT: %[[#VEC1:]] = insertelement <4 x i32> poison, i32 %[[#X1]], i64 0
   // LLVM-NEXT: %[[#VEC2:]] = insertelement <4 x i32> %[[#VEC1]], i32 5, i64 1
   // LLVM-NEXT: %[[#VEC3:]] = insertelement <4 x i32> %[[#VEC2]], i32 6, i64 2
   // LLVM-NEXT: %[[#VEC4:]] = insertelement <4 x i32> %[[#VEC3]], i32 %[[#SUM]], i64 3
@@ -38,7 +38,7 @@ void vector_int_test(int x) {
   // LLVM:      %[[#X1:]] = load i32, ptr %{{[0-9]+}}, align 4
   // LLVM-NEXT: %[[#X2:]] = load i32, ptr %{{[0-9]+}}, align 4
   // LLVM-NEXT: %[[#SUM:]] = add nsw i32 %[[#X2]], 1
-  // LLVM-NEXT: %[[#VEC1:]] = insertelement <4 x i32> undef, i32 %[[#X1]], i64 0
+  // LLVM-NEXT: %[[#VEC1:]] = insertelement <4 x i32> poison, i32 %[[#X1]], i64 0
   // LLVM-NEXT: %[[#VEC2:]] = insertelement <4 x i32> %[[#VEC1]], i32 %[[#SUM]], i64 1
   // LLVM-NEXT: %[[#VEC3:]] = insertelement <4 x i32> %[[#VEC2]], i32 0, i64 2
   // LLVM-NEXT: %[[#VEC4:]] = insertelement <4 x i32> %[[#VEC3]], i32 0, i64 3
@@ -211,7 +211,7 @@ void vector_double_test(int x, double y) {
   // LLVM:      %[[#Y1:]] = load double, ptr %{{[0-9]+}}, align 8
   // LLVM-NEXT: %[[#Y2:]] = load double, ptr %{{[0-9]+}}, align 8
   // LLVM-NEXT: %[[#SUM:]] = fadd double %[[#Y2]], 1.000000e+00
-  // LLVM-NEXT: %[[#VEC1:]] = insertelement <2 x double> undef, double %[[#Y1]], i64 0
+  // LLVM-NEXT: %[[#VEC1:]] = insertelement <2 x double> poison, double %[[#Y1]], i64 0
   // LLVM-NEXT: %[[#VEC2:]] = insertelement <2 x double> %[[#VEC1]], double %[[#SUM]], i64 1
   // LLVM-NEXT: store <2 x double> %[[#VEC2]], ptr %{{[0-9]+}}, align 16
 
@@ -221,7 +221,7 @@ void vector_double_test(int x, double y) {
   // CIR: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %[[#dzero]] : !cir.double, !cir.double) : !cir.vector<!cir.double x 2>
 
   // LLVM:      %[[#Y1:]] = load double, ptr %{{[0-9]+}}, align 8
-  // LLVM-NEXT: %[[#VEC1:]] = insertelement <2 x double> undef, double %[[#Y1]], i64 0
+  // LLVM-NEXT: %[[#VEC1:]] = insertelement <2 x double> poison, double %[[#Y1]], i64 0
   // LLVM-NEXT: %[[#VEC2:]] = insertelement <2 x double> %[[#VEC1]], double 0.000000e+00, i64 1
   // LLVM-NEXT: store <2 x double> %[[#VEC2]], ptr %{{[0-9]+}}, align 16
 

--- a/clang/test/CIR/Lowering/vectype.cpp
+++ b/clang/test/CIR/Lowering/vectype.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: cir-opt %t.cir -cir-to-llvm -o %t.mlir
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ii
 // RUN: FileCheck --input-file=%t.mlir %s
 
 typedef int vi4 __attribute__((vector_size(16)));
@@ -22,7 +23,7 @@ void vector_int_test(int x) {
   // CHECK: %[[#T46:]] = llvm.load %[[#T1]] {alignment = 4 : i64} : !llvm.ptr -> i32
   // CHECK: %[[#T47:]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK: %[[#T48:]] = llvm.add %[[#T46]], %[[#T47]] overflow<nsw> : i32
-  // CHECK: %[[#T49:]] = llvm.mlir.undef : vector<4xi32>
+  // CHECK: %[[#T49:]] = llvm.mlir.poison : vector<4xi32>
   // CHECK: %[[#T50:]] = llvm.mlir.constant(0 : i64) : i64
   // CHECK: %[[#T51:]] = llvm.insertelement %[[#T43]], %[[#T49]][%[[#T50]] : i64] : vector<4xi32>
   // CHECK: %[[#T52:]] = llvm.mlir.constant(1 : i64) : i64
@@ -41,10 +42,10 @@ void vector_int_test(int x) {
 
   // Scalar to vector conversion, a.k.a. vector splat.
   b = a + 7;
-  // CHECK: %[[#undef:]] = llvm.mlir.undef : vector<4xi32>
+  // CHECK: %[[#poison:]] = llvm.mlir.poison : vector<4xi32>
   // CHECK: %[[#zeroInt:]] = llvm.mlir.constant(0 : i64) : i64
-  // CHECK: %[[#inserted:]] = llvm.insertelement %[[#seven:]], %[[#undef]][%[[#zeroInt]] : i64] : vector<4xi32>
-  // CHECK: %[[#shuffled:]] = llvm.shufflevector %[[#inserted]], %[[#undef]] [0, 0, 0, 0] : vector<4xi32>
+  // CHECK: %[[#inserted:]] = llvm.insertelement %[[#seven:]], %[[#poison]][%[[#zeroInt]] : i64] : vector<4xi32>
+  // CHECK: %[[#shuffled:]] = llvm.shufflevector %[[#inserted]], %[[#poison]] [0, 0, 0, 0] : vector<4xi32>
 
   // Extract element.
   int c = a[x];
@@ -233,7 +234,7 @@ void vector_double_test(int x, double y) {
   // CHECK: %[[#T30:]] = llvm.load %[[#T3]] {alignment = 8 : i64} : !llvm.ptr -> f64
   // CHECK: %[[#T31:]] = llvm.mlir.constant(1.000000e+00 : f64) : f64
   // CHECK: %[[#T32:]] = llvm.fadd %[[#T30]], %[[#T31]]  : f64
-  // CHECK: %[[#T33:]] = llvm.mlir.undef : vector<2xf64>
+  // CHECK: %[[#T33:]] = llvm.mlir.poison : vector<2xf64>
   // CHECK: %[[#T34:]] = llvm.mlir.constant(0 : i64) : i64
   // CHECK: %[[#T35:]] = llvm.insertelement %[[#T29]], %[[#T33]][%[[#T34]] : i64] : vector<2xf64>
   // CHECK: %[[#T36:]] = llvm.mlir.constant(1 : i64) : i64


### PR DESCRIPTION
They should use PoisonOp (which becomes PoisonValue in LLVMIR) as it is the OG's choice. 
Proof:
We generate VecCreateOp [here ](https://github.com/llvm/clangir/blob/2ca12fe5ec3a1e7279256f069010be2d68200585/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp#L1975)
And it's OG counterpart is [here](https://github.com/llvm/clangir/blob/2ca12fe5ec3a1e7279256f069010be2d68200585/clang/lib/CodeGen/CGExprScalar.cpp#L2096)
OG uses PoisonValue. 
As to VecSplatOp, OG unconditionally [chooses PoisonValue ](https://github.com/llvm/clangir/blob/2ca12fe5ec3a1e7279256f069010be2d68200585/llvm/lib/IR/IRBuilder.cpp#L1204)

A even more solid proof for this case is that 
when we use OG to generate code for our test case I changed in this PR , its always using poison instead of undef as far as VecSplat and VecCreate is concerned. The [OG generated code for vectype-ext.cpp ](https://godbolt.org/z/eqx1rns86) here.
The [OG generated code for vectype.cpp ](https://godbolt.org/z/frMjbKGeT) here.

For reference, generated CIR for the test case vectype-ext.cpp is [here](https://godbolt.org/z/frMjbKGeT)

This is to unblock https://github.com/llvm/clangir/pull/936/ to help it set on the right path.

Note: There might be other CIR vec ops that need to choose Poison to be consistent with OG, but I'd limit the scope of this PR, and wait to see issue pop up in the future. 




