### PR TITLE
[CIR][CIRGen] support builtin signbit

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -397,6 +397,11 @@ public:
     return create<cir::MemCpyOp>(loc, dst, src, len);
   }
 
+  cir::SignBitOp createSignBit(mlir::Location loc, mlir::Value val) {
+    auto resTy = cir::IntType::get(getContext(), 32, true);
+    return create<cir::SignBitOp>(loc, resTy, val);
+  }
+
   mlir::Value createSub(mlir::Value lhs, mlir::Value rhs, bool hasNUW = false,
                         bool hasNSW = false) {
     auto op = create<cir::BinOp>(lhs.getLoc(), lhs.getType(),

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5127,4 +5127,17 @@ def AtomicCmpXchg : CIR_Op<"atomic.cmp_xchg",
   let hasVerifier = 0;
 }
 
+def SignBitOp : CIR_Op<"signbit", [Pure]> {
+  let summary = "Checks the sign of a floating-point number";
+  let description = [{
+    It returns a non-zero value (true) if the number is negative
+    and zero (false) if the number is positive or zero.
+  }];
+  let arguments = (ins CIR_AnyFloat:$input);
+  let results = (outs SInt32:$res);
+  let assemblyFormat = [{
+      $input attr-dict `:` type($input) `->` qualified(type($res))
+  }];
+}
+
 #endif // LLVM_CLANG_CIR_DIALECT_IR_CIROPS

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -228,6 +228,7 @@ struct MissingFeatures {
   static bool xray() { return false; }
   static bool emitConstrainedFPCall() { return false; }
   static bool emitEmptyRecordCheck() { return false; }
+  static bool isPPC_FP128Ty() { return false; }
 
   // Inline assembly
   static bool asmGoto() { return false; }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4304,6 +4304,37 @@ public:
     return mlir::success();
   }
 };
+class CIRSignBitOpLowering : public mlir::OpConversionPattern<cir::SignBitOp> {
+public:
+  using OpConversionPattern<cir::SignBitOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::SignBitOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    assert(!::cir::MissingFeatures::isPPC_FP128Ty());
+
+    mlir::DataLayout layout(op->getParentOfType<mlir::ModuleOp>());
+    int width = layout.getTypeSizeInBits(op.getInput().getType());
+    if (auto longDoubleType =
+            mlir::dyn_cast<cir::LongDoubleType>(op.getInput().getType())) {
+      if (mlir::isa<cir::FP80Type>(longDoubleType.getUnderlying())) {
+        // see https://github.com/llvm/clangir/issues/1057
+        llvm_unreachable("NYI");
+      }
+    }
+    auto intTy = mlir::IntegerType::get(rewriter.getContext(), width);
+    auto bitcast = rewriter.create<mlir::LLVM::BitcastOp>(op->getLoc(), intTy,
+                                                          adaptor.getInput());
+    auto zero = rewriter.create<mlir::LLVM::ConstantOp>(op->getLoc(), intTy, 0);
+    auto cmpResult = rewriter.create<mlir::LLVM::ICmpOp>(
+        op.getLoc(), mlir::LLVM::ICmpPredicate::slt, bitcast.getResult(), zero);
+    auto converted = rewriter.create<mlir::LLVM::ZExtOp>(
+        op.getLoc(), mlir::IntegerType::get(rewriter.getContext(), 32),
+        cmpResult);
+    rewriter.replaceOp(op, converted);
+    return mlir::success();
+  }
+};
 
 void populateCIRToLLVMConversionPatterns(
     mlir::RewritePatternSet &patterns, mlir::TypeConverter &converter,
@@ -4352,7 +4383,7 @@ void populateCIRToLLVMConversionPatterns(
       CIRAssumeLowering, CIRAssumeAlignedLowering, CIRAssumeSepStorageLowering,
       CIRBaseClassAddrOpLowering, CIRDerivedClassAddrOpLowering,
       CIRVTTAddrPointOpLowering, CIRIsFPClassOpLowering, CIRAbsOpLowering,
-      CIRMemMoveOpLowering, CIRMemsetOpLowering
+      CIRMemMoveOpLowering, CIRMemsetOpLowering, CIRSignBitOpLowering
 #define GET_BUILTIN_LOWERING_LIST
 #include "clang/CIR/Dialect/IR/CIRBuiltinsLowering.inc"
 #undef GET_BUILTIN_LOWERING_LIST

--- a/clang/test/CIR/CodeGen/builtin-signbit.c
+++ b/clang/test/CIR/CodeGen/builtin-signbit.c
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+void test_signbit_float(float val) {
+    // CIR-LABEL: test_signbit_float
+    // CIR: %{{.+}} = cir.signbit %{{.+}} : !cir.float -> !s32i
+    // LLVM-LABEL: test_signbit_float
+    // LLVM: [[TMP1:%.*]] = bitcast float %{{.+}} to i32
+    // LLVM: [[TMP2:%.*]] = icmp slt i32 [[TMP1]], 0
+    // LLVM: %{{.+}} = zext i1 [[TMP2]] to i32
+    __builtin_signbit(val);
+}
+
+void test_signbit_double(double val) {
+    // CIR-LABEL: test_signbit_double
+    // CIR: %{{.+}} = cir.signbit %{{.+}} : !cir.float -> !s32i
+    // LLVM-LABEL: test_signbit_double
+    // LLVM: [[CONV:%.*]] = fptrunc double %{{.+}} to float
+    // LLVM: [[TMP1:%.*]] = bitcast float [[CONV]] to i32
+    // LLVM: [[TMP2:%.*]] = icmp slt i32 [[TMP1]], 0
+    // LLVM: %{{.+}} = zext i1 [[TMP2]] to i32
+    __builtin_signbitf(val);
+}


### PR DESCRIPTION
This patch adds support for the `__builtin_signbit` intrinsic. The intrinsic requires special handling for PowerPC; however, since ClangIR does not currently support PowerPC, this handling is omitted in this implementation.