### PR TITLE
[CIR][CIRGen][Builtin] Support __builtin_memcpy_inline

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4040,6 +4040,30 @@ def MemCpyOp : CIR_MemCpyOp<"libc.memcpy"> {
   }];
 }
 
+def MemCpyInlineOp : CIR_MemCpyOp<"memcpy_inline"> {
+  let summary = "Represent builtin function `__builtin_memcpy_inline`";
+  let description = [{
+    Given two CIR pointers, `src` and `dst`, `memcpy_inline` will copy `len`
+    bytes from the memory pointed by `src` to the memory pointed by `dst`.
+
+    Unlike `cir.libc.memcpy`,  this Op guarantees that no external functions 
+    are called. 
+
+    Examples:
+
+    ```mlir
+      // Copying 2 bytes from one array to a struct:
+      %2 = cir.const #cir.int<2> : !u32i
+      cir.memcpy_inline %2 bytes from %arr to %struct : !cir.ptr<!arr> -> !cir.ptr<!struct>
+    ```
+  }];
+
+  let assemblyFormat = [{
+    $len `bytes` `from` $src `to` $dst attr-dict
+    `:` type($len) `` `,` qualified(type($src)) `->` qualified(type($dst))
+  }];
+}
+
 def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
   let summary = "Equivalent to libc's `memmove`";
   let description = [{
@@ -4063,6 +4087,7 @@ def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
     `:` qualified(type($dst)) `,` type($len)
   }];
 }
+
 //===----------------------------------------------------------------------===//
 // MemSetOp
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4040,30 +4040,6 @@ def MemCpyOp : CIR_MemCpyOp<"libc.memcpy"> {
   }];
 }
 
