### PR TITLE
[CIR] [workaround] Don't use InactiveUnionFieldAttr for non-largest member

### DIFF
--- a/clang/test/CIR/Lowering/union-in-struct-init.c
+++ b/clang/test/CIR/Lowering/union-in-struct-init.c
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll 
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+typedef struct {
+  union {
+    int a;
+    long b;
+  };
+} S;
+
+S s = { .a = 1 };
+
+// LLVM: @s = global { { i32, [4 x i8] } } { { i32, [4 x i8] } { i32 1, [4 x i8] zeroinitializer } }
+
+typedef struct {
+  union {
+    int a;
+    long b;
+  };
+} S2;
+
+S2 s2 = { .b = 1 };
+
+// LLVM: @s2 = global %struct.S2 { %union.anon.1 { i64 1 } }
+
+typedef struct {
+  union {
+    int a;
+    long b;
+    long double c;
+  };
+} S3;
+
+S3 s3 = { .a = 1 };
+
+// LLVM: @s3 = global { { i32, [12 x i8] } } { { i32, [12 x i8] } { i32 1, [12 x i8] zeroinitializer } }


### PR DESCRIPTION
Close https://github.com/llvm/clangir/issues/1131

I took more time than I thought on this. The problem seems to be more complex than I thought. And the patch itself is a workaround to stop the regression.

---

Following off are some details that we can look back future:

1. The direct problem is, when we had paddings for the initializers for a union, with the use of `InactiveUnionFieldAttr`, the line to compare the synthesized type and desired type (the union type) fails. https://github.com/llvm/clangir/blob/3aed38cf52e72cb51a907fad9dd53802f6505b81/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp#L456-L458

then the type of the initializer is not considered to be an union, so the computed size is not correct, which is the reason for the crash.

2. It is worth to note that, before we introduce `InactiveUnionFieldAttr`, the comparison between the synthesized type and the desired type would fail too. But we can have the right size after all. So the reproducer in https://github.com/llvm/clangir/issues/1131 works.

3. It doesn't work if we don't add these padding bits if we used `InactiveUnionFieldAttr`. It can avoid the crash. But then when lowering the code, we have to adding these padding bits by our selves. The problem is the type mismatch.

In such manner, in https://github.com/llvm/clangir/blob/3aed38cf52e72cb51a907fad9dd53802f6505b81/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp#L433, the generated llvm type for the initializer of the union is `struct { i64 }`. But the generated type for the init value (in https://github.com/llvm/clangir/blob/3aed38cf52e72cb51a907fad9dd53802f6505b81/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp#L447) is `i32`. Then we have to consider how to instantiate a `struct { i64 }` with an `i32`. The specific example is easy by using `zext` instruction. But how about the generic case? Especially the type of the struct can be not compatible with the init type. This may not be super hard but I'd like to not fix it in the patch.

4. What's the problematic case now? It is similar to https://github.com/llvm/clangir/pull/1007 but the size of types in the union are not the same and we tried to init the union with the smaller types. Then we failed to recognize them as the same type so that we will failed to recognize their context as an array.