### PR TITLE
[CIR] Add code generation options to lowering context

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -74,6 +74,54 @@ def LangAttr : CIR_Attr<"Lang", "lang"> {
 }
 
 //===----------------------------------------------------------------------===//
+// OptInfoAttr
+//===----------------------------------------------------------------------===//
+
+def CIR_OptInfoAttr : CIR_Attr<"OptInfo", "opt_info"> {
+  let summary =
+    "A module-level attribute that holds the optimization information";
+  let description = [{
+    The `#cir.opt_info` attribute holds the optimization related information.
+    Currently this attribute is a module-level attribute that gets attached to
+    the module operation during CIRGen.
+
+    The `level` parameter gives the optimization level. It must be an integer
+    between 0 and 3, inclusive. It corresponds to the `OptimizationLevel` field
+    within the `clang::CodeGenOptions` structure.
+
+    The `size` parameter gives the code size optimization level. It must be an
+    integer between 0 and 2, inclusive. It corresponds to the `OptimizeSize`
+    field within the `clang::CodeGenOptions` structure.
+
+    The `level` and `size` parameters correspond to the optimization level
+    command line options passed to clang driver. The table below lists the
+    current correspondance relationship:
+
+    | Flag             | `level` | `size` |
+    |------------------|---------|--------|
+    | `-O0` or nothing | 0       | 0      |
+    | `-O1`            | 1       | 0      |
+    | `-O2`            | 2       | 0      |
+    | `-O3`            | 3       | 0      |
+    | `-Os`            | 2       | 1      |
+    | `-Oz`            | 2       | 2      |
+
+    Examples:
+
+    ```mlir
+    #cir.opt_info<level = 2, size = 0>  // -O2
+    ```
+  }];
+
+  let parameters = (ins "unsigned":$level, "unsigned":$size);
+
+  let assemblyFormat = [{
+    `<` `level` `=` $level `,` `size` `=` $size `>`
+  }];
+  let genVerifyDecl = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // BoolAttr
 //===----------------------------------------------------------------------===//
 
@@ -311,7 +359,7 @@ def ComplexAttr : CIR_Attr<"Complex", "complex", [TypedAttrInterface]> {
     contains values of the same CIR type.
   }];
 
