### PR TITLE
[docs] Use clearpathrobotics/jekyll-rtd-theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-remote_theme: just-the-docs/just-the-docs
+remote_theme: clearpathrobotics/jekyll-rtd-theme
 title: ClangIR
 description: A new high-level IR for clang.
 


### PR DESCRIPTION
This is a clone of the original rundocs/jekyll-rtd-theme, which got deleted. It should restore our previous look and feel while still allowing updates. https://smeenai.github.io/clangir/ shows what it looks like.