### PR TITLE
[ClangIR][CIRGen] Handle nested union in arrays of struct

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -93,13 +93,13 @@ def CIR_BoolAttr : CIR_Attr<"Bool", "bool", [TypedAttrInterface]> {
 }
 
 //===----------------------------------------------------------------------===//
-// PlaceholderAttr
+// UninitializedUnionFieldAttr
 //===----------------------------------------------------------------------===//
 
-def PlaceholderAttr : CIR_Attr<"Placeholder", "placeholder", [TypedAttrInterface]> {
-  let summary = "Attribute to represent a placeholder";
+def UninitializedUnionFieldAttr : CIR_Attr<"UninitializedUnionField", "uninitialized_union_field", [TypedAttrInterface]> {
+  let summary = "Attribute to represent an uninitialized field for a union.";
   let description = [{
-    The PlaceholderAttr is used to represent a placeholder.
+    The UninitializedUnionFieldAttr is used to represent an uninitialized field for a union.
   }];
 
   let parameters = (ins AttributeSelfTypeParameter<"">:$type);

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -93,6 +93,20 @@ def CIR_BoolAttr : CIR_Attr<"Bool", "bool", [TypedAttrInterface]> {
 }
 
 //===----------------------------------------------------------------------===//
+// PlaceholderAttr
+//===----------------------------------------------------------------------===//
+
+def PlaceholderAttr : CIR_Attr<"Placeholder", "placeholder", [TypedAttrInterface]> {
+  let summary = "Attribute to represent a placeholder";
+  let description = [{
+    The PlaceholderAttr is used to represent a placeholder.
+  }];
+
+  let parameters = (ins AttributeSelfTypeParameter<"">:$type);
+  let assemblyFormat = [{}];
+}
+
+//===----------------------------------------------------------------------===//
 // ZeroAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -93,7 +93,7 @@ def CIR_BoolAttr : CIR_Attr<"Bool", "bool", [TypedAttrInterface]> {
 }
 
 //===----------------------------------------------------------------------===//
-// UninitializedUnionFieldAttr
+// InactiveUnionFieldAttr
 //===----------------------------------------------------------------------===//
 
 def InactiveUnionFieldAttr : CIR_Attr<"InactiveUnionField", "inactive_field", [TypedAttrInterface]> {

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -96,10 +96,11 @@ def CIR_BoolAttr : CIR_Attr<"Bool", "bool", [TypedAttrInterface]> {
 // UninitializedUnionFieldAttr
 //===----------------------------------------------------------------------===//
 
-def UninitializedUnionFieldAttr : CIR_Attr<"UninitializedUnionField", "uninitialized_union_field", [TypedAttrInterface]> {
+def InactiveUnionFieldAttr : CIR_Attr<"InactiveUnionField", "inactive_field", [TypedAttrInterface]> {
   let summary = "Attribute to represent an uninitialized field for a union.";
   let description = [{
-    The UninitializedUnionFieldAttr is used to represent an uninitialized field for a union.
+    The InactiveUnionFieldAttr is used to represent an uninitialized field
+    for a union.
   }];
 
   let parameters = (ins AttributeSelfTypeParameter<"">:$type);

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -300,7 +300,7 @@ public:
       return true;
     }
 
-    if (mlir::isa<mlir::cir::UninitializedUnionFieldAttr>(attr))
+    if (mlir::isa<mlir::cir::InactiveUnionFieldAttr>(attr))
       return true;
 
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -300,6 +300,9 @@ public:
       return true;
     }
 
+    if (isa<mlir::cir::PlaceholderAttr>(attr))
+      return true;
+
     llvm_unreachable("NYI");
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -300,7 +300,7 @@ public:
       return true;
     }
 
-    if (mlir::isa<mlir::cir::PlaceholderAttr>(attr))
+    if (mlir::isa<mlir::cir::UninitializedUnionFieldAttr>(attr))
       return true;
 
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -300,7 +300,7 @@ public:
       return true;
     }
 
-    if (isa<mlir::cir::PlaceholderAttr>(attr))
+    if (mlir::isa<mlir::cir::PlaceholderAttr>(attr))
       return true;
 
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -380,7 +380,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   bool Packed = false;
   ArrayRef<mlir::Attribute> UnpackedElems;
 
-  // Fullill the init elements for union. This comes from a fundamental
+  // Fill the init elements for union. This comes from a fundamental
   // difference between CIR and LLVM IR. In LLVM IR, the union is simply a
   // struct with the largest member. So it is fine to have only one init
   // element. But in CIR, the union has the information for all members. So if

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -396,7 +396,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
           Ty && Ty.getType() == elemTy)
         UnionElemsStorage.push_back(Elems.back());
       else
