### PR TITLE
[CIR] Force cir.cmp to always return bool

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1268,8 +1268,7 @@ def CmpOp : CIR_Op<"cmp", [Pure, SameTypeOperands]> {
     ```
   }];
 
-  // TODO: get more accurate than CIR_AnyType
-  let results = (outs CIR_AnyType:$result);
+  let results = (outs CIR_BoolType:$result);
   let arguments = (ins Arg<CmpOpKind, "cmp kind">:$kind,
                        CIR_AnyType:$lhs, CIR_AnyType:$rhs);
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -947,12 +947,11 @@ public:
           // Other kinds of vectors.  Element-wise comparison returning
           // a vector.
           cir::CmpOpKind Kind = ClangCmpToCIRCmp(E->getOpcode());
-          return Builder.create<cir::VecCmpOp>(CGF.getLoc(BOInfo.Loc),
-                                               CGF.getCIRType(BOInfo.FullType),
-                                               Kind, BOInfo.LHS, BOInfo.RHS);
+          Result = Builder.create<cir::VecCmpOp>(
+              CGF.getLoc(BOInfo.Loc), CGF.getCIRType(BOInfo.FullType), Kind,
+              BOInfo.LHS, BOInfo.RHS);
         }
-      }
-      if (BOInfo.isFixedPointOp()) {
+      } else if (BOInfo.isFixedPointOp()) {
         assert(0 && "not implemented");
       } else {
         // FIXME(cir): handle another if above for CIR equivalent on
@@ -966,9 +965,7 @@ public:
         }
 
         cir::CmpOpKind Kind = ClangCmpToCIRCmp(E->getOpcode());
-        return Builder.create<cir::CmpOp>(CGF.getLoc(BOInfo.Loc),
-                                          CGF.getCIRType(BOInfo.FullType), Kind,
-                                          BOInfo.LHS, BOInfo.RHS);
+        Result = Builder.createCompare(CGF.getLoc(BOInfo.Loc), Kind, LHS, RHS);
       }
     } else { // Complex Comparison: can only be an equality comparison.
       assert(0 && "not implemented");

--- a/clang/test/CIR/CodeGen/bf16-ops.c
+++ b/clang/test/CIR/CodeGen/bf16-ops.c
@@ -481,11 +481,11 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fsub bfloat %{{.+}}, %[[#A]]
 
   test = (h2 < h0);
-  //      NONATIVE: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NATIVE: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp olt bfloat %{{.+}}, %{{.+}}
 
@@ -494,13 +494,13 @@ void foo(void) {
   test = (h2 < (__bf16)42.0);
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  // NATIVE-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp olt bfloat %{{.+}}, 0xR4228
 
@@ -508,12 +508,12 @@ void foo(void) {
 
   test = (h2 < f0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM: %{{.+}} = fcmp olt float %[[#LHS]], %{{.+}}
@@ -523,12 +523,12 @@ void foo(void) {
 
   test = (f2 < h0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp olt float %{{.+}}, %[[#RHS]]
@@ -538,12 +538,12 @@ void foo(void) {
 
   test = (i0 < h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NONATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM: %{{.+}} = fcmp olt bfloat %[[#LHS]], %{{.+}}
@@ -553,12 +553,12 @@ void foo(void) {
 
   test = (h0 < i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp olt bfloat %{{.+}}, %[[#RHS]]
@@ -567,11 +567,11 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp olt bfloat %{{.+}}, %[[#RHS]]
 
   test = (h0 > h2);
-  //      NONATIVE: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NATIVE: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp ogt bfloat %{{.+}}, %{{.+}}
 
@@ -580,13 +580,13 @@ void foo(void) {
   test = ((__bf16)42.0 > h2);
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  //      NONATIVE: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  //      NONATIVE: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  //      NATIVE: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  //      NATIVE: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp ogt bfloat 0xR4228, %{{.+}}
 
@@ -594,12 +594,12 @@ void foo(void) {
 
   test = (h0 > f2);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM: %{{.+}} = fcmp ogt float %[[#LHS]], %{{.+}}
@@ -609,12 +609,12 @@ void foo(void) {
 
   test = (f0 > h2);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#RHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM: %{{.+}} = fcmp ogt float %{{.+}}, %[[#RHS]]
@@ -624,12 +624,12 @@ void foo(void) {
 
   test = (i0 > h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM: %{{.+}} = fcmp ogt bfloat %[[#LHS]], %{{.+}}
@@ -639,12 +639,12 @@ void foo(void) {
 
   test = (h0 > i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp ogt bfloat %{{.+}}, %[[#RHS]]
@@ -653,11 +653,11 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp ogt bfloat %{{.+}}, %[[#RHS]]
 
   test = (h2 <= h0);
-  //      NONATIVE: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NATIVE: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp ole bfloat %{{.+}}, %{{.+}}
 
@@ -666,13 +666,13 @@ void foo(void) {
   test = (h2 <= (__bf16)42.0);
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  // NATIVE-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp ole bfloat %{{.+}}, 0xR4228
 
@@ -680,12 +680,12 @@ void foo(void) {
 
   test = (h2 <= f0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM: %{{.+}} = fcmp ole float %[[#LHS]], %{{.+}}
@@ -695,12 +695,12 @@ void foo(void) {
 
   test = (f2 <= h0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp ole float %{{.+}}, %[[#RHS]]
@@ -710,12 +710,12 @@ void foo(void) {
 
   test = (i0 <= h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NONATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM: %{{.+}} = fcmp ole bfloat %[[#LHS]], %{{.+}}
@@ -725,12 +725,12 @@ void foo(void) {
 
   test = (h0 <= i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp ole bfloat %{{.+}}, %[[#RHS]]
@@ -739,12 +739,13 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp ole bfloat %{{.+}}, %[[#RHS]]
 
   test = (h0 >= h2);
-  //      NONATIVE: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %[[#B:]] = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
   // NONATIVE-NEXT: %{{.+}} = cir.get_global @test : !cir.ptr<!u32i>
 
-  //      NATIVE: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NATIVE: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp oge bfloat %{{.+}}, %{{.+}}
 
@@ -754,14 +755,14 @@ void foo(void) {
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<2.000000e+00> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.unary(minus, %[[#A]]) : !cir.double, !cir.double
   // NONATIVE-NEXT: %[[#C:]] = cir.cast(floating, %[[#B]] : !cir.double), !cir.bf16
-  // NONATIVE-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#D]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#D]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<2.000000e+00> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.unary(minus, %[[#A]]) : !cir.double, !cir.double
   // NATIVE-NEXT: %[[#C:]] = cir.cast(floating, %[[#B]] : !cir.double), !cir.bf16
-  // NATIVE-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#D]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#D]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp oge bfloat %{{.+}}, 0xRC000
 
@@ -769,12 +770,12 @@ void foo(void) {
 
   test = (h0 >= f2);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM: %{{.+}} = fcmp oge float %[[#LHS]], %{{.+}}
@@ -784,12 +785,12 @@ void foo(void) {
 
   test = (f0 >= h2);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#RHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM: %{{.+}} = fcmp oge float %{{.+}}, %[[#RHS]]
@@ -799,12 +800,12 @@ void foo(void) {
 
   test = (i0 >= h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NONATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM: %{{.+}} = fcmp oge bfloat %[[#LHS]], %{{.+}}
@@ -814,12 +815,12 @@ void foo(void) {
 
   test = (h0 >= i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp oge bfloat %{{.+}}, %[[#RHS]]
@@ -828,11 +829,11 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp oge bfloat %{{.+}}, %[[#RHS]]
 
   test = (h1 == h2);
-  //      NONATIVE: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NATIVE: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp oeq bfloat %{{.+}}, %{{.+}}
 
@@ -841,13 +842,13 @@ void foo(void) {
   test = (h1 == (__bf16)1.0);
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<1.000000e+00> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<1.000000e+00> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  // NATIVE-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp oeq bfloat %{{.+}}, 0xR3F80
 
@@ -855,12 +856,12 @@ void foo(void) {
 
   test = (h1 == f1);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#A:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM: %{{.+}} = fcmp oeq float %[[#A]], %{{.+}}
@@ -870,12 +871,12 @@ void foo(void) {
 
   test = (f1 == h1);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp oeq float %{{.+}}, %[[#RHS]]
@@ -885,12 +886,12 @@ void foo(void) {
 
   test = (i0 == h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NONATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM: %{{.+}} = fcmp oeq bfloat %[[#LHS]], %{{.+}}
@@ -900,12 +901,12 @@ void foo(void) {
 
   test = (h0 == i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp oeq bfloat %{{.+}}, %[[#RHS]]
@@ -914,11 +915,11 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp oeq bfloat %{{.+}}, %[[#RHS]]
 
   test = (h1 != h2);
-  //      NONATIVE: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
+  //      NATIVE: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#A]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp une bfloat %{{.+}}, %{{.+}}
 
@@ -926,13 +927,13 @@ void foo(void) {
 
   test = (h1 != (__bf16)1.0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.double), !cir.bf16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<1.000000e+00> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.bf16
-  // NATIVE-NEXT: %[[#C:]] = cir.cmp(ne, %{{.+}}, %[[#B]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#C:]] = cir.cmp(ne, %{{.+}}, %[[#B]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#C]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp une bfloat %{{.+}}, 0xR3F80
 
@@ -940,12 +941,12 @@ void foo(void) {
 
   test = (h1 != f1);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM: %{{.+}} = fcmp une float %[[#LHS]], %{{.+}}
@@ -955,12 +956,12 @@ void foo(void) {
 
   test = (f1 != h1);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.bf16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = fpext bfloat %{{.+}} to float
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp une float %{{.+}}, %[[#RHS]]
@@ -970,12 +971,12 @@ void foo(void) {
 
   test = (i0 != h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NONATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  //      NATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  //      NATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM: %{{.+}} = fcmp une bfloat %[[#LHS]], %{{.+}}
@@ -985,12 +986,12 @@ void foo(void) {
 
   test = (h0 != i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NONATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.bf16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.bf16, !s32i
-  // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.bf16, !cir.bool
+  // NATIVE-NEXT: %{{.+}} = cir.cast(bool_to_int, %[[#B]] : !cir.bool), !s32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to bfloat
   // NONATIVE-LLVM-NEXT: %{{.+}} = fcmp une bfloat %{{.+}}, %[[#RHS]]

--- a/clang/test/CIR/CodeGen/float16-ops.c
+++ b/clang/test/CIR/CodeGen/float16-ops.c
@@ -477,10 +477,10 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fsub half %{{.+}}, %[[#A]]
 
   test = (h2 < h0);
-  //      NONATIVE: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp olt half %{{.+}}, %{{.+}}
@@ -490,12 +490,12 @@ void foo(void) {
   test = (h2 < (_Float16)42.0);
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // NATIVE-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp olt half %{{.+}}, 0xH5140
@@ -504,11 +504,11 @@ void foo(void) {
 
   test = (h2 < f0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#A:]] = fpext half %{{.+}} to float
@@ -519,11 +519,11 @@ void foo(void) {
 
   test = (f2 < h0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#A:]] = fpext half %{{.=}} to float
@@ -534,11 +534,11 @@ void foo(void) {
 
   test = (i0 < h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NONATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#A:]] = sitofp i32 %{{.+}} to half
@@ -549,11 +549,11 @@ void foo(void) {
 
   test = (h0 < i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#A:]] = sitofp i32 %{{.+}} to half
@@ -563,10 +563,10 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp olt half %{{.+}}, %[[#A]]
 
   test = (h0 > h2);
-  //      NONATIVE: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp ogt half %{{.+}}, %{{.+}}
@@ -576,12 +576,12 @@ void foo(void) {
   test = ((_Float16)42.0 > h2);
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  //      NONATIVE: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  //      NATIVE: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp ogt half 0xH5140, %{{.+}}
@@ -590,11 +590,11 @@ void foo(void) {
 
   test = (h0 > f2);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext half %{{.=}} to float
@@ -605,11 +605,11 @@ void foo(void) {
 
   test = (f0 > h2);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = fpext half %{{.+}} to float
@@ -620,11 +620,11 @@ void foo(void) {
 
   test = (i0 > h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -635,11 +635,11 @@ void foo(void) {
 
   test = (h0 > i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half
@@ -649,10 +649,10 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp ogt half %{{.+}}, %[[#RHS]]
 
   test = (h2 <= h0);
-  //      NONATIVE: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp ole half %{{.+}}, %{{.+}}
@@ -662,12 +662,12 @@ void foo(void) {
   test = (h2 <= (_Float16)42.0);
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // NATIVE-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp ole half %{{.+}}, 0xH5140
@@ -676,11 +676,11 @@ void foo(void) {
 
   test = (h2 <= f0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext half %{{.+}} to float
@@ -691,11 +691,11 @@ void foo(void) {
 
   test = (f2 <= h0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = fpext half %{{.+}} to float
@@ -706,11 +706,11 @@ void foo(void) {
 
   test = (i0 <= h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NONATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -721,11 +721,11 @@ void foo(void) {
 
   test = (h0 <= i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half
@@ -735,11 +735,11 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp ole half %{{.+}}, %[[#RHS]]
 
   test = (h0 >= h2);
-  //      NONATIVE: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
   // NONATIVE-NEXT: %{{.+}} = cir.get_global @test : !cir.ptr<!u32i>
 
-  //      NATIVE: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp oge half %{{.+}}, %{{.+}}
@@ -750,13 +750,13 @@ void foo(void) {
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<2.000000e+00> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.unary(minus, %[[#A]]) : !cir.double, !cir.double
   // NONATIVE-NEXT: %[[#C:]] = cir.cast(floating, %[[#B]] : !cir.double), !cir.f16
-  // NONATIVE-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#D]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<2.000000e+00> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.unary(minus, %[[#A]]) : !cir.double, !cir.double
   // NATIVE-NEXT: %[[#C:]] = cir.cast(floating, %[[#B]] : !cir.double), !cir.f16
-  // NATIVE-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#D]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp oge half %{{.+}}, 0xHC000
@@ -765,11 +765,11 @@ void foo(void) {
 
   test = (h0 >= f2);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext half %{{.+}} to float
@@ -780,11 +780,11 @@ void foo(void) {
 
   test = (f0 >= h2);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = fpext half %{{.+}} to float
@@ -795,11 +795,11 @@ void foo(void) {
 
   test = (i0 >= h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NONATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -810,11 +810,11 @@ void foo(void) {
 
   test = (h0 >= i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half
@@ -824,10 +824,10 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.+}} = fcmp oge half %{{.+}}, %[[#RHS]]
 
   test = (h1 == h2);
-  //      NONATIVE: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp oeq half %{{.+}}, %{{.+}}
@@ -837,12 +837,12 @@ void foo(void) {
   test = (h1 == (_Float16)1.0);
   //      NONATIVE: %[[#A:]] = cir.const #cir.fp<1.000000e+00> : !cir.double
   // NONATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<1.000000e+00> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // NATIVE-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp oeq half %{{.+}}, 0xH3C00
@@ -851,11 +851,11 @@ void foo(void) {
 
   test = (h1 == f1);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext half %{{.+}} to float
@@ -866,11 +866,11 @@ void foo(void) {
 
   test = (f1 == h1);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = fpext half %{{.+}} to float
@@ -881,11 +881,11 @@ void foo(void) {
 
   test = (i0 == h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NONATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -896,11 +896,11 @@ void foo(void) {
 
   test = (h0 == i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half
@@ -910,10 +910,10 @@ void foo(void) {
   // NATIVE-LLVM-NEXT: %{{.=}} = fcmp oeq half %{{.+}}, %[[#RHS]]
 
   test = (h1 != h2);
-  //      NONATIVE: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
-  //      NATIVE: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp une half %{{.+}}, %{{.+}}
@@ -922,12 +922,12 @@ void foo(void) {
 
   test = (h1 != (_Float16)1.0);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.double), !cir.f16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.const #cir.fp<1.000000e+00> : !cir.double
   // NATIVE-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // NATIVE-NEXT: %[[#C:]] = cir.cmp(ne, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#C:]] = cir.cmp(ne, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %{{.+}} = fcmp une half %{{.+}}, 0xH3C00
@@ -936,11 +936,11 @@ void foo(void) {
 
   test = (h1 != f1);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NONATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      NATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = fpext half %{{.+}} to float
@@ -951,11 +951,11 @@ void foo(void) {
 
   test = (f1 != h1);
   //      NONATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#A:]] = fpext half %{{.+}} to float
@@ -966,11 +966,11 @@ void foo(void) {
 
   test = (i0 != h0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NONATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NONATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      NATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      NATIVE: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // NONATIVE-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -981,11 +981,11 @@ void foo(void) {
 
   test = (h0 != i0);
   //      NONATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NONATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NONATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NATIVE: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // NATIVE-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // NATIVE-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      NONATIVE-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half

--- a/clang/test/CIR/CodeGen/fp16-ops.c
+++ b/clang/test/CIR/CodeGen/fp16-ops.c
@@ -228,7 +228,7 @@ void foo(void) {
   // CHECK-LLVM-NEXT: %{{.+}} = fsub half %{{.+}}, %[[#A]]
 
   test = (h2 < h0);
-  //      CHECK: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#A:]] = cir.cmp(lt, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp olt half %{{.+}}, %{{.+}}
@@ -236,14 +236,14 @@ void foo(void) {
   test = (h2 < (__fp16)42.0);
   //      CHECK: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // CHECK-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // CHECK-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#C:]] = cir.cmp(lt, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp olt half %{{.+}}, 0xH5140
 
   test = (h2 < f0);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      CHECK: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#A:]] = fpext half %{{.+}} to float
@@ -251,7 +251,7 @@ void foo(void) {
 
   test = (f2 < h0);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#A:]] = fpext half %{{.=}} to float
@@ -259,7 +259,7 @@ void foo(void) {
 
   test = (i0 < h0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      CHECK: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(lt, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#A:]] = sitofp i32 %{{.+}} to half
@@ -267,14 +267,14 @@ void foo(void) {
 
   test = (h0 < i0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(lt, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#A:]] = sitofp i32 %{{.+}} to half
   // CHECK-LLVM-NEXT: %{{.+}} = fcmp olt half %{{.+}}, %[[#A]]
 
   test = (h0 > h2);
-  //      CHECK: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#A:]] = cir.cmp(gt, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp ogt half %{{.+}}, %{{.+}}
@@ -282,14 +282,14 @@ void foo(void) {
   test = ((__fp16)42.0 > h2);
   //      CHECK: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // CHECK-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  //      CHECK: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#C:]] = cir.cmp(gt, %[[#B]], %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp ogt half 0xH5140, %{{.+}}
 
   test = (h0 > f2);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      CHECK: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = fpext half %{{.=}} to float
@@ -297,7 +297,7 @@ void foo(void) {
 
   test = (f0 > h2);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = fpext half %{{.+}} to float
@@ -305,7 +305,7 @@ void foo(void) {
 
   test = (i0 > h0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      CHECK: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(gt, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -313,14 +313,14 @@ void foo(void) {
 
   test = (h0 > i0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(gt, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half
   // CHECK-LLVM-NEXT: %{{.+}} = fcmp ogt half %{{.+}}, %[[#RHS]]
 
   test = (h2 <= h0);
-  //      CHECK: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#A:]] = cir.cmp(le, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp ole half %{{.+}}, %{{.+}}
@@ -328,14 +328,14 @@ void foo(void) {
   test = (h2 <= (__fp16)42.0);
   //      CHECK: %[[#A:]] = cir.const #cir.fp<4.200000e+01> : !cir.double
   // CHECK-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // CHECK-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#C:]] = cir.cmp(le, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp ole half %{{.+}}, 0xH5140
 
   test = (h2 <= f0);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      CHECK: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = fpext half %{{.+}} to float
@@ -343,7 +343,7 @@ void foo(void) {
 
   test = (f2 <= h0);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = fpext half %{{.+}} to float
@@ -351,7 +351,7 @@ void foo(void) {
 
   test = (i0 <= h0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      CHECK: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(le, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -359,14 +359,14 @@ void foo(void) {
 
   test = (h0 <= i0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(le, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half
   // CHECK-LLVM-NEXT: %{{.+}} = fcmp ole half %{{.+}}, %[[#RHS]]
 
   test = (h0 >= h2);
-  //      CHECK: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#A:]] = cir.cmp(ge, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp oge half %{{.+}}, %{{.+}}
@@ -375,14 +375,14 @@ void foo(void) {
   //      CHECK: %[[#A:]] = cir.const #cir.fp<2.000000e+00> : !cir.double
   // CHECK-NEXT: %[[#B:]] = cir.unary(minus, %[[#A]]) : !cir.double, !cir.double
   // CHECK-NEXT: %[[#C:]] = cir.cast(floating, %[[#B]] : !cir.double), !cir.f16
-  // CHECK-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#D:]] = cir.cmp(ge, %{{.+}}, %[[#C]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#D]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp oge half %{{.+}}, 0xHC000
 
   test = (h0 >= f2);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      CHECK: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = fpext half %{{.+}} to float
@@ -390,7 +390,7 @@ void foo(void) {
 
   test = (f0 >= h2);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = fpext half %{{.+}} to float
@@ -398,7 +398,7 @@ void foo(void) {
 
   test = (i0 >= h0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      CHECK: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(ge, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -406,14 +406,14 @@ void foo(void) {
 
   test = (h0 >= i0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(ge, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half
   // CHECK-LLVM-NEXT: %{{.+}} = fcmp oge half %{{.+}}, %[[#RHS]]
 
   test = (h1 == h2);
-  //      CHECK: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#A:]] = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp oeq half %{{.+}}, %{{.+}}
@@ -421,14 +421,14 @@ void foo(void) {
   test = (h1 == (__fp16)1.0);
   //      CHECK: %[[#A:]] = cir.const #cir.fp<1.000000e+00> : !cir.double
   // CHECK-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // CHECK-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#C:]] = cir.cmp(eq, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp oeq half %{{.+}}, 0xH3C00
 
   test = (h1 == f1);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      CHECK: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = fpext half %{{.+}} to float
@@ -436,7 +436,7 @@ void foo(void) {
 
   test = (f1 == h1);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = fpext half %{{.+}} to float
@@ -444,7 +444,7 @@ void foo(void) {
 
   test = (i0 == h0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      CHECK: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(eq, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -452,14 +452,14 @@ void foo(void) {
 
   test = (h0 == i0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(eq, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half
   // CHECK-LLVM-NEXT: %{{.=}} = fcmp oeq half %{{.+}}, %[[#RHS]]
 
   test = (h1 != h2);
-  //      CHECK: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#A:]] = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#A]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp une half %{{.+}}, %{{.+}}
@@ -467,14 +467,14 @@ void foo(void) {
   test = (h1 != (__fp16)1.0);
   //      CHECK: %[[#A:]] = cir.const #cir.fp<1.000000e+00> : !cir.double
   // CHECK-NEXT: %[[#B:]] = cir.cast(floating, %[[#A]] : !cir.double), !cir.f16
-  // CHECK-NEXT: %[[#C:]] = cir.cmp(ne, %{{.+}}, %[[#B]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#C:]] = cir.cmp(ne, %{{.+}}, %[[#B]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#C]] : !s32i), !u32i
 
   // CHECK-LLVM: %{{.+}} = fcmp une half %{{.+}}, 0xH3C00
 
   test = (h1 != f1);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  //      CHECK: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = fpext half %{{.=}} to float
@@ -482,7 +482,7 @@ void foo(void) {
 
   test = (f1 != h1);
   //      CHECK: %[[#A:]] = cir.cast(floating, %{{.+}} : !cir.f16), !cir.float
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.float, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#A:]] = fpext half %{{.+}} to float
@@ -490,7 +490,7 @@ void foo(void) {
 
   test = (i0 != h0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  //      CHECK: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.f16, !s32i
+  //      CHECK: %[[#B:]] = cir.cmp(ne, %[[#A]], %{{.+}}) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   // CHECK-LLVM: %[[#LHS:]] = sitofp i32 %{{.+}} to half
@@ -498,7 +498,7 @@ void foo(void) {
 
   test = (h0 != i0);
   //      CHECK: %[[#A:]] = cir.cast(int_to_float, %{{.+}} : !s32i), !cir.f16
-  // CHECK-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.f16, !s32i
+  // CHECK-NEXT: %[[#B:]] = cir.cmp(ne, %{{.+}}, %[[#A]]) : !cir.f16, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.cast(integral, %[[#B]] : !s32i), !u32i
 
   //      CHECK-LLVM: %[[#RHS:]] = sitofp i32 %{{.+}} to half

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1437,3 +1437,13 @@ cir.global external @f = #cir.fp<0x7FC00000 : !cir.float> : !cir.float
 // expected-error @below {{unexpected decimal integer literal for a floating point value}}
 // expected-note @below {{add a trailing dot to make the literal a float}}
 cir.global external @f = #cir.fp<42> : !cir.float
+
+// -----
+
+// Verify
+!s32i = !cir.int<s, 32>
+cir.func @cast0(%arg0: !s32i, %arg1: !s32i) {
+  // expected-error @below {{custom op 'cir.cmp' invalid kind of Type specified}}
+  %1 = cir.cmp(eq, %arg0, %arg1): !s32i, !s32i
+  cir.return
+}

--- a/clang/test/CIR/Lowering/ThroughMLIR/doWhile.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/doWhile.c
@@ -43,10 +43,7 @@ void nestedDoWhile() {
 // CHECK:     %[[VAR4:.+]] = memref.load %[[ALLOC1]][] : memref<i32>
 // CHECK:     %[[C10_I32:.+]] = arith.constant 10 : i32
 // CHECK:     %[[CMP:.+]] = arith.cmpi sle, %[[VAR4]], %[[C10_I32]] : i32
-// CHECK:     %[[EXT:.+]] = arith.extui %[[CMP]] : i1 to i32
-// CHECK:     %[[C0_I32_3:.+]] = arith.constant 0 : i32
-// CHECK:     %[[NE:.+]] = arith.cmpi ne, %[[EXT]], %[[C0_I32_3]] : i32
-// CHECK:     %[[EXT1:.+]] = arith.extui %[[NE]] : i1 to i8
+// CHECK:     %[[EXT1:.+]] = arith.extui %[[CMP]] : i1 to i8
 // CHECK:     %[[TRUNC:.+]] = arith.trunci %[[EXT1]] : i8 to i1
 // CHECK:     scf.condition(%[[TRUNC]])
 // CHECK:   } do {
@@ -59,49 +56,43 @@ void nestedDoWhile() {
 // CHECK: return %[[RET]] : i32
 
 // CHECK: func.func @nestedDoWhile() {
-// CHECK:     %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32> 
-// CHECK:     %[[C0_I32:.+]] = arith.constant 0 : i32 
-// CHECK:     memref.store %[[C0_I32]], %[[alloca]][] : memref<i32> 
+// CHECK:     %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+// CHECK:     %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK:     memref.store %[[C0_I32]], %[[alloca]][] : memref<i32>
 // CHECK:     memref.alloca_scope  {
-// CHECK:       %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32> 
+// CHECK:       %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
 // CHECK:       scf.while : () -> () {
-// CHECK:         %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32> 
-// CHECK:         %[[C1_I32:.+]] = arith.constant 1 : i32 
-// CHECK:         %[[ONE:.+]] = arith.addi %[[ZERO]], %[[C1_I32]] : i32 
-// CHECK:         memref.store %[[ONE]], %[[alloca]][] : memref<i32> 
-// CHECK:         %[[C0_I32_1:.+]] = arith.constant 0 : i32 
-// CHECK:         memref.store %[[C0_I32_1]], %[[alloca_0]][] : memref<i32> 
+// CHECK:         %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+// CHECK:         %[[C1_I32:.+]] = arith.constant 1 : i32
+// CHECK:         %[[ONE:.+]] = arith.addi %[[ZERO]], %[[C1_I32]] : i32
+// CHECK:         memref.store %[[ONE]], %[[alloca]][] : memref<i32>
+// CHECK:         %[[C0_I32_1:.+]] = arith.constant 0 : i32
+// CHECK:         memref.store %[[C0_I32_1]], %[[alloca_0]][] : memref<i32>
 // CHECK:         memref.alloca_scope  {
 // CHECK:           scf.while : () -> () {
-// CHECK:             %[[EIGHT:.+]] = memref.load %[[alloca_0]][] : memref<i32> 
-// CHECK:             %[[C2_I32_3:.+]] = arith.constant 2 : i32 
-// CHECK:             %[[NINE:.+]] = arith.cmpi slt, %[[EIGHT]], %[[C2_I32_3]] : i32 
-// CHECK:             %[[TEN:.+]] = arith.extui %9 : i1 to i32 
-// CHECK:             %[[C0_I32_4:.+]] = arith.constant 0 : i32 
-// CHECK:             %[[ELEVEN:.+]] = arith.cmpi ne, %[[TEN]], %[[C0_I32_4]] : i32 
-// CHECK:             %[[TWELVE:.+]] = arith.extui %[[ELEVEN]] : i1 to i8 
-// CHECK:             %[[THIRTEEN:.+]] = arith.trunci %[[TWELVE]] : i8 to i1 
-// CHECK:             scf.condition(%[[THIRTEEN]]) 
+// CHECK:             %[[EIGHT:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+// CHECK:             %[[C2_I32_3:.+]] = arith.constant 2 : i32
+// CHECK:             %[[NINE:.+]] = arith.cmpi slt, %[[EIGHT]], %[[C2_I32_3]] : i32
+// CHECK:             %[[TWELVE:.+]] = arith.extui %[[NINE]] : i1 to i8
+// CHECK:             %[[THIRTEEN:.+]] = arith.trunci %[[TWELVE]] : i8 to i1
+// CHECK:             scf.condition(%[[THIRTEEN]])
 // CHECK:           } do {
-// CHECK:             %[[EIGHT]] = memref.load %[[alloca_0]][] : memref<i32> 
-// CHECK:             %[[C1_I32_3:.+]] = arith.constant 1 : i32 
-// CHECK:             %[[NINE]] = arith.addi %[[EIGHT]], %[[C1_I32_3]] : i32 
-// CHECK:             memref.store %[[NINE]], %[[alloca_0]][] : memref<i32> 
-// CHECK:             scf.yield 
-// CHECK:           } 
-// CHECK:         } 
-// CHECK:         %[[TWO:.+]] = memref.load %[[alloca]][] : memref<i32> 
-// CHECK:         %[[C2_I32:.+]] = arith.constant 2 : i32 
-// CHECK:         %[[THREE:.+]] = arith.cmpi slt, %[[TWO]], %[[C2_I32]] : i32 
-// CHECK:         %[[FOUR:.+]] = arith.extui %[[THREE]] : i1 to i32 
-// CHECK:         %[[C0_I32_2:.+]] = arith.constant 0 : i32 
-// CHECK:         %[[FIVE:.+]] = arith.cmpi ne, %[[FOUR]], %[[C0_I32_2]] : i32 
-// CHECK:         %[[SIX:.+]] = arith.extui %[[FIVE]] : i1 to i8 
-// CHECK:         %[[SEVEN:.+]] = arith.trunci %[[SIX]] : i8 to i1 
-// CHECK:         scf.condition(%[[SEVEN]]) 
+// CHECK:             %[[EIGHT]] = memref.load %[[alloca_0]][] : memref<i32>
+// CHECK:             %[[C1_I32_3:.+]] = arith.constant 1 : i32
+// CHECK:             %[[NINE]] = arith.addi %[[EIGHT]], %[[C1_I32_3]] : i32
+// CHECK:             memref.store %[[NINE]], %[[alloca_0]][] : memref<i32>
+// CHECK:             scf.yield
+// CHECK:           }
+// CHECK:         }
+// CHECK:         %[[TWO:.+]] = memref.load %[[alloca]][] : memref<i32>
+// CHECK:         %[[C2_I32:.+]] = arith.constant 2 : i32
+// CHECK:         %[[THREE:.+]] = arith.cmpi slt, %[[TWO]], %[[C2_I32]] : i32
+// CHECK:         %[[SIX:.+]] = arith.extui %[[THREE]] : i1 to i8
+// CHECK:         %[[SEVEN:.+]] = arith.trunci %[[SIX]] : i8 to i1
+// CHECK:         scf.condition(%[[SEVEN]])
 // CHECK:       } do {
-// CHECK:         scf.yield 
-// CHECK:       } 
-// CHECK:     } 
-// CHECK:     return 
-// CHECK:   } 
+// CHECK:         scf.yield
+// CHECK:       }
+// CHECK:     }
+// CHECK:     return
+// CHECK:   }

--- a/clang/test/CIR/Lowering/ThroughMLIR/if.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/if.c
@@ -13,34 +13,31 @@ void foo() {
 
 //CHECK: func.func @foo() {
 //CHECK:   %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
-//CHECK:   %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32> 
-//CHECK:   %[[C2_I32:.+]] = arith.constant 2 : i32 
-//CHECK:   memref.store %[[C2_I32]], %[[alloca]][] : memref<i32> 
-//CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32 
-//CHECK:   memref.store %[[C0_I32]], %[[alloca_0]][] : memref<i32> 
+//CHECK:   %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+//CHECK:   %[[C2_I32:.+]] = arith.constant 2 : i32
+//CHECK:   memref.store %[[C2_I32]], %[[alloca]][] : memref<i32>
+//CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32
+//CHECK:   memref.store %[[C0_I32]], %[[alloca_0]][] : memref<i32>
 //CHECK:   memref.alloca_scope  {
-//CHECK:     %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32> 
-//CHECK:     %[[C0_I32_1:.+]] = arith.constant 0 : i32 
-//CHECK:     %[[ONE:.+]] = arith.cmpi sgt, %[[ZERO]], %[[C0_I32_1]] : i32 
-//CHECK:     %[[TWO:.+]] = arith.extui %[[ONE]] : i1 to i32 
-//CHECK:     %[[C0_I32_2:.+]] = arith.constant 0 : i32 
-//CHECK:     %[[THREE:.+]] = arith.cmpi ne, %[[TWO]], %[[C0_I32_2]] : i32 
-//CHECK:     %[[FOUR:.+]] = arith.extui %[[THREE]] : i1 to i8 
-//CHECK:     %[[FIVE:.+]] = arith.trunci %[[FOUR]] : i8 to i1 
+//CHECK:     %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+//CHECK:     %[[C0_I32_1:.+]] = arith.constant 0 : i32
+//CHECK:     %[[ONE:.+]] = arith.cmpi sgt, %[[ZERO]], %[[C0_I32_1]] : i32
+//CHECK:     %[[FOUR:.+]] = arith.extui %[[ONE]] : i1 to i8
+//CHECK:     %[[FIVE:.+]] = arith.trunci %[[FOUR]] : i8 to i1
 //CHECK:     scf.if %[[FIVE]] {
-//CHECK:       %[[SIX:.+]] = memref.load %[[alloca_0]][] : memref<i32> 
-//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32 
-//CHECK:       %[[SEVEN:.+]] = arith.addi %[[SIX]], %[[C1_I32]] : i32 
-//CHECK:       memref.store %[[SEVEN]], %[[alloca_0]][] : memref<i32> 
+//CHECK:       %[[SIX:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32
+//CHECK:       %[[SEVEN:.+]] = arith.addi %[[SIX]], %[[C1_I32]] : i32
+//CHECK:       memref.store %[[SEVEN]], %[[alloca_0]][] : memref<i32>
 //CHECK:     } else {
-//CHECK:       %[[SIX:.+]] = memref.load %[[alloca_0]][] : memref<i32> 
-//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32 
-//CHECK:       %[[SEVEN:.+]] = arith.subi %[[SIX]], %[[C1_I32]] : i32 
-//CHECK:       memref.store %[[SEVEN]], %[[alloca_0]][] : memref<i32> 
-//CHECK:     } 
-//CHECK:   } 
-//CHECK:   return 
-//CHECK: } 
+//CHECK:       %[[SIX:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32
+//CHECK:       %[[SEVEN:.+]] = arith.subi %[[SIX]], %[[C1_I32]] : i32
+//CHECK:       memref.store %[[SEVEN]], %[[alloca_0]][] : memref<i32>
+//CHECK:     }
+//CHECK:   }
+//CHECK:   return
+//CHECK: }
 
 void foo2() {
   int a = 2;
@@ -51,30 +48,27 @@ void foo2() {
 }
 
 //CHECK: func.func @foo2() {
-//CHECK:   %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32> 
-//CHECK:   %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32> 
-//CHECK:   %[[C2_I32:.+]] = arith.constant 2 : i32 
-//CHECK:   memref.store %[[C2_I32]], %[[alloca]][] : memref<i32> 
-//CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32 
-//CHECK:   memref.store %[[C0_I32]], %[[alloca_0]][] : memref<i32> 
+//CHECK:   %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+//CHECK:   %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+//CHECK:   %[[C2_I32:.+]] = arith.constant 2 : i32
+//CHECK:   memref.store %[[C2_I32]], %[[alloca]][] : memref<i32>
+//CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32
+//CHECK:   memref.store %[[C0_I32]], %[[alloca_0]][] : memref<i32>
 //CHECK:   memref.alloca_scope  {
-//CHECK:     %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32> 
-//CHECK:     %[[C3_I32:.+]] = arith.constant 3 : i32 
-//CHECK:     %[[ONE:.+]] = arith.cmpi slt, %[[ZERO]], %[[C3_I32]] : i32 
-//CHECK:     %[[TWO:.+]] = arith.extui %[[ONE]] : i1 to i32 
-//CHECK:     %[[C0_I32_1]] = arith.constant 0 : i32 
-//CHECK:     %[[THREE:.+]] = arith.cmpi ne, %[[TWO]], %[[C0_I32_1]] : i32 
-//CHECK:     %[[FOUR:.+]] = arith.extui %[[THREE]] : i1 to i8 
-//CHECK:     %[[FIVE]] = arith.trunci %[[FOUR]] : i8 to i1 
+//CHECK:     %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+//CHECK:     %[[C3_I32:.+]] = arith.constant 3 : i32
+//CHECK:     %[[ONE:.+]] = arith.cmpi slt, %[[ZERO]], %[[C3_I32]] : i32
+//CHECK:     %[[FOUR:.+]] = arith.extui %[[ONE]] : i1 to i8
+//CHECK:     %[[FIVE]] = arith.trunci %[[FOUR]] : i8 to i1
 //CHECK:     scf.if %[[FIVE]] {
-//CHECK:       %[[SIX:.+]] = memref.load %[[alloca_0]][] : memref<i32> 
-//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32 
-//CHECK:       %[[SEVEN:.+]] = arith.addi %[[SIX]], %[[C1_I32]] : i32 
-//CHECK:       memref.store %[[SEVEN]], %[[alloca_0]][] : memref<i32> 
-//CHECK:     } 
-//CHECK:   } 
-//CHECK:   return 
-//CHECK: } 
+//CHECK:       %[[SIX:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32
+//CHECK:       %[[SEVEN:.+]] = arith.addi %[[SIX]], %[[C1_I32]] : i32
+//CHECK:       memref.store %[[SEVEN]], %[[alloca_0]][] : memref<i32>
+//CHECK:     }
+//CHECK:   }
+//CHECK:   return
+//CHECK: }
 
 void foo3() {
   int a = 2;
@@ -93,45 +87,39 @@ void foo3() {
 //CHECK: func.func @foo3() {
 //CHECK:   %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
 //CHECK:   %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
-//CHECK:   %[[C2_I32:.+]] = arith.constant 2 : i32 
-//CHECK:   memref.store %[[C2_I32]], %[[alloca]][] : memref<i32> 
-//CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32 
-//CHECK:   memref.store %[[C0_I32]], %[[alloca_0]][] : memref<i32> 
+//CHECK:   %[[C2_I32:.+]] = arith.constant 2 : i32
+//CHECK:   memref.store %[[C2_I32]], %[[alloca]][] : memref<i32>
+//CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32
+//CHECK:   memref.store %[[C0_I32]], %[[alloca_0]][] : memref<i32>
 //CHECK:   memref.alloca_scope  {
-//CHECK:     %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32> 
-//CHECK:     %[[C3_I32:.+]] = arith.constant 3 : i32 
-//CHECK:     %[[ONE:.+]] = arith.cmpi slt, %[[ZERO]], %[[C3_I32]] : i32 
-//CHECK:     %[[TWO:.+]] = arith.extui %[[ONE]] : i1 to i32 
-//CHECK:     %[[C0_I32_1:.+]] = arith.constant 0 : i32 
-//CHECK:     %[[THREE:.+]] = arith.cmpi ne, %[[TWO:.+]], %[[C0_I32_1]] : i32 
-//CHECK:     %[[FOUR:.+]] = arith.extui %[[THREE]] : i1 to i8 
-//CHECK:     %[[FIVE]] = arith.trunci %[[FOUR]] : i8 to i1 
+//CHECK:     %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+//CHECK:     %[[C3_I32:.+]] = arith.constant 3 : i32
+//CHECK:     %[[ONE:.+]] = arith.cmpi slt, %[[ZERO]], %[[C3_I32]] : i32
+//CHECK:     %[[FOUR:.+]] = arith.extui %[[ONE]] : i1 to i8
+//CHECK:     %[[FIVE]] = arith.trunci %[[FOUR]] : i8 to i1
 //CHECK:     scf.if %[[FIVE]] {
-//CHECK:       %[[alloca_2:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32> 
-//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32 
-//CHECK:       memref.store %[[C1_I32]], %[[alloca_2]][] : memref<i32> 
+//CHECK:       %[[alloca_2:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32
+//CHECK:       memref.store %[[C1_I32]], %[[alloca_2]][] : memref<i32>
 //CHECK:       memref.alloca_scope  {
-//CHECK:         %[[SIX:.+]] = memref.load %[[alloca_2]][] : memref<i32> 
-//CHECK:         %[[C2_I32_3:.+]] = arith.constant 2 : i32 
-//CHECK:         %[[SEVEN:.+]] = arith.cmpi sgt, %[[SIX]], %[[C2_I32_3]] : i32 
-//CHECK:         %[[EIGHT:.+]] = arith.extui %[[SEVEN]] : i1 to i32 
-//CHECK:         %[[C0_I32_4:.+]] = arith.constant 0 : i32 
-//CHECK:         %[[NINE:.+]] = arith.cmpi ne, %[[EIGHT]], %[[C0_I32_4]] : i32 
-//CHECK:         %[[TEN:.+]] = arith.extui %[[NINE]] : i1 to i8 
-//CHECK:         %[[ELEVEN:.+]] = arith.trunci %[[TEN]] : i8 to i1 
+//CHECK:         %[[SIX:.+]] = memref.load %[[alloca_2]][] : memref<i32>
+//CHECK:         %[[C2_I32_3:.+]] = arith.constant 2 : i32
+//CHECK:         %[[SEVEN:.+]] = arith.cmpi sgt, %[[SIX]], %[[C2_I32_3]] : i32
+//CHECK:         %[[TEN:.+]] = arith.extui %[[SEVEN]] : i1 to i8
+//CHECK:         %[[ELEVEN:.+]] = arith.trunci %[[TEN]] : i8 to i1
 //CHECK:         scf.if %[[ELEVEN]] {
-//CHECK:           %[[TWELVE:.+]] = memref.load %[[alloca_0]][] : memref<i32> 
-//CHECK:           %[[C1_I32_5:.+]] = arith.constant 1 : i32 
-//CHECK:           %[[THIRTEEN:.+]] = arith.addi %[[TWELVE]], %[[C1_I32_5]] : i32 
-//CHECK:           memref.store %[[THIRTEEN]], %[[alloca_0]][] : memref<i32> 
+//CHECK:           %[[TWELVE:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+//CHECK:           %[[C1_I32_5:.+]] = arith.constant 1 : i32
+//CHECK:           %[[THIRTEEN:.+]] = arith.addi %[[TWELVE]], %[[C1_I32_5]] : i32
+//CHECK:           memref.store %[[THIRTEEN]], %[[alloca_0]][] : memref<i32>
 //CHECK:         } else {
-//CHECK:           %[[TWELVE:.+]] = memref.load %[[alloca_0]][] : memref<i32> 
-//CHECK:           %[[C1_I32_5:.+]] = arith.constant 1 : i32 
-//CHECK:           %[[THIRTEEN:.+]] = arith.subi %[[TWELVE]], %[[C1_I32_5]] : i32 
-//CHECK:           memref.store %[[THIRTEEN]], %[[alloca_0]][] : memref<i32> 
-//CHECK:         } 
-//CHECK:       } 
-//CHECK:     } 
-//CHECK:   } 
-//CHECK:   return 
-//CHECK: } 
+//CHECK:           %[[TWELVE:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+//CHECK:           %[[C1_I32_5:.+]] = arith.constant 1 : i32
+//CHECK:           %[[THIRTEEN:.+]] = arith.subi %[[TWELVE]], %[[C1_I32_5]] : i32
+//CHECK:           memref.store %[[THIRTEEN]], %[[alloca_0]][] : memref<i32>
+//CHECK:         }
+//CHECK:       }
+//CHECK:     }
+//CHECK:   }
+//CHECK:   return
+//CHECK: }

--- a/clang/test/CIR/Lowering/ThroughMLIR/while.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/while.c
@@ -21,75 +21,66 @@ void nestedWhile() {
 
 //CHECK: func.func @singleWhile() {
 //CHECK:   %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
-//CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32 
-//CHECK:   memref.store %[[C0_I32]], %[[alloca]][] : memref<i32> 
+//CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32
+//CHECK:   memref.store %[[C0_I32]], %[[alloca]][] : memref<i32>
 //CHECK:   memref.alloca_scope  {
 //CHECK:     scf.while : () -> () {
-//CHECK:       %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32> 
-//CHECK:       %[[C2_I32:.+]] = arith.constant 2 : i32 
-//CHECK:       %[[ONE:.+]] = arith.cmpi slt, %[[ZERO:.+]], %[[C2_I32]] : i32 
-//CHECK:       %[[TWO:.+]] = arith.extui %[[ONE:.+]] : i1 to i32 
-//CHECK:       %[[C0_I32_0:.+]] = arith.constant 0 : i32 
-//CHECK:       %[[THREE:.+]] = arith.cmpi ne, %[[TWO:.+]], %[[C0_I32_0]] : i32 
-//CHECK:       %[[FOUR:.+]] = arith.extui %[[THREE:.+]] : i1 to i8 
-//CHECK:       %[[FIVE:.+]] = arith.trunci %[[FOUR:.+]] : i8 to i1 
-//CHECK:       scf.condition(%[[FIVE]]) 
+//CHECK:       %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+//CHECK:       %[[C2_I32:.+]] = arith.constant 2 : i32
+//CHECK:       %[[ONE:.+]] = arith.cmpi slt, %[[ZERO:.+]], %[[C2_I32]] : i32
+//CHECK:       %[[FOUR:.+]] = arith.extui %[[ONE:.+]] : i1 to i8
+//CHECK:       %[[FIVE:.+]] = arith.trunci %[[FOUR:.+]] : i8 to i1
+//CHECK:       scf.condition(%[[FIVE]])
 //CHECK:     } do {
-//CHECK:       %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32> 
-//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32 
-//CHECK:       %[[ONE:.+]] = arith.addi %0, %[[C1_I32:.+]] : i32 
-//CHECK:       memref.store %[[ONE:.+]], %[[alloca]][] : memref<i32> 
-//CHECK:       scf.yield 
-//CHECK:     } 
-//CHECK:  } 
-//CHECK:   return 
-//CHECK: } 
+//CHECK:       %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32
+//CHECK:       %[[ONE:.+]] = arith.addi %0, %[[C1_I32:.+]] : i32
+//CHECK:       memref.store %[[ONE:.+]], %[[alloca]][] : memref<i32>
+//CHECK:       scf.yield
+//CHECK:     }
+//CHECK:  }
+//CHECK:   return
+//CHECK: }
 
 //CHECK: func.func @nestedWhile() {
 //CHECK:   %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
 //CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32
-//CHECK:   memref.store %[[C0_I32]], %[[alloca]][] : memref<i32> 
+//CHECK:   memref.store %[[C0_I32]], %[[alloca]][] : memref<i32>
 //CHECK:   memref.alloca_scope  {
-//CHECK:     %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32> 
+//CHECK:     %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
 //CHECK:     scf.while : () -> () {
-//CHECK:       %[[ZERO:.+]] = memref.load %alloca[] : memref<i32> 
-//CHECK:       %[[C2_I32:.+]] = arith.constant 2 : i32 
-//CHECK:       %[[ONE:.+]] = arith.cmpi slt, %[[ZERO]], %[[C2_I32]] : i32 
-//CHECK:       %[[TWO:.+]] = arith.extui %[[ONE]] : i1 to i32 
-//CHECK:       %[[C0_I32_1:.+]] = arith.constant 0 : i32 
-//CHECK:       %[[THREE:.+]] = arith.cmpi ne, %[[TWO]], %[[C0_I32_1]] : i32 
-//CHECK:       %[[FOUR:.+]] = arith.extui %[[THREE]] : i1 to i8 
-//CHECK:       %[[FIVE:.+]] = arith.trunci %[[FOUR]] : i8 to i1 
-//CHECK:       scf.condition(%[[FIVE]]) 
+//CHECK:       %[[ZERO:.+]] = memref.load %alloca[] : memref<i32>
+//CHECK:       %[[C2_I32:.+]] = arith.constant 2 : i32
+//CHECK:       %[[ONE:.+]] = arith.cmpi slt, %[[ZERO]], %[[C2_I32]] : i32
+//CHECK:       %[[FOUR:.+]] = arith.extui %[[ONE]] : i1 to i8
+//CHECK:       %[[FIVE:.+]] = arith.trunci %[[FOUR]] : i8 to i1
+//CHECK:       scf.condition(%[[FIVE]])
 //CHECK:     } do {
-//CHECK:         %[[C0_I32_1]] = arith.constant 0 : i32 
-//CHECK:         memref.store %[[C0_I32_1]], %[[alloca_0]][] : memref<i32> 
+//CHECK:         %[[C0_I32_1:.+]] = arith.constant 0 : i32
+//CHECK:         memref.store %[[C0_I32_1]], %[[alloca_0]][] : memref<i32>
 //CHECK:         memref.alloca_scope  {
 //CHECK:           scf.while : () -> () {
-//CHECK:             %[[TWO]] = memref.load %[[alloca_0]][] : memref<i32> 
-//CHECK:             %[[C2_I32]] = arith.constant 2 : i32 
-//CHECK:             %[[THREE]] = arith.cmpi slt, %[[TWO]], %[[C2_I32]] : i32 
-//CHECK:             %[[FOUR]] = arith.extui %[[THREE]] : i1 to i32 
-//CHECK:             %[[C0_I32_2:.+]] = arith.constant 0 : i32 
-//CHECK:             %[[FIVE]] = arith.cmpi ne, %[[FOUR]], %[[C0_I32_2]] : i32 
-//CHECK:             %[[SIX:.+]] = arith.extui %[[FIVE]] : i1 to i8 
-//CHECK:             %[[SEVEN:.+]] = arith.trunci %[[SIX]] : i8 to i1 
-//CHECK:             scf.condition(%[[SEVEN]]) 
+//CHECK:             %{{.*}} = memref.load %[[alloca_0]][] : memref<i32>
+//CHECK:             %[[C2_I32]] = arith.constant 2 : i32
+//CHECK:             %{{.*}} = arith.cmpi slt, %{{.*}}, %[[C2_I32]] : i32
+//CHECK:             %[[SIX:.+]] = arith.extui %{{.*}} : i1 to i8
+//CHECK:             %[[SEVEN:.+]] = arith.trunci %[[SIX]] : i8 to i1
+//CHECK:             scf.condition(%[[SEVEN]])
 //CHECK:           } do {
-//CHECK:             %[[TWO]] = memref.load %[[alloca_0]][] : memref<i32> 
-//CHECK:             %[[C1_I32_2:.+]] = arith.constant 1 : i32 
-//CHECK:             %[[THREE]] = arith.addi %[[TWO]], %[[C1_I32_2]] : i32 
-//CHECK:             memref.store %[[THREE]], %[[alloca_0]][] : memref<i32> 
-//CHECK:             scf.yield 
-//CHECK:           } 
-//CHECK:         } 
-//CHECK:         %[[ZERO]] = memref.load %[[alloca]][] : memref<i32> 
-//CHECK:         %[[C1_I32:.+]] = arith.constant 1 : i32 
-//CHECK:         %[[ONE]] = arith.addi %[[ZERO]], %[[C1_I32]] : i32 
-//CHECK:         memref.store %[[ONE]], %[[alloca]][] : memref<i32> 
-//CHECK:         scf.yield 
-//CHECK:       } 
-//CHECK:     } 
-//CHECK:     return 
-//CHECK:   } 
-//CHECK: } 
+//CHECK:             %{{.*}} = memref.load %[[alloca_0]][] : memref<i32>
+//CHECK:             %[[C1_I32_2:.+]] = arith.constant 1 : i32
+//CHECK:             %{{.*}} = arith.addi %{{.*}}, %[[C1_I32_2]] : i32
+//CHECK:             memref.store %{{.*}}, %[[alloca_0]][] : memref<i32>
+//CHECK:             scf.yield
+//CHECK:           }
+//CHECK:         }
+//CHECK:         %[[ZERO]] = memref.load %[[alloca]][] : memref<i32>
+//CHECK:         %[[C1_I32:.+]] = arith.constant 1 : i32
+//CHECK:         %[[ONE]] = arith.addi %[[ZERO]], %[[C1_I32]] : i32
+//CHECK:         memref.store %[[ONE]], %[[alloca]][] : memref<i32>
+//CHECK:         scf.yield
+//CHECK:       }
+//CHECK:     }
+//CHECK:     return
+//CHECK:   }
+//CHECK: }

--- a/clang/test/CIR/Lowering/dot.cir
+++ b/clang/test/CIR/Lowering/dot.cir
@@ -21,9 +21,8 @@ module {
       cir.for : cond {
         %10 = cir.load %8 : !cir.ptr<!s32i>, !s32i
         %11 = cir.load %2 : !cir.ptr<!s32i>, !s32i
-        %12 = cir.cmp(lt, %10, %11) : !s32i, !s32i
-        %13 = cir.cast(int_to_bool, %12 : !s32i), !cir.bool
-        cir.condition(%13)
+        %12 = cir.cmp(lt, %10, %11) : !s32i, !cir.bool
+        cir.condition(%12)
       } body {
         %10 = cir.load %0 : !cir.ptr<!cir.ptr<!cir.double>>, !cir.ptr<!cir.double>
         %11 = cir.load %8 : !cir.ptr<!s32i>, !s32i
@@ -79,10 +78,7 @@ module {
 // MLIR:           %[[VAL_17:.*]] = llvm.load %[[VAL_2]] {alignment = 4 : i64} : !llvm.ptr -> i32
 // MLIR:           %[[VAL_18:.*]] = llvm.load %[[VAL_8]] {alignment = 4 : i64} : !llvm.ptr -> i32
 // MLIR:           %[[VAL_19:.*]] = llvm.icmp "slt" %[[VAL_17]], %[[VAL_18]] : i32
-// MLIR:           %[[VAL_20:.*]] = llvm.zext %[[VAL_19]] : i1 to i32
-// MLIR:           %[[VAL_21:.*]] = llvm.mlir.constant(0 : i32) : i32
-// MLIR:           %[[VAL_22:.*]] = llvm.icmp "ne" %[[VAL_20]], %[[VAL_21]] : i32
-// MLIR:           llvm.cond_br %[[VAL_22]], ^bb3, ^bb5
+// MLIR:           llvm.cond_br %[[VAL_19]], ^bb3, ^bb5
 // MLIR:         ^bb3:
 // MLIR:           %[[VAL_23:.*]] = llvm.load %[[VAL_4]] {alignment = 8 : i64} : !llvm.ptr -> !llvm.ptr
 // MLIR:           %[[VAL_24:.*]] = llvm.load %[[VAL_2]] {alignment = 4 : i64} : !llvm.ptr -> i32

--- a/clang/test/CIR/Lowering/goto.cir
+++ b/clang/test/CIR/Lowering/goto.cir
@@ -3,7 +3,7 @@
 !s32i = !cir.int<s, 32>
 
 module {
-  
+
   cir.func @gotoFromIf(%arg0: !s32i) -> !s32i {
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
@@ -11,9 +11,8 @@ module {
     cir.scope {
       %6 = cir.load %0 : !cir.ptr<!s32i>, !s32i
       %7 = cir.const #cir.int<5> : !s32i
-      %8 = cir.cmp(gt, %6, %7) : !s32i, !s32i
-      %9 = cir.cast(int_to_bool, %8 : !s32i), !cir.bool
-      cir.if %9 {
+      %8 = cir.cmp(gt, %6, %7) : !s32i, !cir.bool
+      cir.if %8 {
         cir.goto "err"
       }
     }

--- a/clang/test/CIR/Lowering/loops-with-break.cir
+++ b/clang/test/CIR/Lowering/loops-with-break.cir
@@ -11,17 +11,15 @@ module {
       cir.for : cond {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<10> : !s32i
-        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       } body {
         cir.scope {
           cir.scope {
             %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
             %3 = cir.const #cir.int<5> : !s32i
-            %4 = cir.cmp(eq, %2, %3) : !s32i, !s32i
-            %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-            cir.if %5 {
+            %4 = cir.cmp(eq, %2, %3) : !s32i, !cir.bool
+            cir.if %4 {
               cir.break
             }
           }
@@ -73,9 +71,8 @@ module {
       cir.for : cond {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<10> : !s32i
-        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       } body {
         cir.scope {
           cir.scope {
@@ -85,17 +82,15 @@ module {
             cir.for : cond {
               %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
               %5 = cir.const #cir.int<10> : !s32i
-              %6 = cir.cmp(lt, %4, %5) : !s32i, !s32i
-              %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-              cir.condition(%7)
+              %6 = cir.cmp(lt, %4, %5) : !s32i, !cir.bool
+              cir.condition(%6)
             } body {
               cir.scope {
                 cir.scope {
                   %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
                   %5 = cir.const #cir.int<5> : !s32i
-                  %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
-                  %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-                  cir.if %7 {
+                  %6 = cir.cmp(eq, %4, %5) : !s32i, !cir.bool
+                  cir.if %6 {
                     cir.break
                   }
                 }
@@ -174,9 +169,8 @@ module {
       cir.while {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<10> : !s32i
-        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       } do {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.unary(inc, %2) : !s32i, !s32i
@@ -184,9 +178,8 @@ module {
         cir.scope {
           %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
           %5 = cir.const #cir.int<5> : !s32i
-          %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
-          %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-          cir.if %7 {
+          %6 = cir.cmp(eq, %4, %5) : !s32i, !cir.bool
+          cir.if %6 {
             cir.break
           }
         }
@@ -233,9 +226,8 @@ cir.func @testDoWhile() {
         cir.scope {
           %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
           %5 = cir.const #cir.int<5> : !s32i
-          %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
-          %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-          cir.if %7 {
+          %6 = cir.cmp(eq, %4, %5) : !s32i, !cir.bool
+          cir.if %6 {
             cir.break
           }
         }
@@ -243,9 +235,8 @@ cir.func @testDoWhile() {
       } while {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<10> : !s32i
-        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       }
     }
     cir.return

--- a/clang/test/CIR/Lowering/loops-with-continue.cir
+++ b/clang/test/CIR/Lowering/loops-with-continue.cir
@@ -11,17 +11,15 @@ module {
       cir.for : cond {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<10> : !s32i
-        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       } body {
         cir.scope {
           cir.scope {
             %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
             %3 = cir.const #cir.int<5> : !s32i
-            %4 = cir.cmp(eq, %2, %3) : !s32i, !s32i
-            %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-            cir.if %5 {
+            %4 = cir.cmp(eq, %2, %3) : !s32i, !cir.bool
+            cir.if %4 {
               cir.continue
             }
           }
@@ -74,9 +72,8 @@ module {
       cir.for : cond {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<10> : !s32i
-        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       } body {
         cir.scope {
           cir.scope {
@@ -86,17 +83,15 @@ module {
             cir.for : cond {
               %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
               %5 = cir.const #cir.int<10> : !s32i
-              %6 = cir.cmp(lt, %4, %5) : !s32i, !s32i
-              %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-              cir.condition(%7)
+              %6 = cir.cmp(lt, %4, %5) : !s32i, !cir.bool
+              cir.condition(%6)
             } body {
               cir.scope {
                 cir.scope {
                   %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
                   %5 = cir.const #cir.int<5> : !s32i
-                  %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
-                  %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-                  cir.if %7 {
+                  %6 = cir.cmp(eq, %4, %5) : !s32i, !cir.bool
+                  cir.if %6 {
                     cir.continue
                   }
                 }
@@ -174,9 +169,8 @@ cir.func @testWhile() {
       cir.while {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<10> : !s32i
-        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       } do {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.unary(inc, %2) : !s32i, !s32i
@@ -184,9 +178,8 @@ cir.func @testWhile() {
         cir.scope {
           %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
           %5 = cir.const #cir.int<5> : !s32i
-          %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
-          %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-          cir.if %7 {
+          %6 = cir.cmp(eq, %4, %5) : !s32i, !cir.bool
+          cir.if %6 {
             cir.continue
           }
         }
@@ -230,9 +223,8 @@ cir.func @testWhile() {
         cir.scope {
           %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
           %5 = cir.const #cir.int<5> : !s32i
-          %6 = cir.cmp(eq, %4, %5) : !s32i, !s32i
-          %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-          cir.if %7 {
+          %6 = cir.cmp(eq, %4, %5) : !s32i, !cir.bool
+          cir.if %6 {
             cir.continue
           }
         }
@@ -240,9 +232,8 @@ cir.func @testWhile() {
       } while {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<10> : !s32i
-        %4 = cir.cmp(lt, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(lt, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       }
     }
     cir.return

--- a/clang/test/CIR/Lowering/switch.cir
+++ b/clang/test/CIR/Lowering/switch.cir
@@ -154,9 +154,8 @@ module {
         cir.scope {
           %6 = cir.load %1 : !cir.ptr<!s32i>, !s32i
           %7 = cir.const #cir.int<0> : !s32i
-          %8 = cir.cmp(ge, %6, %7) : !s32i, !s32i
-          %9 = cir.cast(int_to_bool, %8 : !s32i), !cir.bool
-          cir.if %9 {
+          %8 = cir.cmp(ge, %6, %7) : !s32i, !cir.bool
+          cir.if %8 {
             cir.break
           }
         }

--- a/clang/test/CIR/Transforms/mem2reg.c
+++ b/clang/test/CIR/Transforms/mem2reg.c
@@ -41,9 +41,8 @@ void alloca_in_loop(int* ar, int n) {
 // BEFORE:      cir.for : cond {
 // BEFORE:        %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
 // BEFORE:        %5 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// BEFORE:        %6 = cir.cmp(lt, %4, %5) : !s32i, !s32i
-// BEFORE:        %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-// BEFORE:        cir.condition(%7)
+// BEFORE:        %6 = cir.cmp(lt, %4, %5) : !s32i, !cir.bool
+// BEFORE:        cir.condition(%6)
 // BEFORE:      } body {
 // BEFORE:        cir.scope {
 // BEFORE:          %4 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
@@ -71,21 +70,20 @@ void alloca_in_loop(int* ar, int n) {
 // MEM2REG:    %0 = cir.const #cir.int<0> : !s32i
 // MEM2REG:    cir.br ^bb2(%0 : !s32i)
 // MEM2REG:  ^bb2(%1: !s32i{{.*}}):  // 2 preds: ^bb1, ^bb6
-// MEM2REG:    %2 = cir.cmp(lt, %1, %arg1) : !s32i, !s32i
-// MEM2REG:    %3 = cir.cast(int_to_bool, %2 : !s32i), !cir.bool
-// MEM2REG:    cir.brcond %3 ^bb3, ^bb7
+// MEM2REG:    %2 = cir.cmp(lt, %1, %arg1) : !s32i, !cir.bool
+// MEM2REG:    cir.brcond %2 ^bb3, ^bb7
 // MEM2REG:  ^bb3:  // pred: ^bb2
 // MEM2REG:    cir.br ^bb4
 // MEM2REG:  ^bb4:  // pred: ^bb3
-// MEM2REG:    %4 = cir.const #cir.int<4> : !s32i
-// MEM2REG:    %5 = cir.ptr_stride(%arg0 : !cir.ptr<!s32i>, %1 : !s32i), !cir.ptr<!s32i>
-// MEM2REG:    cir.store %4, %5 : !s32i, !cir.ptr<!s32i>
+// MEM2REG:    %3 = cir.const #cir.int<4> : !s32i
+// MEM2REG:    %4 = cir.ptr_stride(%arg0 : !cir.ptr<!s32i>, %1 : !s32i), !cir.ptr<!s32i>
+// MEM2REG:    cir.store %3, %4 : !s32i, !cir.ptr<!s32i>
 // MEM2REG:    cir.br ^bb5
 // MEM2REG:  ^bb5:  // pred: ^bb4
 // MEM2REG:    cir.br ^bb6
 // MEM2REG:  ^bb6:  // pred: ^bb5
-// MEM2REG:    %6 = cir.unary(inc, %1) : !s32i, !s32i
-// MEM2REG:    cir.br ^bb2(%6 : !s32i)
+// MEM2REG:    %5 = cir.unary(inc, %1) : !s32i, !s32i
+// MEM2REG:    cir.br ^bb2(%5 : !s32i)
 // MEM2REG:  ^bb7:  // pred: ^bb2
 // MEM2REG:    cir.br ^bb8
 // MEM2REG:  ^bb8:  // pred: ^bb7
@@ -116,24 +114,23 @@ int alloca_in_ifelse(int x) {
 // BEFORE:    cir.scope {
 // BEFORE:      %9 = cir.load %0 : !cir.ptr<!s32i>, !s32i
 // BEFORE:      %10 = cir.const #cir.int<42> : !s32i
-// BEFORE:      %11 = cir.cmp(gt, %9, %10) : !s32i, !s32i
-// BEFORE:      %12 = cir.cast(int_to_bool, %11 : !s32i), !cir.bool
-// BEFORE:      cir.if %12 {
-// BEFORE:        %13 = cir.alloca !s32i, !cir.ptr<!s32i>, ["z", init] {alignment = 4 : i64}
-// BEFORE:        %14 = cir.const #cir.int<2> : !s32i
-// BEFORE:        cir.store %14, %13 : !s32i, !cir.ptr<!s32i>
-// BEFORE:        %15 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-// BEFORE:        %16 = cir.load %13 : !cir.ptr<!s32i>, !s32i
-// BEFORE:        %17 = cir.binop(mul, %15, %16) nsw : !s32i
-// BEFORE:        cir.store %17, %2 : !s32i, !cir.ptr<!s32i>
+// BEFORE:      %11 = cir.cmp(gt, %9, %10) : !s32i, !cir.bool
+// BEFORE:      cir.if %11 {
+// BEFORE:        %12 = cir.alloca !s32i, !cir.ptr<!s32i>, ["z", init] {alignment = 4 : i64}
+// BEFORE:        %13 = cir.const #cir.int<2> : !s32i
+// BEFORE:        cir.store %13, %12 : !s32i, !cir.ptr<!s32i>
+// BEFORE:        %14 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// BEFORE:        %15 = cir.load %12 : !cir.ptr<!s32i>, !s32i
+// BEFORE:        %16 = cir.binop(mul, %14, %15) nsw : !s32i
+// BEFORE:        cir.store %16, %2 : !s32i, !cir.ptr<!s32i>
 // BEFORE:      } else {
-// BEFORE:        %13 = cir.alloca !s32i, !cir.ptr<!s32i>, ["z", init] {alignment = 4 : i64}
-// BEFORE:        %14 = cir.const #cir.int<3> : !s32i
-// BEFORE:        cir.store %14, %13 : !s32i, !cir.ptr<!s32i>
-// BEFORE:        %15 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-// BEFORE:        %16 = cir.load %13 : !cir.ptr<!s32i>, !s32i
-// BEFORE:        %17 = cir.binop(mul, %15, %16) nsw : !s32i
-// BEFORE:        cir.store %17, %2 : !s32i, !cir.ptr<!s32i>
+// BEFORE:        %12 = cir.alloca !s32i, !cir.ptr<!s32i>, ["z", init] {alignment = 4 : i64}
+// BEFORE:        %13 = cir.const #cir.int<3> : !s32i
+// BEFORE:        cir.store %13, %12 : !s32i, !cir.ptr<!s32i>
+// BEFORE:        %14 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// BEFORE:        %15 = cir.load %12 : !cir.ptr<!s32i>, !s32i
+// BEFORE:        %16 = cir.binop(mul, %14, %15) nsw : !s32i
+// BEFORE:        cir.store %16, %2 : !s32i, !cir.ptr<!s32i>
 // BEFORE:     }
 // BEFORE:    }
 // BEFORE:    %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
@@ -150,23 +147,22 @@ int alloca_in_ifelse(int x) {
 // MEM2REG:    cir.br ^bb1
 // MEM2REG:  ^bb1:  // pred: ^bb0
 // MEM2REG:    %1 = cir.const #cir.int<42> : !s32i
-// MEM2REG:    %2 = cir.cmp(gt, %arg0, %1) : !s32i, !s32i
-// MEM2REG:    %3 = cir.cast(int_to_bool, %2 : !s32i), !cir.bool
-// MEM2REG:    cir.brcond %3 ^bb2, ^bb3
+// MEM2REG:    %2 = cir.cmp(gt, %arg0, %1) : !s32i, !cir.bool
+// MEM2REG:    cir.brcond %2 ^bb2, ^bb3
 // MEM2REG:  ^bb2:  // pred: ^bb1
-// MEM2REG:    %4 = cir.const #cir.int<2> : !s32i
-// MEM2REG:    %5 = cir.binop(mul, %arg0, %4) nsw : !s32i
-// MEM2REG:    cir.br ^bb4(%5 : !s32i)
+// MEM2REG:    %3 = cir.const #cir.int<2> : !s32i
+// MEM2REG:    %4 = cir.binop(mul, %arg0, %3) nsw : !s32i
+// MEM2REG:    cir.br ^bb4(%4 : !s32i)
 // MEM2REG:  ^bb3:  // pred: ^bb1
-// MEM2REG:    %6 = cir.const #cir.int<3> : !s32i
-// MEM2REG:    %7 = cir.binop(mul, %arg0, %6) nsw : !s32i
-// MEM2REG:    cir.br ^bb4(%7 : !s32i)
-// MEM2REG:  ^bb4(%8: !s32i{{.*}}):  // 2 preds: ^bb2, ^bb3
+// MEM2REG:    %5 = cir.const #cir.int<3> : !s32i
+// MEM2REG:    %6 = cir.binop(mul, %arg0, %5) nsw : !s32i
+// MEM2REG:    cir.br ^bb4(%6 : !s32i)
+// MEM2REG:  ^bb4(%7: !s32i{{.*}}):  // 2 preds: ^bb2, ^bb3
 // MEM2REG:    cir.br ^bb5
 // MEM2REG:  ^bb5:  // pred: ^bb4
-// MEM2REG:    %9 = cir.const #cir.int<1> : !s32i
-// MEM2REG:    %10 = cir.binop(add, %8, %9) nsw : !s32i
-// MEM2REG:    cir.return %10 : !s32i
+// MEM2REG:    %8 = cir.const #cir.int<1> : !s32i
+// MEM2REG:    %9 = cir.binop(add, %7, %8) nsw : !s32i
+// MEM2REG:    cir.return %9 : !s32i
 // MEM2REG:  }
 
 

--- a/clang/test/CIR/Transforms/scf-prepare.cir
+++ b/clang/test/CIR/Transforms/scf-prepare.cir
@@ -14,7 +14,7 @@ module {
     // CHECK: %[[BOUND:.*]] = cir.load %[[BOUND_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
     // CHECK: cir.for : cond {
     // CHECK:   %[[IV:.*]] = cir.load %[[IV_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
-    // CHECK:   %[[COND:.*]] = cir.cmp(lt, %[[IV]], %4) : !s32i, !s32i
+    // CHECK:   %[[COND:.*]] = cir.cmp(lt, %[[IV]], %4) : !s32i, !cir.bool
 
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["l", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["u", init] {alignment = 4 : i64}
@@ -27,9 +27,8 @@ module {
       cir.for : cond {
         %4 = cir.load %1 : !cir.ptr<!s32i>, !s32i
         %5 = cir.load %2 : !cir.ptr<!s32i>, !s32i
-        %6 = cir.cmp(gt, %4, %5) : !s32i, !s32i
-        %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-        cir.condition(%7)
+        %6 = cir.cmp(gt, %4, %5) : !s32i, !cir.bool
+        cir.condition(%6)
       } body {
         %4 = cir.const #cir.int<3> : !s32i
         %5 = cir.get_global @a : !cir.ptr<!cir.array<!s32i x 100>>
@@ -57,8 +56,8 @@ module {
     // CHECK: %[[BOUND:.*]] = cir.const #cir.int<50> : !s32i
     // CHECK: cir.for : cond {
     // CHECK:   %[[IV:.*]] = cir.load %[[IV_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
-    // CHECK:   %[[COND:.*]] = cir.cmp(le, %[[IV]], %[[BOUND]]) : !s32i, !s32i
- 
+    // CHECK:   %[[COND:.*]] = cir.cmp(le, %[[IV]], %[[BOUND]]) : !s32i, !cir.bool
+
     cir.scope {
       %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
       %1 = cir.const #cir.int<0> : !s32i
@@ -66,9 +65,8 @@ module {
       cir.for : cond {
         %2 = cir.const #cir.int<50> : !s32i
         %3 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-        %4 = cir.cmp(ge, %2, %3) : !s32i, !s32i
-        %5 = cir.cast(int_to_bool, %4 : !s32i), !cir.bool
-        cir.condition(%5)
+        %4 = cir.cmp(ge, %2, %3) : !s32i, !cir.bool
+        cir.condition(%4)
       } body {
         %2 = cir.const #cir.int<3> : !s32i
         %3 = cir.get_global @a : !cir.ptr<!cir.array<!s32i x 100>>
@@ -99,7 +97,7 @@ module {
     // CHECK: cir.for : cond {
     // CHECK:   %[[BOUND:.*]] = cir.load %[[BOUND_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
     // CHECK:   %[[IV:.*]] = cir.load %[[IV_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
-    // CHECK:   %[[COND:.*]] = cir.cmp(lt, %[[IV]], %[[BOUND]]) : !s32i, !s32i
+    // CHECK:   %[[COND:.*]] = cir.cmp(lt, %[[IV]], %[[BOUND]]) : !s32i, !cir.bool
 
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["l", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["u", init] {alignment = 4 : i64}
@@ -112,9 +110,8 @@ module {
       cir.for : cond {
         %4 = cir.load %1 : !cir.ptr<!s32i>, !s32i
         %5 = cir.load %2 : !cir.ptr<!s32i>, !s32i
-        %6 = cir.cmp(gt, %4, %5) : !s32i, !s32i
-        %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-        cir.condition(%7)
+        %6 = cir.cmp(gt, %4, %5) : !s32i, !cir.bool
+        cir.condition(%6)
       } body {
         cir.scope {
           %4 = cir.load %1 : !cir.ptr<!s32i>, !s32i
@@ -157,9 +154,8 @@ module {
         %3 = cir.const #cir.int<100> : !s32i
         %4 = cir.const #cir.int<1> : !s32i
         %5 = cir.binop(sub, %3, %4) nsw : !s32i
-        %6 = cir.cmp(lt, %2, %5) : !s32i, !s32i
-        %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-        cir.condition(%7)
+        %6 = cir.cmp(lt, %2, %5) : !s32i, !cir.bool
+        cir.condition(%6)
       } body {
         cir.scope {
         }
@@ -192,9 +188,8 @@ module {
         %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
         %3 = cir.const #cir.int<100> : !s32i
         %5 = cir.binop(sub, %3, %arg0) nsw : !s32i
-        %6 = cir.cmp(lt, %2, %5) : !s32i, !s32i
-        %7 = cir.cast(int_to_bool, %6 : !s32i), !cir.bool
-        cir.condition(%7)
+        %6 = cir.cmp(lt, %2, %5) : !s32i, !cir.bool
+        cir.condition(%6)
       } body {
         cir.scope {
         }

--- a/clang/test/CIR/Transforms/simpl.c
+++ b/clang/test/CIR/Transforms/simpl.c
@@ -18,8 +18,9 @@ int foo(int* ptr) {
 // BEFORE:  cir.func {{.*@foo}}
 // BEFORE:  [[X0:%.*]] = cir.load {{.*}} : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // BEFORE:  [[X1:%.*]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i>
-// BEFORE:  [[X2:%.*]] = cir.cmp(eq, [[X0]], [[X1]]) : !cir.ptr<!s32i>, !s32i
-// BEFORE:  [[X3:%.*]] = cir.cast(int_to_bool, [[X2]] : !s32i), !cir.bool
+// BEFORE:  [[X2:%.*]] = cir.cmp(eq, [[X0]], [[X1]]) : !cir.ptr<!s32i>, !cir.bool
+// BEFORE:  [[BOOL_TO_INT:%.*]] = cir.cast(bool_to_int, [[X2]] : !cir.bool), !s32i
+// BEFORE:  [[X3:%.*]] = cir.cast(int_to_bool, [[BOOL_TO_INT]] : !s32i), !cir.bool
 // BEFORE:  [[X4:%.*]] = cir.unary(not, [[X3]]) : !cir.bool, !cir.bool
 // BEFORE:  [[X5:%.*]] = cir.cast(bool_to_int, [[X4]] : !cir.bool), !s32i
 // BEFORE:  [[X6:%.*]] = cir.cast(int_to_bool, [[X5]] : !s32i), !cir.bool
@@ -33,6 +34,5 @@ int foo(int* ptr) {
 
 // AFTER:   [[X0:%.*]] = cir.load {{.*}} : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // AFTER:   [[X1:%.*]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i>
-// AFTER:   [[X2:%.*]] = cir.cmp(eq, [[X0]], [[X1]]) : !cir.ptr<!s32i>, !s32i
-// AFTER:   [[X3:%.*]] = cir.cast(int_to_bool, [[X2]] : !s32i), !cir.bool
-// AFTER:   cir.if [[X3]]
+// AFTER:   [[X2:%.*]] = cir.cmp(eq, [[X0]], [[X1]]) : !cir.ptr<!s32i>, !cir.bool
+// AFTER:   cir.if [[X2]]

--- a/clang/test/CIR/Transforms/switch.cir
+++ b/clang/test/CIR/Transforms/switch.cir
@@ -174,9 +174,8 @@ module {
         cir.scope {
           %6 = cir.load %1 : !cir.ptr<!s32i>, !s32i
           %7 = cir.const #cir.int<0> : !s32i
-          %8 = cir.cmp(ge, %6, %7) : !s32i, !s32i
-          %9 = cir.cast(int_to_bool, %8 : !s32i), !cir.bool
-          cir.if %9 {
+          %8 = cir.cmp(ge, %6, %7) : !s32i, !cir.bool
+          cir.if %8 {
             cir.break
           }
         }


### PR DESCRIPTION
It was always the intention for `cir.cmp` operations to return bool result. Due
to missing constraints, a bug in codegen has slipped in which created `cir.cmp`
operations with result type that matches the original AST expression type. In
C, as opposed to C++, boolean expression types are "int". This resulted with
extra operations being codegened around boolean expressions and their usage.

This commit both enforces `cir.cmp` in the op definition and fixes the
mentioned bug.