### PR TITLE
[CIR][CIRGen][Builtin] Support __builtin_char_memchr

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1423,7 +1423,8 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     llvm_unreachable("BI__builtin_memcpy_inline NYI");
 
   case Builtin::BI__builtin_char_memchr:
-    llvm_unreachable("BI__builtin_char_memchr NYI");
+    BuiltinID = Builtin::BI__builtin_memchr;
+    break;
 
   case Builtin::BI__builtin___memcpy_chk: {
     // fold __builtin_memcpy_chk(x, y, cst1, cst2) to memcpy iff cst1<=cst2.

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1423,8 +1423,16 @@ RValue CIRGenFunction::buildBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     llvm_unreachable("BI__builtin_memcpy_inline NYI");
 
   case Builtin::BI__builtin_char_memchr:
-    BuiltinID = Builtin::BI__builtin_memchr;
-    break;
+  case Builtin::BI__builtin_memchr: {
+    Address srcPtr = buildPointerWithAlignment(E->getArg(0));
+    mlir::Value src =
+        builder.createBitcast(srcPtr.getPointer(), builder.getVoidPtrTy());
+    mlir::Value pattern = buildScalarExpr(E->getArg(1));
+    mlir::Value len = buildScalarExpr(E->getArg(2));
+    mlir::Value res =
+        builder.create<MemChrOp>(getLoc(E->getExprLoc()), src, pattern, len);
+    return RValue::get(res);
+  }
 
   case Builtin::BI__builtin___memcpy_chk: {
     // fold __builtin_memcpy_chk(x, y, cst1, cst2) to memcpy iff cst1<=cst2.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -734,6 +734,34 @@ public:
     return mlir::success();
   }
 };
+
+class CIRMemChrOpLowering
+    : public mlir::OpConversionPattern<mlir::cir::MemChrOp> {
+public:
+  using mlir::OpConversionPattern<mlir::cir::MemChrOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::MemChrOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto llvmPtrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    llvm::SmallVector<mlir::Type> arguments;
+    const mlir::TypeConverter *converter = getTypeConverter();
+    mlir::Type srcTy = converter->convertType(op.getSrc().getType());
+    mlir::Type patternTy = converter->convertType(op.getPattern().getType());
+    mlir::Type lenTy = converter->convertType(op.getLen().getType());
+    auto fnTy =
+        mlir::LLVM::LLVMFunctionType::get(llvmPtrTy, {srcTy, patternTy, lenTy},
+                                          /*isVarArg=*/false);
+    llvm::StringRef fnName = "memchr";
+    getOrCreateLLVMFuncOp(rewriter, op, fnName, fnTy);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
+        op, mlir::TypeRange{llvmPtrTy}, fnName,
+        mlir::ValueRange{adaptor.getSrc(), adaptor.getPattern(),
+                         adaptor.getLen()});
+    return mlir::success();
+  }
+};
+
 class CIRMemMoveOpLowering
     : public mlir::OpConversionPattern<mlir::cir::MemMoveOp> {
 public:
@@ -4233,6 +4261,7 @@ public:
     return mlir::success();
   }
 };
