### PR TITLE
[CIR][CIRGen] Fix "definition with same mangled name" error

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -607,20 +607,17 @@ void CIRGenModule::buildGlobalFunctionDefinition(GlobalDecl GD,
   auto Ty = getTypes().GetFunctionType(FI);
 
   // Get or create the prototype for the function.
-  // if (!V || (V.getValueType() != Ty))
-  // TODO(cir): Figure out what to do here? llvm uses a GlobalValue for the
-  // FuncOp in mlir
-  Op = GetAddrOfFunction(GD, Ty, /*ForVTable=*/false, /*DontDefer=*/true,
-                         ForDefinition);
+  auto Fn = dyn_cast_if_present<mlir::cir::FuncOp>(Op);
+  if (!Fn || Fn.getFunctionType() != Ty)
+    Fn = GetAddrOfFunction(GD, Ty, /*ForVTable=*/false, /*DontDefer=*/true,
+                           ForDefinition);
 
-  auto globalVal = dyn_cast_or_null<mlir::cir::CIRGlobalValueInterface>(Op);
-  if (globalVal && !globalVal.isDeclaration()) {
-    // Already emitted.
+  // Already emitted.
+  if (!Fn.isDeclaration())
     return;
-  }
-  auto Fn = cast<mlir::cir::FuncOp>(Op);
+
   setFunctionLinkage(GD, Fn);
-  setGVProperties(Op, D);
+  setGVProperties(Fn, D);
   // TODO(cir): MaubeHandleStaticInExternC
   // TODO(cir): maybeSetTrivialComdat
   // TODO(cir): setLLVMFunctionFEnvAttributes
@@ -633,7 +630,7 @@ void CIRGenModule::buildGlobalFunctionDefinition(GlobalDecl GD,
   }
   CurCGF = nullptr;
 
-  setNonAliasAttributes(GD, Op);
+  setNonAliasAttributes(GD, Fn);
   setCIRFunctionAttributesForDefinition(D, Fn);
 
   if (const ConstructorAttr *CA = D->getAttr<ConstructorAttr>())
@@ -2670,7 +2667,8 @@ mlir::cir::FuncOp CIRGenModule::GetOrCreateCIRFunction(
       // CHeck that GD is not yet in DiagnosedConflictingDefinitions is required
       // to make sure that we issue and error only once.
       if (lookupRepresentativeDecl(MangledName, OtherGD) &&
-          (GD.getCanonicalDecl().getDecl()) &&
+          (GD.getCanonicalDecl().getDecl() !=
+           OtherGD.getCanonicalDecl().getDecl()) &&
           DiagnosedConflictingDefinitions.insert(GD).second) {
         getDiags().Report(D->getLocation(), diag::err_duplicate_mangled_name)
             << MangledName;

--- a/clang/test/CIR/CodeGen/same-mangled-name.cpp
+++ b/clang/test/CIR/CodeGen/same-mangled-name.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// This would previously emit a "definition with same mangled name as another
+// definition" error: https://github.com/llvm/clangir/issues/991.
+namespace N {
+struct S {
+  // CHECK: cir.func linkonce_odr @_ZN1N1S3fooEv({{.*}} {
+  void foo() {}
+};
+
+// CHECK: cir.func @_ZN1N1fEv() {{.*}} {
+// CHECK:   cir.call @_ZN1N1S3fooEv(
+void f() { S().foo(); }
+} // namespace N


### PR DESCRIPTION
We had some incorrect logic when creating functions and getting their
address which resulted in spurious "definition with the same mangled
name" errors. Fix that logic to match original CodeGen, which also fixes
these errors.

It's expected that decls can appear in the deferred decl list multiple
times, and CodeGen has to guard against that. In the case that triggered
the error, both `CIRGenerator::HandleInlineFunctionDefinition` and
CIRGenModule were deferring the declaration.

Something else I discovered here is that we emit these functions in the
opposite order as regular CodeGen: https://godbolt.org/z/4PrKG7h9b.
That might be a meaningful difference worth investigating further.

Fixes https://github.com/llvm/clangir/issues/991
