### PR TITLE
[CIR][CIRGen] Removed extra space in "cir.shift( right)" (#997)

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1199,7 +1199,7 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
 
   let assemblyFormat = [{
     `(`
-      (`left` $isShiftleft^) : (`right`)?
+      (`left` $isShiftleft^) : (```right`)?
       `,` $value `:` type($value)
       `,` $amount `:` type($amount)
     `)` `->` type($result) attr-dict

--- a/clang/test/CIR/CodeGen/binassign.cpp
+++ b/clang/test/CIR/CodeGen/binassign.cpp
@@ -34,7 +34,7 @@ int foo(int a, int b) {
 // CHECK: = cir.binop(sub,
 // CHECK: cir.store {{.*}}[[Value]]
 // CHECK: = cir.load {{.*}}[[Value]]
-// CHECK: = cir.shift( right
+// CHECK: = cir.shift(right
 // CHECK: cir.store {{.*}}[[Value]]
 // CHECK: = cir.load {{.*}}[[Value]]
 // CHECK: = cir.shift(left

--- a/clang/test/CIR/CodeGen/binop.cpp
+++ b/clang/test/CIR/CodeGen/binop.cpp
@@ -19,7 +19,7 @@ void b0(int a, int b) {
 // CHECK: = cir.binop(rem, %9, %10) : !s32i
 // CHECK: = cir.binop(add, %12, %13) nsw : !s32i
 // CHECK: = cir.binop(sub, %15, %16) nsw : !s32i
-// CHECK: = cir.shift( right, %18 : !s32i, %19 : !s32i) -> !s32i
+// CHECK: = cir.shift(right, %18 : !s32i, %19 : !s32i) -> !s32i
 // CHECK: = cir.shift(left, %21 : !s32i, %22 : !s32i) -> !s32i
 // CHECK: = cir.binop(and, %24, %25) : !s32i
 // CHECK: = cir.binop(xor, %27, %28) : !s32i

--- a/clang/test/CIR/CodeGen/vectype.cpp
+++ b/clang/test/CIR/CodeGen/vectype.cpp
@@ -108,7 +108,7 @@ void vector_int_test(int x, unsigned short usx) {
   // CHECK: %{{[0-9]+}} = cir.shift(left, {{%.*}} : !cir.vector<!s32i x 4>, 
   // CHECK-SAME: {{%.*}} : !cir.vector<!s32i x 4>) -> !cir.vector<!s32i x 4>
   vi4 y = a >> b;
-  // CHECK: %{{[0-9]+}} = cir.shift( right, {{%.*}} : !cir.vector<!s32i x 4>, 
+  // CHECK: %{{[0-9]+}} = cir.shift(right, {{%.*}} : !cir.vector<!s32i x 4>, 
   // CHECK-SAME: {{%.*}} : !cir.vector<!s32i x 4>) -> !cir.vector<!s32i x 4>
 
   vus2 z = { usx, usx };  
@@ -116,7 +116,7 @@ void vector_int_test(int x, unsigned short usx) {
   vus2 zamt = { 3, 4 };
   // CHECK: %{{[0-9]+}} = cir.const #cir.const_vector<[#cir.int<3> : !u16i, #cir.int<4> : !u16i]> : !cir.vector<!u16i x 2>
   vus2 zzz = z >> zamt;
-  // CHECK: %{{[0-9]+}} = cir.shift( right, {{%.*}} : !cir.vector<!u16i x 2>, 
+  // CHECK: %{{[0-9]+}} = cir.shift(right, {{%.*}} : !cir.vector<!u16i x 2>, 
   // CHECK-SAME: {{%.*}} : !cir.vector<!u16i x 2>) -> !cir.vector<!u16i x 2> 
 }
 


### PR DESCRIPTION
The MLIR docs at https://mlir.llvm.org/docs/DefiningDialects/Operations/#literals specify that "An empty literal `` may be used to remove a space that is inserted implicitly after certain literal elements", so I inserted one before the `right` literal to remove the extra space that was being printed. Oddly, the bug is also fixed by inserting an empty literal _after_ the `left` literal, which leads me to believe that tablegen is inserting an implicit space after the `left` literal.