### PR TITLE
[CIR] [CodeGen] Introduce IsFPClassOp to support builtin_isfpclass

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4027,6 +4027,39 @@ def FMinOp : BinaryFPToFPBuiltinOp<"fmin", "MinNumOp">;
 def FModOp : BinaryFPToFPBuiltinOp<"fmod", "FRemOp">;
 def PowOp : BinaryFPToFPBuiltinOp<"pow", "PowOp">;
 
+def IsFPClassOp : CIR_Op<"is_fp_class"> {
+  let summary = "Corresponding to the `__builtin_fpclassify` builtin function in clang";
+
+  let description = [{
+    The `cir.is_fp_class` operation takes a floating-point value as its first
+    argument and a bitfield of flags as its second argument. The operation
+    returns a boolean value indicating whether the floating-point value
+    satisfies the given flags.
+
+    The flags must be a compile time constant and the values are:
+
+    | Bit # | floating-point class |
+    | -------- | ------- |
+    | 0 | Signaling NaN      |
+    | 1 | Quiet NaN          |
+    | 2 | Negative infinity  |
+    | 3 | Negative normal    |
+    | 4 | Negative subnormal |
+    | 5 | Negative zero      |
+    | 6 | Positive zero      |
+    | 7 | Positive subnormal |
+    | 8 | Positive normal    |
+    | 9 | Positive infinity  |
+  }];
+
+  let arguments = (ins CIR_AnyFloat:$src,
+                       I32Attr:$flags);
+  let results = (outs CIR_BoolType:$result);
+  let assemblyFormat = [{
+    $src `,` $flags `:` functional-type($src, $result) attr-dict
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Assume Operations
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -202,7 +202,8 @@ def CIR_LongDouble : CIR_FloatType<"LongDouble", "long_double"> {
 
 // Constraints
 
-def CIR_AnyFloat: AnyTypeOf<[CIR_Single, CIR_Double, CIR_FP80, CIR_FP128, CIR_LongDouble]>;
+def CIR_AnyFloat: AnyTypeOf<[CIR_Single, CIR_Double, CIR_FP80, CIR_FP128, CIR_LongDouble,
+    CIR_FP16, CIR_BFloat16]>;
 def CIR_AnyIntOrFloat: AnyTypeOf<[CIR_AnyFloat, CIR_IntType]>;
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -584,6 +584,11 @@ public:
                                          getAttr<mlir::cir::FPAttr>(t, fpVal));
   }
 
+  mlir::cir::IsFPClassOp createIsFPClass(mlir::Location loc, mlir::Value src,
+                                         unsigned flags) {
+    return create<mlir::cir::IsFPClassOp>(loc, src, flags);
+  }
+
   /// Create constant nullptr for pointer-to-data-member type ty.
   mlir::cir::ConstantOp getNullDataMemberPtr(mlir::cir::DataMemberType ty,
                                              mlir::Location loc) {

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -25,6 +25,7 @@ namespace cir {
 
 class CIRGenFunction;
 class CIRGenModule;
+class CIRGenBuilderTy;
 
 /// This class organizes various target-specific codegeneration issues, like
 /// target-specific attributes, builtins and so on.
@@ -41,6 +42,15 @@ public:
   virtual bool isScalarizableAsmOperand(CIRGenFunction &CGF,
                                         mlir::Type Ty) const {
     return false;
+  }
+
+  /// Performs a target specific test of a floating point value for things
+  /// like IsNaN, Infinity, ... Nullptr is returned if no implementation
+  /// exists.
+  virtual mlir::Value testFPKind(mlir::Value V, unsigned BuiltinID,
+                                 CIRGenBuilderTy &Builder,
+                                 CIRGenModule &CGM) const {
+    return {};
   }
 
   /// Corrects the MLIR type for a given constraint and "usual"

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4119,6 +4119,33 @@ public:
   }
 };
 
+class CIRIsFPClassOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::IsFPClassOp> {
+public:
+  using OpConversionPattern<mlir::cir::IsFPClassOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::IsFPClassOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto src = adaptor.getSrc();
+    auto flags = adaptor.getFlags();
+    auto retTy = rewriter.getI1Type();
+
+    auto loc = op->getLoc();
+
+    auto intrinsic =
+        rewriter.create<mlir::LLVM::IsFPClass>(loc, retTy, src, flags);
+    // FIMXE: CIR now will convert cir::BoolType to i8 type unconditionally.
+    // Remove this conversion after we fix
+    // https://github.com/llvm/clangir/issues/480
+    auto converted = rewriter.create<mlir::LLVM::ZExtOp>(
+        loc, rewriter.getI8Type(), intrinsic->getResult(0));
+
+    rewriter.replaceOp(op, converted);
+    return mlir::success();
+  }
+};
+
 void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter,
                                          mlir::DataLayout &dataLayout) {
@@ -4151,7 +4178,7 @@ void populateCIRToLLVMConversionPatterns(mlir::RewritePatternSet &patterns,
       CIREhTypeIdOpLowering, CIRCatchParamOpLowering, CIRResumeOpLowering,
       CIRAllocExceptionOpLowering, CIRFreeExceptionOpLowering,
       CIRThrowOpLowering, CIRIntrinsicCallLowering, CIRBaseClassAddrOpLowering,
-      CIRVTTAddrPointOpLowering
+      CIRVTTAddrPointOpLowering, CIRIsFPClassOpLowering
 #define GET_BUILTIN_LOWERING_LIST
 #include "clang/CIR/Dialect/IR/CIRBuiltinsLowering.inc"
 #undef GET_BUILTIN_LOWERING_LIST

--- a/clang/test/CIR/CodeGen/builtin-isfpclass.c
+++ b/clang/test/CIR/CodeGen/builtin-isfpclass.c
@@ -1,0 +1,129 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+int finite(double);
+
+// CHECK: cir.func {{.*}}@test_is_finite
+void test_is_finite(__fp16 *H, float F, double D, long double LD) {
+    volatile int res;
+    res = __builtin_isinf(*H);
+    // CHECK: cir.is_fp_class %{{.*}}, 516 : (!cir.f16) -> !cir.bool
+
+    res = __builtin_isinf(F);
+    // CHECK: cir.is_fp_class %{{.*}}, 516 : (!cir.float) -> !cir.bool
+
+    res = __builtin_isinf(D);
+    // CHECK: cir.is_fp_class %{{.*}}, 516 : (!cir.double) -> !cir.bool
+
+    res = __builtin_isinf(LD);
+    // CHECK: cir.is_fp_class %{{.*}}, 516 : (!cir.long_double<!cir.f80>) -> !cir.bool
+
+    res = __builtin_isfinite(*H);
+    // CHECK: cir.is_fp_class %{{.*}}, 504 : (!cir.f16) -> !cir.bool
+    res = __builtin_isfinite(F);
+    // CHECK: cir.is_fp_class %{{.*}}, 504 : (!cir.float) -> !cir.bool
+    res = finite(D);
+    // CHECK: cir.is_fp_class %{{.*}}, 504 : (!cir.double) -> !cir.bool
+
+    res = __builtin_isnormal(*H);
+    // CHECK: cir.is_fp_class %{{.*}}, 264 : (!cir.f16) -> !cir.bool
+    res = __builtin_isnormal(F);
+    // CHECK: cir.is_fp_class %{{.*}}, 264 : (!cir.float) -> !cir.bool
+
+    res = __builtin_issubnormal(F);
+    // CHECK: cir.is_fp_class %{{.*}}, 144 : (!cir.float) -> !cir.bool
+    res = __builtin_iszero(F);
+    // CHECK: cir.is_fp_class %{{.*}}, 96 : (!cir.float) -> !cir.bool
+    res = __builtin_issignaling(F);
+    // CHECK: cir.is_fp_class %{{.*}}, 1 : (!cir.float) -> !cir.bool
+}
+
+_Bool check_isfpclass_finite(float x) {
+  return __builtin_isfpclass(x, 504 /*Finite*/);
+}
+
+// CHECK: cir.func {{.*}}@check_isfpclass_finite
+// CHECK: cir.is_fp_class %{{.*}}, 504 : (!cir.float)
+
+_Bool check_isfpclass_nan_f32(float x) {
+  return __builtin_isfpclass(x, 3 /*NaN*/);
+}
+
+// CHECK: cir.func {{.*}}@check_isfpclass_nan_f32
+// CHECK: cir.is_fp_class %{{.*}}, 3 : (!cir.float)
+
+
+_Bool check_isfpclass_snan_f64(double x) {
+  return __builtin_isfpclass(x, 1 /*SNaN*/);
+}
+
+// CHECK: cir.func {{.*}}@check_isfpclass_snan_f64
+// CHECK: cir.is_fp_class %{{.*}}, 1 : (!cir.double)
+
+
+_Bool check_isfpclass_zero_f16(_Float16 x) {
+  return __builtin_isfpclass(x, 96 /*Zero*/);
+}
+
+// CHECK: cir.func {{.*}}@check_isfpclass_zero_f16
+// CHECK: cir.is_fp_class %{{.*}}, 96 : (!cir.f16)
+
+// Update when we support FP pragma in functions and can convert BoolType in prvalue to i1.
+
+// _Bool check_isfpclass_finite_strict(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 504 /*Finite*/);
+// }
+// 
+// _Bool check_isfpclass_nan_f32_strict(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 3 /*NaN*/);
+// }
+// 
+// _Bool check_isfpclass_snan_f64_strict(double x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 1 /*NaN*/);
+// }
+// 
+// _Bool check_isfpclass_zero_f16_strict(_Float16 x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 96 /*Zero*/);
+// }
+// 
+// _Bool check_isnan(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isnan(x);
+// }
+// 
+// _Bool check_isinf(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isinf(x);
+// }
+// 
+// _Bool check_isfinite(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfinite(x);
+// }
+// 
+// _Bool check_isnormal(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isnormal(x);
+// }
+// 
+// typedef float __attribute__((ext_vector_type(4))) float4;
+// typedef double __attribute__((ext_vector_type(4))) double4;
+// typedef int __attribute__((ext_vector_type(4))) int4;
+// typedef long __attribute__((ext_vector_type(4))) long4;
+// 
+// int4 check_isfpclass_nan_v4f32(float4 x) {
+//   return __builtin_isfpclass(x, 3 /*NaN*/);
+// }
+// 
+// int4 check_isfpclass_nan_strict_v4f32(float4 x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 3 /*NaN*/);
+// }
+// 
+// long4 check_isfpclass_nan_v4f64(double4 x) {
+//   return __builtin_isfpclass(x, 3 /*NaN*/);
+// }

--- a/clang/test/CIR/Lowering/builtin-isfpclass.c
+++ b/clang/test/CIR/Lowering/builtin-isfpclass.c
@@ -1,0 +1,125 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s
+
+int finite(double);
+
+// CHECK: define {{.*}}@test_is_finite
+void test_is_finite(__fp16 *H, float F, double D, long double LD) {
+    volatile int res;
+    res = __builtin_isinf(*H);
+    // CHECK: call i1 @llvm.is.fpclass.f16(half %{{.*}}, i32 516)
+    res = __builtin_isinf(F);
+    // CHECK: call i1 @llvm.is.fpclass.f32(float %{{.*}}, i32 516)
+    res = __builtin_isinf(D);
+    // CHECK: call i1 @llvm.is.fpclass.f64(double %{{.*}}, i32 516)
+    res = __builtin_isinf(LD);
+    // CHECK: call i1 @llvm.is.fpclass.f80(x86_fp80 %{{.*}}, i32 516)
+
+    res = __builtin_isfinite(*H);
+    // CHECK: call i1 @llvm.is.fpclass.f16(half %{{.*}}, i32 504)
+    res = __builtin_isfinite(F);
+    // CHECK: call i1 @llvm.is.fpclass.f32(float %{{.*}}, i32 504)
+    res = finite(D);
+    // CHECK: call i1 @llvm.is.fpclass.f64(double %{{.*}}, i32 504)
+
+    res = __builtin_isnormal(*H);
+    // CHECK: call i1 @llvm.is.fpclass.f16(half %{{.*}}, i32 264)
+    res = __builtin_isnormal(F);
+    // CHECK: call i1 @llvm.is.fpclass.f32(float %{{.*}}, i32 264)
+
+    res = __builtin_issubnormal(F);
+    // CHECK: call i1 @llvm.is.fpclass.f32(float %{{.*}}, i32 144)
+    res = __builtin_iszero(F);
+    // CHECK: call i1 @llvm.is.fpclass.f32(float %{{.*}}, i32 96)
+    res = __builtin_issignaling(F);
+    // CHECK: call i1 @llvm.is.fpclass.f32(float %{{.*}}, i32 1)
+}
+
+_Bool check_isfpclass_finite(float x) {
+  return __builtin_isfpclass(x, 504 /*Finite*/);
+}
+
+// CHECK: define {{.*}}@check_isfpclass_finite
+// CHECK: call i1 @llvm.is.fpclass.f32(float %{{.*}}, i32 504)
+
+_Bool check_isfpclass_nan_f32(float x) {
+  return __builtin_isfpclass(x, 3 /*NaN*/);
+}
+
+// CHECK: define {{.*}}@check_isfpclass_nan_f32
+// CHECK: call i1 @llvm.is.fpclass.f32(float %{{.*}}, i32 3)
+
+_Bool check_isfpclass_snan_f64(double x) {
+  return __builtin_isfpclass(x, 1 /*SNaN*/);
+}
+
+// CHECK: define {{.*}}@check_isfpclass_snan_f64
+// CHECK: call i1 @llvm.is.fpclass.f64(double %{{.*}}, i32 1)
+
+
+_Bool check_isfpclass_zero_f16(_Float16 x) {
+  return __builtin_isfpclass(x, 96 /*Zero*/);
+}
+
+// CHECK: define {{.*}}@check_isfpclass_zero_f16
+// CHECK: call i1 @llvm.is.fpclass.f16(half %{{.*}}, i32 96)
+
+// Update when we support FP pragma in functions.
+
+// _Bool check_isfpclass_finite_strict(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 504 /*Finite*/);
+// }
+// 
+// _Bool check_isfpclass_nan_f32_strict(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 3 /*NaN*/);
+// }
+// 
+// _Bool check_isfpclass_snan_f64_strict(double x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 1 /*NaN*/);
+// }
+// 
+// _Bool check_isfpclass_zero_f16_strict(_Float16 x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 96 /*Zero*/);
+// }
+// 
+// _Bool check_isnan(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isnan(x);
+// }
+// 
+// _Bool check_isinf(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isinf(x);
+// }
+// 
+// _Bool check_isfinite(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfinite(x);
+// }
+// 
+// _Bool check_isnormal(float x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isnormal(x);
+// }
+// 
+// typedef float __attribute__((ext_vector_type(4))) float4;
+// typedef double __attribute__((ext_vector_type(4))) double4;
+// typedef int __attribute__((ext_vector_type(4))) int4;
+// typedef long __attribute__((ext_vector_type(4))) long4;
+// 
+// int4 check_isfpclass_nan_v4f32(float4 x) {
+//   return __builtin_isfpclass(x, 3 /*NaN*/);
+// }
+// 
+// int4 check_isfpclass_nan_strict_v4f32(float4 x) {
+// #pragma STDC FENV_ACCESS ON
+//   return __builtin_isfpclass(x, 3 /*NaN*/);
+// }
+// 
+// long4 check_isfpclass_nan_v4f64(double4 x) {
+//   return __builtin_isfpclass(x, 3 /*NaN*/);
+// }


### PR DESCRIPTION
The llvm's intrinsic `llvm.is.fpclass` is used to support multiple float point builtins: https://clang.llvm.org/docs/LanguageExtensions.html#builtin-isfpclass

> The `__builtin_isfpclass()` builtin is a generalization of functions
> isnan, isinf, isfinite and some others defined by the C standard. It tests
> if the floating-point value, specified by the first argument, falls into
> any of data classes, specified by the second argument.

I meant to support this by creating IntrinsicCallOp directly. But I can't make it due to https://github.com/llvm/clangir/issues/480 since the return type of the intrinsic will mismatch. So I have to create a new Op for it. But I feel it might not be too bad. At least it is more explicit and more expressive.