### PR TITLE
[CIR][CodeGen][LowerToLLVM] String literals for OpenCL

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -375,11 +375,16 @@ public:
     return createAlloca(loc, addrType, type, name, alignmentIntAttr);
   }
 
-  mlir::Value createGetGlobal(cir::GlobalOp global, bool threadLocal = false) {
+  mlir::Value createGetGlobal(mlir::Location loc, cir::GlobalOp global,
+                              bool threadLocal = false) {
     return create<cir::GetGlobalOp>(
-        global.getLoc(),
-        getPointerTo(global.getSymType(), global.getAddrSpaceAttr()),
+        loc, getPointerTo(global.getSymType(), global.getAddrSpaceAttr()),
         global.getName(), threadLocal);
+  }
+
+  mlir::Value createGetGlobal(cir::GlobalOp global,
+                              bool threadLocal = false) {
+    return createGetGlobal(global.getLoc(), global, threadLocal);
   }
 
   /// Create a copy with inferred length.

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -382,8 +382,7 @@ public:
         global.getName(), threadLocal);
   }
 
-  mlir::Value createGetGlobal(cir::GlobalOp global,
-                              bool threadLocal = false) {
+  mlir::Value createGetGlobal(cir::GlobalOp global, bool threadLocal = false) {
     return createGetGlobal(global.getLoc(), global, threadLocal);
   }
 
@@ -552,8 +551,7 @@ public:
         });
 
     if (last != block->rend())
-      return OpBuilder::InsertPoint(block,
-                                    ++mlir::Block::iterator(&*last));
+      return OpBuilder::InsertPoint(block, ++mlir::Block::iterator(&*last));
     return OpBuilder::InsertPoint(block, block->begin());
   };
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1840,12 +1840,9 @@ LValue CIRGenFunction::emitStringLiteralLValue(const StringLiteral *E) {
   auto g = dyn_cast<cir::GlobalOp>(cstGlobal);
   assert(g && "unaware of other symbol providers");
 
-  auto ptrTy =
-      cir::PointerType::get(CGM.getBuilder().getContext(), g.getSymType());
   assert(g.getAlignment() && "expected alignment for string literal");
   auto align = *g.getAlignment();
-  auto addr = builder.create<cir::GetGlobalOp>(getLoc(E->getSourceRange()),
-                                               ptrTy, g.getSymName());
+  auto addr = builder.createGetGlobal(getLoc(E->getSourceRange()), g);
   return makeAddrLValue(
       Address(addr, g.getSymType(), CharUnits::fromQuantity(align)),
       E->getType(), AlignmentSource::Decl);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -347,6 +347,19 @@ void lowerAnnotationValue(
   }
 }
 
