### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower neon_vshl_n_v and neon_vshlq_n_v

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1183,7 +1183,7 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
     Shift `left` or `right`, according to the first operand. Second operand is
     the shift target and the third the amount. Second and the thrid operand can
     be either integer type or vector of integer type. However, they must be
-    either vector of integer type, or all integer type.  
+    either all vector of integer type, or all integer type.  
 
     ```mlir
     %7 = cir.shift(left, %1 : !u64i, %4 : !s32i) -> !u64i

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1187,7 +1187,7 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
 
     ```mlir
     %7 = cir.shift(left, %1 : !u64i, %4 : !s32i) -> !u64i
-    %8 = cir.shift(left, %1 : !cir.vector<!s32i x 2>, %2 : !cir.vector<!s32i x 2>) -> !cir.vector<!s32i x 2>
+    %8 = cir.shift(left, %2 : !cir.vector<!s32i x 2>, %3 : !cir.vector<!s32i x 2>) -> !cir.vector<!s32i x 2>
     ```
   }];
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1182,11 +1182,12 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
   let description = [{
     Shift `left` or `right`, according to the first operand. Second operand is
     the shift target and the third the amount. Second and the thrid operand can
-    be vector of integer type. However, if one of them is vector of integer
-    type, the other must be vector of integer type as well.
+    be either integer type or vector of integer type. However, they must be
+    either vector of integer type, or all integer type.  
 
     ```mlir
     %7 = cir.shift(left, %1 : !u64i, %4 : !s32i) -> !u64i
+    %8 = cir.shift(left, %1 : !cir.vector<!s32i x 2>, %2 : !cir.vector<!s32i x 2>) -> !cir.vector<!s32i x 2>
     ```
   }];
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1181,15 +1181,17 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
   let summary = "Shift";
   let description = [{
     Shift `left` or `right`, according to the first operand. Second operand is
-    the shift target and the third the amount.
+    the shift target and the third the amount. Second and the thrid operand can
+    be vector of integer type. However, if one of them is vector of integer
+    type, the other must be vector of integer type as well.
 
     ```mlir
     %7 = cir.shift(left, %1 : !u64i, %4 : !s32i) -> !u64i
     ```
   }];
 
-  let results = (outs CIR_IntType:$result);
-  let arguments = (ins CIR_IntType:$value, CIR_IntType:$amount,
+  let results = (outs CIR_AnyIntOrVecofInt:$result);
+  let arguments = (ins CIR_AnyIntOrVecofInt:$value, CIR_AnyIntOrVecofInt:$amount,
                        UnitAttr:$isShiftleft);
 
   let assemblyFormat = [{
@@ -1200,8 +1202,7 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
     `)` `->` type($result) attr-dict
   }];
 
-  // Already covered by the traits
-  let hasVerifier = 0;
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1183,7 +1183,9 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
     Shift `left` or `right`, according to the first operand. Second operand is
     the shift target and the third the amount. Second and the thrid operand can
     be either integer type or vector of integer type. However, they must be
-    either all vector of integer type, or all integer type.  
+    either all vector of integer type, or all integer type. If they are vectors,
+    each vector element of the shift target is shifted by the corresponding
+    shift amount in the shift amount vector. 
 
     ```mlir
     %7 = cir.shift(left, %1 : !u64i, %4 : !s32i) -> !u64i
