### PR TITLE
[CIR][ABI][Lowering] Fixes calls with union type

### DIFF
--- a/clang/test/CIR/CallConvLowering/AArch64/union.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/union.c
@@ -39,3 +39,33 @@ U init() {
   U u;
   return u;
 }
+
+typedef union {
+
+  struct {
+    short a;
+    char b;
+    char c;
+  };
+
+  int x;
+} A;
+
+void passA(A x) {}
+
+// CIR: cir.func {{.*@callA}}()
+// CIR:   %[[#V0:]] = cir.alloca !ty_A, !cir.ptr<!ty_A>, ["x"] {alignment = 4 : i64}
+// CIR:   %[[#V1:]] = cir.cast(bitcast, %[[#V0:]] : !cir.ptr<!ty_A>), !cir.ptr<!s32i>
+// CIR:   %[[#V2:]] = cir.load %[[#V1]] : !cir.ptr<!s32i>, !s32i
+// CIR:   %[[#V3:]] = cir.cast(integral, %[[#V2]] : !s32i), !u64i
+// CIR:   cir.call @passA(%[[#V3]]) : (!u64i) -> ()
+
+// LLVM: void @callA()
+// LLVM:   %[[#V0:]] = alloca %union.A, i64 1, align 4
+// LLVM:   %[[#V1:]] = load i32, ptr %[[#V0]], align 4
+// LLVM:   %[[#V2:]] = sext i32 %[[#V1]] to i64
+// LLVM:   call void @passA(i64 %[[#V2]])
+void callA() {
+  A x;
+  passA(x);
+}


### PR DESCRIPTION
This PR handles calls with unions passed by value in the calling convention pass.

#### Implementation
As one may know, data layout for unions in CIR and in LLVM differ one from another. In CIR we track all the union members, while in LLVM IR only the largest one.

And here we need to take this difference into account: we need to find a type of the largest member and treat it as the first (and only) union member in order to preserve all the logic from the original codegen.  

There is a method StructType::getLargestMember - but looks like it produces different results - maybe it's done intentionally, I don't know.

The LLVM IR produced has also some difference from the original one. In the original IR `gep` is emitted - and we can not do the same. If we  create `getMemberOp` we may fail on type checking for unions - since the first member type may differ from the largest type. This is why we create `bitcast` instead. 