### PR TITLE
[CIR][CIRGen][Builtin] Support __builtin_launder except in the case of -fstrict-vtable-pointers

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -230,6 +230,7 @@ struct MissingFeatures {
   static bool emitEmptyRecordCheck() { return false; }
   static bool isPPC_FP128Ty() { return false; }
   static bool emitBinaryAtomicPostHasInvert() { return false; }
+  static bool createLaunderInvariantGroup() { return false; }
 
   // Inline assembly
   static bool asmGoto() { return false; }


### PR DESCRIPTION
Without using flag `-fstrict-vtable-pointers`,  `__builtin_launder` is a noop. This PR implements that, and leave implementation for the case of  `-fstrict-vtable-pointers` to future where there is a need.

This PR also adapted most of test cases from [OG test case](https://github.com/llvm/clangir/blob/3aed38cf52e72cb51a907fad9dd53802f6505b81/clang/test/CodeGenCXX/builtin-launder.cpp#L1).
I didn't use test cases in the namespace [pessimizing_cases](https://github.com/llvm/clangir/blob/3aed38cf52e72cb51a907fad9dd53802f6505b81/clang/test/CodeGenCXX/builtin-launder.cpp#L269), as they have no difference even when `-fstrict-vtable-pointers` is on.