### PR TITLE
[CIR][FlattenCFG] Fix rewrite API misuse

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -313,7 +313,7 @@ public:
     if (!callOp.getCleanup().empty()) {
       mlir::Block *cleanupBlock = &callOp.getCleanup().getBlocks().back();
       auto cleanupYield = cast<cir::YieldOp>(cleanupBlock->getTerminator());
-      cleanupYield->erase();
+      rewriter.eraseOp(cleanupYield);
       rewriter.mergeBlocks(cleanupBlock, landingPadBlock);
       rewriter.setInsertionPointToEnd(landingPadBlock);
     }


### PR DESCRIPTION
We need to perform all erasures via the rewrite API instead of directly
for the framework to work correctly. This was detected by a combination
of `-DMLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON` [1] and ASAN.

[1] https://mlir.llvm.org/getting_started/Debugging/#detecting-invalid-api-usage
