### PR TITLE
[CIR][CIRGen] Add support for memmove

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3933,7 +3933,7 @@ def CopyOp : CIR_Op<"copy",
 class CIR_MemCpyOp<string mnemonic>: CIR_Op<mnemonic, [AllTypesMatch<["dst", "src"]>]> {
   let arguments = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
                        Arg<VoidPtr, "", [MemRead]>:$src,
-                       PrimitiveUInt:$len, UnitAttr:$memory_overlap);
+                       PrimitiveUInt:$len);
   let hasVerifier = 0;
 
   let extraClassDeclaration = [{
@@ -3973,7 +3973,7 @@ def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
     Given two CIR pointers, `src` and `dst`, `cir.libc.memmove` will copy `len`
     bytes from the memory pointed by `src` to the memory pointed by `dst`.
 
-    The `memory_overlap` argument indicate whether accounts for overlapping memory.
+    similiar to `cir.libc.memcpy` but accounts for overlapping memory.
 
     Examples:
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3971,6 +3971,42 @@ def MemCpyOp : CIR_Op<"libc.memcpy"> {
 }
 
 //===----------------------------------------------------------------------===//
+// MemMoveOp
+//===----------------------------------------------------------------------===//
+
+def MemMoveOp : CIR_Op<"libc.memmove", [AllTypesMatch<["dst", "src"]>]> {
+  let arguments = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
+                       Arg<VoidPtr, "", [MemRead]>:$src,
+                       PrimitiveUInt:$len);
+  let summary = "Equivalent to libc's `memmove`";
+  let description = [{
+    Given two CIR pointers, `src` and `dst`, `cir.libc.memmove` will copy `len`
+    bytes from the memory pointed by `src` to the memory pointed by `dst`.
+
+    similiar to `cir.libc.memcpy` but accounts for overlapping memory.
+
+    Examples:
+
+    ```mlir
+      // Copying 2 bytes from one array to a struct:
+      %2 = cir.const #cir.int<2> : !u32i
+      cir.libc.memmove %2 bytes from %arr to %struct : !cir.ptr<!void>, !u64i
+    ```
+  }];
+
+  let assemblyFormat = [{
+    $len `bytes` `from` $src `to` $dst attr-dict
+    `:` qualified(type($dst)) `,` type($len)
+  }];
+  let hasVerifier = 0;
+
+  let extraClassDeclaration = [{
+    /// Returns the byte length type.
+    mlir::cir::IntType getLenTy() { return getLen().getType(); }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // MemChrOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3927,13 +3927,22 @@ def CopyOp : CIR_Op<"copy",
 }
 
 //===----------------------------------------------------------------------===//
-// MemCpyOp
+// MemCpyOp && MemMoveOp
 //===----------------------------------------------------------------------===//
 
-def MemCpyOp : CIR_Op<"libc.memcpy"> {
-  let arguments = (ins Arg<CIR_PointerType, "", [MemWrite]>:$dst,
-                       Arg<CIR_PointerType, "", [MemRead]>:$src,
-                       PrimitiveInt:$len);
+class CIR_MemCpyOp<string mnemonic>: CIR_Op<mnemonic, [AllTypesMatch<["dst", "src"]>]> {
+  let arguments = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
+                       Arg<VoidPtr, "", [MemRead]>:$src,
+                       PrimitiveUInt:$len, UnitAttr:$memory_overlap);
+  let hasVerifier = 0;
+
+  let extraClassDeclaration = [{
+    /// Returns the byte length type.
+    mlir::cir::IntType getLenTy() { return getLen().getType(); }
+  }];
+}
+
+def MemCpyOp : CIR_MemCpyOp<"libc.memcpy"> {
   let summary = "Equivalent to libc's `memcpy`";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.libc.memcpy` will copy `len`
@@ -3956,34 +3965,15 @@ def MemCpyOp : CIR_Op<"libc.memcpy"> {
     $len `bytes` `from` $src `to` $dst attr-dict
     `:` type($len) `` `,` qualified(type($src)) `->` qualified(type($dst))
   }];
-  let hasVerifier = 1;
-
-  let extraClassDeclaration = [{
-    /// Returns the data source pointer type.
-    mlir::cir::PointerType getSrcTy() { return getSrc().getType(); }
-
-    /// Returns the data destination pointer type.
-    mlir::cir::PointerType getDstTy() { return getDst().getType(); }
-
-    /// Returns the byte length type.
-    mlir::cir::IntType getLenTy() { return getLen().getType(); }
-  }];
 }
 
-//===----------------------------------------------------------------------===//
-// MemMoveOp
-//===----------------------------------------------------------------------===//
-
-def MemMoveOp : CIR_Op<"libc.memmove", [AllTypesMatch<["dst", "src"]>]> {
-  let arguments = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
-                       Arg<VoidPtr, "", [MemRead]>:$src,
-                       PrimitiveUInt:$len);
+def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
   let summary = "Equivalent to libc's `memmove`";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.libc.memmove` will copy `len`
     bytes from the memory pointed by `src` to the memory pointed by `dst`.
 
-    similiar to `cir.libc.memcpy` but accounts for overlapping memory.
+    The `memory_overlap` argument indicate whether accounts for overlapping memory.
 
     Examples:
 
@@ -3994,15 +3984,10 @@ def MemMoveOp : CIR_Op<"libc.memmove", [AllTypesMatch<["dst", "src"]>]> {
     ```
   }];
 
+
   let assemblyFormat = [{
     $len `bytes` `from` $src `to` $dst attr-dict
     `:` qualified(type($dst)) `,` type($len)
-  }];
-  let hasVerifier = 0;
-
-  let extraClassDeclaration = [{
-    /// Returns the byte length type.
-    mlir::cir::IntType getLenTy() { return getLen().getType(); }
   }];
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -623,6 +623,16 @@ public:
     return create<mlir::cir::ContinueOp>(loc);
   }
 
+  mlir::cir::MemCpyOp createMemCpy(mlir::Location loc, mlir::Value dst,
+                                   mlir::Value src, mlir::Value len) {
+    return create<mlir::cir::MemCpyOp>(loc, dst, src, len);
+  }
+
+  mlir::cir::MemMoveOp createMemMove(mlir::Location loc, mlir::Value dst,
+                                     mlir::Value src, mlir::Value len) {
+    return create<mlir::cir::MemMoveOp>(loc, dst, src, len);
+  }
+
   mlir::Value createNeg(mlir::Value value) {
 
     if (auto intTy = mlir::dyn_cast<mlir::cir::IntType>(value.getType())) {

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1435,9 +1435,19 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     llvm_unreachable("BI__builtin___memmove_chk NYI");
 
   case Builtin::BImemmove:
-  case Builtin::BI__builtin_memmove:
-    llvm_unreachable("BImemmove like NYI");
-
+  case Builtin::BI__builtin_memmove: {
+    Address Dest = buildPointerWithAlignment(E->getArg(0));
+    Address Src = buildPointerWithAlignment(E->getArg(1));
+    mlir::Value SizeVal = buildScalarExpr(E->getArg(2));
+    buildNonNullArgCheck(RValue::get(Dest.getPointer()),
+                         E->getArg(0)->getType(), E->getArg(0)->getExprLoc(),
+                         FD, 0);
+    buildNonNullArgCheck(RValue::get(Src.getPointer()), E->getArg(1)->getType(),
+                         E->getArg(1)->getExprLoc(), FD, 1);
+    builder.createMemMove(getLoc(E->getSourceRange()), Dest.getPointer(),
+                          Src.getPointer(), SizeVal);
+    return RValue::get(Dest.getPointer());
+  }
   case Builtin::BImemset:
   case Builtin::BI__builtin_memset:
     llvm_unreachable("BImemset like NYI");

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3490,23 +3490,6 @@ LogicalResult mlir::cir::CopyOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// MemCpyOp Definitions
-//===----------------------------------------------------------------------===//
-
-LogicalResult mlir::cir::MemCpyOp::verify() {
-  auto voidPtr =
-      cir::PointerType::get(getContext(), cir::VoidType::get(getContext()));
-
-  if (!getLenTy().isUnsigned())
-    return emitError() << "memcpy length must be an unsigned integer";
-
-  if (getSrcTy() != voidPtr || getDstTy() != voidPtr)
-    return emitError() << "memcpy src and dst must be void pointers";
-
-  return mlir::success();
-}
-
-//===----------------------------------------------------------------------===//
 // GetMemberOp Definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -713,6 +713,20 @@ public:
     return mlir::success();
   }
 };
+class CIRMemMoveOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::MemMoveOp> {
+public:
+  using mlir::OpConversionPattern<mlir::cir::MemMoveOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::MemMoveOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::MemmoveOp>(
+        op, adaptor.getDst(), adaptor.getSrc(), adaptor.getLen(),
+        /*isVolatile=*/false);
+    return mlir::success();
+  }
+};
 
 static mlir::Value getLLVMIntCast(mlir::ConversionPatternRewriter &rewriter,
                                   mlir::Value llvmSrc, mlir::Type llvmDstIntTy,
@@ -4208,7 +4222,8 @@ void populateCIRToLLVMConversionPatterns(
       CIREhTypeIdOpLowering, CIRCatchParamOpLowering, CIRResumeOpLowering,
       CIRAllocExceptionOpLowering, CIRFreeExceptionOpLowering,
       CIRThrowOpLowering, CIRIntrinsicCallLowering, CIRBaseClassAddrOpLowering,
-      CIRVTTAddrPointOpLowering, CIRIsFPClassOpLowering, CIRAbsOpLowering
+      CIRVTTAddrPointOpLowering, CIRIsFPClassOpLowering, CIRAbsOpLowering,
+      CIRMemMoveOpLowering
 #define GET_BUILTIN_LOWERING_LIST
 #include "clang/CIR/Dialect/IR/CIRBuiltinsLowering.inc"
 #undef GET_BUILTIN_LOWERING_LIST

--- a/clang/test/CIR/CodeGen/libc.c
+++ b/clang/test/CIR/CodeGen/libc.c
@@ -15,6 +15,14 @@ void testMemcpy(void *dst, const void *src, unsigned long size) {
   // CHECK: cir.libc.memcpy %{{.+}} bytes from %{{.+}} to %{{.+}} : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
 }
 
+// Should generate CIR's builtin memmove op.
+void *memmove(void *, const void *, unsigned long);
+void testMemmove(void *src, const void *dst, unsigned long size) {
+  memmove(dst, src, size);
+  // CHECK: cir.libc.memmove %{{.+}} bytes from %{{.+}} to %{{.+}} : !cir.ptr<!void>, !u64i
+  // LLVM: call void @llvm.memmove.{{.+}}.i64(ptr %{{.+}}, ptr %{{.+}}, i64 %{{.+}}, i1 false),
+}
+
 double fabs(double);
 double testFabs(double x) {
   return fabs(x);

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -715,7 +715,7 @@ module {
 module {
   // Should not memcpy with invalid length type.
   cir.func @invalid_memcpy_len(%arg0 : !cir.ptr<!cir.void>, %arg1 : !s8i) {
-    // expected-error@+1 {{memcpy length must be an unsigned integer}}
+    // expected-error@+1 {{'cir.libc.memcpy' op operand #2 must be primitive unsigned int, but got '!cir.int<s, 8>'}}
     cir.libc.memcpy %arg1 bytes from %arg0 to %arg0 : !s8i, !cir.ptr<!cir.void> -> !cir.ptr<!cir.void>
     cir.return
   }
@@ -727,9 +727,22 @@ module {
 !u32i = !cir.int<u, 32>
 module {
   // Should not memcpy non-void pointers.
-  cir.func @invalid_memcpy_len(%arg0 : !cir.ptr<!s8i>, %arg1 : !u32i) {
-    // expected-error@+1 {{memcpy src and dst must be void pointers}}
+  cir.func @invalid_memcpy_pointer_0(%arg0 : !cir.ptr<!s8i>, %arg1 : !u32i) {
+    // expected-error@+1 {{'cir.libc.memcpy' op operand #0 must be void*, but got '!cir.ptr<!cir.int<s, 8>>'}}
     cir.libc.memcpy %arg1 bytes from %arg0 to %arg0 : !u32i, !cir.ptr<!s8i> -> !cir.ptr<!s8i>
+    cir.return
+  }
+}
+
+// -----
+
+!s8i = !cir.int<s, 8>
+!u32i = !cir.int<u, 32>
+module {
+  // Should not memcpy non-void pointers.
+  cir.func @invalid_memcpy_pointer_1(%arg0 : !cir.ptr<!cir.void>, %arg1 : !cir.ptr<!s8i>, %arg2 : !u32i) {
+    // expected-error@+1 {{'cir.libc.memcpy' op operand #1 must be void*, but got '!cir.ptr<!cir.int<s, 8>>'}}
+    cir.libc.memcpy %arg2 bytes from %arg1 to %arg0 : !u32i, !cir.ptr<!s8i> -> !cir.ptr<!cir.void>
     cir.return
   }
 }


### PR DESCRIPTION
due to the issue described in https://github.com/llvm/clangir/issues/1018, 
the MLIR lowering for `memmove` has been excluded in this patch.