+// Get addrspace by converting a pointer type.
+// TODO: The approach here is a little hacky. We should access the target info
+// directly to convert the address space of global op, similar to what we do
+// for type converter.
+unsigned getGlobalOpTargetAddrSpace(mlir::ConversionPatternRewriter &rewriter,
+                                    const mlir::TypeConverter *converter,
+                                    cir::GlobalOp op) {
+  auto tempPtrTy = cir::PointerType::get(rewriter.getContext(), op.getSymType(),
+                                         op.getAddrSpaceAttr());
+  return cast<mlir::LLVM::LLVMPointerType>(converter->convertType(tempPtrTy))
+      .getAddressSpace();
+}
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -568,28 +581,36 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
                                 const mlir::TypeConverter *converter) {
   auto module = parentOp->getParentOfType<mlir::ModuleOp>();
   mlir::Type sourceType;
+  unsigned sourceAddrSpace = 0;
   llvm::StringRef symName;
   auto *sourceSymbol =
       mlir::SymbolTable::lookupSymbolIn(module, globalAttr.getSymbol());
   if (auto llvmSymbol = dyn_cast<mlir::LLVM::GlobalOp>(sourceSymbol)) {
     sourceType = llvmSymbol.getType();
     symName = llvmSymbol.getSymName();
+    sourceAddrSpace = llvmSymbol.getAddrSpace();
   } else if (auto cirSymbol = dyn_cast<cir::GlobalOp>(sourceSymbol)) {
     sourceType = converter->convertType(cirSymbol.getSymType());
     symName = cirSymbol.getSymName();
+    sourceAddrSpace =
+        getGlobalOpTargetAddrSpace(rewriter, converter, cirSymbol);
   } else if (auto llvmFun = dyn_cast<mlir::LLVM::LLVMFuncOp>(sourceSymbol)) {
     sourceType = llvmFun.getFunctionType();
     symName = llvmFun.getSymName();
+    sourceAddrSpace = 0;
   } else if (auto fun = dyn_cast<cir::FuncOp>(sourceSymbol)) {
     sourceType = converter->convertType(fun.getFunctionType());
     symName = fun.getSymName();
+    sourceAddrSpace = 0;
   } else {
     llvm_unreachable("Unexpected GlobalOp type");
   }
 
   auto loc = parentOp->getLoc();
   mlir::Value addrOp = rewriter.create<mlir::LLVM::AddressOfOp>(
-      loc, mlir::LLVM::LLVMPointerType::get(rewriter.getContext()), symName);
+      loc,
+      mlir::LLVM::LLVMPointerType::get(rewriter.getContext(), sourceAddrSpace),
+      symName);
 
   if (globalAttr.getIndices()) {
     llvm::SmallVector<mlir::LLVM::GEPArg> indices;
@@ -2322,18 +2343,6 @@ class CIRGlobalOpLowering : public mlir::OpConversionPattern<cir::GlobalOp> {
 public:
   using OpConversionPattern<cir::GlobalOp>::OpConversionPattern;
 
-  // Get addrspace by converting a pointer type.
-  // TODO: The approach here is a little hacky. We should access the target info
-  // directly to convert the address space of global op, similar to what we do
-  // for type converter.
-  unsigned getGlobalOpTargetAddrSpace(cir::GlobalOp op) const {
-    auto tempPtrTy = cir::PointerType::get(getContext(), op.getSymType(),
-                                           op.getAddrSpaceAttr());
-    return cast<mlir::LLVM::LLVMPointerType>(
-               typeConverter->convertType(tempPtrTy))
-        .getAddressSpace();
-  }
-
   /// Replace CIR global with a region initialized LLVM global and update
   /// insertion point to the end of the initializer block.
   inline void setupRegionInitializedLLVMGlobalOp(
@@ -2344,7 +2353,7 @@ public:
         op, llvmType, op.getConstant(), convertLinkage(op.getLinkage()),
         op.getSymName(), nullptr,
         /*alignment*/ op.getAlignment().value_or(0),
-        /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
+        /*addrSpace*/ getGlobalOpTargetAddrSpace(rewriter, typeConverter, op),
         /*dsoLocal*/ false, /*threadLocal*/ (bool)op.getTlsModelAttr(),
         /*comdat*/ mlir::SymbolRefAttr(), attributes);
     newGlobalOp.getRegion().push_back(new mlir::Block());
@@ -2379,7 +2388,8 @@ public:
     if (!init.has_value()) {
       rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
           op, llvmType, isConst, linkage, symbol, mlir::Attribute(),
-          /*alignment*/ 0, /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
+          /*alignment*/ 0,
+          /*addrSpace*/ getGlobalOpTargetAddrSpace(rewriter, typeConverter, op),
           /*dsoLocal*/ isDsoLocal, /*threadLocal*/ (bool)op.getTlsModelAttr(),
           /*comdat*/ mlir::SymbolRefAttr(), attributes);
       return mlir::success();
@@ -2468,7 +2478,7 @@ public:
     auto llvmGlobalOp = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
         op, llvmType, isConst, linkage, symbol, init.value(),
         /*alignment*/ op.getAlignment().value_or(0),
-        /*addrSpace*/ getGlobalOpTargetAddrSpace(op),
+        /*addrSpace*/ getGlobalOpTargetAddrSpace(rewriter, typeConverter, op),
         /*dsoLocal*/ false, /*threadLocal*/ (bool)op.getTlsModelAttr(),
         /*comdat*/ mlir::SymbolRefAttr(), attributes);
 

--- a/clang/test/CIR/CodeGen/OpenCL/printf.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/printf.cl
@@ -1,0 +1,55 @@
+// RUN: %clang_cc1 -fclangir -no-enable-noundef-analysis -cl-std=CL1.2 -cl-ext=-+cl_khr_fp64 -triple spirv64-unknown-unknown -disable-llvm-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.12fp64.cir %s
+// RUN: FileCheck -input-file=%t.12fp64.cir -check-prefixes=CIR-FP64,CIR-ALL %s
+// RUN: %clang_cc1 -fclangir -no-enable-noundef-analysis -cl-std=CL1.2 -cl-ext=-cl_khr_fp64 -triple spirv64-unknown-unknown -disable-llvm-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.12nofp64.cir %s
+// RUN: FileCheck -input-file=%t.12nofp64.cir -check-prefixes=CIR-NOFP64,CIR-ALL %s
+// RUN: %clang_cc1 -fclangir -no-enable-noundef-analysis -cl-std=CL3.0 -cl-ext=+__opencl_c_fp64,+cl_khr_fp64 -triple spirv64-unknown-unknown -disable-llvm-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.30fp64.cir %s
+// RUN: FileCheck -input-file=%t.30fp64.cir -check-prefixes=CIR-FP64,CIR-ALL %s
+// RUN: %clang_cc1 -fclangir -no-enable-noundef-analysis -cl-std=CL3.0 -cl-ext=-__opencl_c_fp64,-cl_khr_fp64 -triple spirv64-unknown-unknown -disable-llvm-passes -emit-cir -fno-clangir-call-conv-lowering -o %t.30nofp64.cir %s
+// RUN: FileCheck -input-file=%t.30nofp64.cir -check-prefixes=CIR-NOFP64,CIR-ALL %s
+// RUN: %clang_cc1 -fclangir -no-enable-noundef-analysis -cl-std=CL1.2 -cl-ext=-+cl_khr_fp64 -triple spirv64-unknown-unknown -disable-llvm-passes -emit-llvm -fno-clangir-call-conv-lowering -o %t.12fp64.ll %s
+// RUN: FileCheck -input-file=%t.12fp64.ll -check-prefixes=LLVM-FP64,LLVM-ALL %s
+// RUN: %clang_cc1 -fclangir -no-enable-noundef-analysis -cl-std=CL1.2 -cl-ext=-cl_khr_fp64 -triple spirv64-unknown-unknown -disable-llvm-passes -emit-llvm -fno-clangir-call-conv-lowering -o %t.12nofp64.ll %s
+// RUN: FileCheck -input-file=%t.12nofp64.ll -check-prefixes=LLVM-NOFP64,LLVM-ALL %s
+// RUN: %clang_cc1 -fclangir -no-enable-noundef-analysis -cl-std=CL3.0 -cl-ext=+__opencl_c_fp64,+cl_khr_fp64 -triple spirv64-unknown-unknown -disable-llvm-passes -emit-llvm -fno-clangir-call-conv-lowering -o %t.30fp64.ll %s
+// RUN: FileCheck -input-file=%t.30fp64.ll -check-prefixes=LLVM-FP64,LLVM-ALL %s
+// RUN: %clang_cc1 -fclangir -no-enable-noundef-analysis -cl-std=CL3.0 -cl-ext=-__opencl_c_fp64,-cl_khr_fp64 -triple spirv64-unknown-unknown -disable-llvm-passes -emit-llvm -fno-clangir-call-conv-lowering -o %t.30nofp64.ll %s
+// RUN: FileCheck -input-file=%t.30nofp64.ll -check-prefixes=LLVM-NOFP64,LLVM-ALL %s
+
+typedef __attribute__((ext_vector_type(2))) float float2;
+typedef __attribute__((ext_vector_type(2))) half half2;
+
+#if defined(cl_khr_fp64) || defined(__opencl_c_fp64)
+typedef __attribute__((ext_vector_type(2))) double double2;
+#endif
+
+int printf(__constant const char* st, ...) __attribute__((format(printf, 1, 2)));
+
+kernel void test_printf_float2(float2 arg) {
+  printf("%v2hlf", arg);
+}
+// CIR-ALL-LABEL: @test_printf_float2(
+// CIR-FP64: %{{.+}} = cir.call @printf(%{{.+}}, %{{.+}}) : (!cir.ptr<!s8i, addrspace(offload_constant)>, !cir.vector<!cir.float x 2>) -> !s32i cc(spir_function)
+// CIR-NOFP64:%{{.+}} = cir.call @printf(%{{.+}}, %{{.+}}) : (!cir.ptr<!s8i, addrspace(offload_constant)>, !cir.vector<!cir.float x 2>) -> !s32i cc(spir_function)
+// LLVM-ALL-LABEL: @test_printf_float2(
+// LLVM-FP64: %{{.+}} = call spir_func i32 (ptr addrspace(2), ...) @{{.*}}printf{{.*}}(ptr addrspace(2) @.str, <2 x float> %{{.*}})
+// LLVM-NOFP64:  call spir_func i32 (ptr addrspace(2), ...) @{{.*}}printf{{.*}}(ptr addrspace(2) @.str, <2 x float> %{{.*}})
+
+kernel void test_printf_half2(half2 arg) {
+  printf("%v2hf", arg);
+}
+// CIR-ALL-LABEL: @test_printf_half2(
+// CIR-FP64: %{{.+}} = cir.call @printf(%{{.+}}, %{{.+}}) : (!cir.ptr<!s8i, addrspace(offload_constant)>, !cir.vector<!cir.f16 x 2>) -> !s32i cc(spir_function)
+// CIR-NOFP64:%{{.+}} = cir.call @printf(%{{.+}}, %{{.+}}) : (!cir.ptr<!s8i, addrspace(offload_constant)>, !cir.vector<!cir.f16 x 2>) -> !s32i cc(spir_function)
+// LLVM-ALL-LABEL: @test_printf_half2(
+// LLVM-FP64:  %{{.+}} = call spir_func i32 (ptr addrspace(2), ...) @{{.*}}printf{{.*}}(ptr addrspace(2) @.str.1, <2 x half> %{{.*}})
+// LLVM-NOFP64:  %{{.+}} = call spir_func i32 (ptr addrspace(2), ...) @{{.*}}printf{{.*}}(ptr addrspace(2) @.str.1, <2 x half> %{{.*}})
+
+#if defined(cl_khr_fp64) || defined(__opencl_c_fp64)
+kernel void test_printf_double2(double2 arg) {
+  printf("%v2lf", arg);
+}
+// CIR-FP64-LABEL: @test_printf_double2(
+// CIR-FP64: %{{.+}} = cir.call @printf(%{{.+}}, %{{.+}}) : (!cir.ptr<!s8i, addrspace(offload_constant)>, !cir.vector<!cir.double x 2>) -> !s32i cc(spir_function)
+// LLVM-FP64-LABEL: @test_printf_double2(
+// LLVM-FP64: call spir_func i32 (ptr addrspace(2), ...) @{{.*}}printf{{.*}}(ptr addrspace(2) @.str.2, <2 x double> %{{.*}})
+#endif

--- a/clang/test/CIR/CodeGen/OpenCL/str_literals.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/str_literals.cl
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 %s -fclangir -triple=spirv64-unknown-unknown -cl-opt-disable -emit-cir -o %t.cir -ffake-address-space-map
+// RUN: FileCheck -input-file=%t.cir -check-prefix=CIR %s
+// RUN: %clang_cc1 %s -fclangir -triple=spirv64-unknown-unknown -cl-opt-disable -emit-llvm -o %t.ll -ffake-address-space-map
+// RUN: FileCheck -input-file=%t.ll -check-prefix=LLVM %s
+
+__constant char *__constant x = "hello world";
+__constant char *__constant y = "hello world";
+
+// CIR: cir.global{{.*}} constant {{.*}}addrspace(offload_constant) @".str" = #cir.const_array<"hello world\00" : !cir.array<!s8i x 12>> : !cir.array<!s8i x 12>
+// CIR: cir.global{{.*}} constant {{.*}}addrspace(offload_constant) @x = #cir.global_view<@".str"> : !cir.ptr<!s8i, addrspace(offload_constant)>
+// CIR: cir.global{{.*}} constant {{.*}}addrspace(offload_constant) @y = #cir.global_view<@".str"> : !cir.ptr<!s8i, addrspace(offload_constant)>
+// CIR: cir.global{{.*}} constant {{.*}}addrspace(offload_constant) @".str.1" = #cir.const_array<"f\00" : !cir.array<!s8i x 2>> : !cir.array<!s8i x 2>
+// LLVM: addrspace(2) constant{{.*}}"hello world\00"
+// LLVM-NOT: addrspace(2) constant
+// LLVM: @x = {{(dso_local )?}}addrspace(2) constant ptr addrspace(2)
+// LLVM: @y = {{(dso_local )?}}addrspace(2) constant ptr addrspace(2)
+// LLVM: addrspace(2) constant{{.*}}"f\00"
+
+void f() {
+  // CIR: cir.store %{{.*}}, %{{.*}} : !cir.ptr<!s8i, addrspace(offload_constant)>, !cir.ptr<!cir.ptr<!s8i, addrspace(offload_constant)>, addrspace(offload_private)>
+  // LLVM: store ptr addrspace(2) {{.*}}, ptr
+  constant const char *f3 = __func__;
+}


### PR DESCRIPTION
This PR supports string literals in OpenCL end to end, making it possible to use `printf`. This involves two changes:

* In CIRGen, ensure we create the global symbol for string literals with correct `constant` address space.
* In LowerToLLVM, make the lowering of `GlobalViewAttr` aware of the upstream address space.

Other proper refactors are also applied.

Two test cases from OG CodeGen are reused. `str_literals.cl` is the primary test, while `printf.cl` is the bonus one.
