### PR TITLE
[CIR][Dialect][NFC] Fix double whitespaces in `cir.func` assembly

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2416,44 +2416,39 @@ bool mlir::cir::FuncOp::isDeclaration() {
 }
 
 void mlir::cir::FuncOp::print(OpAsmPrinter &p) {
-  p << ' ';
-
   // When adding a specific keyword here, do not forget to omit it in
   // printFunctionAttributes below or there will be a syntax error when
   // parsing
   if (getBuiltin())
-    p << "builtin ";
+    p << " builtin";
 
   if (getCoroutine())
-    p << "coroutine ";
+    p << " coroutine";
 
   if (getLambda())
-    p << "lambda ";
+    p << " lambda";
 
   if (getNoProto())
-    p << "no_proto ";
+    p << " no_proto";
 
   if (getComdat())
-    p << "comdat ";
+    p << " comdat";
 
   if (getLinkage() != GlobalLinkageKind::ExternalLinkage)
-    p << stringifyGlobalLinkageKind(getLinkage()) << ' ';
+    p << ' ' << stringifyGlobalLinkageKind(getLinkage());
 
   auto vis = getVisibility();
   if (vis != mlir::SymbolTable::Visibility::Public)
-    p << vis << " ";
+    p << ' ' << vis;
 
   auto cirVisibilityAttr = getGlobalVisibilityAttr();
-  printVisibilityAttr(p, cirVisibilityAttr);
-  // TODO: This is a problematic space to be handled conditionally by
-  // printVisibilityAttr which leads often to a double space in the output. But
-  // it looks like from here we have also switched from adding a conditional
-  // trailing space to inserting a leading space, to avoid trailing space at
-  // EOL.
-  // TODO: Only use the "insert leading space everywhere".
-  p << " ";
+  if (!cirVisibilityAttr.isDefault()) {
+    p << ' ';
+    printVisibilityAttr(p, cirVisibilityAttr);
+  }
 
   // Print function name, signature, and control.
+  p << ' ';
   p.printSymbolName(getSymName());
   auto fnType = getFunctionType();
   SmallVector<Type, 1> resultTypes;
@@ -2466,7 +2461,7 @@ void mlir::cir::FuncOp::print(OpAsmPrinter &p) {
         p, *this, fnType.getInputs(), fnType.isVarArg(), {});
 
   if (mlir::ArrayAttr annotations = getAnnotationsAttr()) {
-    p << " ";
+    p << ' ';
     p.printAttribute(annotations);
   }
 

--- a/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
+++ b/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
@@ -27,9 +27,9 @@ void bar() __attribute__((annotate("withargfunc", "os", 22))) {
 // BEFORE: cir.global external @tile = #cir.int<7> : !s32i
 // BEFORE-SAME: #cir.annotation<name = "cir.aie.device.tile", args = [42 : i8]>]
 
-// BEFORE: cir.func  @_Z3fooi(%arg0: !s32i) [#cir.annotation<name = "noargfunc", args = []>,
+// BEFORE: cir.func @_Z3fooi(%arg0: !s32i) [#cir.annotation<name = "noargfunc", args = []>,
 // BEFORE-SAME: #cir.annotation<name = "withargfunc", args = ["os", 23 : i32]>]
-// BEFORE: cir.func  @_Z3barv() [#cir.annotation<name = "withargfunc", args = ["os", 22 : i32]>]
+// BEFORE: cir.func @_Z3barv() [#cir.annotation<name = "withargfunc", args = ["os", 22 : i32]>]
 
 
 // AFTER: module {{.*}}attribute-annotate-multiple.cpp" attributes

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -284,7 +284,7 @@ void foo() {
   }   
 }
 
-// NOFLAT: cir.func  @_Z3foov()
+// NOFLAT: cir.func @_Z3foov()
 // NOFLAT:   cir.scope {
 // NOFLAT:     cir.label "label"
 // NOFLAT:     %0 = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["agg.tmp0"]
@@ -324,7 +324,7 @@ extern "C" void case_follow_label(int v) {
   }
 }
 
