### PR TITLE
[CIR][CIRGen] Port 1d0bd8e51be2627f79bede54735c38b917ea04ee

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2130,16 +2130,6 @@ mlir::cir::GlobalLinkageKind CIRGenModule::getFunctionLinkage(GlobalDecl GD) {
   if (const auto *Dtor = dyn_cast<CXXDestructorDecl>(D))
     return getCXXABI().getCXXDestructorLinkage(Linkage, Dtor, GD.getDtorType());
 
-  if (isa<CXXConstructorDecl>(D) &&
-      cast<CXXConstructorDecl>(D)->isInheritingConstructor() &&
-      astCtx.getTargetInfo().getCXXABI().isMicrosoft()) {
-    // Just like in LLVM codegen:
-    // Our approach to inheriting constructors is fundamentally different from
-    // that used by the MS ABI, so keep our inheriting constructor thunks
-    // internal rather than trying to pick an unambiguous mangling for them.
-    return mlir::cir::GlobalLinkageKind::InternalLinkage;
-  }
-
   return getCIRLinkageForDeclarator(D, Linkage, /*IsConstantVariable=*/false);
 }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/1d0bd8e51be2627f79bede54735c38b917ea04ee
moves a conditional from CodeGen to AST, and this follows suit for
consistency. (Our support for the Microsoft ABI is NYI anyway; this is
just to make things simpler to follow when matching up logic between
CodeGen and CIRGen.)
