### PR TITLE
[CIR][NFC] Conform if/else lowering order to match clang's output

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -91,7 +91,7 @@ struct CIRIfFlattening : public OpRewritePattern<IfOp> {
     if (!emptyElse) {
       elseBeforeBody = &ifOp.getElseRegion().front();
       elseAfterBody = &ifOp.getElseRegion().back();
-      rewriter.inlineRegionBefore(ifOp.getElseRegion(), thenAfterBody);
+      rewriter.inlineRegionBefore(ifOp.getElseRegion(), continueBlock);
     } else {
       elseBeforeBody = elseAfterBody = continueBlock;
     }

--- a/clang/test/CIR/CodeGen/abstract-cond.c
+++ b/clang/test/CIR/CodeGen/abstract-cond.c
@@ -27,10 +27,10 @@ int f6(int a0, struct s6 a1, struct s6 a2) {
 // LLVM:    %[[LOAD_A0:.*]] = load i32, ptr {{.*}}
 // LLVM:    %[[COND:.*]] = icmp ne i32 %[[LOAD_A0]], 0
 // LLVM:    br i1 %[[COND]], label %[[A1_PATH:.*]], label %[[A2_PATH:.*]],
-// LLVM:  [[A2_PATH]]:
+// LLVM:  [[A1_PATH]]:
 // LLVM:    call void @llvm.memcpy.p0.p0.i32(ptr %[[TMP:.*]], ptr {{.*}}, i32 4, i1 false)
 // LLVM:    br label %[[EXIT:[a-z0-9]+]]
-// LLVM:  [[A1_PATH]]:
+// LLVM:  [[A2_PATH]]:
 // LLVM:    call void @llvm.memcpy.p0.p0.i32(ptr %[[TMP]], ptr {{.*}}, i32 4, i1 false)
 // LLVM:    br label %[[EXIT]]
 // LLVM:  [[EXIT]]:

--- a/clang/test/CIR/Lowering/if.cir
+++ b/clang/test/CIR/Lowering/if.cir
@@ -18,12 +18,12 @@ module {
 //      MLIR:   llvm.func @foo(%arg0: i32) -> i32
 // MLIR-NEXT:     %0 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:     %1 = llvm.icmp "ne" %arg0, %0 : i32
-// MLIR-NEXT:     llvm.cond_br %1, ^bb2, ^bb1
+// MLIR-NEXT:     llvm.cond_br %1, ^bb1, ^bb2
 // MLIR-NEXT:   ^bb1:  // pred: ^bb0
-// MLIR-NEXT:     %2 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:     %2 = llvm.mlir.constant(1 : i32) : i32
 // MLIR-NEXT:     llvm.return %2 : i32
 // MLIR-NEXT:   ^bb2:  // pred: ^bb0
-// MLIR-NEXT:     %3 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:     %3 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:     llvm.return %3 : i32
 // MLIR-NEXT:   ^bb3:  // no predecessors
 // MLIR-NEXT:     llvm.return %arg0 : i32
@@ -31,13 +31,13 @@ module {
 
 //       LLVM: define i32 @foo(i32 %0)
 //  LLVM-NEXT:   %2 = icmp ne i32 %0, 0
-//  LLVM-NEXT:   br i1 %2, label %4, label %3
+//  LLVM-NEXT:   br i1 %2, label %3, label %4
 // LLVM-EMPTY:
 //  LLVM-NEXT: 3:
-//  LLVM-NEXT:   ret i32 0
+//  LLVM-NEXT:   ret i32 1
 // LLVM-EMPTY:
 //  LLVM-NEXT: 4:
-//  LLVM-NEXT:   ret i32 1
+//  LLVM-NEXT:   ret i32 0
 // LLVM-EMPTY:
 //  LLVM-NEXT: 5:
 //  LLVM-NEXT:   ret i32 %0
@@ -85,12 +85,12 @@ module {
     %4 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
     // MLIR: llvm.cond_br {{%.*}}, ^[[T:.*]], ^[[F:.*]]
     cir.if %4 {
-    } else {
-    }
-    // MLIR-NEXT: ^[[F]]:
-    // MLIR-NEXT:   llvm.br ^[[PHI:.*]]
     // MLIR-NEXT: ^[[T]]:
+    // MLIR-NEXT:   llvm.br ^[[PHI:.*]]
+    } else {
+    // MLIR-NEXT: ^[[F]]:
     // MLIR-NEXT:   llvm.br ^[[PHI]]
+    }
     // MLIR-NEXT: ^[[PHI]]:
     // MLIR-NEXT:   llvm.return
     cir.return %arg0 : !s32i

--- a/clang/test/CIR/Transforms/if.cir
+++ b/clang/test/CIR/Transforms/if.cir
@@ -16,12 +16,12 @@ module {
   }
 //      CHECK: cir.func @foo(%arg0: !s32i) -> !s32i {
 // CHECK-NEXT:   %0 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
-// CHECK-NEXT:   cir.brcond %0 ^bb2, ^bb1
+// CHECK-NEXT:   cir.brcond %0 ^bb1, ^bb2
 // CHECK-NEXT: ^bb1:  // pred: ^bb0
-// CHECK-NEXT:   %1 = cir.const #cir.int<0> : !s32i
+// CHECK-NEXT:   %1 = cir.const #cir.int<1> : !s32i
 // CHECK-NEXT:   cir.return %1 : !s32i
 // CHECK-NEXT: ^bb2:  // pred: ^bb0
-// CHECK-NEXT:   %2 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:   %2 = cir.const #cir.int<0> : !s32i
 // CHECK-NEXT:   cir.return %2 : !s32i
 // CHECK-NEXT: ^bb3:  // no predecessors
 // CHECK-NEXT:   cir.return %arg0 : !s32i

--- a/clang/test/CIR/Transforms/mem2reg.c
+++ b/clang/test/CIR/Transforms/mem2reg.c
@@ -1,18 +1,18 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir 
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=BEFORE
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -fclangir-mem2reg %s -o %t.cir 
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -fclangir-mem2reg %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=MEM2REG
 
 int return_42() {
   int y = 42;
-  return y;  
+  return y;
 }
 
 // BEFORE: cir.func {{.*@return_42}}
 // BEFORE:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // BEFORE:   %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["y", init] {alignment = 4 : i64}
 // BEFORE:   %2 = cir.const #cir.int<42> : !s32i
-// BEFORE:   cir.store %2, %1 : !s32i, !cir.ptr<!s32i> 
+// BEFORE:   cir.store %2, %1 : !s32i, !cir.ptr<!s32i>
 // BEFORE:   %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
 // BEFORE:   cir.store %3, %0 : !s32i, !cir.ptr<!s32i>
 // BEFORE:   %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
@@ -63,7 +63,7 @@ void alloca_in_loop(int* ar, int n) {
 // BEFORE:        cir.yield
 // BEFORE:      }
 // BEFORE:    }
-// BEFORE:    cir.return  
+// BEFORE:    cir.return
 
 // MEM2REG:  cir.func {{.*@alloca_in_loop}}
 // MEM2REG:    cir.br ^bb1
@@ -152,13 +152,13 @@ int alloca_in_ifelse(int x) {
 // MEM2REG:    %1 = cir.const #cir.int<42> : !s32i
 // MEM2REG:    %2 = cir.cmp(gt, %arg0, %1) : !s32i, !s32i
 // MEM2REG:    %3 = cir.cast(int_to_bool, %2 : !s32i), !cir.bool
-// MEM2REG:    cir.brcond %3 ^bb3, ^bb2
+// MEM2REG:    cir.brcond %3 ^bb2, ^bb3
 // MEM2REG:  ^bb2:  // pred: ^bb1
-// MEM2REG:    %4 = cir.const #cir.int<3> : !s32i
+// MEM2REG:    %4 = cir.const #cir.int<2> : !s32i
 // MEM2REG:    %5 = cir.binop(mul, %arg0, %4) nsw : !s32i
 // MEM2REG:    cir.br ^bb4(%5 : !s32i)
 // MEM2REG:  ^bb3:  // pred: ^bb1
-// MEM2REG:    %6 = cir.const #cir.int<2> : !s32i
+// MEM2REG:    %6 = cir.const #cir.int<3> : !s32i
 // MEM2REG:    %7 = cir.binop(mul, %arg0, %6) nsw : !s32i
 // MEM2REG:    cir.br ^bb4(%7 : !s32i)
 // MEM2REG:  ^bb4(%8: !s32i{{.*}}):  // 2 preds: ^bb2, ^bb3
@@ -174,7 +174,7 @@ int alloca_in_ifelse(int x) {
 
 typedef __SIZE_TYPE__ size_t;
 void *alloca(size_t size);
-  
+
 void test_bitcast(size_t n) {
   int *c1 = alloca(n);
 }
@@ -189,7 +189,7 @@ void test_bitcast(size_t n) {
 // BEFORE:    %5 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!s32i>
 // BEFORE:    cir.store %5, %1 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // BEFORE:    cir.return
-  
+
 // MEM2REG:  cir.func {{.*@test_bitcast}}
 // MEM2REG:    cir.return
 // MEM2REG:  }


### PR DESCRIPTION
Before the commit, when flattening if/else clauses - the else body came before the "then" body, as opposed to clang's output order.

This commit reverses this and hopefully allows easier comparisson between clang's output and cir's.