-def MemCpyInlineOp : CIR_MemCpyOp<"memcpy_inline"> {
-  let summary = "Represent builtin function `__builtin_memcpy_inline`";
-  let description = [{
-    Given two CIR pointers, `src` and `dst`, `memcpy_inline` will copy `len`
-    bytes from the memory pointed by `src` to the memory pointed by `dst`.
-
-    Unlike `cir.libc.memcpy`,  this Op guarantees that no external functions 
-    are called. 
-
-    Examples:
-
-    ```mlir
-      // Copying 2 bytes from one array to a struct:
-      %2 = cir.const #cir.int<2> : !u32i
-      cir.memcpy_inline %2 bytes from %arr to %struct : !cir.ptr<!arr> -> !cir.ptr<!struct>
-    ```
-  }];
-
-  let assemblyFormat = [{
-    $len `bytes` `from` $src `to` $dst attr-dict
-    `:` type($len) `` `,` qualified(type($src)) `->` qualified(type($dst))
-  }];
-}
-
 def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
   let summary = "Equivalent to libc's `memmove`";
   let description = [{
@@ -4085,6 +4061,36 @@ def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
   let assemblyFormat = [{
     $len `bytes` `from` $src `to` $dst attr-dict
     `:` qualified(type($dst)) `,` type($len)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// MemCpyInlineOp
+//===----------------------------------------------------------------------===//
+def MemCpyInlineOp : CIR_Op<"memcpy_inline"> {
+  let arguments = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
+                       Arg<VoidPtr, "", [MemRead]>:$src,
+                       I64Attr:$len);
+  let summary = "Memory copy with constant length without calling" 
+                "any external function";
+  let description = [{
+    Given two CIR pointers, `src` and `dst`, `memcpy_inline` will copy `len`
+    bytes from the memory pointed by `src` to the memory pointed by `dst`.
+
+    Unlike `cir.libc.memcpy`,  this Op guarantees that no external functions 
+    are called, and length of copied bytes is a constant.
+
+    Examples:
+
+    ```mlir
+      // Copying 2 bytes from one array to a struct:
+      cir.memcpy_inline 2 bytes from %arr to %struct : !cir.ptr<!arr> -> !cir.ptr<!struct>
+    ```
+  }];
+
+  let assemblyFormat = [{
+    $len `bytes` `from` $src `to` $dst attr-dict
+    `:` qualified(type($src)) `->` qualified(type($dst))
   }];
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4003,19 +4003,14 @@ def CopyOp : CIR_Op<"copy",
 // MemCpyOp && MemMoveOp
 //===----------------------------------------------------------------------===//
 
-class CIR_MemCpyOp<string mnemonic>: CIR_Op<mnemonic, [AllTypesMatch<["dst", "src"]>]> {
-  let arguments = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
-                       Arg<VoidPtr, "", [MemRead]>:$src,
-                       PrimitiveUInt:$len);
+class CIR_MemOp<string mnemonic>
+    : CIR_Op<mnemonic, [AllTypesMatch<["dst", "src"]>]> {
+  dag commonArgs = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
+      Arg<VoidPtr, "", [MemRead]>:$src);
   let hasVerifier = 0;
-
-  let extraClassDeclaration = [{
-    /// Returns the byte length type.
-    cir::IntType getLenTy() { return getLen().getType(); }
-  }];
 }
 
-def MemCpyOp : CIR_MemCpyOp<"libc.memcpy"> {
+def MemCpyOp : CIR_MemOp<"libc.memcpy"> {
   let summary = "Equivalent to libc's `memcpy`";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.libc.memcpy` will copy `len`
@@ -4034,13 +4029,20 @@ def MemCpyOp : CIR_MemCpyOp<"libc.memcpy"> {
     ```
   }];
 
+  let arguments = !con(commonArgs, (ins PrimitiveUInt:$len));
+
   let assemblyFormat = [{
     $len `bytes` `from` $src `to` $dst attr-dict
     `:` type($len) `` `,` qualified(type($src)) `->` qualified(type($dst))
   }];
+
+  let extraClassDeclaration = [{
+    /// Returns the byte length type.
+    cir::IntType getLenTy() { return getLen().getType(); }
+  }];
 }
 
-def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
+def MemMoveOp : CIR_MemOp<"libc.memmove"> {
   let summary = "Equivalent to libc's `memmove`";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.libc.memmove` will copy `len`
@@ -4057,21 +4059,25 @@ def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
     ```
   }];
 
+  let arguments = !con(commonArgs, (ins PrimitiveUInt:$len));
 
   let assemblyFormat = [{
     $len `bytes` `from` $src `to` $dst attr-dict
     `:` qualified(type($dst)) `,` type($len)
+  }];
+
+  let extraClassDeclaration = [{
+    /// Returns the byte length type.
+    cir::IntType getLenTy() { return getLen().getType(); }
   }];
 }
 
 //===----------------------------------------------------------------------===//
 // MemCpyInlineOp
 //===----------------------------------------------------------------------===//
