### PR TITLE
[CIR][ABI][Lowering] Supports function pointers in the calling convention lowering pass

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -73,30 +73,6 @@ public:
   }
 };
 
-//===----------------------------------------------------------------------===//
-// Pass
-//===----------------------------------------------------------------------===//
-
-void initTypeConverter(mlir::TypeConverter& converter,
-                       mlir::cir::LowerModule& module) {
-   
-  converter.addConversion([](mlir::Type typ) -> mlir::Type { return typ; });
-
-  converter.addConversion([&](mlir::cir::FuncType funTy) -> mlir::Type {
-    return lowerFuncType(module, funTy);
-  });
-
-  converter.addConversion([&](mlir::cir::PointerType ptrTy) -> mlir::Type {
-    auto pointee = converter.convertType(ptrTy.getPointee());
-    return PointerType::get(module.getMLIRContext(), pointee);
-  });
-
-  converter.addConversion([&](mlir::cir::ArrayType arTy) -> mlir::Type {
-    auto eltType = converter.convertType(arTy.getEltType());
-    return ArrayType::get(module.getMLIRContext(), eltType, arTy.getSize());
-  });
-}
-
 class CCGetGlobalOpLowering 
     : public mlir::OpConversionPattern<mlir::cir::GetGlobalOp> {
 
@@ -122,7 +98,6 @@ public:
   
     return failure();
   }
