### PR TITLE
[CIR][ABI][AArch64] convers aarch64_be return struct case

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -134,7 +134,7 @@ ABIArgInfo AArch64ABIInfo::classifyReturnType(Type RetTy,
           mlir::cir::ArrayType::get(LT.getMLIRContext(), baseTy, Size / 64));
     }
 
-    cir_cconv_unreachable("NYI");
+    return ABIArgInfo::getDirect(IntType::get(LT.getMLIRContext(), Size, false));
   }
 
   return getNaturalAlignIndirect(RetTy);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -134,7 +134,8 @@ ABIArgInfo AArch64ABIInfo::classifyReturnType(Type RetTy,
           mlir::cir::ArrayType::get(LT.getMLIRContext(), baseTy, Size / 64));
     }
 
-    return ABIArgInfo::getDirect(IntType::get(LT.getMLIRContext(), Size, false));
+    return ABIArgInfo::getDirect(
+        IntType::get(LT.getMLIRContext(), Size, false));
   }
 
   return getNaturalAlignIndirect(RetTy);

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64_be-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64_be-cc-structs.c
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -triple aarch64_be-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-cir-flat -mmlir --mlir-print-ir-after=cir-call-conv-lowering %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+typedef struct {
+  int a;
+  int b;
+} __attribute__((alligned (4))) S;
+
+// CHECK: cir.func {{.*@init}}() -> !u64i
+// CHECK:    %[[#V0:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["__retval"] {alignment = 4 : i64}
+// CHECK:    %[[#V1:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S>), !cir.ptr<!u64i>
+// CHECK:    %[[#V2:]] = cir.load %[[#V1]] : !cir.ptr<!u64i>, !u64i
+// CHECK:    cir.return %[[#V2]] : !u64i
+S init() {
+  S s;
+  return s;
+}


### PR DESCRIPTION
This PR adds a support return struct as a value for one missed case for AArch64 big endian arch