### PR TITLE
[CIR][ABI][AArch64][Lowering] support for passing struct types > 128 bits

### DIFF
--- a/clang/include/clang/CIR/ABIArgInfo.h
+++ b/clang/include/clang/CIR/ABIArgInfo.h
@@ -215,9 +215,19 @@ public:
     IndirectAttr.Align = align;
   }
 
+  bool getIndirectByVal() const {
+    assert(isIndirect() && "Invalid kind!");
+    return IndirectByVal;
+  }
+
   void setIndirectByVal(bool IBV) {
     assert(isIndirect() && "Invalid kind!");
     IndirectByVal = IBV;
+  }
+
+  bool getIndirectRealign() const {
+    assert((isIndirect() || isIndirectAliased()) && "Invalid kind!");
+    return IndirectRealign;
   }
 
   void setIndirectRealign(bool IR) {

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -269,6 +269,9 @@ struct MissingFeatures {
   static bool ABIPointerParameterAttrs() { return false; }
   static bool ABITransparentUnionHandling() { return false; }
   static bool ABIPotentialArgAccess() { return false; }
+  static bool ABIByValAttribute() { return false; }
+  static bool ABIAlignmentAttribute() { return false; }
+  static bool ABINoAliasAttribute() { return false; }
 
   //-- Missing AST queries
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
@@ -226,6 +226,8 @@ void LowerModule::constructAttributeList(StringRef Name,
       // Attrs.addStackAlignmentAttr(llvm::MaybeAlign(AI.getDirectAlign()));
       cir_cconv_assert(!::cir::MissingFeatures::noFPClass());
       break;
+    case ABIArgInfo::Indirect:
+      break;
     default:
       cir_cconv_unreachable("Missing ABIArgInfo::Kind");
     }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
@@ -226,8 +226,14 @@ void LowerModule::constructAttributeList(StringRef Name,
       // Attrs.addStackAlignmentAttr(llvm::MaybeAlign(AI.getDirectAlign()));
       cir_cconv_assert(!::cir::MissingFeatures::noFPClass());
       break;
-    case ABIArgInfo::Indirect:
+    case ABIArgInfo::Indirect: {
+      cir_cconv_assert(!::cir::MissingFeatures::ABIInRegAttribute());
+      cir_cconv_assert(!::cir::MissingFeatures::ABIByValAttribute());
+      cir_cconv_assert(!::cir::MissingFeatures::ABINoAliasAttribute());
+      cir_cconv_assert(!::cir::MissingFeatures::ABIAlignmentAttribute());
+      cir_cconv_assert(!::cir::MissingFeatures::ABIPotentialArgAccess());
       break;
+     }
     default:
       cir_cconv_unreachable("Missing ABIArgInfo::Kind");
     }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
@@ -233,7 +233,7 @@ void LowerModule::constructAttributeList(StringRef Name,
       cir_cconv_assert(!::cir::MissingFeatures::ABIAlignmentAttribute());
       cir_cconv_assert(!::cir::MissingFeatures::ABIPotentialArgAccess());
       break;
-     }
+    }
     default:
       cir_cconv_unreachable("Missing ABIArgInfo::Kind");
     }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
@@ -99,6 +99,12 @@ FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {
       }
       break;
     }
+    case ABIArgInfo::Indirect: {
+      mlir::Type argType = (FI.arg_begin()  + ArgNo)->type;
+      ArgTypes[FirstIRArg] =
+        mlir::cir::PointerType::get(getMLIRContext(), argType);
+      break;
+    }
     default:
       cir_cconv_unreachable("Missing ABIArgInfo::Kind");
     }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
@@ -100,9 +100,9 @@ FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {
       break;
     }
     case ABIArgInfo::Indirect: {
-      mlir::Type argType = (FI.arg_begin()  + ArgNo)->type;
+      mlir::Type argType = (FI.arg_begin() + ArgNo)->type;
       ArgTypes[FirstIRArg] =
-        mlir::cir::PointerType::get(getMLIRContext(), argType);
+          mlir::cir::PointerType::get(getMLIRContext(), argType);
       break;
     }
     default:

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -188,7 +188,7 @@ AArch64ABIInfo::classifyArgumentType(Type Ty, bool IsVariadic,
     return ABIArgInfo::getDirect(argTy);
   }
 
-  cir_cconv_unreachable("NYI");
+  return getNaturalAlignIndirect(Ty, /*ByVal=*/false);
 }
 
 std::unique_ptr<TargetLoweringInfo>

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -115,3 +115,14 @@ void pass_lt_128(LT_128 s) {}
 // LLVM:   %[[#V1]] = alloca %struct.EQ_128, i64 1, align 4
 // LLVM:   store [2 x i64] %0, ptr %[[#V1]], align 8
 void pass_eq_128(EQ_128 s) {}
+
+// CHECK: cir.func @pass_gt_128(%arg0: !cir.ptr<!ty_GT_128_>
+// CHECK:   %[[#V0:]] = cir.alloca !cir.ptr<!ty_GT_128_>, !cir.ptr<!cir.ptr<!ty_GT_128_>>, [""] {alignment = 8 : i64}
+// CHECK:   cir.store %arg0, %[[#V0]] : !cir.ptr<!ty_GT_128_>, !cir.ptr<!cir.ptr<!ty_GT_128_>>
+// CHECK:   %[[#V1:]] = cir.load %[[#V0]] : !cir.ptr<!cir.ptr<!ty_GT_128_>>, !cir.ptr<!ty_GT_128_>
+
+// LLVM: void @pass_gt_128(ptr %0)
+// LLVM:   %[[#V1:]] = alloca ptr, i64 1, align 8
+// LLVM:   store ptr %0, ptr %[[#V1]], align 8
+// LLVM:   %[[#V2:]] = load ptr, ptr %[[#V1]], align 8
+void pass_gt_128(GT_128 s) {}


### PR DESCRIPTION
This PR adds a partial support  for so-called indirect function arguments for struct types with size > 128 bits for aarch64.

#### Couple words about the implementation
The hard part is that it's not one-to-one copy from the original codegen, but the code is inspired by it of course.
In the original codegen there is no much job is done for the indirect arguments inside the loop in the `EmitFunctionProlog`, and  additional alloca is added in the end, in the call for `EmitParamDecl` function. 

In our case, for the indirect argument (which is a pointer) we replace the original alloca with a new one, and store the pointer in there. And replace all the uses of the old alloca with the load from the new one, i.e. in both cases users works with the pointer to a structure.

Also, I added several missed features in the `constructAttributeList` for indirect arguments, but didn't preserve the original code structure, so let me know if I need to do it.