-// NOFLAT: cir.func  @case_follow_label
+// NOFLAT: cir.func @case_follow_label
 // NOFLAT: cir.switch
 // NOFLAT: cir.case(equal, [#cir.int<1> : !s32i]) {
 // NOFLAT: cir.label "label"
@@ -348,7 +348,7 @@ extern "C" void default_follow_label(int v) {
   }
 }
 
-// NOFLAT: cir.func  @default_follow_label
+// NOFLAT: cir.func @default_follow_label
 // NOFLAT: cir.switch
 // NOFLAT: cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // NOFLAT: cir.call @action1()

--- a/clang/test/CIR/CodeGen/temporaries.cpp
+++ b/clang/test/CIR/CodeGen/temporaries.cpp
@@ -17,7 +17,7 @@ void f() {
 //      CIR: cir.func private  @_ZN1EC1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
 // CIR-NEXT: cir.func private  @_ZN1EntEv(!cir.ptr<!ty_E>) -> !ty_E
 // CIR-NEXT: cir.func private  @_ZN1ED1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
-// CIR-NEXT: cir.func  @_Z1fv() extra(#fn_attr1) {
+// CIR-NEXT: cir.func @_Z1fv() extra(#fn_attr1) {
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     %[[ONE:[0-9]+]] = cir.alloca !ty_E, !cir.ptr<!ty_E>, ["agg.tmp.ensured"] {alignment = 1 : i64}
 // CIR-NEXT:     %[[TWO:[0-9]+]] = cir.alloca !ty_E, !cir.ptr<!ty_E>, ["ref.tmp0"] {alignment = 1 : i64}

--- a/clang/test/CIR/CodeGen/vtt.cpp
+++ b/clang/test/CIR/CodeGen/vtt.cpp
@@ -171,7 +171,7 @@ namespace other {
   }
 }
 
-// CIR-LABEL:   cir.func  @_ZN5other1BD1Ev(
+// CIR-LABEL:   cir.func @_ZN5other1BD1Ev(
 // CIR-SAME:                               %[[VAL_0:.*]]: !cir.ptr<!ty_other3A3AB>
 // CIR:           %[[VAL_1:.*]] = cir.alloca !cir.ptr<!ty_other3A3AB>, !cir.ptr<!cir.ptr<!ty_other3A3AB>>, ["this", init] {alignment = 8 : i64}
 // CIR:           cir.store %[[VAL_0]], %[[VAL_1]] : !cir.ptr<!ty_other3A3AB>, !cir.ptr<!cir.ptr<!ty_other3A3AB>>

--- a/clang/test/CIR/Lowering/loops-with-break.cir
+++ b/clang/test/CIR/Lowering/loops-with-break.cir
@@ -166,7 +166,7 @@ module {
   //           [...]
   // CHECK:  }
 
-  cir.func  @testWhile() {
+  cir.func @testWhile() {
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
     %1 = cir.const #cir.int<0> : !s32i
     cir.store %1, %0 : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/Transforms/ternary-fold.cpp
+++ b/clang/test/CIR/Transforms/ternary-fold.cpp
@@ -33,7 +33,7 @@ int test2(bool cond) {
   return cond ? x : y;
 }
 
-//      CIR-BEFORE: cir.func  @_Z5test2b
+//      CIR-BEFORE: cir.func @_Z5test2b
 //      CIR-BEFORE:   %[[#COND:]] = cir.load %{{.+}} : !cir.ptr<!cir.bool>, !cir.bool
 // CIR-BEFORE-NEXT:   %{{.+}} = cir.ternary(%[[#COND]], true {
 // CIR-BEFORE-NEXT:     %[[#A:]] = cir.const #cir.int<1> : !s32i


### PR DESCRIPTION
This PR fixes the notorious double whitespaces introduced by visibility attribute, for `cir.func` only.

It uses "leading whitespace" for every print. And the printing of visibility attr is properly guarded by a check of `!isDefault()`.

Double whitespaces in test files are removed.