### PR TITLE
[CIR][Dialect][NFC] Refactor hardcoded attribute name strings

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -34,6 +34,15 @@ def CIR_Dialect : Dialect {
     // Names of CIR parameter attributes.
     static llvm::StringRef getSExtAttrName() { return "cir.signext"; }
     static llvm::StringRef getZExtAttrName() { return "cir.zeroext"; }
+    static llvm::StringRef getSOBAttrName() { return "cir.sob"; }
+    static llvm::StringRef getLangAttrName() { return "cir.lang"; }
+    static llvm::StringRef getTripleAttrName() { return "cir.triple"; }
+
+    static llvm::StringRef getGlobalCtorsAttrName() { return "cir.global_ctors"; }
+    static llvm::StringRef getGlobalDtorsAttrName() { return "cir.global_dtors"; }
+    static llvm::StringRef getGlobalAnnotationsAttrName() { return "cir.global_annotations"; }
+
+    static llvm::StringRef getOpenCLVersionAttrName() { return "cir.cl.version"; }
 
     void registerAttributes();
     void registerTypes();

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -185,11 +185,13 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
 
   // FIXME(cir): Implement a custom CIR Module Op and attributes to leverage
   // MLIR features.
-  theModule->setAttr("cir.sob",
+  theModule->setAttr(cir::CIRDialect::getSOBAttrName(),
                      cir::SignedOverflowBehaviorAttr::get(&context, sob));
   auto lang = SourceLanguageAttr::get(&context, getCIRSourceLanguage());
-  theModule->setAttr("cir.lang", cir::LangAttr::get(&context, lang));
-  theModule->setAttr("cir.triple", builder.getStringAttr(getTriple().str()));
+  theModule->setAttr(cir::CIRDialect::getLangAttrName(),
+                     cir::LangAttr::get(&context, lang));
+  theModule->setAttr(cir::CIRDialect::getTripleAttrName(),
+                     builder.getStringAttr(getTriple().str()));
   // Set the module name to be the name of the main file. TranslationUnitDecl
   // often contains invalid source locations and isn't a reliable source for the
   // module location.

--- a/clang/lib/CIR/CodeGen/CIRGenOpenCL.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenCL.cpp
@@ -260,5 +260,6 @@ void CIRGenModule::emitOpenCLMetadata() {
   auto clVersionAttr =
       cir::OpenCLVersionAttr::get(&getMLIRContext(), major, minor);
 
-  theModule->setAttr("cir.cl.version", clVersionAttr);
+  theModule->setAttr(cir::CIRDialect::getOpenCLVersionAttrName(),
+                     clVersionAttr);
 }

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -881,11 +881,11 @@ void LoweringPreparePass::lowerGlobalOp(GlobalOp op) {
 
 void LoweringPreparePass::buildGlobalCtorDtorList() {
   if (!globalCtorList.empty()) {
-    theModule->setAttr("cir.global_ctors",
+    theModule->setAttr(cir::CIRDialect::getGlobalCtorsAttrName(),
                        mlir::ArrayAttr::get(&getContext(), globalCtorList));
   }
   if (!globalDtorList.empty()) {
-    theModule->setAttr("cir.global_dtors",
+    theModule->setAttr(cir::CIRDialect::getGlobalDtorsAttrName(),
                        mlir::ArrayAttr::get(&getContext(), globalDtorList));
   }
 }
@@ -1129,7 +1129,7 @@ void LoweringPreparePass::buildGlobalAnnotationValues() {
     return;
   mlir::ArrayAttr annotationValueArray =
       mlir::ArrayAttr::get(theModule.getContext(), globalAnnotations);
-  theModule->setAttr("cir.global_annotations",
+  theModule->setAttr(cir::CIRDialect::getGlobalAnnotationsAttrName(),
                      cir::GlobalAnnotationValuesAttr::get(
                          theModule.getContext(), annotationValueArray));
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerCall.cpp
@@ -211,12 +211,12 @@ void LowerModule::constructAttributeList(llvm::StringRef Name,
     switch (AI.getKind()) {
     case ABIArgInfo::Extend:
       if (AI.isSignExt())
-        Attrs.push_back(
-            rewriter.getNamedAttr("cir.signext", rewriter.getUnitAttr()));
+        Attrs.push_back(rewriter.getNamedAttr(
+            cir::CIRDialect::getSExtAttrName(), rewriter.getUnitAttr()));
       else
         // FIXME(cir): Add a proper abstraction to create attributes.
-        Attrs.push_back(
-            rewriter.getNamedAttr("cir.zeroext", rewriter.getUnitAttr()));
+        Attrs.push_back(rewriter.getNamedAttr(
+            cir::CIRDialect::getZExtAttrName(), rewriter.getUnitAttr()));
       [[fallthrough]];
     case ABIArgInfo::Direct:
       if (ArgNo == 0 && cir::MissingFeatures::chainCall())

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -236,8 +236,9 @@ createLowerModule(mlir::ModuleOp module, mlir::PatternRewriter &rewriter) {
       module->getAttr(mlir::LLVM::LLVMDialect::getDataLayoutAttrName()));
 
   // Fetch target information.
-  llvm::Triple triple(
-      mlir::cast<mlir::StringAttr>(module->getAttr("cir.triple")).getValue());
+  llvm::Triple triple(mlir::cast<mlir::StringAttr>(
+                          module->getAttr(cir::CIRDialect::getTripleAttrName()))
+                          .getValue());
   clang::TargetOptions targetOptions;
   targetOptions.Triple = triple.str();
   auto targetInfo = clang::targets::AllocateTarget(triple, targetOptions);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4412,7 +4412,7 @@ std::unique_ptr<cir::LowerModule> prepareLowerModule(mlir::ModuleOp module) {
   // If the triple is not present, e.g. CIR modules parsed from text, we
   // cannot init LowerModule properly.
   assert(!cir::MissingFeatures::makeTripleAlwaysPresent());
-  if (!module->hasAttr("cir.triple"))
+  if (!module->hasAttr(cir::CIRDialect::getTripleAttrName()))
     return {};
   return cir::createLowerModule(module, rewriter);
 }
@@ -4670,7 +4670,8 @@ void ConvertCIRToLLVMPass::buildGlobalAnnotationsVar(
     llvm::StringMap<mlir::LLVM::GlobalOp> &argStringGlobalsMap,
     llvm::MapVector<mlir::ArrayAttr, mlir::LLVM::GlobalOp> &argsVarMap) {
   mlir::ModuleOp module = getOperation();
-  mlir::Attribute attr = module->getAttr("cir.global_annotations");
+  mlir::Attribute attr =
+      module->getAttr(cir::CIRDialect::getGlobalAnnotationsAttrName());
   if (!attr)
     return;
   if (auto globalAnnotValues =
@@ -4798,8 +4799,8 @@ void ConvertCIRToLLVMPass::runOnOperation() {
   // Allow operations that will be lowered directly to LLVM IR.
   target.addLegalOp<mlir::LLVM::ZeroOp>();
 
-  getOperation()->removeAttr("cir.sob");
-  getOperation()->removeAttr("cir.lang");
+  getOperation()->removeAttr(cir::CIRDialect::getSOBAttrName());
+  getOperation()->removeAttr(cir::CIRDialect::getLangAttrName());
 
   llvm::SmallVector<mlir::Operation *> ops;
   ops.push_back(module);
@@ -4809,8 +4810,8 @@ void ConvertCIRToLLVMPass::runOnOperation() {
     signalPassFailure();
 
   // Emit the llvm.global_ctors array.
-  buildCtorDtorList(module, "cir.global_ctors", "llvm.global_ctors",
-                    [](mlir::Attribute attr) {
+  buildCtorDtorList(module, cir::CIRDialect::getGlobalCtorsAttrName(),
+                    "llvm.global_ctors", [](mlir::Attribute attr) {
                       assert(mlir::isa<cir::GlobalCtorAttr>(attr) &&
                              "must be a GlobalCtorAttr");
                       auto ctorAttr = mlir::cast<cir::GlobalCtorAttr>(attr);
@@ -4818,8 +4819,8 @@ void ConvertCIRToLLVMPass::runOnOperation() {
                                             ctorAttr.getPriority());
                     });
   // Emit the llvm.global_dtors array.
-  buildCtorDtorList(module, "cir.global_dtors", "llvm.global_dtors",
-                    [](mlir::Attribute attr) {
+  buildCtorDtorList(module, cir::CIRDialect::getGlobalDtorsAttrName(),
+                    "llvm.global_dtors", [](mlir::Attribute attr) {
                       assert(mlir::isa<cir::GlobalDtorAttr>(attr) &&
                              "must be a GlobalDtorAttr");
                       auto dtorAttr = mlir::cast<cir::GlobalDtorAttr>(attr);


### PR DESCRIPTION
As title, this patch refactors raw string literals for (module) attribute names into static methods of `CIRDialect`, following the convention of MLIR.