### PR TITLE
[CIR][CIRGen][Builtin] Support __builtin_elementwise_abs and extend AbsOp to take vector input

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4331,8 +4331,8 @@ def SqrtOp : UnaryFPToFPBuiltinOp<"sqrt", "SqrtOp">;
 def TruncOp : UnaryFPToFPBuiltinOp<"trunc", "FTruncOp">;
 
 def AbsOp : CIR_Op<"abs", [Pure, SameOperandsAndResultType]> {
-  let arguments = (ins PrimitiveSInt:$src, UnitAttr:$poison);
-  let results = (outs PrimitiveSInt:$result);
+  let arguments = (ins CIR_AnySignedIntOrVecOfSignedInt:$src, UnitAttr:$poison);
+  let results = (outs CIR_AnySignedIntOrVecOfSignedInt:$result);
   let summary = [{
     libc builtin equivalent abs, labs, llabs
 
@@ -4345,6 +4345,7 @@ def AbsOp : CIR_Op<"abs", [Pure, SameOperandsAndResultType]> {
     ```mlir
       %0 = cir.const #cir.int<-42> : s32i
       %1 = cir.abs %0 poison : s32i
+      %2 = cir.abs %3 : !cir.vector<!s32i x 4>
     ```
   }];
   let assemblyFormat = "$src ( `poison` $poison^ )? `:` type($src) attr-dict";

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -184,6 +184,7 @@ private:
 
 bool isAnyFloatingPointType(mlir::Type t);
 bool isFPOrFPVectorTy(mlir::Type);
+bool isCIRIntOrIntVectorTy(mlir::Type);
 } // namespace cir
 
 mlir::ParseResult parseAddrSpaceAttribute(mlir::AsmParser &p,

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -184,7 +184,7 @@ private:
 
 bool isAnyFloatingPointType(mlir::Type t);
 bool isFPOrFPVectorTy(mlir::Type);
-bool isCIRIntOrIntVectorTy(mlir::Type);
+bool isIntOrIntVectorTy(mlir::Type);
 } // namespace cir
 
 mlir::ParseResult parseAddrSpaceAttribute(mlir::AsmParser &p,

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -60,6 +60,9 @@ def CIR_IntType : CIR_Type<"Int", "int",
     bool isPrimitive() const {
       return isValidPrimitiveIntBitwidth(getWidth());
     }
+    bool isSignedPrimitive() const {
+      return isPrimitive() && isSigned();
+    }
 
     /// Returns a minimum bitwidth of cir::IntType
     static unsigned minBitwidth() { return 1; }
@@ -538,8 +541,22 @@ def IntegerVector : Type<
     ]>, "!cir.vector of !cir.int"> {
 }
 
+// Vector of signed integral type
+def SignedIntegerVector : Type<
+    And<[
+      CPred<"::mlir::isa<::cir::VectorType>($_self)">,
+      CPred<"::mlir::isa<::cir::IntType>("
+            "::mlir::cast<::cir::VectorType>($_self).getEltType())">,
+      CPred<"::mlir::cast<::cir::IntType>("
+            "::mlir::cast<::cir::VectorType>($_self).getEltType())"
+            ".isSignedPrimitive()">
+    ]>, "!cir.vector of !cir.int"> {
+}
+
 // Constraints
 def CIR_AnyIntOrVecOfInt: AnyTypeOf<[CIR_IntType, IntegerVector]>;
+def CIR_AnySignedIntOrVecOfSignedInt: AnyTypeOf<
+                                        [PrimitiveSInt, SignedIntegerVector]>;
 
 // Pointer to Arrays
 def ArrayPtr : Type<

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -329,6 +329,9 @@ struct MissingFeatures {
 
   //-- Other missing features
 
+  // We need to extend fpUnaryOPs to support vector types.
+  static bool fpUnaryOPsSupportVectorType() { return false; }
+
   // We need to track the parent record types that represent a field
   // declaration. This is necessary to determine the layout of a class.
   static bool fieldDeclAbstraction() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1255,9 +1255,22 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_nondeterministic_value:
     llvm_unreachable("BI__builtin_nondeterministic_value NYI");
 
-  case Builtin::BI__builtin_elementwise_abs:
-    llvm_unreachable("BI__builtin_elementwise_abs NYI");
-
+  case Builtin::BI__builtin_elementwise_abs: {
+    mlir::Type cirTy = ConvertType(E->getArg(0)->getType());
+    bool isIntTy = cir::isCIRIntOrIntVectorTy(cirTy);
+    if (!isIntTy) {
+      if (cir::isAnyFloatingPointType(cirTy)) {
+        return emitUnaryFPBuiltin<cir::FAbsOp>(*this, *E);
+      }
+      assert(!MissingFeatures::fpUnaryOPsSupportVectorType());
+      llvm_unreachable("unsupported type for BI__builtin_elementwise_abs");
+    }
+    mlir::Value arg = emitScalarExpr(E->getArg(0));
+    auto call = getBuilder().create<cir::AbsOp>(getLoc(E->getExprLoc()),
+                                                arg.getType(), arg, false);
+    mlir::Value result = call->getResult(0);
+    return RValue::get(result);
+  }
   case Builtin::BI__builtin_elementwise_acos:
     llvm_unreachable("BI__builtin_elementwise_acos NYI");
   case Builtin::BI__builtin_elementwise_asin:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1257,7 +1257,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
 
   case Builtin::BI__builtin_elementwise_abs: {
     mlir::Type cirTy = ConvertType(E->getArg(0)->getType());
-    bool isIntTy = cir::isCIRIntOrIntVectorTy(cirTy);
+    bool isIntTy = cir::isIntOrIntVectorTy(cirTy);
     if (!isIntTy) {
       if (cir::isAnyFloatingPointType(cirTy)) {
         return emitUnaryFPBuiltin<cir::FAbsOp>(*this, *E);

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -829,7 +829,7 @@ bool cir::isAnyFloatingPointType(mlir::Type t) {
 }
 
 //===----------------------------------------------------------------------===//
-// Floating-point and Float-point Vecotr type helpers
+// Floating-point and Float-point Vector type helpers
 //===----------------------------------------------------------------------===//
 
 bool cir::isFPOrFPVectorTy(mlir::Type t) {
@@ -839,6 +839,18 @@ bool cir::isFPOrFPVectorTy(mlir::Type t) {
         mlir::dyn_cast<cir::VectorType>(t).getEltType());
   }
   return isAnyFloatingPointType(t);
+}
+
+//===----------------------------------------------------------------------===//
+// CIR Integer and Integer Vector type helpers
+//===----------------------------------------------------------------------===//
+
+bool cir::isCIRIntOrIntVectorTy(mlir::Type t) {
+
+  if (isa<cir::VectorType>(t)) {
+    return isa<cir::IntType>(mlir::dyn_cast<cir::VectorType>(t).getEltType());
+  }
+  return isa<cir::IntType>(t);
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -845,7 +845,7 @@ bool cir::isFPOrFPVectorTy(mlir::Type t) {
 // CIR Integer and Integer Vector type helpers
 //===----------------------------------------------------------------------===//
 
-bool cir::isCIRIntOrIntVectorTy(mlir::Type t) {
+bool cir::isIntOrIntVectorTy(mlir::Type t) {
 
   if (isa<cir::VectorType>(t)) {
     return isa<cir::IntType>(mlir::dyn_cast<cir::VectorType>(t).getEltType());

--- a/clang/test/CIR/CodeGen/builtins-elementwise.c
+++ b/clang/test/CIR/CodeGen/builtins-elementwise.c
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android24  -emit-cir %s -o %t.cir  
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple aarch64-none-linux-android24  -fclangir \
+// RUN:  -emit-llvm  %s -o %t.ll
+// RUN: FileCheck  --check-prefix=LLVM --input-file=%t.ll %s
+
+typedef int vint4 __attribute__((ext_vector_type(4)));
+
+void test_builtin_elementwise_abs(vint4 vi4, int i, float f, double d) {
+    // CIR-LABEL: test_builtin_elementwise_abs
+    // LLVM-LABEL: test_builtin_elementwise_abs
+    // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.float
+    // LLVM: {{%.*}} = call float @llvm.fabs.f32(float {{%.*}})
+    f = __builtin_elementwise_abs(f);
+
+    // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.double
+    // LLVM: {{%.*}} = call double @llvm.fabs.f64(double {{%.*}})
+    d = __builtin_elementwise_abs(d);
+
+    // CIR: {{%.*}} = cir.abs {{%.*}} : !cir.vector<!s32i x 4>
+    // LLVM: {{%.*}} = call <4 x i32> @llvm.abs.v4i32(<4 x i32> {{%.*}}, i1 false)
+    vi4 = __builtin_elementwise_abs(vi4);
+
+    // CIR: {{%.*}} = cir.abs {{%.*}} : !s32
+    // LLVM: {{%.*}} = call i32 @llvm.abs.i32(i32 {{%.*}}, i1 false)
+    i = __builtin_elementwise_abs(i);
+}


### PR DESCRIPTION
Extend AbsOp to take vector of int input. With it, we can support  __builtin_elementwise_abs. 
We should in the next PR extend FpUnaryOps to support vector type input so we won't have blocker to implement all elementwise builtins completely. Now just temporarily have missingFeature `fpUnaryOPsSupportVectorType`.  
Currently, int type UnaryOp support vector type. 

FYI:
[clang's documentation about elementwise builtins](https://clang.llvm.org/docs/LanguageExtensions.html#vector-builtins)