-
 };
 
 class CCAllocaOpLowering : public mlir::OpConversionPattern<mlir::cir::AllocaOp> {
@@ -149,6 +124,30 @@ public:
     return failure();
   }
 };
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+void initTypeConverter(mlir::TypeConverter& converter,
+                       mlir::cir::LowerModule& module) {
+   
+  converter.addConversion([](mlir::Type typ) -> mlir::Type { return typ; });
+
+  converter.addConversion([&](mlir::cir::FuncType funTy) -> mlir::Type {
+    return lowerFuncType(module, funTy);
+  });
+
+  converter.addConversion([&](mlir::cir::PointerType ptrTy) -> mlir::Type {
+    auto pointee = converter.convertType(ptrTy.getPointee());
+    return PointerType::get(module.getMLIRContext(), pointee);
+  });
+
+  converter.addConversion([&](mlir::cir::ArrayType arTy) -> mlir::Type {
+    auto eltType = converter.convertType(arTy.getEltType());
+    return ArrayType::get(module.getMLIRContext(), eltType, arTy.getSize());
+  });
+}
 
 struct CallConvLoweringPass
     : ::impl::CallConvLoweringBase<CallConvLoweringPass> {

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -53,16 +53,14 @@ public:
     auto calls = op.getSymbolUses(module);
     if (calls.has_value()) {
       for (auto call : calls.value()) {
-        // // FIXME(cir): Function pointers are ignored.
-        // if (isa<GetGlobalOp>(call.getUser())) {
-        //   cir_cconv_assert_or_abort(!::cir::MissingFeatures::ABIFuncPtr(),
-        //                             "NYI");
-        //   continue;
-        // }
+        // FIXME(cir): Function pointers are ignored except the next cases
+        if (!isa<GetGlobalOp, CallOp>(call.getUser())) {
+          cir_cconv_assert_or_abort(!::cir::MissingFeatures::ABIFuncPtr(),
+                                    "NYI");
+          continue;
+        }
 
         auto callOp = dyn_cast_or_null<CallOp>(call.getUser());
-        // if (!callOp)
-        //   cir_cconv_unreachable("NYI empty callOp");
         if (auto callOp = dyn_cast_or_null<CallOp>(call.getUser()))
           if (lowerModule.rewriteFunctionCall(callOp, op).failed())
             return failure();

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -8,6 +8,7 @@
 
 #include "TargetLowering/LowerModule.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -23,55 +24,133 @@
 namespace mlir {
 namespace cir {
 
+FuncType lowerFuncType(LowerModule& mod, FuncType ftyp) {
+  auto& typs = mod.getTypes();
+  auto& info = typs.arrangeFreeFunctionType(ftyp);
+  return typs.getFunctionType(info);
+}
+
 //===----------------------------------------------------------------------===//
 // Rewrite Patterns
 //===----------------------------------------------------------------------===//
 
-struct CallConvLoweringPattern : public OpRewritePattern<FuncOp> {
+class CCFuncOpLowering : public mlir::OpRewritePattern<FuncOp> { 
   using OpRewritePattern<FuncOp>::OpRewritePattern;
+  LowerModule& lowerModule;
 
-  LogicalResult matchAndRewrite(FuncOp op,
-                                PatternRewriter &rewriter) const final {
+public:
+  CCFuncOpLowering(LowerModule& mod, mlir::MLIRContext *context)      
+      : OpRewritePattern(context)
+      , lowerModule(mod) {}
+
+  LogicalResult matchAndRewrite(FuncOp op,  
+                                PatternRewriter &rewriter) const final {    
     llvm::TimeTraceScope scope("Call Conv Lowering Pass", op.getSymName().str());
-
     const auto module = op->getParentOfType<mlir::ModuleOp>();
-
-    auto modOp = op->getParentOfType<ModuleOp>();
-    std::unique_ptr<LowerModule> lowerModule =
-        createLowerModule(modOp, rewriter);
 
     // Rewrite function calls before definitions. This should be done before
     // lowering the definition.
     auto calls = op.getSymbolUses(module);
     if (calls.has_value()) {
       for (auto call : calls.value()) {
-        // FIXME(cir): Function pointers are ignored.
-        if (isa<GetGlobalOp>(call.getUser())) {
-          cir_cconv_assert_or_abort(!::cir::MissingFeatures::ABIFuncPtr(),
-                                    "NYI");
-          continue;
-        }
+        // // FIXME(cir): Function pointers are ignored.
+        // if (isa<GetGlobalOp>(call.getUser())) {
+        //   cir_cconv_assert_or_abort(!::cir::MissingFeatures::ABIFuncPtr(),
+        //                             "NYI");
+        //   continue;
+        // }
 
         auto callOp = dyn_cast_or_null<CallOp>(call.getUser());
-        if (!callOp)
-          cir_cconv_unreachable("NYI empty callOp");
-        if (lowerModule->rewriteFunctionCall(callOp, op).failed())
-          return failure();
+        // if (!callOp)
+        //   cir_cconv_unreachable("NYI empty callOp");
+        if (auto callOp = dyn_cast_or_null<CallOp>(call.getUser()))
+          if (lowerModule.rewriteFunctionCall(callOp, op).failed())
+            return failure();
       }
     }
 
     // TODO(cir): Instead of re-emmiting every load and store, bitcast arguments
     // and return values to their ABI-specific counterparts when possible.
-    if (lowerModule->rewriteFunctionDefinition(op).failed())
-      return failure();
-
-    return success();
+    return lowerModule.rewriteFunctionDefinition(op);      
   }
 };
 
 //===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//
+
+void initTypeConverter(mlir::TypeConverter& converter,
+                       mlir::cir::LowerModule& module) {
+   
+  converter.addConversion([](mlir::Type typ) -> mlir::Type { return typ; });
+
+  converter.addConversion([&](mlir::cir::FuncType funTy) -> mlir::Type {
+    return lowerFuncType(module, funTy);
+  });
+
+  converter.addConversion([&](mlir::cir::PointerType ptrTy) -> mlir::Type {
+    auto pointee = converter.convertType(ptrTy.getPointee());
+    return PointerType::get(module.getMLIRContext(), pointee);
+  });
+
+  converter.addConversion([&](mlir::cir::ArrayType arTy) -> mlir::Type {
+    auto eltType = converter.convertType(arTy.getEltType());
+    return ArrayType::get(module.getMLIRContext(), eltType, arTy.getSize());
+  });
+}
+
+class CCGetGlobalOpLowering 
+    : public mlir::OpConversionPattern<mlir::cir::GetGlobalOp> {
+
+public:
+  CCGetGlobalOpLowering(const mlir::TypeConverter &typeConverter,
+                        mlir::MLIRContext *context)
+      : OpConversionPattern<mlir::cir::GetGlobalOp>(typeConverter, context) 
+      {}
+  
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::GetGlobalOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto resTy = op.getResult().getType();
+    if (auto ptrTy = dyn_cast<PointerType>(resTy)) {
+      if (isa<FuncType>(ptrTy.getPointee())) {
+        rewriter.replaceOpWithNewOp<GetGlobalOp>(op,
+            getTypeConverter()->convertType(resTy),
+            op.getName());
+
+        return success();
+      }
+    }
+  
+    return failure();
+  }
+
+};
+
+class CCAllocaOpLowering : public mlir::OpConversionPattern<mlir::cir::AllocaOp> {
+
+public:
+  CCAllocaOpLowering(const mlir::TypeConverter &typeConverter,
+                     mlir::MLIRContext *context)
+      : OpConversionPattern<mlir::cir::AllocaOp>(typeConverter, context) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::AllocaOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto eltTy = getTypeConverter()->convertType(op.getAllocaType());
+    if (op.getAllocaType() != eltTy) {
+      rewriter.replaceOpWithNewOp<AllocaOp>(op,
+          getTypeConverter()->convertType(op.getResult().getType()),
+          eltTy,
+          op.getName(),
+          op.getAlignmentAttr(),
+          op.getDynAllocSize());
+      return success();
+    }
+
+    return failure();
+  }
+};
 
 struct CallConvLoweringPass
     : ::impl::CallConvLoweringBase<CallConvLoweringPass> {
@@ -81,19 +160,32 @@ struct CallConvLoweringPass
   StringRef getArgument() const override { return "cir-call-conv-lowering"; };
 };
 
-void populateCallConvLoweringPassPatterns(RewritePatternSet &patterns) {
-  patterns.add<CallConvLoweringPattern>(patterns.getContext());
+void populateCallConvLoweringPassPatterns(const mlir::TypeConverter& converter,
+                                          LowerModule& mod, 
+                                          RewritePatternSet &patterns) {  
+  patterns.add<CCFuncOpLowering>(mod, patterns.getContext());  
+  patterns.add<CCGetGlobalOpLowering, CCAllocaOpLowering>(converter, patterns.getContext());   
 }
 
 void CallConvLoweringPass::runOnOperation() {
+  auto module = dyn_cast<ModuleOp>(getOperation());
+  mlir::PatternRewriter rewriter(module.getContext());
+  std::unique_ptr<LowerModule> lowerModule = 
+      createLowerModule(module, rewriter);
+  
+  mlir::TypeConverter converter;
+  initTypeConverter(converter, *lowerModule.get());
 
   // Collect rewrite patterns.
   RewritePatternSet patterns(&getContext());
-  populateCallConvLoweringPassPatterns(patterns);
+  populateCallConvLoweringPassPatterns(converter, *lowerModule.get(), patterns);
 
   // Collect operations to be considered by the pass.
   SmallVector<Operation *, 16> ops;
-  getOperation()->walk([&](FuncOp op) { ops.push_back(op); });
+  getOperation()->walk([&](Operation*op) {
+    if (isa<AllocaOp, FuncOp, GetGlobalOp>(op))
+      ops.push_back(op);
+  });
 
   // Configure rewrite to ignore new ops created during the pass.
   GreedyRewriteConfig config;

--- a/clang/test/CIR/Transforms/call-conv-fptr.c
+++ b/clang/test/CIR/Transforms/call-conv-fptr.c
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-flat -fclangir-call-conv-lowering %s -o - | FileCheck %s
+
+typedef struct {
+  int a;
+} S;
+
+typedef int (*myfptr)(S);
+
+int foo(S s) { return 42 + s.a; }
+
+// CHECK: cir.func {{.*@bar}}
+// CHECK:   %0 = cir.alloca !cir.ptr<!cir.func<!s32i (!s32i)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i)>>>, ["a"]
+// CHECK:   %1 = cir.get_global @foo : !cir.ptr<!cir.func<!s32i (!s32i)>>
+// CHECK:   cir.store %1, %0 : !cir.ptr<!cir.func<!s32i (!s32i)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i)>>>
+void bar() {
+  myfptr a = foo;
+}


### PR DESCRIPTION
This PR adds initial function pointers support for the calling convention lowering pass. This is a suggestion, so any other ideas are welcome.

Several ideas was described in the #995 

#### Problem
Looks like we can not just lower the function type and cast the value since too many operations are involved. For instance, for the
next simple code: 
```
typedef struct {
  int a;
} S;

typedef int (*myfptr)(S);

int foo(S s) { return 42 + s.a; }

void bar() {
  myfptr a = foo;
}
```
we get the next CIR for the function `bar` , before the calling convention lowering pass:
```
cir.func no_proto  @bar() extra(#fn_attr) {
    %0 = cir.alloca !cir.ptr<!cir.func<!s32i (!ty_S)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!ty_S)>>>, ["a", init]
    %1 = cir.get_global @foo : !cir.ptr<!cir.func<!s32i (!ty_S)>> 
    cir.store %1, %0 : !cir.ptr<!cir.func<!s32i (!ty_S)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!ty_S)>>>
    cir.return 
  } 
```
As one can see, first three operations depend on the function type. Once `foo` is lowered, we need to fix `GetGlobalOp`: 
otherwise the code will fail with the verification error  since actual `foo` type (lowered) differs from the one currently expected by the `GetGlobalOp`.
First idea would just rewrite only the `GetGlobalOp`  and insert a bitcast after, so both  `AllocaOp` and `StoreOp` would work witth proper types. 
This will work for this small example. 
Once the code will be more complex, e.g. if we use arrays, we need also fix the array types and track array accesses as well in order to insert this bitcast every time the array element is accessed.  
Another example: a function pointer as an argument to a function.  We need to cover this case as well, and be sure that whenever this pointer is stored, we don't forget to insert a bitcast again.  The same if a function pointer is returned from a function. And who knows what else.
So instead of trying to cover all these cases I suggest to use type converter and rewrite any operation that may deal with function pointers.  

#### What's done
I tried to prepare a short PR, in order to make it more readable. 
So now just several patterns are supported: for `AllocaOp`, `GetGlobalOp` and for `FuncOp` (former `CallConvLoweringPattern`).
Next I will add a type converter for the struct type, patterns for `ConstantOp` (for const arrays and `GlobalViewAttr`) and for `CallOp` (and place in there several line from the pattern for `FuncOp`).


cc @sitio-couto  @bcardosolopes 
