### PR TITLE
[CIR][TargetLowering] Fix use iteration

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -1275,12 +1275,14 @@ mlir::Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
           mlir::cast<StructType>(RetTy).getNumElements() != 0) {
         RetVal = newCallOp.getResult();
 
-        for (auto user : Caller.getOperation()->getUsers()) {
-          if (auto storeOp = mlir::dyn_cast<StoreOp>(user)) {
-            auto DestPtr = createCoercedBitcast(storeOp.getAddr(),
-                                                RetVal.getType(), *this);
-            rewriter.replaceOpWithNewOp<StoreOp>(storeOp, RetVal, DestPtr);
-          }
+        llvm::SmallVector<StoreOp, 8> workList;
+        for (auto *user : Caller->getUsers())
+          if (auto storeOp = mlir::dyn_cast<StoreOp>(user))
+            workList.push_back(storeOp);
+        for (StoreOp storeOp : workList) {
+          auto destPtr =
+              createCoercedBitcast(storeOp.getAddr(), RetVal.getType(), *this);
+          rewriter.replaceOpWithNewOp<StoreOp>(storeOp, RetVal, destPtr);
         }
       }
 


### PR DESCRIPTION
Based on https://mlir.llvm.org/docs/Tutorials/UnderstandingTheIRStructure/#traversing-the-def-use-chains,
the users of an op are linked together in a doubly-linked list, so
replacing a user while iterating the users causes a use-after-free.
Store the users in a worklist and process them afterwards instead to
avoid this.
