### PR TITLE
[CIR][CIRGen] Emit required vtables

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -90,6 +90,7 @@ public:
   void HandleTagDeclRequiredDefinition(const clang::TagDecl *D) override;
   void HandleCXXStaticMemberVarInstantiation(clang::VarDecl *D) override;
   void CompleteTentativeDefinition(clang::VarDecl *D) override;
+  void HandleVTable(clang::CXXRecordDecl *rd) override;
 
   mlir::ModuleOp getModule();
   std::unique_ptr<mlir::MLIRContext> takeContext() {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -345,6 +345,8 @@ public:
   void buildDeferredVTables();
   bool shouldOpportunisticallyEmitVTables();
 
+  void buildVTable(CXXRecordDecl *rd);
+
   void setDSOLocal(mlir::cir::CIRGlobalValueInterface GV) const;
 
   /// Return the appropriate linkage for the vtable, VTT, and type information

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -150,6 +150,16 @@ void CIRGenModule::buildDeferredVTables() {
   DeferredVTables.clear();
 }
 
+/// This is a callback from Sema to tell us that a particular vtable is
+/// required to be emitted in this translation unit.
+///
+/// This is only called for vtables that _must_ be emitted (mainly due to key
+/// functions).  For weak vtables, CodeGen tracks when they are needed and
+/// emits them as-needed.
+void CIRGenModule::buildVTable(CXXRecordDecl *rd) {
+  VTables.GenerateClassData(rd);
+}
+
 void CIRGenVTables::GenerateClassData(const CXXRecordDecl *RD) {
   assert(!MissingFeatures::generateDebugInfo());
 

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -190,3 +190,10 @@ void CIRGenerator::CompleteTentativeDefinition(VarDecl *D) {
 
   CGM->buildTentativeDefinition(D);
 }
+
+void CIRGenerator::HandleVTable(CXXRecordDecl *rd) {
+  if (Diags.hasErrorOccurred())
+    return;
+
+  CGM->buildVTable(rd);
+}

--- a/clang/test/CIR/CodeGen/vtable-emission.cpp
+++ b/clang/test/CIR/CodeGen/vtable-emission.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+struct S {
+  virtual void key();
+  virtual void nonKey() {}
+};
+
+void S::key() {}
+
+// The definition of the key function should result in the vtable being emitted.
+// CHECK: cir.global external @_ZTV1S = #cir.vtable
+
+// The reference from the vtable should result in nonKey being emitted.
+// CHECK: cir.func linkonce_odr @_ZN1S6nonKeyEv({{.*}} {


### PR DESCRIPTION
We were missing an override for this previously and thus not emitting
vtables when key functions were defined.
