### PR TITLE
[CIR][ABI][AArch64][Lowering] support for calling struct types in range (64, 128)

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -336,10 +336,15 @@ mlir::Value createCoercedValue(mlir::Value Src, mlir::Type Ty,
     return CGF.buildAggregateBitcast(Src, Ty);
   }
 
-  auto alloca = createTmpAlloca(CGF, Src.getLoc(), Ty);
   Src = findAlloca(Src.getDefiningOp());
-  createMemCpy(CGF, alloca, Src, SrcSize.getFixedValue());
-  return CGF.getRewriter().create<LoadOp>(Src.getLoc(), alloca.getResult());
+  if (Src) {
+    auto tmpAlloca = createTmpAlloca(CGF, Src.getLoc(), Ty);
+    createMemCpy(CGF, tmpAlloca, Src, SrcSize.getFixedValue());
+    return CGF.getRewriter().create<LoadOp>(Src.getLoc(),
+                                            tmpAlloca.getResult());
+  }
+
+  cir_cconv_unreachable("NYI");
 }
 
 mlir::Value emitAddressAtOffset(LowerFunction &LF, mlir::Value addr,

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -336,11 +336,10 @@ mlir::Value createCoercedValue(mlir::Value Src, mlir::Type Ty,
     return CGF.buildAggregateBitcast(Src, Ty);
   }
 
-  auto &bld = CGF.getRewriter();
   auto alloca = createTmpAlloca(CGF, Src.getLoc(), Ty);
   Src = findAlloca(Src.getDefiningOp());
   createMemCpy(CGF, alloca, Src, SrcSize.getFixedValue());
-  return bld.create<LoadOp>(Src.getLoc(), alloca.getResult());
+  return CGF.getRewriter().create<LoadOp>(Src.getLoc(), alloca.getResult());
 }
 
 mlir::Value emitAddressAtOffset(LowerFunction &LF, mlir::Value addr,

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -336,11 +336,10 @@ mlir::Value createCoercedValue(mlir::Value Src, mlir::Type Ty,
     return CGF.buildAggregateBitcast(Src, Ty);
   }
 
-  Src = findAlloca(Src.getDefiningOp());
-  if (Src) {
-    auto tmpAlloca = createTmpAlloca(CGF, Src.getLoc(), Ty);
-    createMemCpy(CGF, tmpAlloca, Src, SrcSize.getFixedValue());
-    return CGF.getRewriter().create<LoadOp>(Src.getLoc(),
+  if (auto alloca = findAlloca(Src.getDefiningOp()) {
+    auto tmpAlloca = createTmpAlloca(CGF, alloca.getLoc(), Ty);
+    createMemCpy(CGF, tmpAlloca, alloca, SrcSize.getFixedValue());
+    return CGF.getRewriter().create<LoadOp>(alloca.getLoc(),
                                             tmpAlloca.getResult());
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -336,7 +336,7 @@ mlir::Value createCoercedValue(mlir::Value Src, mlir::Type Ty,
     return CGF.buildAggregateBitcast(Src, Ty);
   }
 
-  if (auto alloca = findAlloca(Src.getDefiningOp()) {
+  if (auto alloca = findAlloca(Src.getDefiningOp())) {
     auto tmpAlloca = createTmpAlloca(CGF, alloca.getLoc(), Ty);
     createMemCpy(CGF, tmpAlloca, alloca, SrcSize.getFixedValue());
     return CGF.getRewriter().create<LoadOp>(alloca.getLoc(),

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -337,9 +337,7 @@ mlir::Value createCoercedValue(mlir::Value Src, mlir::Type Ty,
   }
 
   auto &bld = CGF.getRewriter();
-  auto alloca = bld.create<AllocaOp>(
-      Src.getLoc(), bld.getType<PointerType>(Ty), Ty,
-      /*name=*/llvm::StringRef(""), /*alignment=*/bld.getI64IntegerAttr(4));
+  auto alloca = createTmpAlloca(CGF, Src.getLoc(), Ty);
   Src = findAlloca(Src.getDefiningOp());
   createMemCpy(CGF, alloca, Src, SrcSize.getFixedValue());
   return bld.create<LoadOp>(Src.getLoc(), alloca.getResult());

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -206,80 +206,27 @@ GT_128 call_and_get_gt_128() {
 // LLVM:   call void @llvm.memcpy.p0.p0.i64(ptr %[[#V1]], ptr %[[#V2]], i64 12, i1 false)
 void passS(S s) {}
 
-typedef struct {
-  uint8_t a;
-  uint16_t b;
-  uint8_t c;
-} S_PAD;
-
-// CHECK: cir.func {{.*@ret_s_pad}}()  -> !u48i
-// CHECK: %[[#V0:]] = cir.alloca !ty_S_PAD, !cir.ptr<!ty_S_PAD>, ["__retval"] {alignment = 2 : i64}
-// CHECK: %[[#V1:]] = cir.load %[[#V0]] : !cir.ptr<!ty_S_PAD>, !ty_S_PAD
-// CHECK: %[[#V2:]] = cir.alloca !u48i, !cir.ptr<!u48i>, [""] {alignment = 2 : i64}
-// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S_PAD>)
-// CHECK: %[[#V4:]] = cir.cast(bitcast, %[[#V2:]] : !cir.ptr<!u48i>), !cir.ptr<!void>
-// CHECK: %[[#V5:]] = cir.const #cir.int<6> : !u64i
-// CHECK: cir.libc.memcpy %[[#V5]] bytes from %[[#V3]] to %[[#V4]] : !u64i, !cir.ptr<!void>
-// CHECK: %[[#V6:]] = cir.load %[[#V2]] : !cir.ptr<!u48i>
-// CHECK: cir.return %[[#V6]]
-
-// LLVM: i48 @ret_s_pad()
-// LLVM: %[[#V1:]] = alloca %struct.S_PAD, i64 1, align 2
-// LLVM: %[[#V2:]] = load %struct.S_PAD, ptr %[[#V1]], align 2
-// LLVM: %[[#V3:]] = alloca i48, i64 1, align 2
-// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V3]], ptr %[[#V1]], i64 6, i1 false)
-// LLVM: %[[#V4:]] = load i48, ptr %[[#V3]]
-// LLVM: ret i48 %[[#V4]]
-S_PAD ret_s_pad() {
-  S_PAD s;
-  return s;
-}
-
-typedef struct {
-  int a;
-  int b;
-  short c;
-} GT_64_LT_128;
-
-// CHECK: @pass_gt_64_lt_128(%arg0: !cir.array<!u64i x 2>
-// CHECK: %[[#V0:]] = cir.alloca !ty_GT_64_LT_128_, !cir.ptr<!ty_GT_64_LT_128_>, [""] {alignment = 4 : i64}
+// CHECK: @callS()
+// CHECK: %[[#V0:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["s"] {alignment = 4 : i64}
 // CHECK: %[[#V1:]] = cir.alloca !cir.array<!u64i x 2>, !cir.ptr<!cir.array<!u64i x 2>>, ["tmp"] {alignment = 8 : i64}
-// CHECK: cir.store %arg0, %[[#V1]] : !cir.array<!u64i x 2>, !cir.ptr<!cir.array<!u64i x 2>>
-// CHECK: %[[#V2:]] = cir.cast(bitcast, %[[#V1]] : !cir.ptr<!cir.array<!u64i x 2>>), !cir.ptr<!void>
-// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_GT_64_LT_128_>), !cir.ptr<!void>
-// CHECK: %[[#V4:]] = cir.const #cir.int<12> : !u64i
-// CHECK: cir.libc.memcpy %[[#V4]] bytes from %[[#V2]] to %[[#V3]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
-// CHECK: cir.return
-
-// LLVM: @pass_gt_64_lt_128([2 x i64] %[[#V0:]])
-// LLVM: %[[#V2:]] = alloca %struct.GT_64_LT_128, i64 1, align 4
-// LLVM: %[[#V3:]] = alloca [2 x i64], i64 1, align 8
-// LLVM: store [2 x i64] %[[#V0]], ptr %[[#V3]], align 8
-// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V2]], ptr %[[#V3]], i64 12, i1 false)
-// LLVM: ret void
-void pass_gt_64_lt_128(GT_64_LT_128 s) {}
-
-// CHECK: @call_gt_64_lt_128()
-// CHECK: %[[#V0:]] = cir.alloca !ty_GT_64_LT_128_, !cir.ptr<!ty_GT_64_LT_128_>, ["s"] {alignment = 4 : i64}
-// CHECK: %[[#V1:]] = cir.load %[[#V0]] : !cir.ptr<!ty_GT_64_LT_128_>, !ty_GT_64_LT_128_
-// CHECK: %[[#V2:]] = cir.alloca !cir.array<!u64i x 2>, !cir.ptr<!cir.array<!u64i x 2>>, [""] {alignment = 4 : i64}
-// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_GT_64_LT_128_>), !cir.ptr<!void>
-// CHECK: %[[#V4:]] = cir.cast(bitcast, %[[#V2]] : !cir.ptr<!cir.array<!u64i x 2>>), !cir.ptr<!void>
+// CHECK: %[[#V2:]] = cir.load %[[#V0]] : !cir.ptr<!ty_S>, !ty_S
+// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S>), !cir.ptr<!void>
+// CHECK: %[[#V4:]] = cir.cast(bitcast, %[[#V1]] : !cir.ptr<!cir.array<!u64i x 2>>), !cir.ptr<!void>
 // CHECK: %[[#V5:]] = cir.const #cir.int<12> : !u64i
 // CHECK: cir.libc.memcpy %[[#V5]] bytes from %[[#V3]] to %[[#V4]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
-// CHECK: %[[#V6:]] = cir.load %[[#V2]] : !cir.ptr<!cir.array<!u64i x 2>>, !cir.array<!u64i x 2>
-// CHECK: cir.call @pass_gt_64_lt_128(%[[#V6]]) : (!cir.array<!u64i x 2>) -> ()
+// CHECK: %[[#V6:]] = cir.load %[[#V1]] : !cir.ptr<!cir.array<!u64i x 2>>, !cir.array<!u64i x 2>
+// CHECK: cir.call @passS(%[[#V6]]) : (!cir.array<!u64i x 2>) -> ()
 // CHECK: cir.return
 
-// LLVM: @call_gt_64_lt_128()
-// LLVM: %[[#V1:]] = alloca %struct.GT_64_LT_128, i64 1, align 4
-// LLVM: %[[#V2:]] = load %struct.GT_64_LT_128, ptr %[[#V1]], align 4
-// LLVM: %[[#V3:]] = alloca [2 x i64], i64 1, align 4
-// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V3]], ptr %[[#V1]], i64 12, i1 false)
-// LLVM: %[[#V4:]] = load [2 x i64], ptr %[[#V3]], align 8
-// LLVM: call void @pass_gt_64_lt_128([2 x i64] %[[#V4]])
+// LLVM: @callS()
+// LLVM: %[[#V1:]] = alloca %struct.S, i64 1, align 4
+// LLVM: %[[#V2:]] = alloca [2 x i64], i64 1, align 8
+// LLVM: %[[#V3:]] = load %struct.S, ptr %[[#V1]], align 4
+// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V2]], ptr %[[#V1]], i64 12, i1 false)
+// LLVM: %[[#V4:]] = load [2 x i64], ptr %[[#V2]], align 8
+// LLVM: call void @passS([2 x i64] %[[#V4]])
 // LLVM: ret void
-void call_gt_64_lt_128() {
-  GT_64_LT_128 s;
-  pass_gt_64_lt_128(s);
+void callS() {
+  S s;
+  passS(s);
 }

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -234,3 +234,52 @@ S_PAD ret_s_pad() {
   S_PAD s;
   return s;
 }
+
+typedef struct {
+  int a;
+  int b;
+  short c;
+} GT_64_LT_128;
+
+// CHECK: @pass_gt_64_lt_128(%arg0: !cir.array<!u64i x 2>
+// CHECK: %[[#V0:]] = cir.alloca !ty_GT_64_LT_128_, !cir.ptr<!ty_GT_64_LT_128_>, [""] {alignment = 4 : i64}
+// CHECK: %[[#V1:]] = cir.alloca !cir.array<!u64i x 2>, !cir.ptr<!cir.array<!u64i x 2>>, ["tmp"] {alignment = 8 : i64}
+// CHECK: cir.store %arg0, %[[#V1]] : !cir.array<!u64i x 2>, !cir.ptr<!cir.array<!u64i x 2>>
+// CHECK: %[[#V2:]] = cir.cast(bitcast, %[[#V1]] : !cir.ptr<!cir.array<!u64i x 2>>), !cir.ptr<!void>
+// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_GT_64_LT_128_>), !cir.ptr<!void>
+// CHECK: %[[#V4:]] = cir.const #cir.int<12> : !u64i
+// CHECK: cir.libc.memcpy %[[#V4]] bytes from %[[#V2]] to %[[#V3]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+// CHECK: cir.return
+
+// LLVM: @pass_gt_64_lt_128([2 x i64] %[[#V0:]])
+// LLVM: %[[#V2:]] = alloca %struct.GT_64_LT_128, i64 1, align 4
+// LLVM: %[[#V3:]] = alloca [2 x i64], i64 1, align 8
+// LLVM: store [2 x i64] %[[#V0]], ptr %[[#V3]], align 8
+// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V2]], ptr %[[#V3]], i64 12, i1 false)
+// LLVM: ret void
+void pass_gt_64_lt_128(GT_64_LT_128 s) {}
+
+// CHECK: @call_gt_64_lt_128()
+// CHECK: %[[#V0:]] = cir.alloca !ty_GT_64_LT_128_, !cir.ptr<!ty_GT_64_LT_128_>, ["s"] {alignment = 4 : i64}
+// CHECK: %[[#V1:]] = cir.load %[[#V0]] : !cir.ptr<!ty_GT_64_LT_128_>, !ty_GT_64_LT_128_
+// CHECK: %[[#V2:]] = cir.alloca !cir.array<!u64i x 2>, !cir.ptr<!cir.array<!u64i x 2>>, [""] {alignment = 4 : i64}
+// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_GT_64_LT_128_>), !cir.ptr<!void>
+// CHECK: %[[#V4:]] = cir.cast(bitcast, %[[#V2]] : !cir.ptr<!cir.array<!u64i x 2>>), !cir.ptr<!void>
+// CHECK: %[[#V5:]] = cir.const #cir.int<12> : !u64i
+// CHECK: cir.libc.memcpy %[[#V5]] bytes from %[[#V3]] to %[[#V4]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+// CHECK: %[[#V6:]] = cir.load %[[#V2]] : !cir.ptr<!cir.array<!u64i x 2>>, !cir.array<!u64i x 2>
+// CHECK: cir.call @pass_gt_64_lt_128(%[[#V6]]) : (!cir.array<!u64i x 2>) -> ()
+// CHECK: cir.return
+
+// LLVM: @call_gt_64_lt_128()
+// LLVM: %[[#V1:]] = alloca %struct.GT_64_LT_128, i64 1, align 4
+// LLVM: %[[#V2:]] = load %struct.GT_64_LT_128, ptr %[[#V1]], align 4
+// LLVM: %[[#V3:]] = alloca [2 x i64], i64 1, align 4
+// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V3]], ptr %[[#V1]], i64 12, i1 false)
+// LLVM: %[[#V4:]] = load [2 x i64], ptr %[[#V3]], align 8
+// LLVM: call void @pass_gt_64_lt_128([2 x i64] %[[#V4]])
+// LLVM: ret void
+void call_gt_64_lt_128() {
+  GT_64_LT_128 s;
+  pass_gt_64_lt_128(s);
+}

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -230,3 +230,32 @@ void callS() {
   S s;
   passS(s);
 }
+
+typedef struct {
+  uint8_t a;
+  uint16_t b;
+  uint8_t c;
+} S_PAD;
+
+// CHECK: cir.func {{.*@ret_s_pad}}()  -> !u48i
+// CHECK: %[[#V0:]] = cir.alloca !ty_S_PAD, !cir.ptr<!ty_S_PAD>, ["__retval"] {alignment = 2 : i64}
+// CHECK: %[[#V1:]] = cir.load %[[#V0]] : !cir.ptr<!ty_S_PAD>, !ty_S_PAD
+// CHECK: %[[#V2:]] = cir.alloca !u48i, !cir.ptr<!u48i>, [""] {alignment = 2 : i64}
+// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S_PAD>)
+// CHECK: %[[#V4:]] = cir.cast(bitcast, %[[#V2:]] : !cir.ptr<!u48i>), !cir.ptr<!void>
+// CHECK: %[[#V5:]] = cir.const #cir.int<6> : !u64i
+// CHECK: cir.libc.memcpy %[[#V5]] bytes from %[[#V3]] to %[[#V4]] : !u64i, !cir.ptr<!void>
+// CHECK: %[[#V6:]] = cir.load %[[#V2]] : !cir.ptr<!u48i>
+// CHECK: cir.return %[[#V6]]
+
+// LLVM: i48 @ret_s_pad()
+// LLVM: %[[#V1:]] = alloca %struct.S_PAD, i64 1, align 2
+// LLVM: %[[#V2:]] = load %struct.S_PAD, ptr %[[#V1]], align 2
+// LLVM: %[[#V3:]] = alloca i48, i64 1, align 2
+// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V3]], ptr %[[#V1]], i64 6, i1 false)
+// LLVM: %[[#V4:]] = load i48, ptr %[[#V3]]
+// LLVM: ret i48 %[[#V4]]
+S_PAD ret_s_pad() {
+  S_PAD s;
+  return s;
+}


### PR DESCRIPTION
This PR adds support for the lowering of AArch64 calls with structs having sizes greater than 64 and less than 128. 

The idea is from the original [CodeGen](https://github.com/llvm/clangir/blob/da601b374deea6665f710f7e432dfa82f457059e/clang/lib/CodeGen/CGCall.cpp#L1329), where we perform a coercion through memory for these type of calls. 

I have added a test for this.