### PR TITLE
[CIR][NFC][Testing] Fix test failure

### DIFF
--- a/clang/test/CIR/CodeGen/annotations-var.c
+++ b/clang/test/CIR/CodeGen/annotations-var.c
@@ -4,7 +4,7 @@
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 // LLVM-DAG: @.str.annotation = private unnamed_addr constant [15 x i8] c"localvar_ann_0\00", section "llvm.metadata"
-// LLVM-DAG: @.str.1.annotation = private unnamed_addr constant [81 x i8] c"{{.*}}annotations-var.c\00", section "llvm.metadata"
+// LLVM-DAG: @.str.1.annotation = private unnamed_addr constant [{{[0-9]+}} x i8] c"{{.*}}annotations-var.c\00", section "llvm.metadata"
 // LLVM-DAG: @.str.2.annotation = private unnamed_addr constant [15 x i8] c"localvar_ann_1\00", section "llvm.metadata"
 
 void local(void) {


### PR DESCRIPTION
as title.
Base on my experience of [this type of test ](https://github.com/llvm/clangir/blob/a7ac2b4e2055e169d9f556abf5821a1ccab666cd/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp#L51),
The number of characters varies in this line as it's about full file path which changes during environment.
