### PR TITLE
[ClangIR][CIRGen] Introduce CaseOp and refactor SwitchOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -665,7 +665,7 @@ def StoreOp : CIR_Op<"store", [
 
 def ReturnOp : CIR_Op<"return", [ParentOneOf<["FuncOp", "ScopeOp", "IfOp",
                                               "SwitchOp", "DoWhileOp",
-                                              "WhileOp", "ForOp"]>,
+                                              "WhileOp", "ForOp", "CaseOp"]>,
                                  Terminator]> {
   let summary = "Return from function";
   let description = [{
@@ -900,7 +900,7 @@ def ConditionOp : CIR_Op<"condition", [
 def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
     ParentOneOf<["IfOp", "ScopeOp", "SwitchOp", "WhileOp", "ForOp", "AwaitOp",
                  "TernaryOp", "GlobalOp", "DoWhileOp", "TryOp", "ArrayCtor",
-                 "ArrayDtor", "CallOp"]>]> {
+                 "ArrayDtor", "CallOp", "CaseOp"]>]> {
   let summary = "Represents the default branching behaviour of a region";
   let description = [{
     The `cir.yield` operation terminates regions on different CIR operations,
@@ -1819,22 +1819,38 @@ def CaseOpKind : I32EnumAttr<
   let cppNamespace = "::mlir::cir";
 }
 
-def CaseEltValueListAttr :
-  TypedArrayAttrBase<AnyAttr, "cir.switch case value condition"> {
-  let constBuilderCall = ?;
-}
+def CaseOp : CIR_Op<"case", [
+       DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+       RecursivelySpeculatable, AutomaticAllocationScope]> {
+  let summary = "Case operation";
+  let description = [{
+    The `cir.case` operation represents a case within a C/C++ switch.
+    The `cir.case` operation must be in a `cir.switch` operation directly or indirectly.
 
-def CaseAttr : AttrDef<CIR_Dialect, "Case"> {
-  // FIXME: value should probably be optional for more clear "default"
-  // representation.
-  let parameters = (ins "ArrayAttr":$value, "CaseOpKindAttr":$kind);
-  let mnemonic = "case";
-  let assemblyFormat = "`<` struct(params) `>`";
-}
+    The `cir.case` have 4 kinds:
+    - `equal, <constant>`: equality of the second case operand against the
+    condition.
+    - `anyof, [constant-list]`: equals to any of the values in a subsequent
+    following list.
+    - `range, [lower-bound, upper-bound]`: the condition is within the closed interval.
+    - `default`: any other value.
 
-def CaseArrayAttr :
-  TypedArrayAttrBase<CaseAttr, "cir.switch case array attribute"> {
-  let constBuilderCall = ?;
+    Each case region must be explicitly terminated.
+  }];
+
+  let arguments = (ins ArrayAttr:$value, CaseOpKind:$kind);
+  let regions = (region AnyRegion:$caseRegion);
+
+  let assemblyFormat = "`(` $kind `,` $value `)` $caseRegion attr-dict";
+
+  let hasVerifier = 1;
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "ArrayAttr":$value,
+                   "CaseOpKind":$kind,
+                   "OpBuilder::InsertPoint &":$insertPoint)>
+  ];
 }
 
 def SwitchOp : CIR_Op<"switch",
@@ -1847,45 +1863,136 @@ def SwitchOp : CIR_Op<"switch",
     conditionally executing multiple regions of code. The operand to an switch
     is an integral condition value.
 
-    A variadic list of "case" attribute operands and regions track the possible
-    control flow within `cir.switch`. A `case` must be in one of the following forms:
-    - `equal, <constant>`: equality of the second case operand against the
-    condition.
-    - `anyof, [constant-list]`: equals to any of the values in a subsequent
-    following list.
-    - `range, [lower-bound, upper-bound]`: the condition is within the closed interval.
-    - `default`: any other value.
+    The set of `cir.case` operations and their enclosing `cir.switch`
+    represents the semantics of a C/C++ switch statement. Users can use 
+    `collectCases(llvm::SmallVector<CaseOp> &cases)` to collect the `cir.case`
+    operation in the `cir.switch` operation easily.
 
-    Each case region must be explicitly terminated.
+    The `cir.case` operations doesn't have to be in the region of `cir.switch`
+    directly. However, when all the `cir.case` operations lives in the region
+    of `cir.switch` directly and there is no other operations except the ending
+    `cir.yield` operation in the region of `cir.switch` directly, we call the 
+    `cir.switch` operation is in a simple form. Users can use 
+    `bool isSimpleForm(llvm::SmallVector<CaseOp> &cases)` member function to
+    detect if the `cir.switch` operation is in a simple form. The simple form 
+    makes analysis easier to handle the `cir.switch` operation
+    and makes the boundary to give up pretty clear.
 
-    Examples:
+    To make the simple form as common as possible, CIR code generation attaches
+    operations corresponding to the statements that lives between top level
+    cases into the closest `cir.case` operation.
 
-    ```mlir
-    cir.switch (%b : i32) [
-      case (equal, 20) {
-        ...
-        cir.yield break
-      },
-      case (anyof, [1, 2, 3] : i32) {
-        ...
-        cir.return ...
+    For example,
+
+    ```
+    switch(int cond) {
+      case 4:
+        a++;
+
+      b++;
+      case 5;
+        c++;
+
+      ...
+    }
+    ```
+
+    The statement `b++` is not a sub-statement of the case statement `case 4`.
+    But to make the generated `cir.switch` a simple form, we will attach the
+    statement `b++` into the closest `cir.case` operation. So that the generated
+    code will be like:
+
+    ```
+    cir.switch(int cond) {
+      cir.case(equal, 4) {
+        a++;
+        b++;
+        cir.yield
       }
-      case (range, [10, 15]) {
-        ...
-        cir.yield break
-      },
-      case (default) {
-        ...
-        cir.yield fallthrough
+      cir.case(equal, 5) {
+        c++;
+        cir.yield
       }
-    ]
+      ...
+    }
+    ```
+
+    For the same reason, we will hoist the case statement as the substatement
+    of another case statement so that they will be in the same level. For
+    example,
+
+    ```
+    switch(int cond) {
+      case 4:
+      default;
+      case 5;
+        a++;
+      ...
+    }
+    ```
+
+    will be generated as
+
+    ```
+    cir.switch(int cond) {
+      cir.case(equal, 4) {
+        cir.yield
+      }
+      cir.case(default) {
+        cir.yield
+      }
+      cir.case(equal, 5) {
+        a++;
+        cir.yield
+      }
+      ...
+    }
+    ```
+
+    The cir.switch might not be considered "simple" if any of the following is
+    true:
+    - There are case statements of the switch statement lives in other scopes
+      other than the top level compound statement scope. Note that a case
+      statement itself doesn't form a scope.
+    - The sub-statement of the switch statement is not a compound statement.
+    - There are codes before the first case statement. For example,
+
+    ```
+    switch(int cond) {
+      l:
+        b++;
+  
+      case 4:
+        a++;
+        break;
+
+      case 5:
+        goto l;
+      ...
+    }
+    ```
+
+    the generated CIR for this non-simple switch would be:
+
+    ```
+    cir.switch(int cond) {
+      cir.label "l"
+      b++;
+      cir.case(4) {
+        a++;
+        cir.break
+      }
+      cir.case(5) {
+        goto "l"
+      }
+      cir.yield
+    }
     ```
   }];
 
-  let arguments = (ins CIR_IntType:$condition,
-                       OptionalAttr<CaseArrayAttr>:$cases);
+  let arguments = (ins CIR_IntType:$condition);
 
-  let regions = (region VariadicRegion<AnyRegion>:$regions);
+  let regions = (region AnyRegion:$body);
 
   let hasVerifier = 1;
 
@@ -1897,9 +2004,18 @@ def SwitchOp : CIR_Op<"switch",
 
   let assemblyFormat = [{
     custom<SwitchOp>(
-      $regions, $cases, $condition, type($condition)
+      $body, $condition, type($condition)
     )
     attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    // Collect cases in the switch.
+    void collectCases(llvm::SmallVector<CaseOp> &cases);
+
+    // Check if the switch is in a simple form. If yes, collect the cases to \param cases.
+    // This is an expensive and need to be used with caution.
+    bool isSimpleForm(llvm::SmallVector<CaseOp> &cases);
   }];
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1567,9 +1567,7 @@ void mlir::cir::SwitchOp::getSuccessorRegions(
   regions.push_back(RegionSuccessor(&getBody()));
 }
 
-LogicalResult mlir::cir::SwitchOp::verify() {
-  return success();
-}
+LogicalResult mlir::cir::SwitchOp::verify() { return success(); }
 
 void mlir::cir::SwitchOp::build(
     OpBuilder &builder, OperationState &result, Value cond,

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1486,142 +1486,42 @@ mlir::cir::BrCondOp::getSuccessorForOperands(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// CaseOp
+//===----------------------------------------------------------------------===//
+
+void mlir::cir::CaseOp::getSuccessorRegions(
+    mlir::RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
+  if (!point.isParent()) {
+    regions.push_back(RegionSuccessor());
+    return;
+  }
+
+  regions.push_back(RegionSuccessor(&getCaseRegion()));
+}
+
+void mlir::cir::CaseOp::build(OpBuilder &builder, OperationState &result,
+                              ArrayAttr value, CaseOpKind kind,
+                              OpBuilder::InsertPoint &insertPoint) {
+  OpBuilder::InsertionGuard guardSwitch(builder);
+  result.addAttribute("value", value);
+  result.getOrAddProperties<Properties>().kind =
+      ::mlir::cir::CaseOpKindAttr::get(builder.getContext(), kind);
+  Region *caseRegion = result.addRegion();
+  builder.createBlock(caseRegion);
+
+  insertPoint = builder.saveInsertionPoint();
+}
+
+LogicalResult mlir::cir::CaseOp::verify() { return success(); }
+
+//===----------------------------------------------------------------------===//
 // SwitchOp
 //===----------------------------------------------------------------------===//
 
-ParseResult
-parseSwitchOp(OpAsmParser &parser,
-              llvm::SmallVectorImpl<std::unique_ptr<::mlir::Region>> &regions,
-              ::mlir::ArrayAttr &casesAttr,
-              mlir::OpAsmParser::UnresolvedOperand &cond,
-              mlir::Type &condType) {
+ParseResult parseSwitchOp(OpAsmParser &parser, mlir::Region &regions,
+                          mlir::OpAsmParser::UnresolvedOperand &cond,
+                          mlir::Type &condType) {
   mlir::cir::IntType intCondType;
-  SmallVector<mlir::Attribute, 4> cases;
-
-  auto parseAndCheckRegion = [&]() -> ParseResult {
-    // Parse region attached to case
-    regions.emplace_back(new Region);
-    Region &currRegion = *regions.back().get();
-    auto parserLoc = parser.getCurrentLocation();
-    if (parser.parseRegion(currRegion, /*arguments=*/{}, /*argTypes=*/{})) {
-      regions.clear();
-      return failure();
-    }
-
-    if (currRegion.empty()) {
-      return parser.emitError(parser.getCurrentLocation(),
-                              "case region shall not be empty");
-    }
-
-    if (!(currRegion.back().mightHaveTerminator() &&
-          currRegion.back().getTerminator()))
-      return parser.emitError(parserLoc,
-                              "case regions must be explicitly terminated");
-
-    return success();
-  };
-
-  auto parseCase = [&]() -> ParseResult {
-    auto loc = parser.getCurrentLocation();
-    if (parser.parseKeyword("case").failed())
-      return parser.emitError(loc, "expected 'case' keyword here");
-
-    if (parser.parseLParen().failed())
-      return parser.emitError(parser.getCurrentLocation(), "expected '('");
-
-    ::llvm::StringRef attrStr;
-    ::mlir::NamedAttrList attrStorage;
-
-    //   case (equal, 20) {
-    //   ...
-    // 1. Get the case kind
-    // 2. Get the value (next in list)
-
-    // These needs to be in sync with CIROps.td
-    if (parser.parseOptionalKeyword(&attrStr,
-                                    {"default", "equal", "anyof", "range"})) {
-      ::mlir::StringAttr attrVal;
-      ::mlir::OptionalParseResult parseResult = parser.parseOptionalAttribute(
-          attrVal, parser.getBuilder().getNoneType(), "kind", attrStorage);
-      if (parseResult.has_value()) {
-        if (failed(*parseResult))
-          return ::mlir::failure();
-        attrStr = attrVal.getValue();
-      }
-    }
-
-    if (attrStr.empty()) {
-      return parser.emitError(
-          loc,
-          "expected string or keyword containing one of the following "
-          "enum values for attribute 'kind' [default, equal, anyof, range]");
-    }
-
-    auto attrOptional = ::mlir::cir::symbolizeCaseOpKind(attrStr.str());
-    if (!attrOptional)
-      return parser.emitError(loc, "invalid ")
-             << "kind attribute specification: \"" << attrStr << '"';
-
-    auto kindAttr = ::mlir::cir::CaseOpKindAttr::get(
-        parser.getBuilder().getContext(), attrOptional.value());
-
-    // `,` value or `,` [values,...]
-    SmallVector<mlir::Attribute, 4> caseEltValueListAttr;
-    mlir::ArrayAttr caseValueList;
-
-    switch (kindAttr.getValue()) {
-    case mlir::cir::CaseOpKind::Equal: {
-      if (parser.parseComma().failed())
-        return mlir::failure();
-      int64_t val = 0;
-      if (parser.parseInteger(val).failed())
-        return ::mlir::failure();
-      caseEltValueListAttr.push_back(mlir::cir::IntAttr::get(intCondType, val));
-      break;
-    }
-    case mlir::cir::CaseOpKind::Range:
-    case mlir::cir::CaseOpKind::Anyof: {
-      if (parser.parseComma().failed())
-        return mlir::failure();
-      if (parser.parseLSquare().failed())
-        return mlir::failure();
-      if (parser.parseCommaSeparatedList([&]() {
-            int64_t val = 0;
-            if (parser.parseInteger(val).failed())
-              return ::mlir::failure();
-            caseEltValueListAttr.push_back(
-                mlir::cir::IntAttr::get(intCondType, val));
-            return ::mlir::success();
-          }))
-        return mlir::failure();
-      if (parser.parseRSquare().failed())
-        return mlir::failure();
-      break;
-    }
-    case mlir::cir::CaseOpKind::Default: {
-      if (parser.parseRParen().failed())
-        return parser.emitError(parser.getCurrentLocation(), "expected ')'");
-      cases.push_back(mlir::cir::CaseAttr::get(
-          parser.getContext(), parser.getBuilder().getArrayAttr({}), kindAttr));
-      return parseAndCheckRegion();
-    }
-    }
-
-    caseValueList = parser.getBuilder().getArrayAttr(caseEltValueListAttr);
-    cases.push_back(
-        mlir::cir::CaseAttr::get(parser.getContext(), caseValueList, kindAttr));
-    if (succeeded(parser.parseOptionalColon())) {
-      Type caseIntTy;
-      if (parser.parseType(caseIntTy).failed())
-        return parser.emitError(parser.getCurrentLocation(), "expected type");
-      if (intCondType != caseIntTy)
-        return parser.emitError(parser.getCurrentLocation(),
-                                "expected a match with the condition type");
-    }
-    if (parser.parseRParen().failed())
-      return parser.emitError(parser.getCurrentLocation(), "expected ')'");
-    return parseAndCheckRegion();
-  };
 
   if (parser.parseLParen())
     return ::mlir::failure();
@@ -1635,93 +1535,26 @@ parseSwitchOp(OpAsmParser &parser,
   condType = intCondType;
   if (parser.parseRParen())
     return ::mlir::failure();
-
-  if (parser
-          .parseCommaSeparatedList(OpAsmParser::Delimiter::Square, parseCase,
-                                   " in cases list")
-          .failed())
+  if (parser.parseRegion(regions, /*arguments=*/{}, /*argTypes=*/{}))
     return failure();
 
-  casesAttr = parser.getBuilder().getArrayAttr(cases);
   return ::mlir::success();
 }
 
 void printSwitchOp(OpAsmPrinter &p, mlir::cir::SwitchOp op,
-                   mlir::MutableArrayRef<::mlir::Region> regions,
-                   mlir::ArrayAttr casesAttr, mlir::Value condition,
+                   mlir::Region &bodyRegion, mlir::Value condition,
                    mlir::Type condType) {
-  int idx = 0, lastIdx = regions.size() - 1;
-
   p << "(";
   p << condition;
   p << " : ";
   p.printStrippedAttrOrType(condType);
-  p << ") [";
-  // FIXME: ideally we want some extra indentation for "cases" but too
-  // cumbersome to pull it out now, since most handling is private. Perhaps
-  // better improve overall mechanism.
-  p.printNewline();
-  for (auto &r : regions) {
-    p << "case (";
+  p << ")";
 
-    auto attr = cast<mlir::cir::CaseAttr>(casesAttr[idx]);
-    auto kind = attr.getKind().getValue();
-    assert((kind == mlir::cir::CaseOpKind::Default ||
-            kind == mlir::cir::CaseOpKind::Equal ||
-            kind == mlir::cir::CaseOpKind::Anyof ||
-            kind == mlir::cir::CaseOpKind::Range) &&
-           "unknown case");
-
-    // Case kind
-    p << stringifyCaseOpKind(kind);
-
-    // Case value
-    switch (kind) {
-    case mlir::cir::CaseOpKind::Equal: {
-      p << ", ";
-      auto intAttr = cast<mlir::cir::IntAttr>(attr.getValue()[0]);
-      auto intAttrTy = cast<mlir::cir::IntType>(intAttr.getType());
-      (intAttrTy.isSigned() ? p << intAttr.getSInt() : p << intAttr.getUInt());
-      break;
-    }
-    case mlir::cir::CaseOpKind::Range:
-      assert(attr.getValue().size() == 2 && "range must have two values");
-      // The print format of the range is the same as anyof
-      LLVM_FALLTHROUGH;
-    case mlir::cir::CaseOpKind::Anyof: {
-      p << ", [";
-      llvm::interleaveComma(attr.getValue(), p, [&](const Attribute &a) {
-        auto intAttr = cast<mlir::cir::IntAttr>(a);
-        auto intAttrTy = cast<mlir::cir::IntType>(intAttr.getType());
-        (intAttrTy.isSigned() ? p << intAttr.getSInt()
-                              : p << intAttr.getUInt());
-      });
-      p << "] : ";
-      auto typedAttr = dyn_cast<TypedAttr>(attr.getValue()[0]);
-      assert(typedAttr && "this should never not have a type!");
-      p.printType(typedAttr.getType());
-      break;
-    }
-    case mlir::cir::CaseOpKind::Default:
-      break;
-    }
-
-    p << ") ";
-    p.printRegion(r, /*printEntryBLockArgs=*/false,
-                  /*printBlockTerminators=*/true);
-    if (idx < lastIdx)
-      p << ",";
-    p.printNewline();
-    idx++;
-  }
-  p << "]";
+  p << ' ';
+  p.printRegion(bodyRegion, /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/true);
 }
 
-/// Given the region at `index`, or the parent operation if `index` is None,
-/// return the successor regions. These are the regions that may be selected
-/// during the flow of control. `operands` is a set of optional attributes
-/// that correspond to a constant value for each operand, or null if that
-/// operand is not a constant.
 void mlir::cir::SwitchOp::getSuccessorRegions(
     mlir::RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
   // If any index all the underlying regions branch back to the parent
@@ -1731,29 +1564,10 @@ void mlir::cir::SwitchOp::getSuccessorRegions(
     return;
   }
 
-  // for (auto &r : this->getRegions()) {
-  // If we can figure out the case stmt we are landing, this can be
-  // overly simplified.
-  // bool condition;
-  // if (auto condAttr = operands.front().dyn_cast_or_null<IntegerAttr>()) {
-  //   assert(0 && "not implemented");
-  //   (void)r;
-  // condition = condAttr.getValue().isOneValue();
-  // Add the successor regions using the condition.
-  // regions.push_back(RegionSuccessor(condition ? &thenRegion() :
-  // elseRegion));
-  // return;
-  // }
-  // }
-
-  // If the condition isn't constant, all regions may be executed.
-  for (auto &r : this->getRegions())
-    regions.push_back(RegionSuccessor(&r));
+  regions.push_back(RegionSuccessor(&getBody()));
 }
 
 LogicalResult mlir::cir::SwitchOp::verify() {
-  if (getCases().has_value() && getCases()->size() != getNumRegions())
-    return emitOpError("number of cases attributes and regions must match");
   return success();
 }
 
@@ -1762,8 +1576,41 @@ void mlir::cir::SwitchOp::build(
     function_ref<void(OpBuilder &, Location, OperationState &)> switchBuilder) {
   assert(switchBuilder && "the builder callback for regions must be present");
   OpBuilder::InsertionGuard guardSwitch(builder);
+  Region *swtichRegion = result.addRegion();
+  builder.createBlock(swtichRegion);
   result.addOperands({cond});
   switchBuilder(builder, result.location, result);
+}
+
+void mlir::cir::SwitchOp::collectCases(llvm::SmallVector<CaseOp> &cases) {
+  walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+    // Don't walk in nested switch op.
+    if (isa<mlir::cir::SwitchOp>(op) && op != *this)
+      return WalkResult::skip();
+
+    if (isa<mlir::cir::CaseOp>(op))
+      cases.push_back(cast<mlir::cir::CaseOp>(*op));
+
+    return WalkResult::advance();
+  });
+}
+
+bool mlir::cir::SwitchOp::isSimpleForm(llvm::SmallVector<CaseOp> &cases) {
+  collectCases(cases);
+
+  if (getBody().empty())
+    return false;
+
+  if (!isa<YieldOp>(getBody().front().back()))
+    return false;
+
+  if (!llvm::all_of(getBody().front(),
+                    [](Operation &op) { return isa<CaseOp, YieldOp>(op); }))
+    return false;
+
+  return llvm::all_of(cases, [this](CaseOp op) {
+    return op->getParentOfType<SwitchOp>() == *this;
+  });
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -74,7 +74,8 @@ struct RemoveEmptySwitch : public OpRewritePattern<SwitchOp> {
   using OpRewritePattern<SwitchOp>::OpRewritePattern;
 
   LogicalResult match(SwitchOp op) const final {
-    return success(op.getRegions().empty());
+    return success(op.getBody().empty() ||
+                   isa<YieldOp>(op.getBody().front().front()));
   }
 
   void rewrite(SwitchOp op, PatternRewriter &rewriter) const final {

--- a/clang/test/CIR/CodeGen/atomic-runtime.cpp
+++ b/clang/test/CIR/CodeGen/atomic-runtime.cpp
@@ -16,23 +16,23 @@ int runtime_load(int *ptr, int order) {
 
 // CHECK: %[[ptr:.*]] = cir.load %[[ptr_var:.*]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: %[[order:.*]] = cir.load %[[order_var:.*]] : !cir.ptr<!s32i>, !s32i
-// CHECK: cir.switch (%[[order]] : !s32i) [
-// CHECK: case (default) {
+// CHECK: cir.switch (%[[order]] : !s32i) {
+// CHECK: cir.case(default, []) {
 // CHECK:   %[[T8:.*]] = cir.load atomic(relaxed) %[[ptr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   cir.store %[[T8]], %[[temp_var:.*]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (anyof, [1, 2] : !s32i) {
+// CHECK: }
+// CHECK: cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK:   %[[T8:.*]] = cir.load atomic(acquire) %[[ptr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   cir.store %[[T8]], %[[temp_var]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 5) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<5> : !s32i]) {
 // CHECK:   %[[T8:.*]] = cir.load atomic(seq_cst) %[[ptr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   cir.store %[[T8]], %[[temp_var]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
 // CHECK: }
-// CHECK: ]
+// CHECK: }
 
 void atomic_store_n(int* ptr, int val, int order) {
   __atomic_store_n(ptr, val, order);
@@ -42,23 +42,23 @@ void atomic_store_n(int* ptr, int val, int order) {
 // CHECK: %[[order:.*]] = cir.load %[[order_var:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK: %[[val:.*]] = cir.load %[[val_var:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK: cir.store %[[val]], %[[temp_var:.*]] : !s32i, !cir.ptr<!s32i>
-// CHECK: cir.switch (%[[order]] : !s32i) [
-// CHECK: case (default) {
+// CHECK: cir.switch (%[[order]] : !s32i) {
+// CHECK: cir.case(default, []) {
 // CHECK:   %[[T7:.*]] = cir.load %[[temp_var:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   cir.store atomic(relaxed) %[[T7]], %[[ptr]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 3) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<3> : !s32i]) {
 // CHECK:   %[[T7:.*]] = cir.load %[[temp_var:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   cir.store atomic(release) %[[T7]], %[[ptr]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 5) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<5> : !s32i]) {
 // CHECK:   %[[T7:.*]] = cir.load %[[temp_var:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   cir.store atomic(seq_cst) %[[T7]], %[[ptr]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
 // CHECK: }
-// CHECK: ]
+// CHECK: }
 
 int atomic_exchange_n(int* ptr, int val, int order) {
   return __atomic_exchange_n(ptr, val, order);
@@ -68,38 +68,38 @@ int atomic_exchange_n(int* ptr, int val, int order) {
 // CHECK: %[[order:.*]] = cir.load %[[order_var:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK: %[[val:.*]] = cir.load %[[val_var:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK: cir.store %[[val]], %[[temp_var:.*]] : !s32i, !cir.ptr<!s32i>
-// CHECK: cir.switch (%[[order]] : !s32i) [
-// CHECK: case (default) {
+// CHECK: cir.switch (%[[order]] : !s32i) {
+// CHECK: cir.case(default, []) {
 // CHECK:   %[[T11:.*]] = cir.load %[[temp_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   %[[T12:.*]] = cir.atomic.xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[T11]] : !s32i, relaxed) : !s32i
 // CHECK:   cir.store %[[T12]], %[[result:.*]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (anyof, [1, 2] : !s32i) {
+// CHECK: }
+// CHECK: cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK:   %[[T11:.*]] = cir.load %[[temp_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   %[[T12:.*]] = cir.atomic.xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[T11]] : !s32i, acquire) : !s32i
 // CHECK:   cir.store %[[T12]], %[[result]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 3) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<3> : !s32i]) {
 // CHECK:   %[[T11:.*]] = cir.load %[[temp_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   %[[T12:.*]] = cir.atomic.xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[T11]] : !s32i, release) : !s32i
 // CHECK:   cir.store %[[T12]], %[[result]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 4) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<4> : !s32i]) {
 // CHECK:   %[[T11:.*]] = cir.load %[[temp_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   %[[T12:.*]] = cir.atomic.xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[T11]] : !s32i, acq_rel) : !s32i
 // CHECK:   cir.store %[[T12]], %[[result]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 5) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<5> : !s32i]) {
 // CHECK:   %[[T11:.*]] = cir.load %[[temp_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   %[[T12:.*]] = cir.atomic.xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[T11]] : !s32i, seq_cst) : !s32i
 // CHECK:   cir.store %[[T12]], %[[result]] : !s32i, !cir.ptr<!s32i>
 // CHECK:   cir.break
 // CHECK: }
-// CHECK: ]
+// CHECK: }
 
 bool atomic_compare_exchange_n(int* ptr, int* expected,
                                int desired, int success, int failure) {
@@ -114,10 +114,10 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK: cir.store %[[T11]], %[[desired_var:.*]] : !s32i, !cir.ptr<!s32i>
 // CHECK: %[[failure:.*]] = cir.load %[[T4:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK: %[[T13:.*]] = cir.const #false
-// CHECK: cir.switch (%[[success]] : !s32i) [
-// CHECK: case (default) {
-// CHECK:   cir.switch (%[[failure]] : !s32i) [
-// CHECK:   case (default) {
+// CHECK: cir.switch (%[[success]] : !s32i) {
+// CHECK: cir.case(default, []) {
+// CHECK:   cir.switch (%[[failure]] : !s32i) {
+// CHECK:   cir.case(default, []) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = relaxed, failure = relaxed) : (!s32i, !cir.bool)
@@ -127,8 +127,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var:.*]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (anyof, [1, 2] : !s32i) {
+// CHECK:   }
+// CHECK:   cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = relaxed, failure = acquire) : (!s32i, !cir.bool)
@@ -138,8 +138,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (equal, 5) {
+// CHECK:   }
+// CHECK:   cir.case(equal, [#cir.int<5> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = relaxed, failure = seq_cst) : (!s32i, !cir.bool)
@@ -150,12 +150,12 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
 // CHECK:   }
-// CHECK:   ]
+// CHECK:   }
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (anyof, [1, 2] : !s32i) {
-// CHECK:   cir.switch (%[[failure]] : !s32i) [
-// CHECK:   case (default) {
+// CHECK: }
+// CHECK: cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
+// CHECK:   cir.switch (%[[failure]] : !s32i) {
+// CHECK:   cir.case(default, []) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = acquire, failure = relaxed) : (!s32i, !cir.bool)
@@ -165,8 +165,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (anyof, [1, 2] : !s32i) {
+// CHECK:   }
+// CHECK:   cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = acquire, failure = acquire) : (!s32i, !cir.bool)
@@ -176,8 +176,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (equal, 5) {
+// CHECK:   }
+// CHECK:   cir.case(equal, [#cir.int<5> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = acquire, failure = seq_cst) : (!s32i, !cir.bool)
@@ -188,12 +188,12 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
 // CHECK:   }
-// CHECK:   ]
+// CHECK:   }
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 3) {
-// CHECK:   cir.switch (%[[failure]] : !s32i) [
-// CHECK:   case (default) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<3> : !s32i])
+// CHECK:   cir.switch (%[[failure]] : !s32i) {
+// CHECK:   cir.case(default, []) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = release, failure = relaxed) : (!s32i, !cir.bool)
@@ -203,8 +203,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (anyof, [1, 2] : !s32i) {
+// CHECK:   }
+// CHECK:   cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = release, failure = acquire) : (!s32i, !cir.bool)
@@ -214,8 +214,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (equal, 5) {
+// CHECK:   }
+// CHECK:   cir.case(equal, [#cir.int<5> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = release, failure = seq_cst) : (!s32i, !cir.bool)
@@ -226,12 +226,12 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
 // CHECK:   }
-// CHECK:   ]
+// CHECK:   }
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 4) {
-// CHECK:   cir.switch (%[[failure]] : !s32i) [
-// CHECK:   case (default) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<4> : !s32i]) {
+// CHECK:   cir.switch (%[[failure]] : !s32i) {
+// CHECK:   cir.case(default, []) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = acq_rel, failure = relaxed) : (!s32i, !cir.bool)
@@ -241,8 +241,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (anyof, [1, 2] : !s32i) {
+// CHECK:   }
+// CHECK:   cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = acq_rel, failure = acquire) : (!s32i, !cir.bool)
@@ -252,8 +252,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (equal, 5) {
+// CHECK:   }
+// CHECK:   cir.case(equal, [#cir.int<5> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = acq_rel, failure = seq_cst) : (!s32i, !cir.bool)
@@ -264,12 +264,12 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
 // CHECK:   }
-// CHECK:   ]
+// CHECK:   }
 // CHECK:   cir.break
-// CHECK: },
-// CHECK: case (equal, 5) {
-// CHECK:   cir.switch (%[[failure]] : !s32i) [
-// CHECK:   case (default) {
+// CHECK: }
+// CHECK: cir.case(equal, [#cir.int<5> : !s32i]) {
+// CHECK:   cir.switch (%[[failure]] : !s32i) {
+// CHECK:   cir.case(default, []) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = seq_cst, failure = relaxed) : (!s32i, !cir.bool)
@@ -279,8 +279,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (anyof, [1, 2] : !s32i) {
+// CHECK:   }
+// CHECK:   cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = seq_cst, failure = acquire) : (!s32i, !cir.bool)
@@ -290,8 +290,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     }
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
-// CHECK:   },
-// CHECK:   case (equal, 5) {
+// CHECK:   }
+// CHECK:   cir.case(equal, [#cir.int<5> : !s32i]) {
 // CHECK:     %[[expected:.*]] = cir.load %[[expected_addr]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %[[desired:.*]] = cir.load %[[desired_var]] : !cir.ptr<!s32i>, !s32i
 // CHECK:     %old, %cmp = cir.atomic.cmp_xchg(%[[ptr]] : !cir.ptr<!s32i>, %[[expected]] : !s32i, %[[desired]] : !s32i, success = seq_cst, failure = seq_cst) : (!s32i, !cir.bool)
@@ -302,8 +302,8 @@ bool atomic_compare_exchange_n(int* ptr, int* expected,
 // CHECK:     cir.store %cmp, %[[result_var]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:     cir.break
 // CHECK:   }
-// CHECK:   ]
+// CHECK:   }
 // CHECK:   cir.break
 // CHECK: }
-// CHECK: ]
+// CHECK: }
 

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -303,7 +303,7 @@ extern "C" void multiple_non_case(int v) {
 
 // NOFLAT: cir.func @multiple_non_case
 // NOFLAT: cir.switch
-// NOFLAT: case (default)
+// NOFLAT: cir.case(default, []) {
 // NOFLAT: cir.call @action1()
 // NOFLAT: cir.br ^[[BB1:[a-zA-Z0-9]+]]
 // NOFLAT: ^[[BB1]]:
@@ -326,13 +326,12 @@ extern "C" void case_follow_label(int v) {
 
 // NOFLAT: cir.func  @case_follow_label
 // NOFLAT: cir.switch
-// NOFLAT: case (equal, 1)
+// NOFLAT: cir.case(equal, [#cir.int<1> : !s32i]) {
 // NOFLAT: cir.label "label"
-// NOFLAT: cir.yield
-// NOFLAT: case (equal, 2)
+// NOFLAT: cir.case(equal, [#cir.int<2> : !s32i]) {
 // NOFLAT: cir.call @action1()
 // NOFLAT: cir.break
-// NOFLAT: case (default)
+// NOFLAT: cir.case(default, []) {
 // NOFLAT: cir.call @action2()
 // NOFLAT: cir.goto "label"
 
@@ -351,10 +350,10 @@ extern "C" void default_follow_label(int v) {
 
 // NOFLAT: cir.func  @default_follow_label
 // NOFLAT: cir.switch
-// NOFLAT: case (anyof, [1, 2] : !s32i)
+// NOFLAT: cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // NOFLAT: cir.call @action1()
 // NOFLAT: cir.break
 // NOFLAT: cir.label "label"
-// NOFLAT: case (default)
+// NOFLAT: cir.case(default, []) {
 // NOFLAT: cir.call @action2()
 // NOFLAT: cir.goto "label"

--- a/clang/test/CIR/CodeGen/switch-gnurange.cpp
+++ b/clang/test/CIR/CodeGen/switch-gnurange.cpp
@@ -22,25 +22,18 @@ int sw1(enum letter c) {
 //      CIR:  cir.func @_Z3sw16letter
 //      CIR:    cir.scope {
 //      CIR:      cir.switch
-// CIR-NEXT:      case (range, [0, 2] : !s32i) {
-// CIR-NEXT:        cir.yield
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [4, 5] : !s32i) {
-// CIR-NEXT:        cir.yield
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [6, 10] : !s32i) {
-// CIR-NEXT:        cir.yield
-// CIR-NEXT:      },
-// CIR-NEXT:      case (equal, 3) {
-// CIR-NEXT:        cir.int<1>
-//      CIR:        cir.return
-// CIR-NEXT:      },
-// CIR-NEXT:      case (default) {
+// CIR-NEXT:      cir.case(range, [#cir.int<0> : !s32i, #cir.int<2> : !s32i]) {
+// CIR-NEXT:        cir.case(equal, [#cir.int<3> : !s32i]) {
+// CIR-NEXT:          cir.case(range, [#cir.int<4> : !s32i, #cir.int<5> : !s32i]) {
+// CIR-NEXT:            cir.case(range, [#cir.int<6> : !s32i, #cir.int<10> : !s32i]) {
+//      CIR:              cir.int<1>
+//      CIR:              cir.return 
+//      CIR:          cir.yield
+//      CIR:        cir.yield
+//      CIR:      cir.yield
+//      CIR:      cir.case(default, []) {
 // CIR-NEXT:        cir.int<0>
 //      CIR:        cir.return
-// CIR-NEXT:      }
-// CIR-NEXT:      ]
-// CIR-NEXT:    }
 
 //      LLVM:  @_Z3sw16letter
 //      LLVM:    switch i32 %[[C:[0-9]+]], label %[[DEFAULT:[0-9]+]] [
@@ -57,12 +50,12 @@ int sw1(enum letter c) {
 // LLVM-NEXT:      i32 10, label %[[CASE_6_10]]
 // LLVM-NEXT:    ]
 //      LLVM:  [[CASE_0_2]]:
+//      LLVM:    br label %[[CASE_3]]
+//      LLVM:  [[CASE_3]]:
 //      LLVM:    br label %[[CASE_4_5]]
 //      LLVM:  [[CASE_4_5]]:
 //      LLVM:    br label %[[CASE_6_10]]
 //      LLVM:  [[CASE_6_10]]:
-//      LLVM:    br label %[[CASE_3]]
-//      LLVM:  [[CASE_3]]:
 //      LLVM:    store i32 1
 //      LLVM:    ret
 //      LLVM:  [[DEFAULT]]:
@@ -83,14 +76,13 @@ int sw2(enum letter c) {
 //      CIR:  cir.func @_Z3sw26letter
 //      CIR:    cir.scope {
 //      CIR:      cir.switch
-// CIR-NEXT:      case (range, [0, 2] : !s32i) {
-//      CIR:        cir.return
-// CIR-NEXT:      },
-// CIR-NEXT:      case (default) {
+// CIR-NEXT:      cir.case(range, [#cir.int<0> : !s32i, #cir.int<2> : !s32i]) {
+//      CIR:          cir.case(range, [#cir.int<10> : !s32i, #cir.int<0> : !s32i]) {
 //      CIR:        cir.return
 // CIR-NEXT:      }
-// CIR-NEXT:      ]
-// CIR-NEXT:    }
+//      CIR:      cir.case(default, []) {
+//      CIR:        cir.return
+// CIR-NEXT:      }
 
 //      LLVM:  @_Z3sw26letter
 //      LLVM:    switch i32 %[[C:[0-9]+]], label %[[DEFAULT:[0-9]+]] [
@@ -99,6 +91,8 @@ int sw2(enum letter c) {
 // LLVM-NEXT:      i32 2, label %[[CASE]]
 // LLVM-NEXT:    ]
 //      LLVM:  [[CASE]]:
+//      LLVM:    br label %[[IMPL:[0-9]+]]
+//      LLVM:  [[IMPL]]:
 //      LLVM:    store i32 1
 //      LLVM:    ret
 //      LLVM:  [[DEFAULT]]:
@@ -126,24 +120,22 @@ void sw3(enum letter c) {
 //      CIR:  cir.func @_Z3sw36letter
 //      CIR:    cir.scope {
 //      CIR:      cir.switch
-// CIR-NEXT:      case (range, [0, 2] : !s32i) {
+// CIR-NEXT:      cir.case(range, [#cir.int<0> : !s32i, #cir.int<2> : !s32i]) {
 // CIR-NEXT:        cir.int<1>
 //      CIR:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [3, 5] : !s32i) {
+// CIR-NEXT:      }
+//      CIR:      cir.case(range, [#cir.int<3> : !s32i, #cir.int<5> : !s32i]) {
 // CIR-NEXT:        cir.int<2>
 //      CIR:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [6, 8] : !s32i) {
+// CIR-NEXT:      }
+//      CIR:      cir.case(range, [#cir.int<6> : !s32i, #cir.int<8> : !s32i]) {
 // CIR-NEXT:        cir.int<3>
 //      CIR:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [9, 10] : !s32i) {
+// CIR-NEXT:      }
+//      CIR:      cir.case(range, [#cir.int<9> : !s32i, #cir.int<10> : !s32i]) {
 // CIR-NEXT:        cir.int<4>
 //      CIR:        cir.break
 // CIR-NEXT:      }
-// CIR-NEXT:      ]
-// CIR-NEXT:    }
 
 //      LLVM:  @_Z3sw36letter
 //      LLVM:    switch i32 %[[C:[0-9]+]], label %[[DEFAULT:[0-9]+]] [
@@ -188,18 +180,19 @@ void sw4(int x) {
 //      CIR:  cir.func @_Z3sw4i
 //      CIR:    cir.scope {
 //      CIR:      cir.switch
-// CIR-NEXT:      case (range, [66, 233] : !s32i) {
-// CIR-NEXT:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [-50, 50] : !s32i) {
+// CIR-NEXT:      cir.case(range, [#cir.int<66> : !s32i, #cir.int<233> : !s32i]) {
 // CIR-NEXT:        cir.break
 // CIR-NEXT:      }
-// CIR-NEXT:      ]
-// CIR-NEXT:    }
+//      CIR:      cir.case(range, [#cir.int<-50> : !s32i, #cir.int<50> : !s32i]) {
+// CIR-NEXT:        cir.break
+// CIR-NEXT:      }
+
 
 //      LLVM:  @_Z3sw4i
 //      LLVM:    switch i32 %[[X:[0-9]+]], label %[[JUDGE_NEG50_50:[0-9]+]] [
 // LLVM-NEXT:    ]
+//      LLVM:  [[UNREACHABLE_BB:[0-9]+]]: {{.*}} No predecessors!
+// LLVM-NEXT:    br label
 //      LLVM:  [[CASE_66_233:[0-9]+]]:
 // LLVM-NEXT:    br label %[[EPILOG:[0-9]+]]
 //      LLVM:  [[CASE_NEG50_50:[0-9]+]]:
@@ -228,18 +221,21 @@ void sw5(int x) {
 //      CIR:  cir.func @_Z3sw5i
 //      CIR:    cir.scope {
 //      CIR:      cir.switch
-// CIR-NEXT:      case (range, [100, -100] : !s32i) {
+// CIR-NEXT:      cir.case(range, [#cir.int<100> : !s32i, #cir.int<-100> : !s32i]) {
 // CIR-NEXT:        cir.int<1>
 //      CIR:        cir.yield
 // CIR-NEXT:      }
-// CIR-NEXT:      ]
 
 //      LLVM:  @_Z3sw5i
 //      LLVM:    switch i32 %[[X:[0-9]+]], label %[[EPILOG:[0-9]+]] [
 // LLVM-NEXT:    ]
+//      LLVM:  [[UNREACHABLE_BB:[0-9]+]]: {{.*}} No predecessors!
+// LLVM-NEXT:    br label
 //      LLVM:  [[CASE_100_NEG100:[0-9]+]]:
 // LLVM-NEXT:    store i32 1, ptr %[[Y:[0-9]+]]
-// LLVM-NEXT:    br label %[[EPILOG]]
+// LLVM-NEXT:    br label %[[EPILOG_PRED:.+]]
+//      LLVM:  [[EPILOG_PRED:[0-9]+]]:
+//      LLVM-NEXT:    br label %[[EPILOG]]
 //      LLVM:  [[EPILOG]]:
 // LLVM-NEXT:    br label %[[EPILOG_END:[0-9]+]]
 //      LLVM:  [[EPILOG_END]]:
@@ -256,22 +252,23 @@ void sw6(int x) {
 //      CIR:  cir.func @_Z3sw6i
 //      CIR:    cir.scope {
 //      CIR:      cir.switch
-// CIR-NEXT:      case (range, [-2147483648, 2147483647] : !s32i) {
+// CIR-NEXT:      cir.case(range, [#cir.int<-2147483648> : !s32i, #cir.int<2147483647> : !s32i]) {
 // CIR-NEXT:        cir.int<1>
 //      CIR:        cir.yield
 // CIR-NEXT:      }
-// CIR-NEXT:      ]
 
 //      LLVM:  @_Z3sw6i
 //      LLVM:    switch i32 %[[X:[0-9]+]], label %[[DEFAULT:[0-9]+]] [
 // LLVM-NEXT:    ]
+//      LLVM:  [[UNREACHABLE_BB:[0-9]+]]: {{.*}} No predecessors!
+// LLVM-NEXT:    br label
 //      LLVM:  [[CASE_MIN_MAX:[0-9]+]]:
 // LLVM-NEXT:    store i32 1, ptr %[[Y:[0-9]+]]
-// LLVM-NEXT:    br label %[[EPILOG:[0-9]+]]
+// LLVM-NEXT:    br label
 //      LLVM:  [[DEFAULT]]:
 // LLVM-NEXT:    %[[DIFF:[0-9]+]] = sub i32 %[[X]], -2147483648
 // LLVM-NEXT:    %[[DIFF_CMP:[0-9]+]] = icmp ule i32 %[[DIFF]], -1
-// LLVM-NEXT:    br i1 %[[DIFF_CMP]], label %[[CASE_MIN_MAX]], label %[[EPILOG]]
+// LLVM-NEXT:    br i1 %[[DIFF_CMP]], label %[[CASE_MIN_MAX]], label %[[EPILOG:[0-9]+]]
 //      LLVM:  [[EPILOG]]:
 // LLVM-NEXT:    br label %[[EPILOG_END:[0-9]+]]
 //      LLVM:  [[EPILOG_END]]:
@@ -297,22 +294,22 @@ void sw7(int x) {
 //      CIR:  cir.func @_Z3sw7i
 //      CIR:    cir.scope {
 //      CIR:      cir.switch
-// CIR-NEXT:      case (equal, 0) {
+// CIR-NEXT:      cir.case(equal, [#cir.int<0> : !s32i]) {
 // CIR-NEXT:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [100, 200] : !s32i) {
+// CIR-NEXT:      }
+// CIR-NEXT:      cir.case(range, [#cir.int<100> : !s32i, #cir.int<200> : !s32i]) {
 // CIR-NEXT:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (equal, 1) {
+// CIR-NEXT:      }
+// CIR-NEXT:      cir.case(equal, [#cir.int<1> : !s32i]) {
 // CIR-NEXT:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [300, 400] : !s32i) {
+// CIR-NEXT:      }
+// CIR-NEXT:      cir.case(range, [#cir.int<300> : !s32i, #cir.int<400> : !s32i]) {
 // CIR-NEXT:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (default) {
+// CIR-NEXT:      }
+// CIR-NEXT:      cir.case(default, []) {
 // CIR-NEXT:        cir.break
-// CIR-NEXT:      },
-// CIR-NEXT:      case (range, [500, 600] : !s32i) {
+// CIR-NEXT:      }
+// CIR-NEXT:      cir.case(range, [#cir.int<500> : !s32i, #cir.int<600> : !s32i]) {
 // CIR-NEXT:        cir.break
 // CIR-NEXT:      }
 

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -16,30 +16,15 @@ void sw1(int a) {
   }
 }
 // CHECK: cir.func @_Z3sw1i
-// CHECK: cir.switch (%3 : !s32i) [
-// CHECK-NEXT: case (equal, 0)  {
-// CHECK-NEXT:   %4 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:   %5 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:   %6 = cir.binop(add, %4, %5) nsw : !s32i
-// CHECK-NEXT:   cir.store %6, %1 : !s32i, !cir.ptr<!s32i>
-// CHECK-NEXT:   cir.break
-// CHECK-NEXT: },
-// CHECK-NEXT: case (equal, 1)  {
-// CHECK-NEXT:   cir.break
-// CHECK-NEXT: },
-// CHECK-NEXT: case (equal, 2)  {
-// CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:       %4 = cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init]
-// CHECK-NEXT:       %5 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:       %6 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:       %7 = cir.binop(add, %5, %6) nsw : !s32i
-// CHECK-NEXT:       cir.store %7, %1 : !s32i, !cir.ptr<!s32i>
-// CHECK-NEXT:       %8 = cir.const #cir.int<100> : !s32i
-// CHECK-NEXT:       cir.store %8, %4 : !s32i, !cir.ptr<!s32i>
-// CHECK-NEXT:       cir.break
-// CHECK-NEXT:     }
-// CHECK-NEXT:     cir.yield
-// CHECK-NEXT:   }
+// CHECK: cir.switch (%3 : !s32i) {
+// CHECK-NEXT: cir.case(equal, [#cir.int<0> : !s32i]) {
+// CHECK: cir.break
+// CHECK: cir.case(equal, [#cir.int<1> : !s32i]) {
+// CHECK-NEXT: cir.break
+// CHECK: cir.case(equal, [#cir.int<2> : !s32i]) {
+// CHECK: cir.scope {
+// CHECK: cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init]
+// CHECK: cir.break
 
 void sw2(int a) {
   switch (int yolo = 2; a) {
@@ -55,8 +40,8 @@ void sw2(int a) {
 // CHECK: cir.scope {
 // CHECK-NEXT:   %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init]
 // CHECK-NEXT:   %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["fomo", init]
-// CHECK:        cir.switch (%4 : !s32i) [
-// CHECK-NEXT:   case (equal, 3)  {
+// CHECK:        cir.switch (%4 : !s32i) {
+// CHECK-NEXT:   cir.case(equal, [#cir.int<3> : !s32i]) {
 // CHECK-NEXT:     %5 = cir.const #cir.int<0> : !s32i
 // CHECK-NEXT:     cir.store %5, %2 : !s32i, !cir.ptr<!s32i>
 
@@ -70,11 +55,12 @@ void sw3(int a) {
 // CHECK: cir.func @_Z3sw3i
 // CHECK: cir.scope {
 // CHECK-NEXT:   %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:   cir.switch (%1 : !s32i) [
-// CHECK-NEXT:   case (default)  {
+// CHECK-NEXT:   cir.switch (%1 : !s32i) {
+// CHECK-NEXT:   cir.case(default, []) {
 // CHECK-NEXT:     cir.break
 // CHECK-NEXT:   }
-// CHECK-NEXT:   ]
+// CHECK-NEXT:   cir.yield
+// CHECK-NEXT:   }
 
 int sw4(int a) {
   switch (a) {
@@ -88,8 +74,8 @@ int sw4(int a) {
 }
 
 // CHECK: cir.func @_Z3sw4i
-// CHECK:       cir.switch (%4 : !s32i) [
-// CHECK-NEXT:       case (equal, 42)  {
+// CHECK:       cir.switch (%4 : !s32i) {
+// CHECK-NEXT:       cir.case(equal, [#cir.int<42> : !s32i]) {
 // CHECK-NEXT:         cir.scope {
 // CHECK-NEXT:           %5 = cir.const #cir.int<3> : !s32i
 // CHECK-NEXT:           cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
@@ -97,14 +83,15 @@ int sw4(int a) {
 // CHECK-NEXT:           cir.return %6 : !s32i
 // CHECK-NEXT:         }
 // CHECK-NEXT:         cir.yield
-// CHECK-NEXT:       },
-// CHECK-NEXT:       case (default)  {
+// CHECK-NEXT:       }
+// CHECK-NEXT:       cir.case(default, []) {
 // CHECK-NEXT:         %5 = cir.const #cir.int<2> : !s32i
 // CHECK-NEXT:         cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
 // CHECK-NEXT:         %6 = cir.load %1 : !cir.ptr<!s32i>, !s32i
 // CHECK-NEXT:         cir.return %6 : !s32i
 // CHECK-NEXT:       }
-// CHECK-NEXT:       ]
+// CHECK-NEXT:       cir.yield
+// CHECK-NEXT:       }
 
 void sw5(int a) {
   switch (a) {
@@ -113,9 +100,12 @@ void sw5(int a) {
 }
 
 // CHECK: cir.func @_Z3sw5i
-// CHECK: cir.switch (%1 : !s32i) [
-// CHECK-NEXT:   case (equal, 1)  {
+// CHECK: cir.switch (%1 : !s32i) {
+// CHECK-NEXT:   cir.case(equal, [#cir.int<1> : !s32i]) {
 // CHECK-NEXT:     cir.yield
+// CHECK-NEXT:   }
+// CHECK-NEXT:   cir.yield
+// CHECK-NEXT:   }
 
 void sw6(int a) {
   switch (a) {
@@ -131,11 +121,11 @@ void sw6(int a) {
 }
 
 // CHECK: cir.func @_Z3sw6i
-// CHECK: cir.switch (%1 : !s32i) [
-// CHECK-NEXT: case (anyof, [0, 1, 2] : !s32i)  {
+// CHECK: cir.switch (%1 : !s32i) {
+// CHECK-NEXT: cir.case(anyof, [#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK-NEXT:   cir.break
-// CHECK-NEXT: },
-// CHECK-NEXT: case (anyof, [3, 4, 5] : !s32i)  {
+// CHECK-NEXT: }
+// CHECK-NEXT: cir.case(anyof, [#cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i]) {
 // CHECK-NEXT:   cir.break
 // CHECK-NEXT: }
 
@@ -153,10 +143,10 @@ void sw7(int a) {
 }
 
 // CHECK: cir.func @_Z3sw7i
-// CHECK: case (anyof, [0, 1, 2] : !s32i)  {
+// CHECK: cir.case(anyof, [#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // CHECK-NEXT:   cir.yield
-// CHECK-NEXT: },
-// CHECK-NEXT: case (anyof, [3, 4, 5] : !s32i)  {
+// CHECK-NEXT: }
+// CHECK-NEXT: cir.case(anyof, [#cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i]) {
 // CHECK-NEXT:   cir.break
 // CHECK-NEXT: }
 
@@ -172,13 +162,13 @@ void sw8(int a) {
 }
 
 //CHECK:    cir.func @_Z3sw8i
-//CHECK:      case (equal, 3)
+//CHECK:      cir.case(equal, [#cir.int<3> : !s32i]) {
 //CHECK-NEXT:   cir.break
-//CHECK-NEXT: },
-//CHECK-NEXT: case (equal, 4) {
+//CHECK-NEXT: }
+//CHECK-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
 //CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
-//CHECK-NEXT: case (default) {
+//CHECK-NEXT: cir.case(default, []) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 
@@ -194,13 +184,13 @@ void sw9(int a) {
 }
 
 //CHECK:    cir.func @_Z3sw9i
-//CHECK:      case (equal, 3) {
+//CHECK:      cir.case(equal, [#cir.int<3> : !s32i]) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
-//CHECK-NEXT: case (default) {
+//CHECK-NEXT: cir.case(default, []) {
 //CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
-//CHECK:      case (equal, 4)
+//CHECK-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 
@@ -217,16 +207,16 @@ void sw10(int a) {
 }
 
 //CHECK:    cir.func @_Z4sw10i
-//CHECK:      case (equal, 3)
+//CHECK:      cir.case(equal, [#cir.int<3> : !s32i]) {
 //CHECK-NEXT:   cir.break
-//CHECK-NEXT: },
-//CHECK-NEXT: case (equal, 4) {
+//CHECK-NEXT: }
+//CHECK-NEXT: cir.case(equal, [#cir.int<4> : !s32i]) {
 //CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
-//CHECK-NEXT: case (default) {
+//CHECK-NEXT: cir.case(default, []) {
 //CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
-//CHECK-NEXT: case (equal, 5) {
+//CHECK-NEXT: cir.case(equal, [#cir.int<5> : !s32i]) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 
@@ -245,16 +235,16 @@ void sw11(int a) {
 }
 
 //CHECK:    cir.func @_Z4sw11i
-//CHECK:      case (equal, 3)
+//CHECK:      cir.case(equal, [#cir.int<3> : !s32i]) {
 //CHECK-NEXT:   cir.break
-//CHECK-NEXT: },
-//CHECK-NEXT: case (anyof, [4, 5] : !s32i) {
+//CHECK-NEXT: }
+//CHECK-NEXT: cir.case(anyof, [#cir.int<4> : !s32i, #cir.int<5> : !s32i]) {
 //CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
-//CHECK-NEXT: case (default) {
+//CHECK-NEXT: cir.case(default, []) {
 //CHECK-NEXT:   cir.yield
 //CHECK-NEXT: }
-//CHECK-NEXT: case (anyof, [6, 7] : !s32i)  {
+//CHECK-NEXT: cir.case(anyof, [#cir.int<6> : !s32i, #cir.int<7> : !s32i]) {
 //CHECK-NEXT:   cir.break
 //CHECK-NEXT: }
 
@@ -270,7 +260,7 @@ void sw12(int a) {
 //      CHECK: cir.func @_Z4sw12i
 //      CHECK:   cir.scope {
 //      CHECK:     cir.switch
-// CHECK-NEXT:     case (equal, 3) {
+// CHECK-NEXT:     cir.case(equal, [#cir.int<3> : !s32i]) {
 // CHECK-NEXT:       cir.return
 // CHECK-NEXT:     ^bb1:  // no predecessors
 // CHECK-NEXT:       cir.break
@@ -289,16 +279,16 @@ void sw13(int a, int b) {
 //      CHECK:  cir.func @_Z4sw13ii
 //      CHECK:    cir.scope {
 //      CHECK:      cir.switch
-// CHECK-NEXT:      case (equal, 1) {
+// CHECK-NEXT:      cir.case(equal, [#cir.int<1> : !s32i]) {
 // CHECK-NEXT:        cir.scope {
 //      CHECK:          cir.switch
-// CHECK-NEXT:          case (equal, 2) {
+// CHECK-NEXT:          cir.case(equal, [#cir.int<2> : !s32i]) {
 // CHECK-NEXT:            cir.break
 // CHECK-NEXT:          }
-// CHECK-NEXT:          ]
+// CHECK-NEXT:          cir.yield
 // CHECK-NEXT:        }
-// CHECK-NEXT:        cir.yield
 // CHECK-NEXT:      }
+// CHECK:         cir.yield
 //      CHECK:    }
 //      CHECK:    cir.return
 
@@ -315,17 +305,18 @@ void fallthrough(int x) {
 
 //      CHECK:  cir.func @_Z11fallthroughi
 //      CHECK:    cir.scope {
-//      CHECK:      cir.switch (%1 : !s32i) [
-// CHECK-NEXT:      case (equal, 1) {
+//      CHECK:      cir.switch (%1 : !s32i) {
+// CHECK-NEXT:      cir.case(equal, [#cir.int<1> : !s32i]) {
 // CHECK-NEXT:        cir.yield
-// CHECK-NEXT:      },
-// CHECK-NEXT:      case (equal, 2) {
-// CHECK-NEXT:        cir.break
-// CHECK-NEXT:      },
-// CHECK-NEXT:      case (default) {
+// CHECK-NEXT:      }
+// CHECK-NEXT:      cir.case(equal, [#cir.int<2> : !s32i]) {
 // CHECK-NEXT:        cir.break
 // CHECK-NEXT:      }
-// CHECK-NEXT:      ]
+// CHECK-NEXT:      cir.case(default, []) {
+// CHECK-NEXT:        cir.break
+// CHECK-NEXT:      }
+// CHECK-NEXT:      cir.yield
+// CHECK-NEXT:      }
 // CHECK-NEXT:    }
 
 int unreachable_after_break_1(int a) {
@@ -342,8 +333,49 @@ exit:
 
 }
 // CHECK: cir.func @_Z25unreachable_after_break_1i
-// CHECK:   case (equal, 42) {
+// CHECK:   cir.case(equal, [#cir.int<42> : !s32i]) {
 // CHECK:     cir.break
 // CHECK:   ^bb1:  // no predecessors
 // CHECK:     cir.goto "exit"
 // CHECK:   }
+
+int nested_switch(int a) {
+  switch (int b = 1; a) {
+  case 0:
+    b = b + 1;
+  case 1:
+    return b;
+  case 2: {
+    b = b + 1;
+    if (a > 1000) {
+        case 9:
+          b += a;
+    }
+    if (a > 500) {
+        case 7:
+          return a + b;
+    }
+    break;
+  }
+  }
+
+  return 0;
+}
+
+// CHECK: cir.switch (%6 : !s32i) {
+// CHECK:   cir.case(equal, [#cir.int<0> : !s32i]) {
+// CHECK:     cir.yield
+// CHECK:   }
+// CHECK:   cir.case(equal, [#cir.int<1> : !s32i]) {
+// CHECK:     cir.return
+// CHECK:   }
+// CHECK:   cir.case(equal, [#cir.int<2> : !s32i]) {
+// CHECK:     cir.scope {
+// CHECK:     cir.scope {
+// CHECK:       cir.if
+// CHECK:         cir.case(equal, [#cir.int<9> : !s32i]) {
+// CHECK:         cir.yield
+// CHECK:     cir.scope {
+// CHECK:         cir.if
+// CHECK:           cir.case(equal, [#cir.int<7> : !s32i]) {
+// CHECK:           cir.return

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -75,11 +75,11 @@ cir.func @yieldcontinue() {
 !s32i = !cir.int<s, 32>
 cir.func @s0() {
   %1 = cir.const #cir.int<2> : !s32i
-  cir.switch (%1 : !s32i) [
-    case (equal, 5) { // expected-error {{custom op 'cir.switch' case regions must be explicitly terminated}}
-      %2 = cir.const #cir.int<3> : !s32i
+  cir.switch (%1 : !s32i) {
+    cir.case (equal, [#cir.int<5> : !s32i]) {
+      %2 = cir.const #cir.int<3> : !s32i // expected-error {{block with no terminator}}
     }
-  ]
+  }
   cir.return
 }
 
@@ -88,10 +88,10 @@ cir.func @s0() {
 !s32i = !cir.int<s, 32>
 cir.func @s1() {
   %1 = cir.const #cir.int<2> : !s32i
-  cir.switch (%1 : !s32i) [
-    case (equal, 5) {
+  cir.switch (%1 : !s32i) {
+    cir.case (equal, [#cir.int<5> : !s32i]) { // expected-error {{block with no terminator}}
     }
-  ] // expected-error {{case region shall not be empty}}
+  }
   cir.return
 }
 

--- a/clang/test/CIR/IR/switch.cir
+++ b/clang/test/CIR/IR/switch.cir
@@ -3,34 +3,36 @@
 
 cir.func @s0() {
   %1 = cir.const #cir.int<2> : !s32i
-  cir.switch (%1 : !s32i) [
-    case (default) {
+  cir.switch (%1 : !s32i) {
+    cir.case (default, []) {
       cir.return
-    },
-    case (equal, 3) {
-      cir.yield
-    },
-    case (anyof, [6, 7, 8] : !s32i) {
-      cir.break
-    },
-    case (equal, 5 : !s32i) {
+    }
+    cir.case (equal, [#cir.int<3> : !s32i]) {
       cir.yield
     }
-  ]
+    cir.case (anyof, [#cir.int<6> : !s32i, #cir.int<7> : !s32i, #cir.int<8> : !s32i]) {
+      cir.break
+    }
+    cir.case (equal, [#cir.int<5> : !s32i]) {
+      cir.yield
+    }
+    cir.yield
+  }
   cir.return
 }
 
-// CHECK: cir.switch (%0 : !s32i) [
-// CHECK-NEXT: case (default)  {
+// CHECK: cir.switch (%0 : !s32i) {
+// CHECK-NEXT: cir.case(default, [])  {
 // CHECK-NEXT:   cir.return
-// CHECK-NEXT: },
-// CHECK-NEXT: case (equal, 3)  {
-// CHECK-NEXT:   cir.yield
-// CHECK-NEXT: },
-// CHECK-NEXT: case (anyof, [6, 7, 8] : !s32i) {
-// CHECK-NEXT:   cir.break
-// CHECK-NEXT: },
-// CHECK-NEXT: case (equal, 5)  {
+// CHECK-NEXT: }
+// CHECK-NEXT: cir.case(equal, [#cir.int<3> : !s32i])  {
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT: }
-// CHECK-NEXT: ]
+// CHECK-NEXT: cir.case(anyof, [#cir.int<6> : !s32i, #cir.int<7> : !s32i, #cir.int<8> : !s32i]) {
+// CHECK-NEXT:   cir.break
+// CHECK-NEXT: }
+// CHECK-NEXT: cir.case(equal, [#cir.int<5> : !s32i])  {
+// CHECK-NEXT:   cir.yield
+// CHECK-NEXT: }
+// CHECK-NEXT: cir.yield
+// CHECK-NEXT: }

--- a/clang/test/CIR/Lowering/nested-switch.cpp
+++ b/clang/test/CIR/Lowering/nested-switch.cpp
@@ -1,0 +1,69 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s
+
+int nested_switch(int a) {
+  switch (int b = 1; a) {
+  case 0:
+    b = b + 1;
+  case 1:
+    return b;
+  case 2: {
+    b = b + 1;
+    if (a > 1000) {
+        case 9:
+          b += a;
+    }
+    if (a > 500) {
+        case 7:
+          return a + b;
+    }
+    break;
+  }
+  }
+
+  return 0;
+}
+
+// CHECK: define {{.*}}@_Z13nested_switchi(
+// CHECK: switch i32 %6, label %[[DEFAULT_BB:[0-9]+]] [
+// CHECK:   i32 0, label %[[ZERO_BB:[0-9]+]]
+// CHECK:   i32 1, label %[[ONE_BB:[0-9]+]]
+// CHECK:   i32 2, label %[[TWO_BB:[0-9]+]]
+// CHECK:   i32 9, label %[[NINE_BB:[0-9]+]]
+// CHECK:   i32 7, label %[[SEVEN_BB:[0-9]+]]
+// CHECK: ]
+//
+// CHECK: [[ZERO_BB]]:
+// CHECK:   add {{.*}}, 1
+// CHECK:   br label %[[ONE_BB]]
+//
+// CHECK: [[ONE_BB]]:
+// CHECK:   ret
+//
+// CHECK: [[TWO_BB]]:
+// CHECK:   add {{.*}}, 1
+// CHECK:   br label %[[IF_BB:[0-9]+]]
+//
+// CHECK: [[IF_BB]]:
+// CHECK:   %[[CMP:.+]] = icmp sgt i32 %{{.*}}, 1000
+// CHECK:   br i1 %[[CMP]], label %[[IF_TRUE_BB:[0-9]+]], label %[[IF_FALSE_BB:[0-9]+]]
+//
+// CHECK: [[IF_TRUE_BB]]:
+// CHECK:   br label %[[NINE_BB]]
+//
+// CHECK: [[NINE_BB]]:
+// CHECK:   %[[A_VALUE:.+]] = load i32
+// CHECK:   %[[B_VALUE:.+]] = load i32
+// CHECK:   add nsw i32 %[[B_VALUE]], %[[A_VALUE]]
+//
+// CHECK: %[[CMP2:.+]] = icmp sgt i32 %{{.*}}, 500
+// CHECK:   br i1 %[[CMP2]], label %[[IF2_TRUE_BB:[0-9]+]], label %[[IF2_FALSE_BB:[0-9]+]]
+//
+// CHECK: [[IF2_TRUE_BB]]:
+// CHECK:   br label %[[SEVEN_BB]]
+//
+// CHECK: [[SEVEN_BB]]:
+// CHECK:   ret
+//
+// CHECK: [[DEFAULT_BB]]:
+// CHECK:   ret

--- a/clang/test/CIR/Lowering/switch-while.c
+++ b/clang/test/CIR/Lowering/switch-while.c
@@ -1,0 +1,84 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s
+void func100();
+int f(int a, int cond) {
+  int b = 1; 
+  switch (a) 
+    while (1) {
+        b++;
+
+        default:
+            if (cond)
+                return a;
+
+            a = a + b;
+
+        case 2:
+            a++;
+
+        case 3:
+            continue;
+
+        case 5:
+            break;
+
+        case 100:
+            func100();
+  }
+
+  return a;
+}
+
+// CHECK: switch i32 %[[A:.+]], label %[[DEFAULT_BB:.+]] [
+// CHECK:   i32 2, label %[[TWO_BB:.+]]
+// CHECK:   i32 3, label %[[THREE_BB:.+]]
+// CHECK:   i32 5, label %[[FIVE_BB:.+]]
+// CHECK:   i32 100, label %[[HUNDRED_BB:.+]]
+// CHECK: ],
+//
+// CHECK: [[UNREACHABLE_BB:.+]]: {{.*}}; No predecessors!
+// 
+// CHECK: [[LOOP_ENTRY:.+]]:
+// CHECK: br label %[[LOOP_HEADER:.+]],
+//
+// CHECK: [[LOOP_HEADER]]:
+// CHECK:   add i32 %{{.*}}, 1
+// CHECK: br label %[[DEFAULT_BB:.+]],
+//
+// CHECK: [[DEFAULT_BB]]:
+// CHECK:   br label %[[IF_BB:.+]],
+//
+// CHECK: [[IF_BB]]:
+// CHECK:   %[[CMP:.+]] = icmp ne i32 %[[COND:.+]], 0
+// CHECK:   br i1 %[[CMP]], label %[[IF_TRUE_BB:.+]], label %[[IF_FALSE_BB:.+]],
+//
+// CHECK: [[IF_TRUE_BB]]:
+// CHECK:   ret
+//
+// CHECK: [[IF_FALSE_BB]]:
+// CHECK:   %[[V1:.+]] = load i32
+// CHECK:   %[[V2:.+]] = load i32
+// CHECK:   add nsw i32 %[[V1]], %[[V2]]
+//
+// CHECK: [[TWO_BB]]:
+// CHECK:   add i32 %{{.*}}, 1
+// CHECK:   br label %[[FALLTHOUGH_BB:.+]],
+//
+// CHECK: [[FALLTHOUGH_BB]]:
+// CHECK:   br label %[[LOOP_HEADER]],
+//
+// CHECK: [[FIVE_BB]]:
+// CHECK:   br label %[[LOOP_EXIT_BB:.+]],
+//
+// CHECK: [[HUNDRED_BB]]:
+// CHECK:   call {{.*}}@func100()
+// CHECK:   br label %[[CONTINUE_BB:.+]],
+//
+// CHECK: [[CONTINUE_BB]]:
+// CHECK:  br label %[[LOOP_HEADER]]
+//
+// CHECK: [[LOOP_EXIT_BB]]:
+// CHECK:   br label %[[RET_BB:.+]],
+//
+// CHECK: [[RET_BB]]:
+// CHECK:   ret

--- a/clang/test/CIR/Lowering/switch.cir
+++ b/clang/test/CIR/Lowering/switch.cir
@@ -7,101 +7,107 @@
 
 module {
   cir.func @shouldLowerSwitchWithDefault(%arg0: !s8i) {
-    cir.switch (%arg0 : !s8i) [
+    cir.switch (%arg0 : !s8i) {
     // CHECK: llvm.switch %arg0 : i8, ^bb[[#DEFAULT:]] [
     // CHECK:   1: ^bb[[#CASE1:]]
     // CHECK: ]
-    case (equal, 1) {
+    cir.case (equal, [#cir.int<1> : !s8i]) {
       cir.break
-    },
+    }
     // CHECK: ^bb[[#CASE1]]:
     // CHECK:   llvm.br ^bb[[#EXIT:]]
-    case (default) {
+    cir.case (default, []) {
       cir.break
     }
     // CHECK: ^bb[[#DEFAULT]]:
     // CHECK:   llvm.br ^bb[[#EXIT]]
-    ]
+    cir.yield
+    }
     // CHECK: ^bb[[#EXIT]]:
     cir.return
   }
 
 
   cir.func @shouldLowerSwitchWithoutDefault(%arg0: !s32i) {
-    cir.switch (%arg0 : !s32i) [
+    cir.switch (%arg0 : !s32i) {
     // Default block is the exit block:
     // CHECK: llvm.switch %arg0 : i32, ^bb[[#EXIT:]] [
     // CHECK:   1: ^bb[[#CASE1:]]
     // CHECK: ]
-    case (equal, 1) {
+    cir.case (equal, [#cir.int<1> : !s32i]) {
       cir.break
     }
     // CHECK: ^bb[[#CASE1]]:
     // CHECK:   llvm.br ^bb[[#EXIT]]
-    ]
+    cir.yield
+    }
     // CHECK: ^bb[[#EXIT]]:
     cir.return
   }
 
 
   cir.func @shouldLowerSwitchWithImplicitFallthrough(%arg0: !s64i) {
-    cir.switch (%arg0 : !s64i) [
+    cir.switch (%arg0 : !s64i) {
     // CHECK: llvm.switch %arg0 : i64, ^bb[[#EXIT:]] [
     // CHECK:   1: ^bb[[#CASE1N2:]],
     // CHECK:   2: ^bb[[#CASE1N2]]
     // CHECK: ]
-    case (anyof, [1, 2] : !s64i) { // case 1 and 2 use same region
+    cir.case (anyof, [#cir.int<1> : !s64i, #cir.int<2> : !s64i]) { // case 1 and 2 use same region
       cir.break
     }
     // CHECK: ^bb[[#CASE1N2]]:
     // CHECK:   llvm.br ^bb[[#EXIT]]
-    ]
+    cir.yield
+    }
     // CHECK: ^bb[[#EXIT]]:
     cir.return
   }
 
 
   cir.func @shouldLowerSwitchWithExplicitFallthrough(%arg0: !s64i) {
-      cir.switch (%arg0 : !s64i) [
+      cir.switch (%arg0 : !s64i) {
       // CHECK: llvm.switch %arg0 : i64, ^bb[[#EXIT:]] [
       // CHECK:   1: ^bb[[#CASE1:]],
       // CHECK:   2: ^bb[[#CASE2:]]
       // CHECK: ]
-      case (equal, 1 : !s64i) { // case 1 has its own region
+      cir.case (equal, [#cir.int<1> : !s64i]) { // case 1 has its own region
         cir.yield // fallthrough to case 2
-      },
+      }
       // CHECK: ^bb[[#CASE1]]:
       // CHECK:   llvm.br ^bb[[#CASE2]]
-      case (equal, 2 : !s64i) {
+      cir.case (equal, [#cir.int<2> : !s64i]) {
         cir.break
       }
       // CHECK: ^bb[[#CASE2]]:
       // CHECK:   llvm.br ^bb[[#EXIT]]
-      ]
+      cir.yield
+      }
       // CHECK: ^bb[[#EXIT]]:
     cir.return
   }
 
 
   cir.func @shouldLowerSwitchWithFallthroughToExit(%arg0: !s64i) {
-      cir.switch (%arg0 : !s64i) [
+      cir.switch (%arg0 : !s64i) {
       // CHECK: llvm.switch %arg0 : i64, ^bb[[#EXIT:]] [
       // CHECK:   1: ^bb[[#CASE1:]]
       // CHECK: ]
-      case (equal, 1 : !s64i) {
+       cir.case (equal, [#cir.int<1> : !s64i]) {
         cir.yield // fallthrough to exit
       }
       // CHECK: ^bb[[#CASE1]]:
       // CHECK:   llvm.br ^bb[[#EXIT]]
-      ]
+      cir.yield
+      }
       // CHECK: ^bb[[#EXIT]]:
     cir.return
   }
 
 
   cir.func @shouldDropEmptySwitch(%arg0: !s64i) {
-    cir.switch (%arg0 : !s64i) [
-    ]
+    cir.switch (%arg0 : !s64i) {
+      cir.yield
+    }
     // CHECK-NOT: llvm.switch
     cir.return
   }
@@ -111,28 +117,27 @@ module {
     cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
     cir.scope {
       %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-      cir.switch (%1 : !s32i) [
-      case (equal, 3) {
+      cir.switch (%1 : !s32i) {
+      cir.case (equal, [#cir.int<3> : !s32i]) {
         cir.return
       ^bb1:  // no predecessors
         cir.break
       }
-      ]
+      cir.yield
+      }
     }
     cir.return
   }
   // CHECK: llvm.func @shouldLowerMultiBlockCase
   // CHECK: ^bb1:  // pred: ^bb0
-  // CHECK:   llvm.switch {{.*}} : i32, ^bb4 [
-  // CHECK:     3: ^bb2
+  // CHECK:   llvm.switch {{.*}} : i32, ^[[DEFAULT_BB:.+]] [
+  // CHECK:     3: ^[[DIRECTLY_RET_BB:.+]]
   // CHECK:   ]
-  // CHECK: ^bb2:  // pred: ^bb1
+  // CHECK: ^[[DIRECTLY_RET_BB]]:
   // CHECK:   llvm.return
-  // CHECK: ^bb3:  // no predecessors
-  // CHECK:   llvm.br ^bb4
-  // CHECK: ^bb4:  // 2 preds: ^bb1, ^bb3
-  // CHECK:   llvm.br ^bb5
-  // CHECK: ^bb5:  // pred: ^bb4
+  // CHECK: ^[[DEFAULT_BB:.+]]:
+  // CHECK:   llvm.br ^[[RET_BB:.+]]
+  // CHECK: ^[[RET_BB:.+]]:  // pred: ^[[DEFAULT_BB:.+]]
   // CHECK:   llvm.return
   // CHECK: }
 
@@ -144,8 +149,8 @@ module {
     cir.store %arg1, %1 : !s32i, !cir.ptr<!s32i>
     cir.scope {
       %5 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-      cir.switch (%5 : !s32i) [
-      case (equal, 0) {
+      cir.switch (%5 : !s32i) {
+      cir.case (equal, [#cir.int<0> : !s32i]) {
         cir.scope {
           %6 = cir.load %1 : !cir.ptr<!s32i>, !s32i
           %7 = cir.const #cir.int<0> : !s32i
@@ -157,7 +162,8 @@ module {
         }
         cir.break
       }
-      ]
+      cir.yield
+      }
     }
     %3 = cir.const #cir.int<3> : !s32i
     cir.store %3, %2 : !s32i, !cir.ptr<!s32i>
@@ -165,21 +171,21 @@ module {
     cir.return %4 : !s32i
   }
   // CHECK:  llvm.func @shouldLowerNestedBreak
-  // CHECK:    llvm.switch %6 : i32, ^bb7 [
-  // CHECK:      0: ^bb2
+  // CHECK:    llvm.switch %6 : i32, ^[[DEFAULT_BB:.+]] [
+  // CHECK:      0: ^[[ZERO_BB:.+]]
   // CHECK:    ]
-  // CHECK:  ^bb2:  // pred: ^bb1
-  // CHECK:    llvm.br ^bb3
-  // CHECK:  ^bb3:  // pred: ^bb2
-  // CHECK:    llvm.cond_br {{%.*}}, ^bb4, ^bb5
-  // CHECK:  ^bb4:  // pred: ^bb3
-  // CHECK:    llvm.br ^bb7
-  // CHECK:  ^bb5:  // pred: ^bb3
-  // CHECK:    llvm.br ^bb6
-  // CHECK:  ^bb6:  // pred: ^bb5
-  // CHECK:    llvm.br ^bb7
-  // CHECK:  ^bb7:  // 3 preds: ^bb1, ^bb4, ^bb6
-  // CHECK:    llvm.br ^bb8
-  // CHECK:  ^bb8:  // pred: ^bb7
+  // CHECK:  ^[[ZERO_BB]]:
+  // CHECK:    llvm.br ^[[ZERO_BB_SUCC:.+]]
+  // CHECK:  ^[[ZERO_BB_SUCC]]:  // pred: ^[[ZERO_BB:]]
+  // CHECK:    llvm.cond_br {{%.*}}, ^[[DEFAULT_BB_PRED1:.+]], ^[[DEFAULT_BB_PRED12:.+]]
+  // CHECK:  ^[[DEFAULT_BB_PRED1]]:  // pred: ^[[ZERO_BB_SUCC]]
+  // CHECK:    llvm.br ^[[DEFAULT_BB]]
+  // CHECK:  ^[[DEFAULT_BB_PRED12]]:  // pred: ^[[ZERO_BB_SUCC]]
+  // CHECK:    llvm.br ^[[DEFAULT_BB_PRED1:.+]]
+  // CHECK:  ^[[DEFAULT_BB_PRED1]]:  // pred: ^[[DEFAULT_BB_PRED12]]
+  // CHECK:    llvm.br ^[[DEFAULT_BB]]
+  // CHECK:  ^[[DEFAULT_BB]]:
+  // CHECK:    llvm.br ^[[RET_BB:.+]]
+  // CHECK:  ^[[RET_BB]]:  // pred: ^[[DEFAULT_BB]]
   // CHECK:    llvm.return
 }

--- a/clang/test/CIR/Transforms/merge-cleanups.cir
+++ b/clang/test/CIR/Transforms/merge-cleanups.cir
@@ -15,8 +15,8 @@ module  {
       %3 = cir.const #cir.int<1> : !s32i
       cir.store %3, %2 : !s32i, !cir.ptr<!s32i>
       %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-      cir.switch (%4 : !s32i) [
-      case (equal, 0 : !s32i)  {
+      cir.switch (%4 : !s32i) {
+      cir.case (equal, [#cir.int<0> : !s32i])  {
         %5 = cir.load %2 : !cir.ptr<!s32i>, !s32i
         %6 = cir.const #cir.int<1> : !s32i
         %7 = cir.binop(add, %5, %6) : !s32i
@@ -24,8 +24,8 @@ module  {
         cir.br ^bb1
       ^bb1:  // pred: ^bb0
         cir.return
-      },
-      case (equal, 1 : !s32i)  {
+      }
+      cir.case (equal, [#cir.int<1> : !s32i])  {
         cir.scope {
           cir.scope {
             %5 = cir.load %1 : !cir.ptr<!s32i>, !s32i
@@ -40,8 +40,8 @@ module  {
           cir.break
         }
         cir.yield
-      },
-      case (equal, 2 : !s32i)  {
+      }
+      cir.case (equal, [#cir.int<2> : !s32i])  {
         cir.scope {
           %5 = cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init] {alignment = 4 : i64}
           %6 = cir.load %2 : !cir.ptr<!s32i>, !s32i
@@ -56,20 +56,21 @@ module  {
         }
         cir.yield
       }
-      ]
+      cir.yield
+      }
     }
     cir.return
   }
 
-// CHECK: cir.switch (%4 : !s32i) [
-// CHECK-NEXT:   case (equal, 0)  {
+// CHECK: cir.switch (%4 : !s32i) {
+// CHECK-NEXT:   cir.case(equal, [#cir.int<0> : !s32i])  {
 // CHECK-NEXT:     %5 = cir.load %2 : !cir.ptr<!s32i>, !s32i
 // CHECK-NEXT:     %6 = cir.const #cir.int<1> : !s32i
 // CHECK-NEXT:     %7 = cir.binop(add, %5, %6) : !s32i
 // CHECK-NEXT:     cir.store %7, %2 : !s32i, !cir.ptr<!s32i>
 // CHECK-NEXT:     cir.return
-// CHECK-NEXT:   },
-// CHECK-NEXT:   case (equal, 1)  {
+// CHECK-NEXT:   }
+// CHECK-NEXT:   cir.case(equal, [#cir.int<1> : !s32i])  {
 // CHECK-NEXT:     cir.scope {
 // CHECK-NEXT:       cir.scope {
 // CHECK-NEXT:         %5 = cir.load %1 : !cir.ptr<!s32i>, !s32i
@@ -82,8 +83,8 @@ module  {
 // CHECK-NEXT:       cir.break
 // CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield
-// CHECK-NEXT:   },
-// CHECK-NEXT:   case (equal, 2)  {
+// CHECK-NEXT:   }
+// CHECK-NEXT:   cir.case(equal, [#cir.int<2> : !s32i])  {
 // CHECK-NEXT:     cir.scope {
 // CHECK-NEXT:       %5 = cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init] {alignment = 4 : i64}
 // CHECK-NEXT:       %6 = cir.load %2 : !cir.ptr<!s32i>, !s32i
@@ -96,7 +97,8 @@ module  {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   }
-// CHECK-NEXT: ]
+// CHECK-NEXT:   cir.yield
+// CHECK-NEXT: }
 
   // Should remove empty scopes.
   cir.func @removeEmptyScope() {
@@ -110,8 +112,9 @@ module  {
   // Should remove empty switch-case statements.
   cir.func @removeEmptySwitch(%arg0: !s32i) {
   //      CHECK: cir.func @removeEmptySwitch
-    cir.switch (%arg0 : !s32i) [
-    ]
+    cir.switch (%arg0 : !s32i) {
+      cir.yield
+    }
     // CHECK-NOT: cir.switch
     cir.return
     // CHECK: cir.return

--- a/clang/test/CIR/Transforms/switch.cir
+++ b/clang/test/CIR/Transforms/switch.cir
@@ -6,14 +6,15 @@
 
 module {
   cir.func @shouldFlatSwitchWithDefault(%arg0: !s8i) {
-    cir.switch (%arg0 : !s8i) [
-    case (equal, 1) {
-      cir.break
-    },
-    case (default) {
+    cir.switch (%arg0 : !s8i) {
+    cir.case (equal, [#cir.int<1> : !s8i]) {
       cir.break
     }
-    ]
+    cir.case (default, []) {
+      cir.break
+    }
+    cir.yield
+    }
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithDefault(%arg0: !s8i) {
@@ -21,19 +22,20 @@ module {
 // CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
 // CHECK:  ^bb[[#CASE1]]:
-// CHECK:    cir.br ^bb3
-// CHECK:  ^bb[[#DEFAULT]]:
 // CHECK:    cir.br ^bb[[#EXIT:]]
+// CHECK:  ^bb[[#DEFAULT]]:
+// CHECK:    cir.br ^bb[[#EXIT]]
 // CHECK:  ^bb[[#EXIT]]:
 // CHECK:    cir.return
 // CHECK:  }
 
   cir.func @shouldFlatSwitchWithoutDefault(%arg0: !s32i) {
-    cir.switch (%arg0 : !s32i) [
-    case (equal, 1) {
+    cir.switch (%arg0 : !s32i) {
+    cir.case (equal, [#cir.int<1> : !s32i]) {
       cir.break
     }
-    ]
+    cir.yield
+    }
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithoutDefault(%arg0: !s32i) {
@@ -48,11 +50,12 @@ module {
 
 
   cir.func @shouldFlatSwitchWithImplicitFallthrough(%arg0: !s64i) {
-    cir.switch (%arg0 : !s64i) [
-    case (anyof, [1, 2] : !s64i) {
+    cir.switch (%arg0 : !s64i) {
+    cir.case (anyof, [#cir.int<1> : !s64i, #cir.int<2> : !s64i]) {
       cir.break
     }
-    ]
+    cir.yield
+    }
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithImplicitFallthrough(%arg0: !s64i) {
@@ -69,14 +72,15 @@ module {
 
 
   cir.func @shouldFlatSwitchWithExplicitFallthrough(%arg0: !s64i) {
-      cir.switch (%arg0 : !s64i) [
-      case (equal, 1 : !s64i) { // case 1 has its own region
+      cir.switch (%arg0 : !s64i) {
+      cir.case (equal, [#cir.int<1> : !s64i]) { // case 1 has its own region
         cir.yield // fallthrough to case 2
-      },
-      case (equal, 2 : !s64i) {
+      }
+      cir.case (equal, [#cir.int<2> : !s64i]) {
         cir.break
       }
-      ]
+      cir.yield
+      }
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithExplicitFallthrough(%arg0: !s64i) {
@@ -93,11 +97,12 @@ module {
 // CHECK:  }
 
   cir.func @shouldFlatSwitchWithFallthroughToExit(%arg0: !s64i) {
-      cir.switch (%arg0 : !s64i) [
-      case (equal, 1 : !s64i) {
+      cir.switch (%arg0 : !s64i) {
+      cir.case (equal, [#cir.int<1> : !s64i]) {
         cir.yield // fallthrough to exit
       }
-      ]
+      cir.yield
+      }
     cir.return
   }
 // CHECK:  cir.func @shouldFlatSwitchWithFallthroughToExit(%arg0: !s64i) {
@@ -111,8 +116,9 @@ module {
 // CHECK:  }
 
   cir.func @shouldDropEmptySwitch(%arg0: !s64i) {
-    cir.switch (%arg0 : !s64i) [
-    ]
+    cir.switch (%arg0 : !s64i) {
+      cir.yield
+    }
     // CHECK-NOT: llvm.switch
     cir.return
   }
@@ -125,13 +131,14 @@ module {
     cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
     cir.scope {
       %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-      cir.switch (%1 : !s32i) [
-      case (equal, 3) {
+      cir.switch (%1 : !s32i) {
+      cir.case (equal, [#cir.int<3> : !s32i]) {
         cir.return
       ^bb1:  // no predecessors
         cir.break
       }
-      ]
+      cir.yield
+      }
     }
     cir.return
   }
@@ -142,16 +149,14 @@ module {
 // CHECK:     cir.br ^bb1
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-// CHECK:     cir.switch.flat %1 : !s32i, ^bb4 [
-// CHECK:       3: ^bb2
+// CHECK:     cir.switch.flat %1 : !s32i, ^bb[[#DEFAULT:]] [
+// CHECK:       3: ^bb[[#BB1:]]
 // CHECK:     ]
-// CHECK:   ^bb2:  // pred: ^bb1
+// CHECK:   ^bb[[#BB1]]:
 // CHECK:     cir.return
-// CHECK:   ^bb3:  // no predecessors
-// CHECK:     cir.br ^bb4
-// CHECK:   ^bb4:  // 2 preds: ^bb1, ^bb3
-// CHECK:     cir.br ^bb5
-// CHECK:   ^bb5:  // pred: ^bb4
+// CHECK:   ^bb[[#DEFAULT]]:
+// CHECK:     cir.br ^bb[[#RET_BB:]]
+// CHECK:   ^bb[[#RET_BB]]:  // pred: ^bb[[#DEFAULT]]
 // CHECK:     cir.return
 // CHECK:   }
 
@@ -164,8 +169,8 @@ module {
     cir.store %arg1, %1 : !s32i, !cir.ptr<!s32i>
     cir.scope {
       %5 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-      cir.switch (%5 : !s32i) [
-      case (equal, 0) {
+      cir.switch (%5 : !s32i) {
+      cir.case (equal, [#cir.int<0> : !s32i]) {
         cir.scope {
           %6 = cir.load %1 : !cir.ptr<!s32i>, !s32i
           %7 = cir.const #cir.int<0> : !s32i
@@ -177,7 +182,8 @@ module {
         }
         cir.break
       }
-      ]
+      cir.yield
+      }
     }
     %3 = cir.const #cir.int<3> : !s32i
     cir.store %3, %2 : !s32i, !cir.ptr<!s32i>
@@ -185,23 +191,23 @@ module {
     cir.return %4 : !s32i
   }
 // CHECK:  cir.func @shouldFlatNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
-// CHECK:    cir.switch.flat %3 : !s32i, ^bb7 [
-// CHECK:      0: ^bb2
+// CHECK:    cir.switch.flat %3 : !s32i, ^bb[[#DEFAULT_BB:]] [
+// CHECK:      0: ^bb[[#BB1:]]
 // CHECK:    ]
-// CHECK:  ^bb2:  // pred: ^bb1
-// CHECK:    cir.br ^bb3
-// CHECK:  ^bb3:  // pred: ^bb2
-// CHECK:    cir.brcond {{%.*}} ^bb4, ^bb5
-// CHECK:  ^bb4:  // pred: ^bb3
-// CHECK:    cir.br ^bb7
-// CHECK:  ^bb5:  // pred: ^bb3
-// CHECK:    cir.br ^bb6
-// CHECK:  ^bb6:  // pred: ^bb5
-// CHECK:    cir.br ^bb7
-// CHECK:  ^bb7:  // 3 preds: ^bb1, ^bb4, ^bb6
-// CHECK:    cir.br ^bb8
-// CHECK:  ^bb8:  // pred: ^bb7
-// CHECK:    cir.return %9 : !s32i
+// CHECK:  ^bb[[#BB1]]:
+// CHECK:    cir.br ^bb[[#COND_BB:]]
+// CHECK:  ^bb[[#COND_BB]]:
+// CHECK:    cir.brcond {{%.*}} ^bb[[#TRUE_BB:]], ^bb[[#FALSE_BB:]]
+// CHECK:  ^bb[[#TRUE_BB]]:
+// CHECK:    cir.br ^bb[[#DEFAULT_BB]]
+// CHECK:  ^bb[[#FALSE_BB]]:
+// CHECK:    cir.br ^bb[[#PRED_BB:]]
+// CHECK:  ^bb[[#PRED_BB]]:
+// CHECK:    cir.br ^bb[[#DEFAULT_BB]]
+// CHECK:  ^bb[[#DEFAULT_BB]]:
+// CHECK:    cir.br ^bb[[#RET_BB:]]
+// CHECK:  ^bb[[#RET_BB]]:
+// CHECK:    cir.return
 // CHECK:  }
 
 
@@ -214,23 +220,24 @@ module {
     cir.store %3, %2 : !s32i, !cir.ptr<!s32i>
     cir.scope {
       %6 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-      cir.switch (%6 : !s32i) [
-      case (equal, -100) {
+      cir.switch (%6 : !s32i) {
+      cir.case (equal, [#cir.int<-100> : !s32i]) {
         %7 = cir.const #cir.int<1> : !s32i
         cir.store %7, %2 : !s32i, !cir.ptr<!s32i>
         cir.break
-      },
-      case (range, [1, 100] : !s32i) {
+      }
+      cir.case (range, [#cir.int<1> : !s32i, #cir.int<100> : !s32i]) {
         %7 = cir.const #cir.int<2> : !s32i
         cir.store %7, %2 : !s32i, !cir.ptr<!s32i>
         cir.break
-      },
-      case (default) {
+      }
+      cir.case (default, []) {
         %7 = cir.const #cir.int<3> : !s32i
         cir.store %7, %2 : !s32i, !cir.ptr<!s32i>
         cir.break
       }
-      ]
+      cir.yield
+      }
     }
     %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
     cir.store %4, %1 : !s32i, !cir.ptr<!s32i>
@@ -241,6 +248,8 @@ module {
 //      CHECK:    cir.switch.flat %[[X:[0-9]+]] : !s32i, ^[[JUDGE_RANGE:bb[0-9]+]] [
 // CHECK-NEXT:      -100: ^[[CASE_EQUAL:bb[0-9]+]]
 // CHECK-NEXT:    ]
+// CHECK-NEXT:  ^[[UNRACHABLE_BB:.+]]:   // no predecessors
+// CHECK-NEXT:    cir.br ^[[CASE_EQUAL]]
 // CHECK-NEXT:  ^[[CASE_EQUAL]]:
 // CHECK-NEXT:    cir.int<1>
 // CHECK-NEXT:    cir.store


### PR DESCRIPTION
Close https://github.com/llvm/clangir/issues/522

This solves the issue we can't handle `case` in nested scopes and we can't handle if the switch body is not a compound statement.

The core idea of the  patch is to introduce the `cir.case` operation to the language. Then we can get the cases by traversing the body of the `cir.switch` operation easily instead of counting the regions and the attributes.

Every `cir.case` operation has a region and now the `cir.switch` has only one region too. But to make the analysis and optimizations easier, I add a new concept `simple form` here. That a simple `cir.switch` operation is: all the `cir.case` operation owned by the `cir.switch` lives in the top level blocks of the `cir.switch` region and there is no other operations except the ending `cir.yield`. This solves the previous `simplified for common-case` vs `general solution` discussion in https://github.com/llvm/clangir/issues/522. After implemented this, I feel the correct answer to it is, we want a general solution for constructing and lowering the operations but we like simple and common case for analysis and optimizations. We just mixed the different phases.

For other semantics, see `CIROps.td`.

For lowering, we can make it generally by lower the cases one by one and finally lower the switch itself.

Although this patch has 1000+ lines of changes, I feel it is relatively neat especially it erases some odd behaviors before.

Tested with Spec2017's C benchmarks except 500.perlbench_r.