### PR TITLE
[CIR][CodeGen][NFC] Simplify replacing initializer of static decls

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -68,7 +68,6 @@ struct MissingFeatures {
 
   // Address space related
   static bool addressSpace() { return false; }
-  static bool addressSpaceInGlobalVar() { return false; }
 
   // Clang codegen options
   static bool strictVTablePointers() { return false; }

--- a/clang/test/CIR/CodeGen/stmtexpr-init.c
+++ b/clang/test/CIR/CodeGen/stmtexpr-init.c
@@ -33,11 +33,11 @@ struct outer {
 };
 
 void T2(void) {
-  // CIR-DAG: cir.global "private" constant internal @T2._a = #cir.const_struct<{#cir.int<2> : !s32i, #cir.const_array<[#cir.int<50> : !s32i, #cir.int<60> : !s32i]> : !cir.array<!s32i x 2>}>
+  // CIR-DAG: cir.global "private" constant internal dsolocal @T2._a = #cir.const_struct<{#cir.int<2> : !s32i, #cir.const_array<[#cir.int<50> : !s32i, #cir.int<60> : !s32i]> : !cir.array<!s32i x 2>}>
   // LLVM-DAG: internal constant { i32, [2 x i32] } { i32 2, [2 x i32] [i32 50, i32 60] }
   const struct sized_array *A = ARRAY_PTR(50, 60);
 
-  // CIR-DAG: cir.global "private" constant internal @T2._a.1 = #cir.const_struct<{#cir.int<3> : !s32i, #cir.const_array<[#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.int<30> : !s32i]> : !cir.array<!s32i x 3>}>
+  // CIR-DAG: cir.global "private" constant internal dsolocal @T2._a.1 = #cir.const_struct<{#cir.int<3> : !s32i, #cir.const_array<[#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.int<30> : !s32i]> : !cir.array<!s32i x 3>}>
   // LLVM-DAG: internal constant { i32, [3 x i32] } { i32 3, [3 x i32] [i32 10, i32 20, i32 30] }
   struct outer X = {ARRAY_PTR(10, 20, 30)};
 


### PR DESCRIPTION
When emitting initializers for static declarations, it's essential to ensure that the `cir.global` operation aligns its type with that of the initializer.

The original approach creates a new global op and copies every attribute from the old one. But just `setSymType` should work well.

This also removes missing feature flags there.