### PR TITLE
[CIR][CIRGen] Implement CIRGenModule::shouldEmitFunction

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -665,7 +665,9 @@ public:
   // Finalize CIR code generation.
   void Release();
 
-  bool shouldEmitFunction(clang::GlobalDecl GD);
+  bool isTriviallyRecursive(const clang::FunctionDecl *func);
+
+  bool shouldEmitFunction(clang::GlobalDecl globalDecl);
 
   /// Returns a pointer to a global variable representing a temporary with
   /// static or thread storage duration.

--- a/clang/test/CIR/CodeGen/linkage.c
+++ b/clang/test/CIR/CodeGen/linkage.c
@@ -1,5 +1,7 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t-O0.cir
+// RUN: FileCheck --input-file=%t-O0.cir %s -check-prefixes=CIR,CIR-O0
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -O1 -o %t-O1.cir
+// RUN: FileCheck --input-file=%t-O1.cir %s -check-prefixes=CIR,CIR-O1
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
@@ -24,7 +26,8 @@ int get_var(void) {
   return var;
 }
 
-// Should generate available_externally linkage.
+// Should generate available_externally linkage when optimizing.
 inline int availableExternallyMethod(void) { return 0; }
 void callAvailableExternallyMethod(void) { availableExternallyMethod(); }
-// CIR: cir.func available_externally @availableExternallyMethod
+// CIR-O0-NOT: cir.func available_externally @availableExternallyMethod
+// CIR-O1:     cir.func available_externally @availableExternallyMethod


### PR DESCRIPTION
This is the usual copy-paste-modify from CodeGen, though I changed all
the variable names to conform to our new style. All these functions
should be pulled out as common helpers when we're upstream.
