### PR TITLE
[CIR][Dialect][NFC] Fix double white spaces in `cir.global` assembly

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -1016,6 +1016,9 @@ def VisibilityAttr : CIR_Attr<"Visibility", "visibility"> {
 
   let skipDefaultBuilders = 1;
 
+  // Make DefaultValuedAttr accept VisibilityKind as default value ($0).
+  let constBuilderCall = "cir::VisibilityAttr::get($_builder.getContext(), $0)";
+
   let extraClassDeclaration = [{
     bool isDefault() const { return getValue() == VisibilityKind::Default; };
     bool isHidden() const { return getValue() == VisibilityKind::Hidden; };

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2387,7 +2387,10 @@ def GlobalOp : CIR_Op<"global",
   // TODO: sym_visibility can possibly be represented by implementing the
   // necessary Symbol's interface in terms of linkage instead.
   let arguments = (ins SymbolNameAttr:$sym_name,
-                       VisibilityAttr:$global_visibility,
+                       DefaultValuedAttr<
+                        VisibilityAttr,
+                        "VisibilityKind::Default"
+                       >:$global_visibility,
                        OptionalAttr<StrAttr>:$sym_visibility,
                        TypeAttr:$sym_type,
                        Arg<GlobalLinkageKind, "linkage type">:$linkage,
@@ -2405,7 +2408,7 @@ def GlobalOp : CIR_Op<"global",
   let regions = (region AnyRegion:$ctorRegion, AnyRegion:$dtorRegion);
   let assemblyFormat = [{
        ($sym_visibility^)?
-       custom<OmitDefaultVisibility>($global_visibility)
+       (`` $global_visibility^)?
        (`constant` $constant^)?
        $linkage
        (`comdat` $comdat^)?

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -285,19 +285,6 @@ static void printOmittedTerminatorRegion(mlir::OpAsmPrinter &printer,
                       /*printBlockTerminators=*/!omitRegionTerm(region));
 }
 
-static mlir::ParseResult
-parseOmitDefaultVisibility(mlir::OpAsmParser &parser,
-                           cir::VisibilityAttr &visibility) {
-  parseVisibilityAttr(parser, visibility);
-  return success();
-}
-
-static void printOmitDefaultVisibility(mlir::OpAsmPrinter &printer,
-                                       cir::GlobalOp &op,
-                                       cir::VisibilityAttr visibility) {
-  printVisibilityAttr(printer, visibility);
-}
-
 //===----------------------------------------------------------------------===//
 // AllocaOp
 //===----------------------------------------------------------------------===//

--- a/clang/test/CIR/CallConvLowering/AArch64/struct.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/struct.c
@@ -40,7 +40,7 @@ S init(S s) {
   return s;
 }
 
-// CIR: cir.func no_proto  @foo1
+// CIR: cir.func no_proto @foo1
 // CIR: %[[#V0:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["s"]
 // CIR: %[[#V1:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["tmp"] {alignment = 4 : i64}
 // CIR: %[[#V2:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S>), !cir.ptr<!u64i>
@@ -143,7 +143,7 @@ S2 init2(S2 s) {
   return s;
 }
 
-// CIR: cir.func no_proto  @foo3()
+// CIR: cir.func no_proto @foo3()
 // CIR: %[[#V0:]] = cir.alloca !ty_S2_, !cir.ptr<!ty_S2_>, ["s"]
 // CIR: %[[#V1:]] = cir.alloca !ty_S2_, !cir.ptr<!ty_S2_>, ["tmp"] {alignment = 1 : i64}
 // CIR: %[[#V2:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S2_>), !cir.ptr<!u16i>

--- a/clang/test/CIR/CodeGen/AArch64/neon-arith.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-arith.c
@@ -20,7 +20,7 @@
 float32_t test_vrndns_f32(float32_t a) {
   return vrndns_f32(a);
 }
-// CIR: cir.func internal private  @vrndns_f32(%arg0: !cir.float {{.*}}) -> !cir.float
+// CIR: cir.func internal private @vrndns_f32(%arg0: !cir.float {{.*}}) -> !cir.float
 // CIR: cir.store %arg0, [[ARG_SAVE:%.*]] : !cir.float, !cir.ptr<!cir.float> 
 // CIR: [[INTRIN_ARG:%.*]] = cir.load [[ARG_SAVE]] : !cir.ptr<!cir.float>, !cir.float 
 // CIR: {{%.*}} = cir.llvm.intrinsic "roundeven.f32" [[INTRIN_ARG]] : (!cir.float)
@@ -42,7 +42,7 @@ float32x2_t test_vrnda_f32(float32x2_t a) {
   return vrnda_f32(a);
 }
 
-// CIR: cir.func internal private  @vrnda_f32(%arg0: !cir.vector<!cir.float x 2>
+// CIR: cir.func internal private @vrnda_f32(%arg0: !cir.vector<!cir.float x 2>
 // CIR: cir.store %arg0, [[ARG_SAVE:%.*]] : !cir.vector<!cir.float x 2>, !cir.ptr<!cir.vector<!cir.float x 2>>
 // CIR: [[INTRIN_ARG:%.*]] = cir.load [[ARG_SAVE]] : !cir.ptr<!cir.vector<!cir.float x 2>>, !cir.vector<!cir.float x 2>
 // CIR: [[INTRIN_ARG_CAST:%.*]] = cir.cast(bitcast, [[INTRIN_ARG]] : !cir.vector<!cir.float x 2>), !cir.vector<!s8i x 8>
@@ -66,7 +66,7 @@ float32x4_t test_vrndaq_f32(float32x4_t a) {
   return vrndaq_f32(a);
 }
 
-// CIR: cir.func internal private  @vrndaq_f32(%arg0: !cir.vector<!cir.float x 4>
+// CIR: cir.func internal private @vrndaq_f32(%arg0: !cir.vector<!cir.float x 4>
 // CIR: cir.store %arg0, [[ARG_SAVE:%.*]] : !cir.vector<!cir.float x 4>, !cir.ptr<!cir.vector<!cir.float x 4>>
 // CIR: [[INTRIN_ARG:%.*]] = cir.load [[ARG_SAVE]] : !cir.ptr<!cir.vector<!cir.float x 4>>, !cir.vector<!cir.float x 4>
 // CIR: [[INTRIN_ARG_CAST:%.*]] = cir.cast(bitcast, [[INTRIN_ARG]] : !cir.vector<!cir.float x 4>), !cir.vector<!s8i x 16>

--- a/clang/test/CIR/CodeGen/annotations-var.c
+++ b/clang/test/CIR/CodeGen/annotations-var.c
@@ -3,8 +3,8 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
-// CIR-DAG:  cir.global  external @globalvar = #cir.int<3> : !s32i [#cir.annotation<name = "globalvar_ann_0", args = []>] {alignment = 4 : i64}
-// CIR-DAG:  cir.global  external @globalvar2 = #cir.int<2> : !s32i [#cir.annotation<name = "common_ann", args = ["os", 21 : i32]>] {alignment = 4 : i64}
+// CIR-DAG:  cir.global external @globalvar = #cir.int<3> : !s32i [#cir.annotation<name = "globalvar_ann_0", args = []>] {alignment = 4 : i64}
+// CIR-DAG:  cir.global external @globalvar2 = #cir.int<2> : !s32i [#cir.annotation<name = "common_ann", args = ["os", 21 : i32]>] {alignment = 4 : i64}
 
 // LLVM-DAG: @.str.annotation = private unnamed_addr constant [15 x i8] c"localvar_ann_0\00", section "llvm.metadata"
 // LLVM-DAG: @.str.1.annotation = private unnamed_addr constant [{{[0-9]+}} x i8] c"{{.*}}annotations-var.c\00", section "llvm.metadata"

--- a/clang/test/CIR/CodeGen/array-init.c
+++ b/clang/test/CIR/CodeGen/array-init.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s
 
-// CHECK-DAG: cir.global "private"  constant cir_private @__const.foo.bar = #cir.const_array<[#cir.fp<9.000000e+00> : !cir.double, #cir.fp<8.000000e+00> : !cir.double, #cir.fp<7.000000e+00> : !cir.double]> : !cir.array<!cir.double x 3>
+// CHECK-DAG: cir.global "private" constant cir_private @__const.foo.bar = #cir.const_array<[#cir.fp<9.000000e+00> : !cir.double, #cir.fp<8.000000e+00> : !cir.double, #cir.fp<7.000000e+00> : !cir.double]> : !cir.array<!cir.double x 3>
 typedef struct {
   int a;
   long b;

--- a/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
+++ b/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
@@ -18,11 +18,11 @@ void bar() __attribute__((annotate("withargfunc", "os", 22))) {
 
 // BEFORE: module @{{.*}}attribute-annotate-multiple.cpp" attributes {cir.lang =
 
-// BEFORE: cir.global  external @a = #cir.ptr<null> : !cir.ptr<!cir.double>
+// BEFORE: cir.global external @a = #cir.ptr<null> : !cir.ptr<!cir.double>
 // BEFORE-SAME: [#cir.annotation<name = "withargs", args = ["21", 12 : i32]>]
-// BEFORE: cir.global  external @b = #cir.ptr<null> : !cir.ptr<!s32i>
+// BEFORE: cir.global external @b = #cir.ptr<null> : !cir.ptr<!s32i>
 // BEFORE-SAME: [#cir.annotation<name = "withargs", args = ["21", 12 : i32]>]
-// BEFORE: cir.global  external @c = #cir.ptr<null> : !cir.ptr<!void>
+// BEFORE: cir.global external @c = #cir.ptr<null> : !cir.ptr<!void>
 // BEFORE-SAME: [#cir.annotation<name = "noargvar", args = []>]
 // BEFORE: cir.global external @tile = #cir.int<7> : !s32i
 // BEFORE-SAME: #cir.annotation<name = "cir.aie.device.tile", args = [42 : i8]>]

--- a/clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
+++ b/clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
@@ -26,13 +26,13 @@ const int &compat_use_after_redecl1 = compat::c;
 const int &compat_use_after_redecl2 = compat::d;
 const int &compat_use_after_redecl3 = compat::g;
 
-// CIR: cir.global  constant weak_odr comdat @_ZN6compat1bE = #cir.int<2> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant weak_odr comdat @_ZN6compat1aE = #cir.int<1> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant weak_odr comdat @_ZN6compat1cE = #cir.int<3> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant external @_ZN6compat1eE = #cir.int<5> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant weak_odr comdat @_ZN6compat1fE = #cir.int<6> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant linkonce_odr comdat @_ZN6compat1dE = #cir.int<4> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant linkonce_odr comdat @_ZN6compat1gE = #cir.int<7> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant weak_odr comdat @_ZN6compat1bE = #cir.int<2> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant weak_odr comdat @_ZN6compat1aE = #cir.int<1> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant weak_odr comdat @_ZN6compat1cE = #cir.int<3> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant external @_ZN6compat1eE = #cir.int<5> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant weak_odr comdat @_ZN6compat1fE = #cir.int<6> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant linkonce_odr comdat @_ZN6compat1dE = #cir.int<4> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant linkonce_odr comdat @_ZN6compat1gE = #cir.int<7> : !s32i {alignment = 4 : i64}
 
 // LLVM: $_ZN6compat1bE = comdat any
 // LLVM: $_ZN6compat1aE = comdat any

--- a/clang/test/CIR/CodeGen/global-new.cpp
+++ b/clang/test/CIR/CodeGen/global-new.cpp
@@ -14,7 +14,7 @@ e *g = new e(0);
 
 // CIR_BEFORE: ![[ty:.*]] = !cir.struct<struct "e" {!u8i}
 
-// CIR_BEFORE: cir.global  external @g = ctor : !cir.ptr<![[ty]]> {
+// CIR_BEFORE: cir.global external @g = ctor : !cir.ptr<![[ty]]> {
 // CIR_BEFORE:     %[[GlobalAddr:.*]] = cir.get_global @g : !cir.ptr<!cir.ptr<![[ty]]>>
 // CIR_BEFORE:     %[[Size:.*]] = cir.const #cir.int<1> : !u64i
 // CIR_BEFORE:     %[[NewAlloc:.*]] = cir.call @_Znwm(%[[Size]]) : (!u64i) -> !cir.ptr<!void>
@@ -37,7 +37,7 @@ e *g = new e(0);
 // CIR_EH:   cir.resume
 // CIR_EH: }]
 
-// CIR_FLAT_EH: cir.func internal private  @__cxx_global_var_init()
+// CIR_FLAT_EH: cir.func internal private @__cxx_global_var_init()
 // CIR_FLAT_EH: ^bb3:
 // CIR_FLAT_EH:   %exception_ptr, %type_id = cir.eh.inflight_exception
 // CIR_FLAT_EH:   cir.call @_ZdlPvm({{.*}}) : (!cir.ptr<!void>, !u64i) -> ()

--- a/clang/test/CIR/CodeGen/globals-neg-index-array.c
+++ b/clang/test/CIR/CodeGen/globals-neg-index-array.c
@@ -14,7 +14,7 @@ struct __attribute__((packed)) PackedStruct {
 };
 struct PackedStruct packed[10];
 char *packed_element = &(packed[-2].a3);
-// CHECK: cir.global  external @packed = #cir.zero : !cir.array<!ty_PackedStruct x 10> {alignment = 16 : i64} loc(#loc5)
-// CHECK: cir.global  external @packed_element = #cir.global_view<@packed, [-2 : i32, 2 : i32]>
+// CHECK: cir.global external @packed = #cir.zero : !cir.array<!ty_PackedStruct x 10> {alignment = 16 : i64} loc(#loc5)
+// CHECK: cir.global external @packed_element = #cir.global_view<@packed, [-2 : i32, 2 : i32]>
 // LLVM: @packed = global [10 x %struct.PackedStruct] zeroinitializer
 // LLVM: @packed_element = global ptr getelementptr inbounds ([10 x %struct.PackedStruct], ptr @packed, i32 0, i32 -2, i32 2)

--- a/clang/test/CIR/CodeGen/kr-func-promote.c
+++ b/clang/test/CIR/CodeGen/kr-func-promote.c
@@ -6,7 +6,7 @@
 // CHECK:   cir.store %1, %0 : !s16i, !cir.ptr<!s16i>
 void foo(x) short x; {}
 
-// CHECK: cir.func no_proto  @bar(%arg0: !cir.double 
+// CHECK: cir.func no_proto @bar(%arg0: !cir.double 
 // CHECK:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]
 // CHECK:   %1 = cir.cast(floating, %arg0 : !cir.double), !cir.float
 // CHECK:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>

--- a/clang/test/CIR/CodeGen/member-init-struct.cpp
+++ b/clang/test/CIR/CodeGen/member-init-struct.cpp
@@ -15,7 +15,7 @@ struct C {
   C(void (C::*x)(), int y) : b(), c(y), e(x) {}
 };
 
-// CHECK-LABEL:   cir.global  external @x = #cir.zero : !ty_A
+// CHECK-LABEL:   cir.global external @x = #cir.zero : !ty_A
 A x;
 C a, b(x), c(0, 2);
 

--- a/clang/test/CIR/CodeGen/no-pie.c
+++ b/clang/test/CIR/CodeGen/no-pie.c
@@ -7,5 +7,5 @@ extern int var;
 int get() {
   return var;
 }
-// CIR: cir.global "private"  external dsolocal @var : !s32i {alignment = 4 : i64}
+// CIR: cir.global "private" external dsolocal @var : !s32i {alignment = 4 : i64}
 // LLVM: @var = external dso_local global i32

--- a/clang/test/CIR/CodeGen/paren-list-init.cpp
+++ b/clang/test/CIR/CodeGen/paren-list-init.cpp
@@ -23,7 +23,7 @@ template <int I>
 void make1() {
   Vec v;
   S1((Vec&&) v);
-// CIR: cir.func linkonce_odr  @_Z5make1ILi0EEvv()
+// CIR: cir.func linkonce_odr @_Z5make1ILi0EEvv()
 // CIR:   %[[VEC:.*]] = cir.alloca ![[VecType]], !cir.ptr<![[VecType]]>
 // CIR:   cir.call @_ZN3VecC1Ev(%[[VEC]]) : (!cir.ptr<![[VecType]]>)
 // CIR:   cir.scope {
@@ -35,7 +35,7 @@ void make1() {
 // CIR:   cir.call @_ZN3VecD1Ev(%[[VEC]]) : (!cir.ptr<![[VecType]]>) -> ()
 // CIR:   cir.return
 
-// CIR_EH: cir.func linkonce_odr  @_Z5make1ILi0EEvv()
+// CIR_EH: cir.func linkonce_odr @_Z5make1ILi0EEvv()
 // CIR_EH:  %[[VEC:.*]] = cir.alloca ![[VecType]], !cir.ptr<![[VecType]]>, ["v", init]
 
 // Construct v

--- a/clang/test/CIR/CodeGen/static-vars.cpp
+++ b/clang/test/CIR/CodeGen/static-vars.cpp
@@ -38,7 +38,7 @@ void func2(void) {
   // CHECK-DAG: cir.global "private" internal dsolocal @_ZZ5func2vE1j = #cir.fp<0.000000e+00> : !cir.float
 }
 
-// CHECK-DAG: cir.global  linkonce_odr comdat @_ZZ4testvE1c = #cir.int<0> : !s32i
+// CHECK-DAG: cir.global linkonce_odr comdat @_ZZ4testvE1c = #cir.int<0> : !s32i
 
 // LLVM-DAG: $_ZZ4testvE1c = comdat any
 // LLVM-DAG: @_ZZ4testvE1c = linkonce_odr global i32 0, comdat, align 4

--- a/clang/test/CIR/CodeGen/temporaries.cpp
+++ b/clang/test/CIR/CodeGen/temporaries.cpp
@@ -14,9 +14,9 @@ void f() {
   !E();
 }
 
-//      CIR: cir.func private  @_ZN1EC1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
-// CIR-NEXT: cir.func private  @_ZN1EntEv(!cir.ptr<!ty_E>) -> !ty_E
-// CIR-NEXT: cir.func private  @_ZN1ED1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
+//      CIR: cir.func private @_ZN1EC1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
+// CIR-NEXT: cir.func private @_ZN1EntEv(!cir.ptr<!ty_E>) -> !ty_E
+// CIR-NEXT: cir.func private @_ZN1ED1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
 // CIR-NEXT: cir.func @_Z1fv() extra(#fn_attr1) {
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     %[[ONE:[0-9]+]] = cir.alloca !ty_E, !cir.ptr<!ty_E>, ["agg.tmp.ensured"] {alignment = 1 : i64}
@@ -44,8 +44,8 @@ void f() {
 const unsigned int n = 1234;
 const int &r = (const int&)n;
 
-//      CIR: cir.global "private"  constant internal @_ZGR1r_ = #cir.int<1234> : !s32i
-// CIR-NEXT: cir.global  constant external @r = #cir.global_view<@_ZGR1r_> : !cir.ptr<!s32i> {alignment = 8 : i64}
+//      CIR: cir.global "private" constant internal @_ZGR1r_ = #cir.int<1234> : !s32i
+// CIR-NEXT: cir.global constant external @r = #cir.global_view<@_ZGR1r_> : !cir.ptr<!s32i> {alignment = 8 : i64}
 
 //      LLVM: @_ZGR1r_ = internal constant i32 1234, align 4
 // LLVM-NEXT: @r = constant ptr @_ZGR1r_, align 8

--- a/clang/test/CIR/CodeGen/tempref.cpp
+++ b/clang/test/CIR/CodeGen/tempref.cpp
@@ -6,9 +6,9 @@
 struct A { ~A(); };
 A &&a = dynamic_cast<A&&>(A{});
 
-//      CHECK: cir.func private  @_ZN1AD1Ev(!cir.ptr<!ty_A>) extra(#fn_attr)
-// CHECK-NEXT: cir.global  external @a = #cir.ptr<null> : !cir.ptr<!ty_A> {alignment = 8 : i64, ast = #cir.var.decl.ast}
-// CHECK-NEXT: cir.func internal private  @__cxx_global_var_init() {
+//      CHECK: cir.func private @_ZN1AD1Ev(!cir.ptr<!ty_A>) extra(#fn_attr)
+// CHECK-NEXT: cir.global external @a = #cir.ptr<null> : !cir.ptr<!ty_A> {alignment = 8 : i64, ast = #cir.var.decl.ast}
+// CHECK-NEXT: cir.func internal private @__cxx_global_var_init() {
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     %[[SEVEN:[0-9]+]] = cir.get_global @a : !cir.ptr<!cir.ptr<!ty_A>>
 // CHECK-NEXT:     %[[EIGHT:[0-9]+]] = cir.get_global @_ZGR1a_ : !cir.ptr<!ty_A>
@@ -16,7 +16,7 @@ A &&a = dynamic_cast<A&&>(A{});
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }
-// CHECK-NEXT: cir.func private  @_GLOBAL__sub_I_tempref.cpp() {
+// CHECK-NEXT: cir.func private @_GLOBAL__sub_I_tempref.cpp() {
 // CHECK-NEXT:   cir.call @__cxx_global_var_init() : () -> ()
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }

--- a/clang/test/CIR/CodeGen/unary-deref.cpp
+++ b/clang/test/CIR/CodeGen/unary-deref.cpp
@@ -10,7 +10,7 @@ void foo() {
   (void)p.read();
 }
 
-// CHECK:  cir.func linkonce_odr  @_ZNK12MyIntPointer4readEv
+// CHECK:  cir.func linkonce_odr @_ZNK12MyIntPointer4readEv
 // CHECK:  %2 = cir.load %0
 // CHECK:  %3 = cir.get_member %2[0] {name = "ptr"}
 // CHECK:  %4 = cir.load deref %3 : !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGen/union-init.c
+++ b/clang/test/CIR/CodeGen/union-init.c
@@ -34,7 +34,7 @@ void foo(int x) {
 // CHECK:  cir.return
 
 union { int i; float f; } u = { };
-// CHECK: cir.global  external @u = #cir.zero : ![[TY_u]]
+// CHECK: cir.global external @u = #cir.zero : ![[TY_u]]
 
 unsigned is_little(void) {
   const union {

--- a/clang/test/CIR/CodeGen/visibility-attribute.c
+++ b/clang/test/CIR/CodeGen/visibility-attribute.c
@@ -1,5 +1,7 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck %s -input-file=%t.cir -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
+// RUN: FileCheck %s -input-file=%t.ll -check-prefix=LLVM
 
 extern int glob_default;
 // CIR: cir.global "private" external @glob_default : !s32i

--- a/clang/test/CIR/IR/annotations.cir
+++ b/clang/test/CIR/IR/annotations.cir
@@ -28,7 +28,7 @@ cir.func @bar() attributes {annotations = [#cir.annotation<name = "noargfunc", a
 // CHECK-SAME: ["bar", #cir.annotation<name = "noargfunc", args = []>],
 // CHECK-SAME: ["bar", #cir.annotation<name = "withargfunc", args = ["os", 23 : i32]>],
 // CHECK-SAME: ["_Z1fv", #cir.annotation<name = "tile", args = []>]]>}
-// CHECK: cir.global  external @a = #cir.int<0> : !s32i
+// CHECK: cir.global external @a = #cir.int<0> : !s32i
 // CHECK-SAME: [#cir.annotation<name = "testanno", args = ["21", 12 : i32]>]
 // CHECK: cir.func @foo()
 // CHECK-SAME: [#cir.annotation<name = "withargfunc", args = ["os", 22 : i32]>]

--- a/clang/test/CIR/IR/invalid-annotations.cir
+++ b/clang/test/CIR/IR/invalid-annotations.cir
@@ -4,7 +4,7 @@
 
 // expected-error @below {{invalid kind of attribute specified}}
 // expected-error @below {{failed to parse AnnotationAttr parameter 'name' which is to be a `mlir::StringAttr`}}
-cir.global  external @a = #cir.ptr<null> : !cir.ptr<!cir.double> [#cir.annotation<name = 18, args = ["21", 12 : i32]>]
+cir.global external @a = #cir.ptr<null> : !cir.ptr<!cir.double> [#cir.annotation<name = 18, args = ["21", 12 : i32]>]
 
 // -----
 

--- a/clang/test/CIR/Lowering/brcond.cir
+++ b/clang/test/CIR/Lowering/brcond.cir
@@ -3,7 +3,7 @@
 
 !s32i = !cir.int<s, 32>
 #fn_attr = #cir<extra({inline = #cir.inline<no>, nothrow = #cir.nothrow, optnone = #cir.optnone})>
-module { cir.func no_proto  @test() -> !cir.bool extra(#fn_attr) {
+module { cir.func no_proto @test() -> !cir.bool extra(#fn_attr) {
     %0 = cir.const #cir.int<0> : !s32i 
     %1 = cir.cast(int_to_bool, %0 : !s32i), !cir.bool 
     cir.br ^bb1 

--- a/clang/test/CIR/Lowering/store-memcpy.cpp
+++ b/clang/test/CIR/Lowering/store-memcpy.cpp
@@ -5,7 +5,7 @@
 void foo() {
   char s1[] = "Hello";
 }
-// AFTER-DAG:  cir.global "private"  constant cir_private @__const._Z3foov.s1 = #cir.const_array<"Hello\00" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6>
+// AFTER-DAG:  cir.global "private" constant cir_private @__const._Z3foov.s1 = #cir.const_array<"Hello\00" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6>
 // AFTER: @_Z3foov
 // AFTER:    %[[S1:.*]] = cir.alloca !cir.array<!s8i x 6>, !cir.ptr<!cir.array<!s8i x 6>>, ["s1"]
 // AFTER:    %[[HELLO:.*]] = cir.get_global @__const._Z3foov.s1 : !cir.ptr<!cir.array<!s8i x 6>>


### PR DESCRIPTION
Following #1009 and #1028, this PR removes the double white spaces in the assembly format of `cir.global` op.

It's basically some `mlir-tablegen`-builtin magic: With `constBuilderCall` specified, we can apply `DefaultValuedAttr` with any default value we can construct from constant values. Then we can easily omit the default in assembly. Hence, we don't need to compromise anything for the wrapper attribute `cir::VisibilityAttr`.

Similarly to #1009, an empty literal ``` `` ``` is used to omit the leading space emitted by inner attribute.

The test case `visibility-attribute.c` is modified to save the intermediate CIR to disk and reflect the effects.

Double whitespaces in other test files are removed.