### PR TITLE
[CIR][LowerToLLVM] Lowering triple from `cir.triple` attribute

### DIFF
--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -289,8 +289,6 @@ public:
                                feOptions.ClangIRDisableCIRVerifier,
                                !feOptions.ClangIRCallConvLowering);
 
-      llvmModule->setTargetTriple(targetOptions.Triple);
-
       BackendAction backendAction = getBackendActionFromOutputType(action);
 
       EmitBackendOutput(

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1290,6 +1290,8 @@ struct ConvertCIRToLLVMPass
       llvm::StringMap<mlir::LLVM::GlobalOp> &argStringGlobalsMap,
       llvm::MapVector<mlir::ArrayAttr, mlir::LLVM::GlobalOp> &argsVarMap);
 
+  void processCIRAttrs(mlir::ModuleOp moduleOp);
+
   virtual StringRef getArgument() const override { return "cir-flat-to-llvm"; }
 };
 
@@ -4784,6 +4786,18 @@ void ConvertCIRToLLVMPass::buildGlobalAnnotationsVar(
   }
 }
 
+void ConvertCIRToLLVMPass::processCIRAttrs(mlir::ModuleOp module) {
+  // Lower the module attributes to LLVM equivalents.
+  if (auto tripleAttr = module->getAttr(cir::CIRDialect::getTripleAttrName()))
+    module->setAttr(mlir::LLVM::LLVMDialect::getTargetTripleAttrName(),
+                    tripleAttr);
+
+  // Strip the CIR attributes.
+  module->removeAttr(cir::CIRDialect::getSOBAttrName());
+  module->removeAttr(cir::CIRDialect::getLangAttrName());
+  module->removeAttr(cir::CIRDialect::getTripleAttrName());
+}
+
 void ConvertCIRToLLVMPass::runOnOperation() {
   llvm::TimeTraceScope scope("Convert CIR to LLVM Pass");
 
@@ -4834,8 +4848,7 @@ void ConvertCIRToLLVMPass::runOnOperation() {
   // Allow operations that will be lowered directly to LLVM IR.
   target.addLegalOp<mlir::LLVM::ZeroOp>();
 
-  getOperation()->removeAttr(cir::CIRDialect::getSOBAttrName());
-  getOperation()->removeAttr(cir::CIRDialect::getLangAttrName());
+  processCIRAttrs(module);
 
   llvm::SmallVector<mlir::Operation *> ops;
   ops.push_back(module);

--- a/clang/test/CIR/Tools/cir-translate-triple.cir
+++ b/clang/test/CIR/Tools/cir-translate-triple.cir
@@ -1,0 +1,13 @@
+// RUN: cir-translate --cir-to-llvmir --disable-cc-lowering %s -o %t.ll
+// RUN: FileCheck %s -input-file %t.ll -check-prefix=LLVM
+
+module attributes {
+  cir.triple = "x86_64-unknown-linux-gnu",
+  llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+} {
+  cir.func @foo() {
+    cir.return
+  }
+}
+
+// LLVM-DAG: target triple = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
Currently, the final `target triple` in LLVM IR is set in `CIRGenAction`, which is not executed by cir tools like `cir-translate`. This PR delay its assignment to LLVM lowering, enabling sharing the emitting of `target triple` between different invoking paths.