### PR TITLE
[CIR][CodeGen] Fix the default linkage of string literals

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1551,7 +1551,7 @@ CIRGenModule::getAddrOfConstantStringFromLiteral(const StringLiteral *S,
         !getLangOpts().WritableStrings) {
       assert(0 && "not implemented");
     } else {
-      LT = mlir::cir::GlobalLinkageKind::InternalLinkage;
+      LT = mlir::cir::GlobalLinkageKind::PrivateLinkage;
       GlobalVariableName = Name;
     }
 

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -40,7 +40,7 @@ void local_stringlit() {
   const char *s = "whatnow";
 }
 
-// CHECK: cir.global "private" constant internal dsolocal @".str" = #cir.const_array<"whatnow\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
+// CHECK: cir.global "private" constant cir_private dsolocal @".str" = #cir.const_array<"whatnow\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
 // CHECK: cir.func @_Z15local_stringlitv()
 // CHECK-NEXT:  %0 = cir.alloca !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>, ["s", init] {alignment = 8 : i64}
 // CHECK-NEXT:  %1 = cir.get_global @".str" : !cir.ptr<!cir.array<!s8i x 8>>

--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -49,10 +49,10 @@ int use_func() { return func<int>(); }
 // CHECK-NEXT: cir.global external @rgb = #cir.const_array<[#cir.int<0> : !u8i, #cir.int<233> : !u8i, #cir.int<33> : !u8i]> : !cir.array<!u8i x 3>
 // CHECK-NEXT: cir.global external @alpha = #cir.const_array<"abc\00" : !cir.array<!s8i x 4>> : !cir.array<!s8i x 4>
 
-// CHECK-NEXT: cir.global "private" constant internal dsolocal @".str" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
+// CHECK-NEXT: cir.global "private" constant cir_private dsolocal @".str" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
 // CHECK-NEXT: cir.global external @s = #cir.global_view<@".str"> : !cir.ptr<!s8i>
 
-// CHECK-NEXT: cir.global "private" constant internal dsolocal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
+// CHECK-NEXT: cir.global "private" constant cir_private dsolocal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
 // CHECK-NEXT: cir.global external @s1 = #cir.global_view<@".str1"> : !cir.ptr<!s8i>
 
 // CHECK-NEXT: cir.global external @s2 = #cir.global_view<@".str"> : !cir.ptr<!s8i>

--- a/clang/test/CIR/CodeGen/hello.c
+++ b/clang/test/CIR/CodeGen/hello.c
@@ -8,7 +8,7 @@ int main (void) {
 }
 
 // CHECK: cir.func private @printf(!cir.ptr<!s8i>, ...) -> !s32i
-// CHECK: cir.global "private" constant internal dsolocal @".str" = #cir.const_array<"Hello, world!\0A\00" : !cir.array<!s8i x 15>> : !cir.array<!s8i x 15> {alignment = 1 : i64}
+// CHECK: cir.global "private" constant cir_private dsolocal @".str" = #cir.const_array<"Hello, world!\0A\00" : !cir.array<!s8i x 15>> : !cir.array<!s8i x 15> {alignment = 1 : i64}
 // CHECK: cir.func @main() -> !s32i
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.get_global @printf : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s8i>, ...)>>

--- a/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
+++ b/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
@@ -21,8 +21,8 @@ void test() {
 // CIR: cir.store %arg0, [[LOCAL]] : [[INITLIST_TYPE]], !cir.ptr<[[INITLIST_TYPE]]>
 // CIR: cir.return
 
-// CIR: cir.global "private" constant internal dsolocal [[STR_XY:@.*]] = #cir.const_array<"xy\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>
-// CIR: cir.global "private" constant internal dsolocal [[STR_UV:@.*]] = #cir.const_array<"uv\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>
+// CIR: cir.global "private" constant cir_private dsolocal [[STR_XY:@.*]] = #cir.const_array<"xy\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>
+// CIR: cir.global "private" constant cir_private dsolocal [[STR_UV:@.*]] = #cir.const_array<"uv\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>
 
 // CIR: cir.func @_ZSt4testv()
 // CIR: cir.scope {
@@ -53,8 +53,8 @@ void test() {
 
 // LLVM: %"class.std::initializer_list<const char *>" = type { ptr, ptr }
 
-// LLVM: @.str = internal constant [3 x i8] c"xy\00"
-// LLVM: @.str1 = internal constant [3 x i8] c"uv\00"
+// LLVM: @.str = private constant [3 x i8] c"xy\00"
+// LLVM: @.str1 = private constant [3 x i8] c"uv\00"
 
 // LLVM: define linkonce_odr void @_ZSt1fIPKcEvSt16initializer_listIT_E(%"class.std::initializer_list<const char *>" [[ARG0:%.*]])
 // LLVM: [[LOCAL_PTR:%.*]] = alloca %"class.std::initializer_list<const char *>", i64 1, align 8, 

--- a/clang/test/CIR/CodeGen/wide-string.cpp
+++ b/clang/test/CIR/CodeGen/wide-string.cpp
@@ -5,22 +5,22 @@ const char16_t *test_utf16() {
   return u"你好世界";
 }
 
-// CHECK: cir.global "private" constant internal dsolocal @{{.+}} = #cir.const_array<[#cir.int<20320> : !u16i, #cir.int<22909> : !u16i, #cir.int<19990> : !u16i, #cir.int<30028> : !u16i, #cir.int<0> : !u16i]> : !cir.array<!u16i x 5>
+// CHECK: cir.global "private" constant cir_private dsolocal @{{.+}} = #cir.const_array<[#cir.int<20320> : !u16i, #cir.int<22909> : !u16i, #cir.int<19990> : !u16i, #cir.int<30028> : !u16i, #cir.int<0> : !u16i]> : !cir.array<!u16i x 5>
 
 const char32_t *test_utf32() {
   return U"你好世界";
 }
 
-// CHECK: cir.global "private" constant internal dsolocal @{{.+}} = #cir.const_array<[#cir.int<20320> : !u32i, #cir.int<22909> : !u32i, #cir.int<19990> : !u32i, #cir.int<30028> : !u32i, #cir.int<0> : !u32i]> : !cir.array<!u32i x 5>
+// CHECK: cir.global "private" constant cir_private dsolocal @{{.+}} = #cir.const_array<[#cir.int<20320> : !u32i, #cir.int<22909> : !u32i, #cir.int<19990> : !u32i, #cir.int<30028> : !u32i, #cir.int<0> : !u32i]> : !cir.array<!u32i x 5>
 
 const char16_t *test_zero16() {
   return u"\0\0\0\0";
 }
 
-// CHECK: cir.global "private" constant internal dsolocal @{{.+}} = #cir.zero : !cir.array<!u16i x 5>
+// CHECK: cir.global "private" constant cir_private dsolocal @{{.+}} = #cir.zero : !cir.array<!u16i x 5>
 
 const char32_t *test_zero32() {
   return U"\0\0\0\0";
 }
 
-// CHECK: cir.global "private" constant internal dsolocal @{{.+}} = #cir.zero : !cir.array<!u32i x 5>
+// CHECK: cir.global "private" constant cir_private dsolocal @{{.+}} = #cir.zero : !cir.array<!u32i x 5>


### PR DESCRIPTION
In OG CodeGen, string literals has `private` linkage as default (marked by `cir_private` in CIR assembly). But CIR uses `internal`, which is probably an ancient typo.

This PR keeps align with it and thus modifies the existing test files.