### PR TITLE
[CIR] Relax the requirement for ternary operation

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -805,8 +805,8 @@ def TernaryOp : CIR_Op<"ternary",
     ```
   }];
   let arguments = (ins CIR_BoolType:$cond);
-  let regions = (region SizedRegion<1>:$trueRegion,
-                        SizedRegion<1>:$falseRegion);
+  let regions = (region AnyRegion:$trueRegion,
+                        AnyRegion:$falseRegion);
   let results = (outs Optional<CIR_AnyType>:$result);
 
   let skipDefaultBuilders = 1;

--- a/clang/test/CIR/CodeGen/ternary.c
+++ b/clang/test/CIR/CodeGen/ternary.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -fno-clangir-call-conv-lowering %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+#include <stdarg.h>
+
+double f1(int cond, int n, ...) {
+  va_list valist;
+  va_start(valist, n);
+  double res = cond ? va_arg(valist, double) : 0;
+  va_end(valist);
+  return res;
+}
+
+// Fine enough to check it passes the verifying.
+// CIR: cir.ternary


### PR DESCRIPTION
The requirement for the size of then-else part of cir.ternary operation seems to be too conservative. Like the example shows, it is possible the regions got expanded during the transformation.