### PR TITLE
[CIR][Lowering] Add LLVM lowering support for cir.assume

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3010,6 +3010,66 @@ public:
   }
 };
 
+class CIRAssumeLowering
+    : public mlir::OpConversionPattern<mlir::cir::AssumeOp> {
+public:
+  using OpConversionPattern<mlir::cir::AssumeOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::AssumeOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto cond = rewriter.create<mlir::LLVM::TruncOp>(
+        op.getLoc(), rewriter.getI1Type(), adaptor.getPredicate());
+    rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(op, cond);
+    return mlir::success();
+  }
+};
+
+class CIRAssumeAlignedLowering
+    : public mlir::OpConversionPattern<mlir::cir::AssumeAlignedOp> {
+public:
+  using OpConversionPattern<mlir::cir::AssumeAlignedOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::AssumeAlignedOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    SmallVector<mlir::Value, 3> opBundleArgs{adaptor.getPointer()};
+
+    auto alignment = rewriter.create<mlir::LLVM::ConstantOp>(
+        op.getLoc(), rewriter.getI64Type(), op.getAlignment());
+    opBundleArgs.push_back(alignment);
+
+    if (mlir::Value offset = adaptor.getOffset())
+      opBundleArgs.push_back(offset);
+
+    auto cond = rewriter.create<mlir::LLVM::ConstantOp>(
+        op.getLoc(), rewriter.getI1Type(), 1);
+    rewriter.create<mlir::LLVM::AssumeOp>(op.getLoc(), cond, "align",
+                                          opBundleArgs);
+    rewriter.replaceAllUsesWith(op, op.getPointer());
+    rewriter.eraseOp(op);
+
+    return mlir::success();
+  }
+};
+
+class CIRAssumeSepStorageLowering
+    : public mlir::OpConversionPattern<mlir::cir::AssumeSepStorageOp> {
+public:
+  using OpConversionPattern<mlir::cir::AssumeSepStorageOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::cir::AssumeSepStorageOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto cond = rewriter.create<mlir::LLVM::ConstantOp>(
+        op.getLoc(), rewriter.getI1Type(), 1);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(
+        op, cond, "separate_storage",
+        mlir::ValueRange{adaptor.getPtr1(), adaptor.getPtr2()});
+    return mlir::success();
+  }
+};
+
 static mlir::Value createLLVMBitOp(mlir::Location loc,
                                    const llvm::Twine &llvmIntrinBaseName,
                                    mlir::Type resultTy, mlir::Value operand,
@@ -4284,6 +4344,7 @@ void populateCIRToLLVMConversionPatterns(
       CIRCmpThreeWayOpLowering, CIRClearCacheOpLowering, CIREhTypeIdOpLowering,
       CIRCatchParamOpLowering, CIRResumeOpLowering, CIRAllocExceptionOpLowering,
       CIRFreeExceptionOpLowering, CIRThrowOpLowering, CIRIntrinsicCallLowering,
+      CIRAssumeLowering, CIRAssumeAlignedLowering, CIRAssumeSepStorageLowering,
       CIRBaseClassAddrOpLowering, CIRDerivedClassAddrOpLowering,
       CIRVTTAddrPointOpLowering, CIRIsFPClassOpLowering, CIRAbsOpLowering,
       CIRMemMoveOpLowering, CIRMemsetOpLowering

--- a/clang/test/CIR/CodeGen/builtin-assume.cpp
+++ b/clang/test/CIR/CodeGen/builtin-assume.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck %s --check-prefix=CIR --input-file=%t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck %s --check-prefix=LLVM --input-file=%t.ll
 
 int test_assume(int x) {
   __builtin_assume(x > 0);
@@ -13,6 +15,10 @@ int test_assume(int x) {
 // CIR-NEXT:   cir.assume %[[#cond]] : !cir.bool
 //      CIR: }
 
+//      LLVM: @_Z11test_assumei
+//      LLVM: %[[#cond:]] = trunc i8 %{{.+}} to i1
+// LLVM-NEXT: call void @llvm.assume(i1 %[[#cond]])
+
 int test_assume_aligned(int *ptr) {
   int *aligned = (int *)__builtin_assume_aligned(ptr, 8);
   return *aligned;
@@ -25,6 +31,11 @@ int test_assume_aligned(int *ptr) {
 // CIR-NEXT:   %[[#aligned2:]] = cir.load deref %[[#aligned_slot]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CIR-NEXT:   %{{.+}} = cir.load %[[#aligned2]] : !cir.ptr<!s32i>, !s32i
 //      CIR: }
+
+//      LLVM: @_Z19test_assume_alignedPi
+//      LLVM: %[[#ptr:]] = load ptr, ptr %{{.+}}, align 8
+// LLVM-NEXT: call void @llvm.assume(i1 true) [ "align"(ptr %[[#ptr]], i64 8) ]
+// LLVM-NEXT: store ptr %[[#ptr]], ptr %{{.+}}, align 8
 
 int test_assume_aligned_offset(int *ptr) {
   int *aligned = (int *)__builtin_assume_aligned(ptr, 8, 4);
@@ -41,6 +52,11 @@ int test_assume_aligned_offset(int *ptr) {
 // CIR-NEXT:   %{{.+}} = cir.load %[[#aligned2]] : !cir.ptr<!s32i>, !s32i
 //      CIR: }
 
+//      LLVM: @_Z26test_assume_aligned_offsetPi
+//      LLVM: %[[#ptr:]] = load ptr, ptr %{{.+}}, align 8
+// LLVM-NEXT: call void @llvm.assume(i1 true) [ "align"(ptr %[[#ptr]], i64 8, i64 4) ]
+// LLVM-NEXT: store ptr %[[#ptr]], ptr %{{.+}}, align 8
+
 int test_separate_storage(int *p1, int *p2) {
   __builtin_assume_separate_storage(p1, p2);
   return *p1 + *p2;
@@ -53,3 +69,8 @@ int test_separate_storage(int *p1, int *p2) {
 // CIR-NEXT:   %[[#p2_voidptr:]] = cir.cast(bitcast, %[[#p2]] : !cir.ptr<!s32i>), !cir.ptr<!void>
 // CIR-NEXT:   cir.assume.separate_storage %[[#p1_voidptr]], %[[#p2_voidptr]] : !cir.ptr<!void>
 //      CIR: }
+
+//      LLVM: @_Z21test_separate_storagePiS_
+//      LLVM: %[[#ptr1:]] = load ptr, ptr %{{.+}}, align 8
+// LLVM-NEXT: %[[#ptr2:]] = load ptr, ptr %{{.+}}, align 8
+// LLVM-NEXT: call void @llvm.assume(i1 true) [ "separate_storage"(ptr %[[#ptr1]], ptr %[[#ptr2]]) ]


### PR DESCRIPTION
This PR adds LLVMIR lowering support for `cir.assume`, `cir.assume.aligned`, and `cir.assume.separate_storage`.