-  let parameters = (ins 
+  let parameters = (ins
     AttributeSelfTypeParameter<"", "cir::ComplexType">:$type,
     "mlir::TypedAttr":$real, "mlir::TypedAttr":$imag);
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -37,6 +37,7 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getSOBAttrName() { return "cir.sob"; }
     static llvm::StringRef getLangAttrName() { return "cir.lang"; }
     static llvm::StringRef getTripleAttrName() { return "cir.triple"; }
+    static llvm::StringRef getOptInfoAttrName() { return "cir.opt_info"; }
 
     static llvm::StringRef getGlobalCtorsAttrName() { return "cir.global_ctors"; }
     static llvm::StringRef getGlobalDtorsAttrName() { return "cir.global_dtors"; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -377,6 +377,11 @@ struct MissingFeatures {
   // just yet. Right now, it only instantiates the default lang options.
   static bool langOpts() { return false; }
 
+  // CodeGenOpts may affect lowering, but we do not carry this information into
+  // CIR just yet. Right now, it only instantiates the default code generation
+  // options.
+  static bool codeGenOpts() { return false; }
+
   // Several type qualifiers are not yet supported in CIR, but important when
   // evaluating ABI-specific lowering.
   static bool qualifiedTypes() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -192,6 +192,10 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
                      cir::LangAttr::get(&context, lang));
   theModule->setAttr(cir::CIRDialect::getTripleAttrName(),
                      builder.getStringAttr(getTriple().str()));
+  if (CGO.OptimizationLevel > 0 || CGO.OptimizeSize > 0)
+    theModule->setAttr(cir::CIRDialect::getOptInfoAttrName(),
+                       cir::OptInfoAttr::get(&context, CGO.OptimizationLevel,
+                                             CGO.OptimizeSize));
   // Set the module name to be the name of the main file. TranslationUnitDecl
   // often contains invalid source locations and isn't a reliable source for the
   // module location.

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -215,6 +215,23 @@ void LangAttr::print(AsmPrinter &printer) const {
 }
 
 //===----------------------------------------------------------------------===//
+// OptInfoAttr definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult OptInfoAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                                  unsigned level, unsigned size) {
+  if (level > 3) {
+    emitError() << "optimization level must be between 0 and 3 inclusive";
+    return failure();
+  }
+  if (size > 2) {
+    emitError() << "size optimization level must be between 0 and 2 inclusive";
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConstPtrAttr definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -23,8 +23,10 @@
 namespace cir {
 
 CIRLowerContext::CIRLowerContext(mlir::ModuleOp module,
-                                 clang::LangOptions LOpts)
-    : MLIRCtx(module.getContext()), LangOpts(LOpts) {}
+                                 clang::LangOptions LOpts,
+                                 clang::CodeGenOptions CGOpts)
+    : MLIRCtx(module.getContext()), LangOpts(std::move(LOpts)),
+      CodeGenOpts(std::move(CGOpts)) {}
 
 CIRLowerContext::~CIRLowerContext() {}
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.h
@@ -44,6 +44,9 @@ private:
   /// this ASTContext object.
   clang::LangOptions LangOpts;
 
+  /// Options for code generation.
+  clang::CodeGenOptions CodeGenOpts;
+
   //===--------------------------------------------------------------------===//
   //                         Built-in Types
   //===--------------------------------------------------------------------===//
@@ -51,7 +54,8 @@ private:
   mlir::Type CharTy;
 
 public:
-  CIRLowerContext(mlir::ModuleOp module, clang::LangOptions LOpts);
+  CIRLowerContext(mlir::ModuleOp module, clang::LangOptions LOpts,
+                  clang::CodeGenOptions CGOpts);
   CIRLowerContext(const CIRLowerContext &) = delete;
   CIRLowerContext &operator=(const CIRLowerContext &) = delete;
   ~CIRLowerContext();
@@ -72,6 +76,8 @@ public:
   const clang::TargetInfo &getTargetInfo() const { return *Target; }
 
   const clang::LangOptions &getLangOpts() const { return LangOpts; }
+
+  const clang::CodeGenOptions &getCodeGenOpts() const { return CodeGenOpts; }
 
   mlir::MLIRContext *getMLIRContext() const { return MLIRCtx; }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -42,8 +42,8 @@ class LowerModule {
   mlir::PatternRewriter &rewriter;
 
 public:
-  LowerModule(clang::LangOptions opts, mlir::ModuleOp &module,
-              std::unique_ptr<clang::TargetInfo> target,
+  LowerModule(clang::LangOptions langOpts, clang::CodeGenOptions codeGenOpts,
+              mlir::ModuleOp &module, std::unique_ptr<clang::TargetInfo> target,
               mlir::PatternRewriter &rewriter);
   ~LowerModule() = default;
 

--- a/clang/test/CIR/CodeGen/optimization-attr.cpp
+++ b/clang/test/CIR/CodeGen/optimization-attr.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -O0 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CHECK-O0 %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -O1 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CHECK-O1 %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -O2 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CHECK-O2 %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -O3 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CHECK-O3 %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Os -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CHECK-Os %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Oz -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CHECK-Oz %s
+
+void foo() {}
+
+// CHECK-O0: module
+// CHECK-O0-NOT: cir.opt_info
+
+// CHECK-O1: module
+// CHECK-O1: cir.opt_info = #cir.opt_info<level = 1, size = 0>
+
+// CHECK-O2: module
+// CHECK-O2: cir.opt_info = #cir.opt_info<level = 2, size = 0>
+
+// CHECK-O3: module
+// CHECK-O3: cir.opt_info = #cir.opt_info<level = 3, size = 0>
+
+// CHECK-Os: module
+// CHECK-Os: cir.opt_info = #cir.opt_info<level = 2, size = 1>
+
+// CHECK-Oz: module
+// CHECK-Oz: cir.opt_info = #cir.opt_info<level = 2, size = 2>


### PR DESCRIPTION
This PR adds `clang::CodeGenOptions` to the lowering context. Similar to `clang::LangOptions`, the code generation options are currently set to the default values when initializing the lowering context.

Besides, this PR also adds a new attribute `#cir.opt_level`. The attribute is a module-level attribute and it holds the optimization level (e.g. -O1, -Oz, etc.). The attribute is consumed when initializing the lowering context to populate the `OptimizationLevel` and the `OptimizeSize` field in the code generation options. CIRGen is updated to attach this attribute to the module op.