### PR TITLE
[ClangIR][Lowering] Handle lowered array index

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -578,9 +578,12 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
   if (globalAttr.getIndices()) {
     llvm::SmallVector<mlir::LLVM::GEPArg> indices;
 
-    if (auto stTy = dyn_cast<mlir::LLVM::LLVMStructType>(sourceType))
+    if (auto stTy = dyn_cast<mlir::LLVM::LLVMStructType>(sourceType)) {
       if (stTy.isIdentified())
         indices.push_back(0);
+    } else if (isa<mlir::LLVM::LLVMArrayType>(sourceType)) {
+      indices.push_back(0);
+    }
 
     for (auto idx : globalAttr.getIndices()) {
       auto intAttr = dyn_cast<mlir::IntegerAttr>(idx);

--- a/clang/test/CIR/CodeGen/globals-neg-index-array.c
+++ b/clang/test/CIR/CodeGen/globals-neg-index-array.c
@@ -17,4 +17,4 @@ char *packed_element = &(packed[-2].a3);
 // CHECK: cir.global  external @packed = #cir.zero : !cir.array<!ty_PackedStruct x 10> {alignment = 16 : i64} loc(#loc5)
 // CHECK: cir.global  external @packed_element = #cir.global_view<@packed, [-2 : i32, 2 : i32]>
 // LLVM: @packed = global [10 x %struct.PackedStruct] zeroinitializer
-// LLVM: @packed_element = global ptr getelementptr inbounds ([10 x %struct.PackedStruct], ptr @packed, i32 -2, i32 2)
+// LLVM: @packed_element = global ptr getelementptr inbounds ([10 x %struct.PackedStruct], ptr @packed, i32 0, i32 -2, i32 2)


### PR DESCRIPTION
Previously we didn't generate the index for array correct.

The previous test is incorrect already:  globals-neg-index-array.c

```
// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o %t.cir
// RUN: FileCheck --input-file=%t.cir %s
// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
// RUN: %clang_cc1 -x c++ -triple x86_64-unknown-linux-gnu -emit-cir %s -o %t.cir
// RUN: FileCheck --input-file=%t.cir %s
// RUN: %clang_cc1 -x c++ -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s

struct __attribute__((packed)) PackedStruct {
    char a1;
    char a2;
    char a3;
};
struct PackedStruct packed[10];
char *packed_element = &(packed[-2].a3);
// CHECK: cir.global  external @packed = #cir.zero : !cir.array<!ty_PackedStruct x 10> {alignment = 16 : i64} loc(#loc5)
// CHECK: cir.global  external @packed_element = #cir.global_view<@packed, [-2 : i32, 2 : i32]>
// LLVM: @packed = global [10 x %struct.PackedStruct] zeroinitializer
+ // LLVM: @packed_element = global ptr getelementptr inbounds ([10 x %struct.PackedStruct], ptr @packed, i32 0, i32 -2, i32 2)
- // LLVM: @packed_element = global ptr getelementptr inbounds ([10 x %struct.PackedStruct], ptr @packed,  i32 -2, i32 2)
```

Compile it with `-fclangir -S`, we got:

```
packed:
        .zero   30

packed_element:
	.quad	packed-54
```

but the traditional pipeline shows (https://godbolt.org/z/eTj96EP1E):

```
packed:
        .zero   30

packed_element:
        .quad   packed-4
```

this may be a simple mismatch.