+
 class CIRAbsOpLowering : public mlir::OpConversionPattern<mlir::cir::AbsOp> {
 public:
   using OpConversionPattern<mlir::cir::AbsOp>::OpConversionPattern;
@@ -4274,15 +4303,16 @@ void populateCIRToLLVMConversionPatterns(
       CIRVAStartLowering, CIRVAEndLowering, CIRVACopyLowering, CIRVAArgLowering,
       CIRBrOpLowering, CIRGetMemberOpLowering, CIRGetRuntimeMemberOpLowering,
       CIRSwitchFlatOpLowering, CIRPtrDiffOpLowering, CIRCopyOpLowering,
-      CIRMemCpyOpLowering, CIRFAbsOpLowering, CIRExpectOpLowering,
-      CIRVTableAddrPointOpLowering, CIRVectorCreateLowering,
-      CIRVectorCmpOpLowering, CIRVectorSplatLowering, CIRVectorTernaryLowering,
-      CIRVectorShuffleIntsLowering, CIRVectorShuffleVecLowering,
-      CIRStackSaveLowering, CIRUnreachableLowering, CIRTrapLowering,
-      CIRInlineAsmOpLowering, CIRSetBitfieldLowering, CIRGetBitfieldLowering,
-      CIRPrefetchLowering, CIRObjSizeOpLowering, CIRIsConstantOpLowering,
-      CIRCmpThreeWayOpLowering, CIRClearCacheOpLowering, CIREhTypeIdOpLowering,
-      CIRCatchParamOpLowering, CIRResumeOpLowering, CIRAllocExceptionOpLowering,
+      CIRMemCpyOpLowering, CIRMemChrOpLowering, CIRFAbsOpLowering,
+      CIRExpectOpLowering, CIRVTableAddrPointOpLowering,
+      CIRVectorCreateLowering, CIRVectorCmpOpLowering, CIRVectorSplatLowering,
+      CIRVectorTernaryLowering, CIRVectorShuffleIntsLowering,
+      CIRVectorShuffleVecLowering, CIRStackSaveLowering, CIRUnreachableLowering,
+      CIRTrapLowering, CIRInlineAsmOpLowering, CIRSetBitfieldLowering,
+      CIRGetBitfieldLowering, CIRPrefetchLowering, CIRObjSizeOpLowering,
+      CIRIsConstantOpLowering, CIRCmpThreeWayOpLowering,
+      CIRClearCacheOpLowering, CIREhTypeIdOpLowering, CIRCatchParamOpLowering,
+      CIRResumeOpLowering, CIRAllocExceptionOpLowering,
       CIRFreeExceptionOpLowering, CIRThrowOpLowering, CIRIntrinsicCallLowering,
       CIRBaseClassAddrOpLowering, CIRDerivedClassAddrOpLowering,
       CIRVTTAddrPointOpLowering, CIRIsFPClassOpLowering, CIRAbsOpLowering,

--- a/clang/test/CIR/CodeGen/builtins.cpp
+++ b/clang/test/CIR/CodeGen/builtins.cpp
@@ -61,16 +61,16 @@ extern "C" char* test_memchr(const char arg[32]) {
   return __builtin_char_memchr(arg, 123, 32);
 
   // CIR-LABEL: test_memchr
-  // [[NEEDLE:%.*]] = cir.const #cir.int<123> : !s32i 
-  // [[SIZE:%.*]] = cir.const #cir.int<32> : !s32i 
-  // [[SIZE_U64:%.*]] = cir.cast(integral, [[SIZE]] : !s32i), !u64i 
-  // {{%.*}} = cir.call @memchr({{%.*}}, [[NEEDLE]], [[SIZE_U64]]) : (!cir.ptr<!s8i>, !s32i, !u64i) -> !cir.ptr<!s8i>
+  // CIR: [[PATTERN:%.*]] = cir.const #cir.int<123> : !s32i 
+  // CIR: [[LEN:%.*]] = cir.const #cir.int<32> : !s32i 
+  // CIR: [[LEN_U64:%.*]] = cir.cast(integral, [[LEN]] : !s32i), !u64i 
+  // CIR: {{%.*}} = cir.libc.memchr({{%.*}}, [[PATTERN]], [[LEN_U64]])
 
   // LLVM: {{.*}}@test_memchr(ptr{{.*}}[[ARG:%.*]]) 
   // LLVM: [[TMP0:%.*]] = alloca ptr, i64 1, align 8
   // LLVM: store ptr [[ARG]], ptr [[TMP0]], align 8
-  // LLVM: [[HAYSTACK:%.*]] = load ptr, ptr [[TMP0]], align 8
-  // LLVM: [[RES:%.*]] = call ptr @memchr(ptr [[HAYSTACK]], i32 123, i64 32)
+  // LLVM: [[SRC:%.*]] = load ptr, ptr [[TMP0]], align 8
+  // LLVM: [[RES:%.*]] = call ptr @memchr(ptr [[SRC]], i32 123, i64 32)
   // LLVM: store ptr [[RES]], ptr [[RET_P:%.*]], align 8
   // LLVM: [[RET:%.*]] = load ptr, ptr [[RET_P]], align 8
   // LLVM: ret ptr [[RET]]

--- a/clang/test/CIR/CodeGen/builtins.cpp
+++ b/clang/test/CIR/CodeGen/builtins.cpp
@@ -56,3 +56,22 @@ int *test_std_addressof2() {
   // LLVM: [[RES:%.*]] = load ptr, ptr [[ADDR]], align 8
   // LLVM: ret ptr [[RES]]
 }
+
+extern "C" char* test_memchr(const char arg[32]) {
+  return __builtin_char_memchr(arg, 123, 32);
+
+  // CIR-LABEL: test_memchr
+  // [[NEEDLE:%.*]] = cir.const #cir.int<123> : !s32i 
+  // [[SIZE:%.*]] = cir.const #cir.int<32> : !s32i 
+  // [[SIZE_U64:%.*]] = cir.cast(integral, [[SIZE]] : !s32i), !u64i 
+  // {{%.*}} = cir.call @memchr({{%.*}}, [[NEEDLE]], [[SIZE_U64]]) : (!cir.ptr<!s8i>, !s32i, !u64i) -> !cir.ptr<!s8i>
+
+  // LLVM: {{.*}}@test_memchr(ptr{{.*}}[[ARG:%.*]]) 
+  // LLVM: [[TMP0:%.*]] = alloca ptr, i64 1, align 8
+  // LLVM: store ptr [[ARG]], ptr [[TMP0]], align 8
+  // LLVM: [[HAYSTACK:%.*]] = load ptr, ptr [[TMP0]], align 8
+  // LLVM: [[RES:%.*]] = call ptr @memchr(ptr [[HAYSTACK]], i32 123, i64 32)
+  // LLVM: store ptr [[RES]], ptr [[RET_P:%.*]], align 8
+  // LLVM: [[RET:%.*]] = load ptr, ptr [[RET_P]], align 8
+  // LLVM: ret ptr [[RET]]
+}


### PR DESCRIPTION
This should fix NYI like `BI__builtin_char_memchr NYI UNREACHABLE executed at clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp:1402`
The test is from [OG](https://github.com/llvm/clangir/blob/3ef67c19917ad26ed8b19d4d13a43458a952fddb/clang/test/CodeGenCXX/builtins.cpp#L64) 

see builtin's prototype 
[char *__builtin_char_memchr(const char *haystack, int needle, size_t size); ](https://clang.llvm.org/docs/LanguageExtensions.html#string-builtins)