@@ -1191,8 +1193,8 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
     ```
   }];
 
-  let results = (outs CIR_AnyIntOrVecofInt:$result);
-  let arguments = (ins CIR_AnyIntOrVecofInt:$value, CIR_AnyIntOrVecofInt:$amount,
+  let results = (outs CIR_AnyIntOrVecOfInt:$result);
+  let arguments = (ins CIR_AnyIntOrVecOfInt:$value, CIR_AnyIntOrVecOfInt:$amount,
                        UnitAttr:$isShiftleft);
 
   let assemblyFormat = [{

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -537,6 +537,9 @@ def IntegerVector : Type<
     ]>, "!cir.vector of !cir.int"> {
 }
 
+// Constraints
+def CIR_AnyIntOrVecofInt: AnyTypeOf<[CIR_IntType, IntegerVector]>;
+
 // Pointer to Arrays
 def ArrayPtr : Type<
     And<[

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -538,7 +538,7 @@ def IntegerVector : Type<
 }
 
 // Constraints
-def CIR_AnyIntOrVecofInt: AnyTypeOf<[CIR_IntType, IntegerVector]>;
+def CIR_AnyIntOrVecOfInt: AnyTypeOf<[CIR_IntType, IntegerVector]>;
 
 // Pointer to Arrays
 def ArrayPtr : Type<

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -2207,10 +2207,10 @@ static int64_t getIntValueFromConstOp(mlir::Value val) {
 }
 
 /// This function `buildCommonNeonCallPattern0` implements a common way
-//  to generate neon intrinsic call that has following pattern:
-//  1. There is a need to cast result of the intrinsic call back to
-//     expression type.
-//  2. Function arg types are given, not deduced from actual arg types.
+///  to generate neon intrinsic call that has following pattern:
+///  1. There is a need to cast result of the intrinsic call back to
+///     expression type.
+///  2. Function arg types are given, not deduced from actual arg types.
 static mlir::Value
 buildCommonNeonCallPattern0(CIRGenFunction &cgf, std::string &intrincsName,
                             llvm::SmallVector<mlir::Type> argTypes,
@@ -2222,6 +2222,23 @@ buildCommonNeonCallPattern0(CIRGenFunction &cgf, std::string &intrincsName,
                     cgf.getLoc(e->getExprLoc()));
   mlir::Type resultType = cgf.ConvertType(e->getType());
   return builder.createBitcast(res, resultType);
+}
+
+/// Build a constant shift amount vector of `vecTy` to shift a vector
+/// Here `shitfVal` is a constant integer that will be splated into a
+/// a const vector of `vecTy` which is the return of this function
+static mlir::Value buildNeonShiftVector(CIRGenBuilderTy &builder,
+                                        mlir::Value shiftVal,
+                                        mlir::cir::VectorType vecTy,
+                                        mlir::Location loc, bool neg) {
+  int shiftAmt = getIntValueFromConstOp(shiftVal);
+  llvm::SmallVector<mlir::Attribute> vecAttr{
+      vecTy.getSize(),
+      // ConstVectorAttr requires cir::IntAttr
+      mlir::cir::IntAttr::get(vecTy.getEltType(), shiftAmt)};
+  mlir::cir::ConstVectorAttr constVecAttr = mlir::cir::ConstVectorAttr::get(
+      vecTy, mlir::ArrayAttr::get(builder.getContext(), vecAttr));
+  return builder.create<mlir::cir::ConstantOp>(loc, vecTy, constVecAttr);
 }
 
 mlir::Value CIRGenFunction::buildCommonNeonBuiltinExpr(
@@ -2299,6 +2316,13 @@ mlir::Value CIRGenFunction::buildCommonNeonBuiltinExpr(
                              ? "llvm.aarch64.neon.sqdmulh.lane"
                              : "llvm.aarch64.neon.sqrdmulh.lane",
                          resTy, getLoc(e->getExprLoc()));
+  }
+  case NEON::BI__builtin_neon_vshl_n_v:
+  case NEON::BI__builtin_neon_vshlq_n_v: {
+    mlir::Location loc = getLoc(e->getExprLoc());
+    ops[1] = buildNeonShiftVector(builder, ops[1], vTy, loc, false);
+    return builder.create<mlir::cir::ShiftOp>(
+        loc, vTy, builder.createBitcast(ops[0], vTy), ops[1], true);
   }
   }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3940,6 +3940,23 @@ LogicalResult BinOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ShiftOp Definitions
+//===----------------------------------------------------------------------===//
+LogicalResult ShiftOp::verify() {
+  mlir::Operation *op = getOperation();
+  mlir::Type resType = getResult().getType();
+  bool isOp0Vec = mlir::isa<mlir::cir::VectorType>(op->getOperand(0).getType());
+  bool isOp1Vec = mlir::isa<mlir::cir::VectorType>(op->getOperand(1).getType());
+  if (isOp0Vec != isOp1Vec)
+    return emitOpError() << "input types cannot be one vector and one scalar";
+  if (isOp1Vec && op->getOperand(1).getType() != resType) {
+    return emitOpError() << "shift amount must have the type of the result "
+                         << "if it is vector shift";
+  }
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // LabelOp Definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2802,7 +2802,11 @@ public:
     if (op.getIsShiftleft())
       rewriter.replaceOpWithNewOp<mlir::LLVM::ShlOp>(op, llvmTy, val, amt);
     else {
-      if (cirValTy.isUnsigned())
+      bool isUnSigned =
+          cirValTy ? !cirValTy.isSigned()
+                   : !mlir::cast<mlir::cir::IntType>(cirValVTy.getEltType())
+                          .isSigned();
+      if (isUnSigned)
         rewriter.replaceOpWithNewOp<mlir::LLVM::LShrOp>(op, llvmTy, val, amt);
       else
         rewriter.replaceOpWithNewOp<mlir::LLVM::AShrOp>(op, llvmTy, val, amt);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2773,18 +2773,30 @@ public:
     auto cirAmtTy =
         mlir::dyn_cast<mlir::cir::IntType>(op.getAmount().getType());
     auto cirValTy = mlir::dyn_cast<mlir::cir::IntType>(op.getValue().getType());
+
+    // Operands could also be vector type
+    auto cirAmtVTy =
+        mlir::dyn_cast<mlir::cir::VectorType>(op.getAmount().getType());
+    auto cirValVTy =
+        mlir::dyn_cast<mlir::cir::VectorType>(op.getValue().getType());
     auto llvmTy = getTypeConverter()->convertType(op.getType());
     mlir::Value amt = adaptor.getAmount();
     mlir::Value val = adaptor.getValue();
 
-    assert(cirValTy && cirAmtTy && "non-integer shift is NYI");
-    assert(cirValTy == op.getType() && "inconsistent operands' types NYI");
+    assert(((cirValTy && cirAmtTy) || (cirAmtVTy && cirValVTy)) &&
+           "shift input type must be integer or vector type, otherwise NYI");
+
+    assert((cirValTy == op.getType() || cirValVTy == op.getType()) &&
+           "inconsistent operands' types NYI");
 
     // Ensure shift amount is the same type as the value. Some undefined
     // behavior might occur in the casts below as per [C99 6.5.7.3].
-    amt = getLLVMIntCast(rewriter, amt, mlir::cast<mlir::IntegerType>(llvmTy),
-                         !cirAmtTy.isSigned(), cirAmtTy.getWidth(),
-                         cirValTy.getWidth());
+    // Vector type shift amount needs no cast as type consistency is expected to
+    // be already be enforced at CIRGen.
+    if (cirAmtTy)
+      amt = getLLVMIntCast(rewriter, amt, mlir::cast<mlir::IntegerType>(llvmTy),
+                           !cirAmtTy.isSigned(), cirAmtTy.getWidth(),
+                           cirValTy.getWidth());
 
     // Lower to the proper LLVM shift operation.
     if (op.getIsShiftleft())

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -4634,123 +4634,203 @@ int8x8_t test_vqadd_s8(int8x8_t a, int8x8_t b) {
 //   return vmulxq_f64(a, b);
 // }
 
-// NYI-LABEL: @test_vshl_n_s8(
-// NYI:   [[VSHL_N:%.*]] = shl <8 x i8> %a, <i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>
-// NYI:   ret <8 x i8> [[VSHL_N]]
-// int8x8_t test_vshl_n_s8(int8x8_t a) {
-//   return vshl_n_s8(a, 3);
-// }
 
-// NYI-LABEL: @test_vshl_n_s16(
-// NYI:   [[TMP0:%.*]] = bitcast <4 x i16> %a to <8 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// NYI:   [[VSHL_N:%.*]] = shl <4 x i16> [[TMP1]], <i16 3, i16 3, i16 3, i16 3>
-// NYI:   ret <4 x i16> [[VSHL_N]]
-// int16x4_t test_vshl_n_s16(int16x4_t a) {
-//   return vshl_n_s16(a, 3);
-// }
+int8x8_t test_vshl_n_s8(int8x8_t a) {
+  return vshl_n_s8(a, 3);
 
-// NYI-LABEL: @test_vshl_n_s32(
-// NYI:   [[TMP0:%.*]] = bitcast <2 x i32> %a to <8 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// NYI:   [[VSHL_N:%.*]] = shl <2 x i32> [[TMP1]], <i32 3, i32 3>
-// NYI:   ret <2 x i32> [[VSHL_N]]
-// int32x2_t test_vshl_n_s32(int32x2_t a) {
-//   return vshl_n_s32(a, 3);
-// }
+ // CIR-LABEL: @test_vshl_n_s8
+ // CIR: [[AMT:%.*]] = cir.const #cir.const_vector<[#cir.int<3> : !s8i, #cir.int<3> : !s8i, #cir.int<3> : !s8i, 
+ // CIR-SAME: #cir.int<3> : !s8i, #cir.int<3> : !s8i, #cir.int<3> : !s8i, #cir.int<3> : !s8i, #cir.int<3> : !s8i]>
+ // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!s8i x 8>, [[AMT]] : !cir.vector<!s8i x 8>) -> !cir.vector<!s8i x 8> 
+
+ // LLVM: {{.*}}@test_vshl_n_s8(<8 x i8>{{.*}}[[A:%.*]])
+ // LLVM: [[VSHL_N:%.*]] = shl <8 x i8> [[A]], <i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>
+ // LLVM: ret <8 x i8> [[VSHL_N]]
+}
+
+
+int16x4_t test_vshl_n_s16(int16x4_t a) {
+  return vshl_n_s16(a, 3);
+
+ // CIR-LABEL: @test_vshl_n_s16
+ // CIR: [[AMT:%.*]] = cir.const #cir.const_vector<[#cir.int<3> : !s16i, #cir.int<3> : !s16i, #cir.int<3> : !s16i, 
+ // CIR-SAME: #cir.int<3> : !s16i]>
+ // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!s16i x 4>, [[AMT]] : !cir.vector<!s16i x 4>) -> !cir.vector<!s16i x 4> 
+
+ // LLVM: {{.*}}@test_vshl_n_s16(<4 x i16>{{.*}}[[A:%.*]])
+ // LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[A]] to <8 x i8>
+ // LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
+ // LLVM: [[VSHL_N:%.*]] = shl <4 x i16> [[TMP1]], <i16 3, i16 3, i16 3, i16 3>
+ // LLVM: ret <4 x i16> [[VSHL_N]] 
+}
+
+int32x2_t test_vshl_n_s32(int32x2_t a) {
+  return vshl_n_s32(a, 3);
+
+  // CIR-LABEL: @test_vshl_n_s32
+  // CIR: [[AMT:%.*]] = cir.const #cir.const_vector<[#cir.int<3> : !s32i, #cir.int<3> : !s32i]>
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!s32i x 2>, [[AMT]] : !cir.vector<!s32i x 2>) -> !cir.vector<!s32i x 2> 
+
+  // LLVM: {{.*}}@test_vshl_n_s32(<2 x i32>{{.*}}[[A:%.*]])
+  // LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[A]] to <8 x i8>
+  // LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
+  // LLVM: [[VSHL_N:%.*]] = shl <2 x i32> [[TMP1]], <i32 3, i32 3>
+  // LLVM: ret <2 x i32> [[VSHL_N]]
+}
 
 // NYI-LABEL: @test_vshlq_n_s8(
 // NYI:   [[VSHL_N:%.*]] = shl <16 x i8> %a, <i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>
 // NYI:   ret <16 x i8> [[VSHL_N]]
-// int8x16_t test_vshlq_n_s8(int8x16_t a) {
-//   return vshlq_n_s8(a, 3);
-// }
+int8x16_t test_vshlq_n_s8(int8x16_t a) {
+  return vshlq_n_s8(a, 3);
+  
+  // CIR-LABEL: @test_vshlq_n_s8
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!s8i x 16>, {{.*}} : !cir.vector<!s8i x 16>) -> !cir.vector<!s8i x 16> 
 
-// NYI-LABEL: @test_vshlq_n_s16(
-// NYI:   [[TMP0:%.*]] = bitcast <8 x i16> %a to <16 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <8 x i16>
-// NYI:   [[VSHL_N:%.*]] = shl <8 x i16> [[TMP1]], <i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3>
-// NYI:   ret <8 x i16> [[VSHL_N]]
-// int16x8_t test_vshlq_n_s16(int16x8_t a) {
-//   return vshlq_n_s16(a, 3);
-// }
+  // LLVM: {{.*}}@test_vshlq_n_s8(<16 x i8>{{.*}}[[A:%.*]])
+  // LLVM:   [[VSHL_N:%.*]] = shl <16 x i8> [[A]], <i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>
+  // LLVM:   ret <16 x i8> [[VSHL_N]]
+}
 
-// NYI-LABEL: @test_vshlq_n_s32(
-// NYI:   [[TMP0:%.*]] = bitcast <4 x i32> %a to <16 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <4 x i32>
-// NYI:   [[VSHL_N:%.*]] = shl <4 x i32> [[TMP1]], <i32 3, i32 3, i32 3, i32 3>
-// NYI:   ret <4 x i32> [[VSHL_N]]
-// int32x4_t test_vshlq_n_s32(int32x4_t a) {
-//   return vshlq_n_s32(a, 3);
-// }
+int16x8_t test_vshlq_n_s16(int16x8_t a) {
+  return vshlq_n_s16(a, 3);
 
-// NYI-LABEL: @test_vshlq_n_s64(
-// NYI:   [[TMP0:%.*]] = bitcast <2 x i64> %a to <16 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <2 x i64>
-// NYI:   [[VSHL_N:%.*]] = shl <2 x i64> [[TMP1]], <i64 3, i64 3>
-// NYI:   ret <2 x i64> [[VSHL_N]]
-// int64x2_t test_vshlq_n_s64(int64x2_t a) {
-//   return vshlq_n_s64(a, 3);
-// }
+  // CIR-LABEL: @test_vshlq_n_s16
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!s16i x 8>, {{.*}} : !cir.vector<!s16i x 8>) -> !cir.vector<!s16i x 8> 
 
-// NYI-LABEL: @test_vshl_n_u8(
-// NYI:   [[VSHL_N:%.*]] = shl <8 x i8> %a, <i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>
-// NYI:   ret <8 x i8> [[VSHL_N]]
-// uint8x8_t test_vshl_n_u8(uint8x8_t a) {
-//   return vshl_n_u8(a, 3);
-// }
+  // LLVM:   {{.*}}@test_vshlq_n_s16(<8 x i16>{{.*}}[[A:%.*]])
+  // LLVM:   [[TMP0:%.*]] = bitcast <8 x i16> [[A]] to <16 x i8>
+  // LLVM:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <8 x i16>
+  // LLVM:   [[VSHL_N:%.*]] = shl <8 x i16> [[TMP1]], <i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3>
+  // LLVM:   ret <8 x i16> [[VSHL_N]]
+}
 
-// NYI-LABEL: @test_vshl_n_u16(
-// NYI:   [[TMP0:%.*]] = bitcast <4 x i16> %a to <8 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// NYI:   [[VSHL_N:%.*]] = shl <4 x i16> [[TMP1]], <i16 3, i16 3, i16 3, i16 3>
-// NYI:   ret <4 x i16> [[VSHL_N]]
-// uint16x4_t test_vshl_n_u16(uint16x4_t a) {
-//   return vshl_n_u16(a, 3);
-// }
 
-// NYI-LABEL: @test_vshl_n_u32(
-// NYI:   [[TMP0:%.*]] = bitcast <2 x i32> %a to <8 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// NYI:   [[VSHL_N:%.*]] = shl <2 x i32> [[TMP1]], <i32 3, i32 3>
-// NYI:   ret <2 x i32> [[VSHL_N]]
-// uint32x2_t test_vshl_n_u32(uint32x2_t a) {
-//   return vshl_n_u32(a, 3);
-// }
+int32x4_t test_vshlq_n_s32(int32x4_t a) {
+  return vshlq_n_s32(a, 3);
 
-// NYI-LABEL: @test_vshlq_n_u8(
-// NYI:   [[VSHL_N:%.*]] = shl <16 x i8> %a, <i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>
-// NYI:   ret <16 x i8> [[VSHL_N]]
-// uint8x16_t test_vshlq_n_u8(uint8x16_t a) {
-//   return vshlq_n_u8(a, 3);
-// }
+  // CIR-LABEL: @test_vshlq_n_s32
+  // CIR: [[AMT:%.*]] = cir.const #cir.const_vector<[#cir.int<3> : !s32i, #cir.int<3> : 
+  // CIR-SAME: !s32i, #cir.int<3> : !s32i, #cir.int<3> : !s32i]>
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!s32i x 4>, [[AMT]] : 
+  // CIR-SAME: !cir.vector<!s32i x 4>) -> !cir.vector<!s32i x 4> 
 
-// NYI-LABEL: @test_vshlq_n_u16(
-// NYI:   [[TMP0:%.*]] = bitcast <8 x i16> %a to <16 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <8 x i16>
-// NYI:   [[VSHL_N:%.*]] = shl <8 x i16> [[TMP1]], <i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3>
-// NYI:   ret <8 x i16> [[VSHL_N]]
-// uint16x8_t test_vshlq_n_u16(uint16x8_t a) {
-//   return vshlq_n_u16(a, 3);
-// }
+  // LLVM:   {{.*}}@test_vshlq_n_s32(<4 x i32>{{.*}}[[A:%.*]])
+  // LLVM:   [[TMP0:%.*]] = bitcast <4 x i32> [[A]] to <16 x i8>
+  // LLVM:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <4 x i32>
+  // LLVM:   [[VSHL_N:%.*]] = shl <4 x i32> [[TMP1]], <i32 3, i32 3, i32 3, i32 3>
+  // LLVM:   ret <4 x i32> [[VSHL_N]]
+}
 
-// NYI-LABEL: @test_vshlq_n_u32(
-// NYI:   [[TMP0:%.*]] = bitcast <4 x i32> %a to <16 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <4 x i32>
-// NYI:   [[VSHL_N:%.*]] = shl <4 x i32> [[TMP1]], <i32 3, i32 3, i32 3, i32 3>
-// NYI:   ret <4 x i32> [[VSHL_N]]
-// uint32x4_t test_vshlq_n_u32(uint32x4_t a) {
-//   return vshlq_n_u32(a, 3);
-// }
+int64x2_t test_vshlq_n_s64(int64x2_t a) {
+  return vshlq_n_s64(a, 3);
 
-// NYI-LABEL: @test_vshlq_n_u64(
-// NYI:   [[TMP0:%.*]] = bitcast <2 x i64> %a to <16 x i8>
-// NYI:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <2 x i64>
-// NYI:   [[VSHL_N:%.*]] = shl <2 x i64> [[TMP1]], <i64 3, i64 3>
-// NYI:   ret <2 x i64> [[VSHL_N]]
-// uint64x2_t test_vshlq_n_u64(uint64x2_t a) {
-//   return vshlq_n_u64(a, 3);
-// }
+  // CIR-LABEL: @test_vshlq_n_s64
+  // CIR: [[AMT:%.*]] = cir.const #cir.const_vector<[#cir.int<3> : !s64i, #cir.int<3> : !s64i]>
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!s64i x 2>, [[AMT]] : 
+  // CIR-SAME: !cir.vector<!s64i x 2>) -> !cir.vector<!s64i x 2>
+
+  // LLVM:   {{.*}}@test_vshlq_n_s64(<2 x i64>{{.*}}[[A:%.*]])
+  // LLVM:   [[TMP0:%.*]] = bitcast <2 x i64> [[A]] to <16 x i8>
+  // LLVM:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <2 x i64>
+  // LLVM:   [[VSHL_N:%.*]] = shl <2 x i64> [[TMP1]], <i64 3, i64 3>
+  // LLVM:   ret <2 x i64> [[VSHL_N]]
+}
+
+uint8x8_t test_vshl_n_u8(uint8x8_t a) {
+  return vshl_n_u8(a, 3);
+
+  // CIR-LABEL: @test_vshl_n_u8
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!u8i x 8>, {{.*}} : 
+  // CIR-SAME: !cir.vector<!u8i x 8>) -> !cir.vector<!u8i x 8> 
+
+  // LLVM:   {{.*}}@test_vshl_n_u8(<8 x i8>{{.*}}[[A:%.*]])
+  // LLVM:   [[VSHL_N:%.*]] = shl <8 x i8> [[A]], <i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>
+  // LLVM:   ret <8 x i8> [[VSHL_N]]
+}
+
+uint16x4_t test_vshl_n_u16(uint16x4_t a) {
+  return vshl_n_u16(a, 3);
+
+  // CIR-LABEL: @test_vshl_n_u16
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!u16i x 4>, {{.*}} : 
+  // CIR-SAME: !cir.vector<!u16i x 4>) -> !cir.vector<!u16i x 4> 
+
+  // LLVM:   {{.*}}@test_vshl_n_u16(<4 x i16>{{.*}}[[A:%.*]])
+  // LLVM:   [[TMP0:%.*]] = bitcast <4 x i16> [[A]] to <8 x i8>
+  // LLVM:   [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
+  // LLVM:   [[VSHL_N:%.*]] = shl <4 x i16> [[TMP1]], <i16 3, i16 3, i16 3, i16 3>
+  // LLVM:   ret <4 x i16> [[VSHL_N]]
+}
+
+uint32x2_t test_vshl_n_u32(uint32x2_t a) {
+  return vshl_n_u32(a, 3);
+
+  // CIR-LABEL: @test_vshl_n_u32
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!u32i x 2>, {{.*}} : 
+  // CIR-SAME: !cir.vector<!u32i x 2>) -> !cir.vector<!u32i x 2> 
+  
+  // LLVM:   {{.*}}@test_vshl_n_u32(<2 x i32>{{.*}}[[A:%.*]])
+  // LLVM:   [[TMP0:%.*]] = bitcast <2 x i32> [[A]] to <8 x i8>
+  // LLVM:   [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]]
+  // LLVM:   [[VSHL_N:%.*]] = shl <2 x i32> [[TMP1]], <i32 3, i32 3>
+  // LLVM:   ret <2 x i32> [[VSHL_N]]
+}
+
+uint8x16_t test_vshlq_n_u8(uint8x16_t a) {
+  return vshlq_n_u8(a, 3);
+
+  // CIR-LABEL: @test_vshlq_n_u8
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!u8i x 16>, {{.*}} : 
+  // CIR-SAME: !cir.vector<!u8i x 16>) -> !cir.vector<!u8i x 16> 
+
+  // LLVM:   {{.*}}@test_vshlq_n_u8(<16 x i8>{{.*}}[[A:%.*]])
+  // LLVM:   [[VSHL_N:%.*]] = shl <16 x i8> [[A]], <i8 3, i8 3, i8 3, i8 3, i8 3,
+  // LLVM-SAME: i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>
+  // LLVM:   ret <16 x i8> [[VSHL_N]]
+}
+
+uint16x8_t test_vshlq_n_u16(uint16x8_t a) {
+  return vshlq_n_u16(a, 3);
+
+  // CIR-LABEL: @test_vshlq_n_u16
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!u16i x 8>, {{.*}} : 
+  // CIR-SAME: !cir.vector<!u16i x 8>) -> !cir.vector<!u16i x 8> 
+
+  // LLVM:   {{.*}}@test_vshlq_n_u16(<8 x i16>{{.*}}[[A:%.*]])
+  // LLVM:   [[TMP0:%.*]] = bitcast <8 x i16> [[A]] to <16 x i8>
+  // LLVM:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]] to <8 x i16>
+  // LLVM:   [[VSHL_N:%.*]] = shl <8 x i16> [[TMP1]], <i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3>
+  // LLVM:   ret <8 x i16> [[VSHL_N]]
+}
+
+uint32x4_t test_vshlq_n_u32(uint32x4_t a) {
+  return vshlq_n_u32(a, 3);
+
+  // CIR-LABEL: @test_vshlq_n_u32
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!u32i x 4>, {{.*}} : 
+  // CIR-SAME: !cir.vector<!u32i x 4>) -> !cir.vector<!u32i x 4> 
+
+  // LLVM:   {{.*}}@test_vshlq_n_u32(<4 x i32>{{.*}}[[A:%.*]])
+  // LLVM:   [[TMP0:%.*]] = bitcast <4 x i32> [[A]] to <16 x i8>
+  // LLVM:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]]
+  // LLVM:   [[VSHL_N:%.*]] = shl <4 x i32> [[TMP1]], <i32 3, i32 3, i32 3, i32 3>
+  // LLVM:   ret <4 x i32> [[VSHL_N]]
+}
+
+uint64x2_t test_vshlq_n_u64(uint64x2_t a) {
+  return vshlq_n_u64(a, 3);
+
+  // CIR-LABEL: @test_vshlq_n_u64
+  // CIR: {{.*}} = cir.shift(left, {{.*}} : !cir.vector<!u64i x 2>, {{.*}} : 
+  // CIR-SAME: !cir.vector<!u64i x 2>) -> !cir.vector<!u64i x 2> 
+
+  // LLVM:   {{.*}}@test_vshlq_n_u64(<2 x i64>{{.*}}[[A:%.*]])
+  // LLVM:   [[TMP0:%.*]] = bitcast <2 x i64> [[A]] to <16 x i8>
+  // LLVM:   [[TMP1:%.*]] = bitcast <16 x i8> [[TMP0]]
+  // LLVM:   [[VSHL_N:%.*]] = shl <2 x i64> [[TMP1]], <i64 3, i64 3>
+  // LLVM:   ret <2 x i64> [[VSHL_N]]
+}
 
 // NYI-LABEL: @test_vshr_n_s8(
 // NYI:   [[VSHR_N:%.*]] = ashr <8 x i8> %a, <i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3, i8 3>

--- a/clang/test/CIR/CodeGen/vectype.cpp
+++ b/clang/test/CIR/CodeGen/vectype.cpp
@@ -5,7 +5,7 @@ typedef double vd2 __attribute__((vector_size(16)));
 typedef long long vll2 __attribute__((vector_size(16)));
 typedef unsigned short vus2 __attribute__((vector_size(4)));
 
-void vector_int_test(int x) {
+void vector_int_test(int x, unsigned short usx) {
 
   // Vector constant.
   vi4 a = { 1, 2, 3, 4 };
@@ -102,6 +102,22 @@ void vector_int_test(int x) {
   // CHECK: %{{[0-9]+}} = cir.vec.shuffle(%{{[0-9]+}}, %{{[0-9]+}} : !cir.vector<!s32i x 4>) [#cir.int<7> : !s64i, #cir.int<5> : !s64i, #cir.int<3> : !s64i, #cir.int<1> : !s64i] : !cir.vector<!s32i x 4>
   vi4 v = __builtin_shufflevector(a, b);
   // CHECK: %{{[0-9]+}} = cir.vec.shuffle.dynamic %{{[0-9]+}} : !cir.vector<!s32i x 4>, %{{[0-9]+}} : !cir.vector<!s32i x 4>
+
+  // Shifts
+  vi4 w = a << b;
+  // CHECK: %{{[0-9]+}} = cir.shift(left, {{%.*}} : !cir.vector<!s32i x 4>, 
+  // CHECK-SAME: {{%.*}} : !cir.vector<!s32i x 4>) -> !cir.vector<!s32i x 4>
+  vi4 y = a >> b;
+  // CHECK: %{{[0-9]+}} = cir.shift( right, {{%.*}} : !cir.vector<!s32i x 4>, 
+  // CHECK-SAME: {{%.*}} : !cir.vector<!s32i x 4>) -> !cir.vector<!s32i x 4>
+
+  vus2 z = { usx, usx };  
+  // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}} : !u16i, !u16i) : !cir.vector<!u16i x 2>
+  vus2 zamt = { 3, 4 };
+  // CHECK: %{{[0-9]+}} = cir.const #cir.const_vector<[#cir.int<3> : !u16i, #cir.int<4> : !u16i]> : !cir.vector<!u16i x 2>
+  vus2 zzz = z >> zamt;
+  // CHECK: %{{[0-9]+}} = cir.shift( right, {{%.*}} : !cir.vector<!u16i x 2>, 
+  // CHECK-SAME: {{%.*}} : !cir.vector<!u16i x 2>) -> !cir.vector<!u16i x 2> 
 }
 
 void vector_double_test(int x, double y) {

--- a/clang/test/CIR/IR/cir-ops.cir
+++ b/clang/test/CIR/IR/cir-ops.cir
@@ -57,6 +57,14 @@ module  {
     %5 = cir.objsize(%3 : <!s8i>, min) -> !u64i
     cir.return
   }
+
+  cir.func @shiftvec() {
+    %0 = cir.alloca !cir.vector<!s32i x 2>, !cir.ptr<!cir.vector<!s32i x 2>>, ["a", init] {alignment = 8 : i64}
+    %1 = cir.load %0 : !cir.ptr<!cir.vector<!s32i x 2>>, !cir.vector<!s32i x 2>
+    %2 = cir.const #cir.const_vector<[#cir.int<12> : !s32i, #cir.int<12> : !s32i]> : !cir.vector<!s32i x 2>
+    %3 = cir.shift(left, %1 : !cir.vector<!s32i x 2>, %2 : !cir.vector<!s32i x 2>) -> !cir.vector<!s32i x 2>
+    cir.return
+  }
 }
 
 // CHECK: module  {
@@ -101,5 +109,13 @@ module  {
 // CHECK-NEXT:   %3 = cir.objsize(%1 : <!s8i>, min) -> !u64i
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }
+
+// CHECK:  cir.func @shiftvec() {
+// CHECK-NEXT:    %0 = cir.alloca !cir.vector<!s32i x 2>, !cir.ptr<!cir.vector<!s32i x 2>>
+// CHECK-NEXT:    %1 = cir.load %0 : !cir.ptr<!cir.vector<!s32i x 2>>, !cir.vector<!s32i x 2>
+// CHECK-NEXT:    %2 = cir.const #cir.const_vector<[#cir.int<12> : !s32i, #cir.int<12> : !s32i]> : !cir.vector<!s32i x 2>
+// CHECK-NEXT:    %3 = cir.shift(left, %1 : !cir.vector<!s32i x 2>, %2 : !cir.vector<!s32i x 2>) -> !cir.vector<!s32i x 2>
+// CHECK-NEXT:    cir.return
+// CHECK-NEXT:  }
 
 // CHECK: }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1142,7 +1142,7 @@ cir.func @bad_goto() -> () {
 ^bb1:
   cir.label "label"
   cir.return
-} 
+}
 
 // -----
 
@@ -1328,3 +1328,34 @@ module {
 
 }
 
+// -----
+
+!s32i = !cir.int<s, 32>
+!s16i = !cir.int<s, 16>
+module {
+  cir.func @test_shift_vec() {
+    %0 = cir.alloca !cir.vector<!s32i x 2>, !cir.ptr<!cir.vector<!s32i x 2>>, ["a", init] {alignment = 8 : i64}
+    %1 = cir.load %0 : !cir.ptr<!cir.vector<!s32i x 2>>, !cir.vector<!s32i x 2>
+    %2 = cir.const #cir.int<12> : !s32i
+    %4 = cir.const #cir.const_vector<[#cir.int<12> : !s16i, #cir.int<12> : !s16i]> : !cir.vector<!s16i x 2>
+    // expected-error@+1 {{'cir.shift' op input types cannot be one vector and one scalar}}
+    %3 = cir.shift(left, %1 : !cir.vector<!s32i x 2>, %2 : !s32i) -> !cir.vector<!s32i x 2>
+    %5 = cir.shift(left, %1 : !cir.vector<!s32i x 2>, %4 : !cir.vector<!s16i x 2>) -> !cir.vector<!s32i x 2>
+    cir.return
+  }
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!s16i = !cir.int<s, 16>
+module {
+   cir.func @test_shift_vec2() {
+    %0 = cir.alloca !cir.vector<!s32i x 2>, !cir.ptr<!cir.vector<!s32i x 2>>, ["a", init] {alignment = 8 : i64}
+    %1 = cir.load %0 : !cir.ptr<!cir.vector<!s32i x 2>>, !cir.vector<!s32i x 2>
+    %4 = cir.const #cir.const_vector<[#cir.int<12> : !s16i, #cir.int<12> : !s16i]> : !cir.vector<!s16i x 2>
+    // expected-error@+1 {{'cir.shift' op shift amount must have the type of the result if it is vector shift}}
+    %5 = cir.shift(left, %1 : !cir.vector<!s32i x 2>, %4 : !cir.vector<!s16i x 2>) -> !cir.vector<!s32i x 2>
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/vectype.cpp
+++ b/clang/test/CIR/Lowering/vectype.cpp
@@ -219,6 +219,24 @@ void vector_int_test(int x) {
   // CHECK: %[[#svQ:]] = llvm.extractelement %[[#sv_a]][%[[#svP:]] : i32] : vector<4xi32>
   // CHECK: %[[#svR:]] = llvm.insertelement %[[#svQ]], %[[#svN]][%[[#svO]] : i64] : vector<4xi32>
   // CHECK: llvm.store %[[#svR]], %[[#sv_v:]] {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr
+
+  // Shifts
+  vi4 w = a << b;
+  // CHECK: %[[#T198:]] = llvm.load %[[#T3]] {alignment = 16 : i64} : !llvm.ptr -> vector<4xi32>
+  // CHECK: %[[#T199:]] = llvm.load %[[#T5]] {alignment = 16 : i64} : !llvm.ptr -> vector<4xi32>
+  // CHECK: %{{[0-9]+}}  = llvm.shl %[[#T198]], %[[#T199]] : vector<4xi32>
+  vi4 y = a >> b;
+  // CHECK: %[[#T201:]] = llvm.load %[[#T3]] {alignment = 16 : i64} : !llvm.ptr -> vector<4xi32>
+  // CHECK: %[[#T202:]] = llvm.load %[[#T5]] {alignment = 16 : i64} : !llvm.ptr -> vector<4xi32>
+  // CHECK: %{{[0-9]+}}  = llvm.ashr %[[#T201]], %[[#T202]] : vector<4xi32>
+
+  vus2 z = { (unsigned short)x, (unsigned short)x };  
+  vus2 zamt = { 3, 4 };
+  // CHECK: %[[#T219:]] = llvm.mlir.constant(dense<[3, 4]> : vector<2xi16>) : vector<2xi16>
+  // CHECK: llvm.store %[[#T219]], %[[#AMT_SAVE:]] {alignment = 4 : i64} : vector<2xi16>
+  // CHECK: %[[#T221:]] = llvm.load %[[#AMT_SAVE]] {alignment = 4 : i64} : !llvm.ptr -> vector<2xi16>
+  vus2 zzz = z >> zamt;
+  // CHECK: %{{[0-9]+}}  = llvm.lshr %{{[0-9]+}}, %[[#T221]] : vector<2xi16>
 }
 
 void vector_double_test(int x, double y) {


### PR DESCRIPTION
As title, but important step in this PR is to allow CIR ShiftOp to take vector of int type as input type. As result, I added a verifier to ShiftOp with 2 constraints

1. Input type either all vector or int type. This is consistent with LLVM::ShlOp, vector shift amount is expected.
2. In the spirit of C99 6.5.7.3, shift amount type must be the same as result type, the if vector type is used. (This is enforced in LLVM lowering for scalar int type). 