-def MemCpyInlineOp : CIR_Op<"memcpy_inline"> {
-  let arguments = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
-                       Arg<VoidPtr, "", [MemRead]>:$src,
-                       I64Attr:$len);
-  let summary = "Memory copy with constant length without calling" 
+
+def MemCpyInlineOp : CIR_MemOp<"memcpy_inline"> {
+  let summary = "Memory copy with constant length without calling"
                 "any external function";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `memcpy_inline` will copy `len`
@@ -4087,6 +4093,8 @@ def MemCpyInlineOp : CIR_Op<"memcpy_inline"> {
       cir.memcpy_inline 2 bytes from %arr to %struct : !cir.ptr<!arr> -> !cir.ptr<!struct>
     ```
   }];
+
+  let arguments = !con(commonArgs, (ins I64Attr:$len));
 
   let assemblyFormat = [{
     $len `bytes` `from` $src `to` $dst attr-dict

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1408,8 +1408,24 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       return RValue::get(Dest.getPointer());
   }
 
-  case Builtin::BI__builtin_memcpy_inline:
-    llvm_unreachable("BI__builtin_memcpy_inline NYI");
+  case Builtin::BI__builtin_memcpy_inline: {
+    Address dest = buildPointerWithAlignment(E->getArg(0));
+    Address src = buildPointerWithAlignment(E->getArg(1));
+    buildNonNullArgCheck(RValue::get(dest.getPointer()),
+                         E->getArg(0)->getType(), E->getArg(0)->getExprLoc(),
+                         FD, 0);
+    buildNonNullArgCheck(RValue::get(src.getPointer()), E->getArg(1)->getType(),
+                         E->getArg(1)->getExprLoc(), FD, 1);
+    uint64_t size =
+        E->getArg(2)->EvaluateKnownConstInt(getContext()).getZExtValue();
+    auto lenOp =
+        builder.getConstInt(getLoc(E->getSourceRange()), UInt64Ty, size);
+    builder.create<mlir::cir::MemCpyInlineOp>(getLoc(E->getSourceRange()),
+                                              dest.getPointer(),
+                                              src.getPointer(), lenOp);
+    // __builtin_memcpy_inline has no return value
+    return RValue::get(nullptr);
+  }
 
   case Builtin::BI__builtin_char_memchr:
   case Builtin::BI__builtin_memchr: {

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1409,16 +1409,16 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   }
 
   case Builtin::BI__builtin_memcpy_inline: {
-    Address dest = buildPointerWithAlignment(E->getArg(0));
-    Address src = buildPointerWithAlignment(E->getArg(1));
-    buildNonNullArgCheck(RValue::get(dest.getPointer()),
+    Address dest = emitPointerWithAlignment(E->getArg(0));
+    Address src = emitPointerWithAlignment(E->getArg(1));
+    emitNonNullArgCheck(RValue::get(dest.getPointer()),
                          E->getArg(0)->getType(), E->getArg(0)->getExprLoc(),
                          FD, 0);
-    buildNonNullArgCheck(RValue::get(src.getPointer()), E->getArg(1)->getType(),
+    emitNonNullArgCheck(RValue::get(src.getPointer()), E->getArg(1)->getType(),
                          E->getArg(1)->getExprLoc(), FD, 1);
     uint64_t size =
         E->getArg(2)->EvaluateKnownConstInt(getContext()).getZExtValue();
-    builder.create<mlir::cir::MemCpyInlineOp>(
+    builder.create<cir::MemCpyInlineOp>(
         getLoc(E->getSourceRange()), dest.getPointer(), src.getPointer(),
         mlir::IntegerAttr::get(mlir::IntegerType::get(builder.getContext(), 64),
                                size));

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1411,11 +1411,10 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_memcpy_inline: {
     Address dest = emitPointerWithAlignment(E->getArg(0));
     Address src = emitPointerWithAlignment(E->getArg(1));
-    emitNonNullArgCheck(RValue::get(dest.getPointer()),
-                         E->getArg(0)->getType(), E->getArg(0)->getExprLoc(),
-                         FD, 0);
+    emitNonNullArgCheck(RValue::get(dest.getPointer()), E->getArg(0)->getType(),
+                        E->getArg(0)->getExprLoc(), FD, 0);
     emitNonNullArgCheck(RValue::get(src.getPointer()), E->getArg(1)->getType(),
-                         E->getArg(1)->getExprLoc(), FD, 1);
+                        E->getArg(1)->getExprLoc(), FD, 1);
     uint64_t size =
         E->getArg(2)->EvaluateKnownConstInt(getContext()).getZExtValue();
     builder.create<cir::MemCpyInlineOp>(

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1418,11 +1418,10 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
                          E->getArg(1)->getExprLoc(), FD, 1);
     uint64_t size =
         E->getArg(2)->EvaluateKnownConstInt(getContext()).getZExtValue();
-    auto lenOp =
-        builder.getConstInt(getLoc(E->getSourceRange()), UInt64Ty, size);
-    builder.create<mlir::cir::MemCpyInlineOp>(getLoc(E->getSourceRange()),
-                                              dest.getPointer(),
-                                              src.getPointer(), lenOp);
+    builder.create<mlir::cir::MemCpyInlineOp>(
+        getLoc(E->getSourceRange()), dest.getPointer(), src.getPointer(),
+        mlir::IntegerAttr::get(mlir::IntegerType::get(builder.getContext(), 64),
+                               size));
     // __builtin_memcpy_inline has no return value
     return RValue::get(nullptr);
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -781,8 +781,7 @@ public:
 class CIRMemCpyInlineOpLowering
     : public mlir::OpConversionPattern<cir::MemCpyInlineOp> {
 public:
-  using mlir::OpConversionPattern<
-      cir::MemCpyInlineOp>::OpConversionPattern;
+  using mlir::OpConversionPattern<cir::MemCpyInlineOp>::OpConversionPattern;
 
   mlir::LogicalResult
   matchAndRewrite(cir::MemCpyInlineOp op, OpAdaptor adaptor,
@@ -794,8 +793,7 @@ public:
   }
 };
 
-class CIRMemMoveOpLowering
-    : public mlir::OpConversionPattern<cir::MemMoveOp> {
+class CIRMemMoveOpLowering : public mlir::OpConversionPattern<cir::MemMoveOp> {
 public:
   using mlir::OpConversionPattern<cir::MemMoveOp>::OpConversionPattern;
 
@@ -4393,27 +4391,27 @@ std::unique_ptr<cir::LowerModule> prepareLowerModule(mlir::ModuleOp module) {
 void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
                           mlir::DataLayout &dataLayout,
                           cir::LowerModule *lowerModule) {
-  converter.addConversion([&,
-                           lowerModule](cir::PointerType type) -> mlir::Type {
-    // Drop pointee type since LLVM dialect only allows opaque pointers.
+  converter.addConversion(
+      [&, lowerModule](cir::PointerType type) -> mlir::Type {
+        // Drop pointee type since LLVM dialect only allows opaque pointers.
 
-    auto addrSpace =
-        mlir::cast_if_present<cir::AddressSpaceAttr>(type.getAddrSpace());
-    // Null addrspace attribute indicates the default addrspace.
-    if (!addrSpace)
-      return mlir::LLVM::LLVMPointerType::get(type.getContext());
+        auto addrSpace =
+            mlir::cast_if_present<cir::AddressSpaceAttr>(type.getAddrSpace());
+        // Null addrspace attribute indicates the default addrspace.
+        if (!addrSpace)
+          return mlir::LLVM::LLVMPointerType::get(type.getContext());
 
-    assert(lowerModule && "CIR AS map is not available");
-    // Pass through target addrspace and map CIR addrspace to LLVM addrspace by
-    // querying the target info.
-    unsigned targetAS =
-        addrSpace.isTarget()
-            ? addrSpace.getTargetValue()
-            : lowerModule->getTargetLoweringInfo()
-                  .getTargetAddrSpaceFromCIRAddrSpace(addrSpace);
+        assert(lowerModule && "CIR AS map is not available");
+        // Pass through target addrspace and map CIR addrspace to LLVM addrspace
+        // by querying the target info.
+        unsigned targetAS =
+            addrSpace.isTarget()
+                ? addrSpace.getTargetValue()
+                : lowerModule->getTargetLoweringInfo()
+                      .getTargetAddrSpaceFromCIRAddrSpace(addrSpace);
 
-    return mlir::LLVM::LLVMPointerType::get(type.getContext(), targetAS);
-  });
+        return mlir::LLVM::LLVMPointerType::get(type.getContext(), targetAS);
+      });
   converter.addConversion([&](cir::DataMemberType type) -> mlir::Type {
     return mlir::IntegerType::get(type.getContext(),
                                   dataLayout.getTypeSizeInBits(type));

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -787,12 +787,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::MemCpyInlineOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto lenOp = mlir::cast<mlir::cir::ConstantOp>(op.getLen().getDefiningOp());
     rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyInlineOp>(
-        op, adaptor.getDst(), adaptor.getSrc(),
-        rewriter.getIntegerAttr(
-            getTypeConverter()->convertType(lenOp.getType()),
-            mlir::cast<mlir::cir::IntAttr>(lenOp.getValue()).getValue()),
+        op, adaptor.getDst(), adaptor.getSrc(), adaptor.getLenAttr(),
         /*isVolatile=*/false);
     return mlir::success();
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -779,13 +779,13 @@ public:
 };
 
 class CIRMemCpyInlineOpLowering
-    : public mlir::OpConversionPattern<mlir::cir::MemCpyInlineOp> {
+    : public mlir::OpConversionPattern<cir::MemCpyInlineOp> {
 public:
   using mlir::OpConversionPattern<
-      mlir::cir::MemCpyInlineOp>::OpConversionPattern;
+      cir::MemCpyInlineOp>::OpConversionPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(mlir::cir::MemCpyInlineOp op, OpAdaptor adaptor,
+  matchAndRewrite(cir::MemCpyInlineOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyInlineOp>(
         op, adaptor.getDst(), adaptor.getSrc(), adaptor.getLenAttr(),
@@ -795,7 +795,7 @@ public:
 };
 
 class CIRMemMoveOpLowering
-    : public mlir::OpConversionPattern<mlir::cir::MemMoveOp> {
+    : public mlir::OpConversionPattern<cir::MemMoveOp> {
 public:
   using mlir::OpConversionPattern<cir::MemMoveOp>::OpConversionPattern;
 

--- a/clang/test/CIR/CodeGen/builtins-memory.c
+++ b/clang/test/CIR/CodeGen/builtins-memory.c
@@ -1,5 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck %s --check-prefix=CIR --input-file=%t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu  -fclangir -emit-llvm %s -o - \
+// RUN:  | opt -S -passes=instcombine,mem2reg,simplifycfg -o %t.ll 
+// RUN: FileCheck  --check-prefix=LLVM --input-file=%t.ll %s
 
 typedef __SIZE_TYPE__ size_t;
 void test_memcpy_chk(void *dest, const void *src, size_t n) {
@@ -106,4 +109,42 @@ void test_memset_chk(void *dest, int ch, size_t n) {
   // CIR: %[[#N_LOAD2:]] = cir.load %[[#N]]
   // CIR: cir.call @__memset_chk(%[[#DEST_LOAD]], %[[#CH_LOAD]], %[[#N_LOAD1]], %[[#N_LOAD2]])
   __builtin___memset_chk(dest, ch, n, n);
+}
+
+// TODO: The test should test intrinsic argument alignment, however, 
+// currently we lack support for argument attributes. 
+// Thus, added COM lines as a marker to remind us to change the test 
+// when the support of argument attributes is in.
+void test_memcpy_inline(void *dst, const void *src, size_t n) {
+
+  // CIR-LABEL: test_memcpy_inline
+  // CIR: [[SIZE0:%.*]] = cir.const #cir.int<0> : !u64i
+  // CIR: cir.memcpy_inline [[SIZE0]] bytes from {{%.*}} to {{%.*}} : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+
+  // LLVM-LABEL: test_memcpy_inline
+  // LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr {{%.*}}, ptr {{%.*}}, i64 0, i1 false)
+  // COM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 0, i1 false)
+  __builtin_memcpy_inline(dst, src, 0);
+
+  // CIR: [[SIZE1:%.*]] = cir.const #cir.int<1> : !u64i
+  // CIR: cir.memcpy_inline [[SIZE1]] bytes from {{%.*}} to {{%.*}} : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+
+  // LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr {{%.*}}, ptr {{%.*}}, i64 1, i1 false)
+  // COM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 1, i1 false)
+  __builtin_memcpy_inline(dst, src, 1);
+
+  // CIR: [[SIZE4:%.*]] = cir.const #cir.int<4> : !u64i
+  // CIR: cir.memcpy_inline [[SIZE4]] bytes from {{%.*}} to {{%.*}} : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+
+  // LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr {{%.*}}, ptr {{%.*}}, i64 4, i1 false)
+  // COM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 4, i1 false)
+  __builtin_memcpy_inline(dst, src, 4);
+}
+ 
+void test_memcpy_inline_aligned_buffers(unsigned long long *dst, const unsigned long long *src) {
+
+  // LLVM-LABEL: test_memcpy_inline_aligned_buffers
+  // LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr {{%.*}}, ptr {{%.*}}, i64 4, i1 false)
+  // COM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 8 {{%.*}}, ptr align 8 {{%.*}}, i64 4, i1 false)
+  __builtin_memcpy_inline(dst, src, 4);
 }

--- a/clang/test/CIR/CodeGen/builtins-memory.c
+++ b/clang/test/CIR/CodeGen/builtins-memory.c
@@ -111,33 +111,30 @@ void test_memset_chk(void *dest, int ch, size_t n) {
   __builtin___memset_chk(dest, ch, n, n);
 }
 
-// TODO: The test should test intrinsic argument alignment, however, 
+// FIXME: The test should test intrinsic argument alignment, however, 
 // currently we lack support for argument attributes. 
-// Thus, added COM lines as a marker to remind us to change the test 
+// Thus, added `COM: LLVM:` lines so we can easily flip the test 
 // when the support of argument attributes is in.
 void test_memcpy_inline(void *dst, const void *src, size_t n) {
 
   // CIR-LABEL: test_memcpy_inline
-  // CIR: [[SIZE0:%.*]] = cir.const #cir.int<0> : !u64i
-  // CIR: cir.memcpy_inline [[SIZE0]] bytes from {{%.*}} to {{%.*}} : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+  // CIR: cir.memcpy_inline 0 bytes from {{%.*}} to {{%.*}} : !cir.ptr<!void> -> !cir.ptr<!void>
 
   // LLVM-LABEL: test_memcpy_inline
   // LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr {{%.*}}, ptr {{%.*}}, i64 0, i1 false)
-  // COM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 0, i1 false)
+  // COM: LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 0, i1 false)
   __builtin_memcpy_inline(dst, src, 0);
 
-  // CIR: [[SIZE1:%.*]] = cir.const #cir.int<1> : !u64i
-  // CIR: cir.memcpy_inline [[SIZE1]] bytes from {{%.*}} to {{%.*}} : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+  // CIR: cir.memcpy_inline 1 bytes from {{%.*}} to {{%.*}} : !cir.ptr<!void> -> !cir.ptr<!void>
 
   // LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr {{%.*}}, ptr {{%.*}}, i64 1, i1 false)
-  // COM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 1, i1 false)
+  // COM: LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 1, i1 false)
   __builtin_memcpy_inline(dst, src, 1);
 
-  // CIR: [[SIZE4:%.*]] = cir.const #cir.int<4> : !u64i
-  // CIR: cir.memcpy_inline [[SIZE4]] bytes from {{%.*}} to {{%.*}} : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+  // CIR: cir.memcpy_inline 4 bytes from {{%.*}} to {{%.*}} : !cir.ptr<!void> -> !cir.ptr<!void>
 
   // LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr {{%.*}}, ptr {{%.*}}, i64 4, i1 false)
-  // COM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 4, i1 false)
+  // COM: LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 1 {{%.*}}, ptr align 1 {{%.*}}, i64 4, i1 false)
   __builtin_memcpy_inline(dst, src, 4);
 }
  
@@ -145,6 +142,6 @@ void test_memcpy_inline_aligned_buffers(unsigned long long *dst, const unsigned 
 
   // LLVM-LABEL: test_memcpy_inline_aligned_buffers
   // LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr {{%.*}}, ptr {{%.*}}, i64 4, i1 false)
-  // COM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 8 {{%.*}}, ptr align 8 {{%.*}}, i64 4, i1 false)
+  // COM: LLVM: call void @llvm.memcpy.inline.p0.p0.i64(ptr align 8 {{%.*}}, ptr align 8 {{%.*}}, i64 4, i1 false)
   __builtin_memcpy_inline(dst, src, 4);
 }


### PR DESCRIPTION
The test code is from [OG's clang/test/CodeGen/builtins-memcpy-inline.c](https://github.com/llvm/clangir/blob/5f1afad625f1292ffcf02c36402d292c46213c86/clang/test/CodeGen/builtins-memcpy-inline.c#L7)
Also, a little design choice when introducing MemCpyInlineOp, I chose to let it inherit CIR_MemCpyOp, so in future when we optimize MemCpy like Ops, we'd have cleaner and more unified code. 
However, the cost is that during LLVM lowering I'd have to convert the length from ConstOp into IntegerAttr as that's [what LLVM dialect is expecting](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrmemcpyinline-llvmmemcpyinlineop)