### PR TITLE
[CIR] Make use of !invariant.group metadata for const allocas

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -301,8 +301,13 @@ public:
 };
 
 class CIRToLLVMLoadOpLowering : public mlir::OpConversionPattern<cir::LoadOp> {
+  cir::LowerModule *lowerMod;
+
 public:
-  using mlir::OpConversionPattern<cir::LoadOp>::OpConversionPattern;
+  CIRToLLVMLoadOpLowering(const mlir::TypeConverter &typeConverter,
+                          mlir::MLIRContext *context,
+                          cir::LowerModule *lowerModule)
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
 
   mlir::LogicalResult
   matchAndRewrite(cir::LoadOp op, OpAdaptor,
@@ -311,8 +316,13 @@ public:
 
 class CIRToLLVMStoreOpLowering
     : public mlir::OpConversionPattern<cir::StoreOp> {
+  cir::LowerModule *lowerMod;
+
 public:
-  using mlir::OpConversionPattern<cir::StoreOp>::OpConversionPattern;
+  CIRToLLVMStoreOpLowering(const mlir::TypeConverter &typeConverter,
+                           mlir::MLIRContext *context,
+                           cir::LowerModule *lowerModule)
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
 
   mlir::LogicalResult
   matchAndRewrite(cir::StoreOp op, OpAdaptor,

--- a/clang/test/CIR/CodeGen/const-alloca.cpp
+++ b/clang/test/CIR/CodeGen/const-alloca.cpp
@@ -1,5 +1,7 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -O1 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -O1 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
 
 int produce_int();
 void blackbox(const int &);
@@ -8,33 +10,33 @@ void local_const_int() {
   const int x = produce_int();
 }
 
-// CHECK-LABEL: @_Z15local_const_intv
-// CHECK:   %{{.+}} = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init, const]
-// CHECK: }
+// CIR-LABEL: @_Z15local_const_intv
+// CIR:   %{{.+}} = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init, const]
+// CIR: }
 
 void param_const_int(const int x) {}
 
-// CHECK-LABEL: @_Z15param_const_inti
-// CHECK:  %{{.+}} = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init, const]
-// CHECK: }
+// CIR-LABEL: @_Z15param_const_inti
+// CIR:  %{{.+}} = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init, const]
+// CIR: }
 
 void local_constexpr_int() {
   constexpr int x = 42;
   blackbox(x);
 }
 
-// CHECK-LABEL: @_Z19local_constexpr_intv
-// CHECK:   %{{.+}} = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init, const]
-// CHECK: }
+// CIR-LABEL: @_Z19local_constexpr_intv
+// CIR:   %{{.+}} = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init, const]
+// CIR: }
 
 void local_reference() {
   int x = 0;
   int &r = x;
 }
 
-// CHECK-LABEL: @_Z15local_referencev
-// CHECK:   %{{.+}} = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["r", init, const]
-// CHECK: }
+// CIR-LABEL: @_Z15local_referencev
+// CIR:   %{{.+}} = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["r", init, const]
+// CIR: }
 
 struct Foo {
   int a;
@@ -47,6 +49,39 @@ void local_const_struct() {
   const Foo x = produce_foo();
 }
 
-// CHECK-LABEL: @_Z18local_const_structv
-// CHECK:   %{{.+}} = cir.alloca !ty_Foo, !cir.ptr<!ty_Foo>, ["x", init, const]
-// CHECK: }
+// CIR-LABEL: @_Z18local_const_structv
+// CIR:   %{{.+}} = cir.alloca !ty_Foo, !cir.ptr<!ty_Foo>, ["x", init, const]
+// CIR: }
+
+[[clang::optnone]]
+int local_const_load_store() {
+  const int x = produce_int();
+  int y = x;
+  return y;
+}
+
+// CIR-LABEL: @_Z22local_const_load_storev
+// CIR: %{{.+}} = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init, const] {alignment = 4 : i64}
+// CIR: }
+
+// LLVM-LABEL: @_Z22local_const_load_storev
+//      LLVM: %[[#INIT:]] = call i32 @_Z11produce_intv()
+// LLVM-NEXT: store i32 %[[#INIT]], ptr %[[#SLOT:]], align 4, !invariant.group !{{.+}}
+// LLVM-NEXT: %{{.+}} = load i32, ptr %[[#SLOT]], align 4, !invariant.group !{{.+}}
+// LLVM: }
+
+int local_const_optimize() {
+  const int x = produce_int();
+  blackbox(x);
+  blackbox(x);
+  return x;
+}
+
+// LLVM-LABEL: @_Z20local_const_optimizev()
+// LLVM-NEXT:    %[[#slot:]] = alloca i32, align 4
+// LLVM-NEXT:    %[[#init:]] = tail call i32 @_Z11produce_intv()
+// LLVM-NEXT:    store i32 %[[#init]], ptr %[[#slot]], align 4, !invariant.group !{{.+}}
+// LLVM-NEXT:    call void @_Z8blackboxRKi(ptr nonnull %[[#slot]])
+// LLVM-NEXT:    call void @_Z8blackboxRKi(ptr nonnull %[[#slot]])
+// LLVM-NEXT:    ret i32 %[[#init]]
+// LLVM-NEXT:  }


### PR DESCRIPTION
This PR updates the LLVM lowering part of load and stores to const allocas and makes use of the !invariant.group metadata in the result LLVM IR.

The HoistAlloca pass is also updated. The const flag on a hoisted alloca is removed for now since their uses are not always invariants. Will update in later PRs to teach their invariants.