### PR TITLE
[CIR] Correct signedness for createSignedInt

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -50,7 +50,8 @@ public:
 
   mlir::Value getSignedInt(mlir::Location loc, int64_t val, unsigned numBits) {
     return getConstAPSInt(
-        loc, llvm::APSInt(llvm::APInt(numBits, val), /*isUnsigned=*/false));
+        loc, llvm::APSInt(llvm::APInt(numBits, val, /*isSigned=*/true),
+                          /*isUnsigned=*/false));
   }
 
   mlir::Value getUnsignedInt(mlir::Location loc, uint64_t val,

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -45,7 +45,7 @@ mlir::Value emitRoundPointerUpToAlignment(cir::CIRBaseBuilderTy &builder,
       builder.getUnsignedInt(loc, alignment - 1, /*width=*/32));
   return builder.create<cir::PtrMaskOp>(
       loc, roundUp.getType(), roundUp,
-      builder.getSignedInt(loc, -alignment, /*width=*/32));
+      builder.getSignedInt(loc, -(signed)alignment, /*width=*/32));
 }
 
 mlir::Type useFirstFieldIfTransparentUnion(mlir::Type Ty) {


### PR DESCRIPTION
After I rebased, I found these problems with Spec2017. I was surprised why it doesn't have problems. Maybe some updates in LLVM part.