### PR TITLE
[CIR][Transforms][NFC] Fix undesirable include of clang's private header

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -11,10 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME(cir): This header file is not exposed to the public API, but can be
-// reused by CIR ABI lowering since it holds target-specific information.
-#include "../../../../Basic/Targets.h"
 #include "clang/Basic/LangOptions.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
 
 #include "CIRLowerContext.h"


### PR DESCRIPTION
With [llvm-project#116090](https://github.com/llvm/llvm-project/pull/116090) merged, we can get rid of `#include "../../../../Basic/Targets.h"` now.