### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower neon_vaesmcq_u8

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -2476,7 +2476,11 @@ mlir::Value CIRGenFunction::buildCommonNeonBuiltinExpr(
   default:
     llvm::errs() << getAArch64SIMDIntrinsicString(builtinID) << " ";
     llvm_unreachable("NYI");
-
+  case NEON::BI__builtin_neon_vaesmcq_u8: {
+    intrincsName = "aarch64.crypto.aesmc";
+    argTypes.push_back(vTy);
+    break;
+  }
   case NEON::BI__builtin_neon_vpadd_v:
   case NEON::BI__builtin_neon_vpaddq_v: {
     intrincsName = mlir::isa<mlir::FloatType>(vTy.getEltType())

--- a/clang/test/CIR/CodeGen/AArch64/neon-crypto.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-crypto.c
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon \
+// RUN:   -target-feature +sha2 -target-feature +aes \
+// RUN:   -disable-O0-optnone -fclangir -emit-cir -o %t.cir %s 
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -triple arm64-none-linux-gnu -target-feature +neon \
+// RUN:   -target-feature +sha2 -target-feature +aes \
+// RUN:   -disable-O0-optnone  -emit-llvm -o - %s \
+// RUN: | opt -S -passes=mem2reg,simplifycfg -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// REQUIRES: aarch64-registered-target || arm-registered-target
+
+#include <arm_neon.h>
+
+uint8x16_t test_vaesmcq_u8(uint8x16_t data) {
+  return vaesmcq_u8(data);
+
+  // CIR-LABEL: vaesmcq_u8
+  // {{%.*}} = cir.llvm.intrinsic "aarch64.crypto.aesmc" {{%.*}} : (!cir.vector<!u8i x 16>) -> !cir.vector<!u8i x 16>
+
+  // LLVM: {{.*}}vaesmcq_u8(<16 x i8>{{.*}}[[DATA:%.*]])
+  // LLVM: [[RES:%.*]] = call <16 x i8> @llvm.aarch64.crypto.aesmc(<16 x i8> [[DATA]])
+  // LLVM: ret <16 x i8> [[RES]]
+}


### PR DESCRIPTION
The test case is from [clang/test/CodeGen/neon-crypto.c](https://github.com/llvm/clangir/blob/dbf320e5c3db0410566ae561067c595308870bad/clang/test/CodeGen/neon-crypto.c#L28)
Need a dedicated test file as RunOptions has crypto related target features. 