### PR TITLE
[CIR][CodeGen] Use the same SSA name as OG's for string literals

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1536,7 +1536,7 @@ CIRGenModule::getAddrOfConstantStringFromLiteral(const StringLiteral *S,
     SmallString<256> StringNameBuffer = Name;
     llvm::raw_svector_ostream Out(StringNameBuffer);
     if (StringLiteralCnt)
-      Out << StringLiteralCnt;
+      Out << '.' << StringLiteralCnt;
     Name = Out.str();
     StringLiteralCnt++;
 

--- a/clang/test/CIR/CodeGen/dtors-scopes.cpp
+++ b/clang/test/CIR/CodeGen/dtors-scopes.cpp
@@ -24,7 +24,7 @@ void dtor1() {
 
 // DTOR_BODY: cir.func linkonce_odr @_ZN1CD2Ev{{.*}}{
 // DTOR_BODY:   %2 = cir.get_global @printf
-// DTOR_BODY:   %3 = cir.get_global @".str2"
+// DTOR_BODY:   %3 = cir.get_global @".str.2"
 // DTOR_BODY:   %4 = cir.cast(array_to_ptrdecay, %3
 // DTOR_BODY:   %5 = cir.call @printf(%4)
 // DTOR_BODY:   cir.return

--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -52,8 +52,8 @@ int use_func() { return func<int>(); }
 // CHECK-NEXT: cir.global "private" constant cir_private dsolocal @".str" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
 // CHECK-NEXT: cir.global external @s = #cir.global_view<@".str"> : !cir.ptr<!s8i>
 
-// CHECK-NEXT: cir.global "private" constant cir_private dsolocal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
-// CHECK-NEXT: cir.global external @s1 = #cir.global_view<@".str1"> : !cir.ptr<!s8i>
+// CHECK-NEXT: cir.global "private" constant cir_private dsolocal @".str.1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
+// CHECK-NEXT: cir.global external @s1 = #cir.global_view<@".str.1"> : !cir.ptr<!s8i>
 
 // CHECK-NEXT: cir.global external @s2 = #cir.global_view<@".str"> : !cir.ptr<!s8i>
 

--- a/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
+++ b/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
@@ -54,7 +54,7 @@ void test() {
 // LLVM: %"class.std::initializer_list<const char *>" = type { ptr, ptr }
 
 // LLVM: @.str = private constant [3 x i8] c"xy\00"
-// LLVM: @.str1 = private constant [3 x i8] c"uv\00"
+// LLVM: @.str.1 = private constant [3 x i8] c"uv\00"
 
 // LLVM: define linkonce_odr void @_ZSt1fIPKcEvSt16initializer_listIT_E(%"class.std::initializer_list<const char *>" [[ARG0:%.*]])
 // LLVM: [[LOCAL_PTR:%.*]] = alloca %"class.std::initializer_list<const char *>", i64 1, align 8, 
@@ -70,7 +70,7 @@ void test() {
 // LLVM:  [[PTR_FIRST_ELEM:%.*]] = getelementptr ptr, ptr [[ELEM_ARRAY_PTR]], i32 0,
 // LLVM:  store ptr @.str, ptr [[PTR_FIRST_ELEM]], align 8,
 // LLVM:  [[PTR_SECOND_ELEM:%.*]] = getelementptr ptr, ptr [[PTR_FIRST_ELEM]], i64 1,
-// LLVM:  store ptr @.str1, ptr [[PTR_SECOND_ELEM]], align 8,
+// LLVM:  store ptr @.str.1, ptr [[PTR_SECOND_ELEM]], align 8,
 // LLVM:  [[INIT_START_FLD_PTR:%.*]] = getelementptr %"class.std::initializer_list<const char *>", ptr [[INIT_STRUCT]], i32 0, i32 0,
 // LLVM:  [[INIT_END_FLD_PTR:%.*]] = getelementptr %"class.std::initializer_list<const char *>", ptr [[INIT_STRUCT]], i32 0, i32 1,
 // LLVM:  [[ELEM_ARRAY_END:%.*]] = getelementptr [2 x ptr], ptr [[ELEM_ARRAY_PTR]], i64 2,

--- a/clang/test/CIR/CodeGen/predefined.cpp
+++ b/clang/test/CIR/CodeGen/predefined.cpp
@@ -13,9 +13,9 @@ void m() {
 // CHECK:     %0 = cir.get_global @".str" : !cir.ptr<!cir.array<!s8i x 7>>
 // CHECK:     %1 = cir.cast(array_to_ptrdecay, %0 : !cir.ptr<!cir.array<!s8i x 7>>), !cir.ptr<!s8i>
 // CHECK:     %2 = cir.const #cir.int<79> : !s32i
-// CHECK:     %3 = cir.get_global @".str1" : !cir.ptr<!cir.array<!s8i x 9>>
+// CHECK:     %3 = cir.get_global @".str.1" : !cir.ptr<!cir.array<!s8i x 9>>
 // CHECK:     %4 = cir.cast(array_to_ptrdecay, %3 : !cir.ptr<!cir.array<!s8i x 9>>), !cir.ptr<!s8i>
-// CHECK:     %5 = cir.get_global @".str2" : !cir.ptr<!cir.array<!s8i x 5>>
+// CHECK:     %5 = cir.get_global @".str.2" : !cir.ptr<!cir.array<!s8i x 5>>
 // CHECK:     %6 = cir.cast(array_to_ptrdecay, %5 : !cir.ptr<!cir.array<!s8i x 5>>), !cir.ptr<!s8i>
 // CHECK:     cir.call @__assert2(%1, %2, %4, %6) : (!cir.ptr<!s8i>, !s32i, !cir.ptr<!s8i>, !cir.ptr<!s8i>) -> ()
 // CHECK:     cir.return

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -11,8 +11,8 @@ module {
   cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.ptr<null> : !cir.ptr<!s8i>}> : !cir.struct<struct {!s8i, !s64i, !cir.ptr<!s8i>}>
   cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global "private" internal @c : !s32i
-  cir.global "private" constant internal @".str2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
-  cir.global external @s = #cir.global_view<@".str2"> : !cir.ptr<!s8i>
+  cir.global "private" constant internal @".str.2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
+  cir.global external @s = #cir.global_view<@".str.2"> : !cir.ptr<!s8i>
   cir.func @use_global() {
     %0 = cir.get_global @a : !cir.ptr<!s32i>
     cir.return
@@ -80,8 +80,8 @@ module {
 // CHECK: cir.global external @b = #cir.const_array<"example\00" : !cir.array<!s8i x 8>>
 // CHECK: cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
 // CHECK: cir.global "private" internal @c : !s32i
-// CHECK: cir.global "private" constant internal @".str2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
-// CHECK: cir.global external @s = #cir.global_view<@".str2"> : !cir.ptr<!s8i>
+// CHECK: cir.global "private" constant internal @".str.2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
+// CHECK: cir.global external @s = #cir.global_view<@".str.2"> : !cir.ptr<!s8i>
 
 
 // CHECK: cir.func @use_global()

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -352,7 +352,7 @@ module {
 
 module {
   // expected-error@+1 {{expected type declaration for string literal}}
-  cir.global "private" constant external @".str2" = #cir.const_array<"example\00"> {alignment = 1 : i64}
+  cir.global "private" constant external @".str.2" = #cir.const_array<"example\00"> {alignment = 1 : i64}
 }
 
 // -----

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -41,8 +41,8 @@ module {
   // MLIR:   %0 = llvm.mlir.addressof @a : !llvm.ptr
   // MLIR:   llvm.return %0 : !llvm.ptr
   // MLIR: }
-  cir.global "private" constant internal @".str1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
-  cir.global external @s1 = #cir.global_view<@".str1"> : !cir.ptr<!s8i>
+  cir.global "private" constant internal @".str.1" = #cir.const_array<"example1\00" : !cir.array<!s8i x 9>> : !cir.array<!s8i x 9> {alignment = 1 : i64}
+  cir.global external @s1 = #cir.global_view<@".str.1"> : !cir.ptr<!s8i>
   cir.global external @s2 = #cir.global_view<@".str"> : !cir.ptr<!s8i>
   cir.func @_Z10use_globalv() {
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["li", init] {alignment = 4 : i64}


### PR DESCRIPTION
This PR changes the naming format of string literals from `.str1` to `.str.1`, making it easier to reuse the existing testcases of OG CodeGen.