### PR TITLE
[cir] [Lowering] Handle VaArg

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.h
@@ -20,5 +20,8 @@ public:
                                clang::ASTContext &astCtx,
                                mlir::cir::DynamicCastOp op) override;
   mlir::Value lowerVAArg(cir::CIRBaseBuilderTy &builder, mlir::cir::VAArgOp op,
-                         const cir::CIRDataLayout &datalayout) override;
+                         const cir::CIRDataLayout &datalayout) override {
+    // Itanium C++ ABI has nothing to do with VAArg.
+    return {};
+  }
 };

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareItaniumCXXABI.cpp
@@ -163,11 +163,3 @@ LoweringPrepareItaniumCXXABI::lowerDynamicCast(CIRBaseBuilderTy &builder,
           })
       .getResult();
 }
-
-mlir::Value LoweringPrepareItaniumCXXABI::lowerVAArg(
-    CIRBaseBuilderTy &builder, mlir::cir::VAArgOp op,
-    const ::cir::CIRDataLayout &datalayout) {
-  // There is no generic cir lowering for var_arg, here we fail
-  // so to prevent attempt of calling lowerVAArg for ItaniumCXXABI
-  cir_cconv_unreachable("NYI");
-}

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2036,7 +2036,12 @@ public:
   mlir::LogicalResult
   matchAndRewrite(mlir::cir::VAArgOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    return op.emitError("cir.vaarg lowering is NYI");
+    auto vaArgResTy = getTypeConverter()->convertType(op.getType());
+    auto opaquePtr = mlir::LLVM::LLVMPointerType::get(getContext());
+    auto va_list = rewriter.create<mlir::LLVM::BitcastOp>(
+        op.getLoc(), opaquePtr, adaptor.getOperands().front());
+    rewriter.replaceOpWithNewOp<mlir::LLVM::VaArgOp>(op, vaArgResTy, va_list);
+    return mlir::success();
   }
 };
 

--- a/clang/test/CIR/CodeGen/var-arg.c
+++ b/clang/test/CIR/CodeGen/var-arg.c
@@ -2,7 +2,8 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-lowering-prepare -fno-clangir-call-conv-lowering %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=AFTER
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
-
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM-X86
 #include <stdarg.h>
 
 int f1(int n, ...) {
@@ -119,3 +120,9 @@ int f1(int n, ...) {
 // LLVM: store i32 [[RES]], ptr [[RETP]], align 4,
 // LLVM: [[RETV:%.*]] = load i32, ptr [[RETP]], align 4,
 // LLVM-NEXT: ret i32 [[RETV]],
+
+// LLVM-X86: %struct.__va_list_tag = type { i32, i32, ptr, ptr }
+// LLVM-X86: define {{.*}} @f1
+// LLVM-X86: call void @llvm.va_start.p0(
+// LLVM-X86: va_arg ptr %{{.*}}, i32
+// LLVM-X86: call void @llvm.va_end.p0(


### PR DESCRIPTION
I tried to reopen https://github.com/llvm/clangir/pull/865 but github get stucked..

---

After one month's deep experience with this patch, now I am more confident we need this patch.

For the long term, in the end of the day, we will need this since `va_arg` instruction is used in other targets in the traditional CodeGen pipeline. And in fact, the `va_arg` instruction lowering the default one in the traditional CG pipeline.

For the short term, this is still needed given we have non-robust X86 arguments classification today (See https://github.com/llvm/clangir/pull/1087). VAArg is pretty common in C codes. Without this, people who want to try clangir in the early days will meet the failures, this is pretty a bad experience.

For the maintaining concerns, since now we have https://github.com/llvm/clangir/pull/1086, we can add support more types after we make X86's arguments classification more stable. Like we did in https://github.com/llvm/clangir/pull/1087.

And it shows the code generated with `va_arg` is pretty good and LLVM will emit the error immediately if the LLVM can't handle it well.