### PR TITLE
[CIR][CIRGen][Builtin] Support BI__builtin_operator_new and BI__builtin_operator_delete

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1828,9 +1828,12 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_function_start:
     llvm_unreachable("BI__builtin_function_start NYI");
   case Builtin::BI__builtin_operator_new:
-    llvm_unreachable("BI__builtin_operator_new NYI");
+    return buildBuiltinNewDeleteCall(
+        E->getCallee()->getType()->castAs<FunctionProtoType>(), E, false);
   case Builtin::BI__builtin_operator_delete:
-    llvm_unreachable("BI__builtin_operator_delete NYI");
+    buildBuiltinNewDeleteCall(
+        E->getCallee()->getType()->castAs<FunctionProtoType>(), E, true);
+    return RValue::get(nullptr);
   case Builtin::BI__builtin_is_aligned:
     llvm_unreachable("BI__builtin_is_aligned NYI");
   case Builtin::BI__builtin_align_up:

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1175,6 +1175,23 @@ static RValue buildNewDeleteCall(CIRGenFunction &CGF,
   return RV;
 }
 
+RValue CIRGenFunction::buildBuiltinNewDeleteCall(const FunctionProtoType *type,
+                                                 const CallExpr *theCall,
+                                                 bool isDelete) {
+  CallArgList args;
+  buildCallArgs(args, type, theCall->arguments());
+  // Find the allocation or deallocation function that we're calling.
+  ASTContext &ctx = getContext();
+  DeclarationName name =
+      ctx.DeclarationNames.getCXXOperatorName(isDelete ? OO_Delete : OO_New);
+
+  for (auto *decl : ctx.getTranslationUnitDecl()->lookup(name))
+    if (auto *fd = dyn_cast<FunctionDecl>(decl))
+      if (ctx.hasSameType(fd->getType(), QualType(type, 0)))
+        return buildNewDeleteCall(*this, fd, type, args);
+  llvm_unreachable("predeclared global operator new/delete is missing");
+}
+
 void CIRGenFunction::buildDeleteCall(const FunctionDecl *DeleteFD,
                                      mlir::Value Ptr, QualType DeleteTy,
                                      mlir::Value NumElements,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -729,6 +729,9 @@ public:
                        QualType DeleteTy, mlir::Value NumElements = nullptr,
                        CharUnits CookieSize = CharUnits());
 
+  RValue buildBuiltinNewDeleteCall(const FunctionProtoType *type,
+                                   const CallExpr *theCallExpr, bool isDelete);
+
   mlir::Value buildDynamicCast(Address ThisAddr, const CXXDynamicCastExpr *DCE);
 
   mlir::Value createLoad(const clang::VarDecl *VD, const char *Name);


### PR DESCRIPTION
The added test cases are from [OG's counterpart](https://github.com/llvm/clangir/blob/f9c5477ee10c9bc005ffbfe698691cc02193ea81/clang/test/CodeGenCXX/builtin-operator-new-delete.cpp#L7). I changed run option to -std=c++17 to support [std::align_val_t](https://en.cppreference.com/w/cpp/memory/new/align_val_t)