### PR TITLE
[CIR] Make X86ArgClass an `enum class`

### DIFF
--- a/clang/include/clang/CIR/Target/x86.h
+++ b/clang/include/clang/CIR/Target/x86.h
@@ -23,7 +23,7 @@ enum class X86AVXABILevel {
 };
 
 // Possible argument classifications according to the x86 ABI documentation.
-enum X86ArgClass {
+enum class X86ArgClass {
   Integer = 0,
   SSE,
   SSEUp,


### PR DESCRIPTION
It's currently polluting the `cir` namespace with very generic symbols like `Integer` and `Memory`, which is pretty confusing. `X86_64ABIInfo` already has `Class` alias for `X86ArgClass`, so we can use that alias to qualify all uses.