-        UnionElemsStorage.push_back(mlir::cir::PlaceholderAttr::get(
+        UnionElemsStorage.push_back(mlir::cir::UninitializedUnionFieldAttr::get(
             CGM.getBuilder().getContext(), elemTy));
     }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -396,7 +396,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
           Ty && Ty.getType() == elemTy)
         UnionElemsStorage.push_back(Elems.back());
       else
-        UnionElemsStorage.push_back(mlir::cir::UninitializedUnionFieldAttr::get(
+        UnionElemsStorage.push_back(mlir::cir::InactiveUnionFieldAttr::get(
             CGM.getBuilder().getContext(), elemTy));
     }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -378,7 +378,32 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   CharUnits AlignedSize = Size.alignTo(Align);
 
   bool Packed = false;
-  ArrayRef<mlir::Attribute> UnpackedElems = Elems;
+  ArrayRef<mlir::Attribute> UnpackedElems;
+
+  // Fullill the init elements for union. This comes from a fundamental
+  // difference between CIR and LLVM IR. In LLVM IR, the union is simply a
+  // struct with the largest member. So it is fine to have only one init
+  // element. But in CIR, the union has the information for all members. So if
+  // we only pass a single init element, we may be in trouble. We solve the
+  // problem by appending placeholder attribute for the uninitialized fields.
+  if (auto desired = dyn_cast<mlir::cir::StructType>(DesiredTy);
+      desired && desired.isUnion() &&
+      Elems.size() != desired.getNumElements()) {
+    llvm::SmallVector<mlir::Attribute, 32> UnionElemsStorage;
+
+    for (auto elemTy : desired.getMembers()) {
+      if (auto Ty = mlir::dyn_cast<mlir::TypedAttr>(Elems.back());
+          Ty && Ty.getType() == elemTy)
+        UnionElemsStorage.push_back(Elems.back());
+      else
+        UnionElemsStorage.push_back(mlir::cir::PlaceholderAttr::get(
+            CGM.getBuilder().getContext(), elemTy));
+    }
+
+    UnpackedElems = UnionElemsStorage;
+  } else
+    UnpackedElems = Elems;
+
   llvm::SmallVector<mlir::Attribute, 32> UnpackedElemStorage;
   if (DesiredSize < AlignedSize || DesiredSize.alignTo(Align) != DesiredSize) {
     NaturalLayout = false;
@@ -386,7 +411,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   } else if (DesiredSize > AlignedSize) {
     // The natural layout would be too small. Add padding to fix it. (This
     // is ignored if we choose a packed layout.)
-    UnpackedElemStorage.assign(Elems.begin(), Elems.end());
+    UnpackedElemStorage.assign(UnpackedElems.begin(), UnpackedElems.end());
     UnpackedElemStorage.push_back(Utils.getPadding(DesiredSize - Size));
     UnpackedElems = UnpackedElemStorage;
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -439,6 +439,15 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
 
   // Iteratively lower each constant element of the struct.
   for (auto [idx, elt] : llvm::enumerate(constStruct.getMembers())) {
+    if (auto constStructType =
+            dyn_cast<mlir::cir::StructType>(constStruct.getType());
+        constStructType && constStructType.isUnion()) {
+      if (isa<mlir::cir::PlaceholderAttr>(elt))
+        continue;
+
+      idx = 0;
+    }
+
     mlir::Value init = lowerCirAttrAsValue(parentOp, elt, rewriter, converter);
     result = rewriter.create<mlir::LLVM::InsertValueOp>(loc, result, init, idx);
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -442,7 +442,7 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
     if (auto constStructType =
             dyn_cast<mlir::cir::StructType>(constStruct.getType());
         constStructType && constStructType.isUnion()) {
-      if (isa<mlir::cir::UninitializedUnionFieldAttr>(elt))
+      if (isa<mlir::cir::InactiveUnionFieldAttr>(elt))
         continue;
 
       idx = 0;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -442,7 +442,7 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
     if (auto constStructType =
             dyn_cast<mlir::cir::StructType>(constStruct.getType());
         constStructType && constStructType.isUnion()) {
-      if (isa<mlir::cir::PlaceholderAttr>(elt))
+      if (isa<mlir::cir::UninitializedUnionFieldAttr>(elt))
         continue;
 
       idx = 0;

--- a/clang/test/CIR/CodeGen/nested-union-array.c
+++ b/clang/test/CIR/CodeGen/nested-union-array.c
@@ -27,7 +27,7 @@ const struct nested data[] =
     },
 };
 
-// CIR: ![[ANON_TY:.+]] = !cir.struct<union "anon.0" {!cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>}
-// CIR: ![[NESTED_TY:.+]] = !cir.struct<struct "nested" {![[ANON_TY]]}
-// CIR: cir.global  constant external @data = #cir.const_array<[#cir.const_struct<{#cir.const_struct<{#cir.uninitialized_union_field : !cir.ptr<!s8i>, #cir.global_view<@test> : !cir.ptr<!cir.ptr<!s8i>>}> : ![[ANON_TY]]}> : ![[NESTED_TY:.+]], #cir.const_struct<{#cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>, #cir.uninitialized_union_field : !cir.ptr<!cir.ptr<!s8i>>}> : ![[ANON_TY]]}> : ![[NESTED_TY:.+]]]> : !cir.array<![[NESTED_TY:.+]] x 2>
+// CIR: ![[ANON_TY:.+]] = !cir.struct<union "anon.0" {!cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
+// CIR: ![[NESTED_TY:.+]] = !cir.struct<struct "nested" {![[ANON_TY]]
+// CIR: cir.global constant external @data = #cir.const_array<[#cir.const_struct<{#cir.const_struct<{#cir.inactive_field : !cir.ptr<!s8i>, #cir.global_view<@test> : !cir.ptr<!cir.ptr<!s8i>>}> : ![[ANON_TY]]}> : ![[NESTED_TY:.+]], #cir.const_struct<{#cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>, #cir.inactive_field : !cir.ptr<!cir.ptr<!s8i>>}> : ![[ANON_TY]]}> : ![[NESTED_TY:.+]]]> : !cir.array<![[NESTED_TY:.+]] x 2>
 // LLVM: @data = constant [2 x {{.*}}]

--- a/clang/test/CIR/CodeGen/nested-union-array.c
+++ b/clang/test/CIR/CodeGen/nested-union-array.c
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+
+struct nested
+{
+  union {
+    const char *single;
+    const char *const *multi;
+  } output;
+};
+static const char * const test[] = {
+  "test",
+};
+const struct nested data[] = 
+{
+    {
+        {
+            .multi = test,
+        },
+    },
+    {
+        {
+            .single = "hello",
+        },
+    },
+};
+
+// CHECK: cir.global  constant external @data = #cir.const_array
+// LLVM: @data = constant [2 x {{.*}}]

--- a/clang/test/CIR/CodeGen/nested-union-array.c
+++ b/clang/test/CIR/CodeGen/nested-union-array.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
@@ -27,5 +27,7 @@ const struct nested data[] =
     },
 };
 
-// CHECK: cir.global  constant external @data = #cir.const_array
+// CIR: ![[ANON_TY:.+]] = !cir.struct<union "anon.0" {!cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>}
+// CIR: ![[NESTED_TY:.+]] = !cir.struct<struct "nested" {![[ANON_TY]]}
+// CIR: cir.global  constant external @data = #cir.const_array<[#cir.const_struct<{#cir.const_struct<{#cir.uninitialized_union_field : !cir.ptr<!s8i>, #cir.global_view<@test> : !cir.ptr<!cir.ptr<!s8i>>}> : ![[ANON_TY]]}> : ![[NESTED_TY:.+]], #cir.const_struct<{#cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>, #cir.uninitialized_union_field : !cir.ptr<!cir.ptr<!s8i>>}> : ![[ANON_TY]]}> : ![[NESTED_TY:.+]]]> : !cir.array<![[NESTED_TY:.+]] x 2>
 // LLVM: @data = constant [2 x {{.*}}]

--- a/clang/test/CIR/CodeGen/union-init.c
+++ b/clang/test/CIR/CodeGen/union-init.c
@@ -12,10 +12,12 @@ void foo(int x) {
   A a = {.x = x};
 }
 
-// CHECK-DAG: ![[anon0:.*]] = !cir.struct<struct  {!u32i}>
-// CHECK-DAG: ![[anon:.*]] = !cir.struct<struct  {!s32i}>
+// CHECK-DAG: ![[TY_U:.*]] = !cir.struct<union "U" {!s32i}>
+// CHECK-DAG: ![[anon0:.*]] = !cir.struct<struct {{.*}}{!u32i}
+// CHECK-DAG: ![[TY_u:.*]] = !cir.struct<union {{.*}}{!s32i, !cir.float}
 // CHECK-DAG: #[[bfi_x:.*]] = #cir.bitfield_info<name = "x", storage_type = !u32i, size = 16, offset = 0, is_signed = true>
 // CHECK-DAG: #[[bfi_y:.*]] = #cir.bitfield_info<name = "y", storage_type = !u32i, size = 16, offset = 16, is_signed = true>
+// CHECK-DAG: ![[TY_A:.*]] = !cir.struct<union "A" {!s32i, ![[anon0]]}>
 // CHECK-DAG: ![[anon1:.*]] = !cir.struct<union "{{.*}}" {!u32i, !cir.array<!u8i x 4>}
 
 // CHECK-LABEL:   cir.func @foo(
@@ -32,7 +34,7 @@ void foo(int x) {
 // CHECK:  cir.return
 
 union { int i; float f; } u = { };
-// CHECK: cir.global external @u = #cir.zero : ![[anon]]
+// CHECK: cir.global  external @u = #cir.zero : ![[TY_u]]
 
 unsigned is_little(void) {
   const union {
@@ -43,9 +45,8 @@ unsigned is_little(void) {
 }
 
 // CHECK: cir.func @is_little
-// CHECK: %[[VAL_1:.*]] = cir.get_global @is_little.one : !cir.ptr<![[anon0]]>
-// CHECK: %[[VAL_2:.*]] = cir.cast(bitcast, %[[VAL_1]] : !cir.ptr<![[anon0]]>), !cir.ptr<![[anon1]]>
-// CHECK: %[[VAL_3:.*]] = cir.get_member %[[VAL_2]][1] {name = "c"} : !cir.ptr<![[anon1]]> -> !cir.ptr<!cir.array<!u8i x 4>>
+// CHECK: %[[VAL_1:.*]] = cir.get_global @is_little.one : !cir.ptr<![[anon1]]>
+// CHECK: %[[VAL_2:.*]] = cir.get_member %[[VAL_1]][1] {name = "c"} : !cir.ptr<![[anon1]]> -> !cir.ptr<!cir.array<!u8i x 4>>
 
 typedef union {
   int x;


### PR DESCRIPTION
Reproducer:

```
struct nested
{
  union {
    const char *single;
    const char *const *multi;
  } output;
};
static const char * const test[] = {
  "test",
};
const struct nested data[] = 
{
    {
        {
            .multi = test,
        },
    },
    {
        {
            .single = "hello",
        },
    },
};
```

ClangIR now failed to recognize `data` as an array since it failed to recognize the initializer for union. This comes from a fundamental  difference between CIR and LLVM IR. In LLVM IR, the union is simply a struct with the largest member. So it is fine to have only one init element. But in CIR, the union has the information for all members. So if  we only pass a single init element, we may be in trouble. We solve the problem by appending placeholder attribute for the uninitialized fields.