### PR TITLE
[CIR][CIRGen] Introduce cir.delete.array op

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3498,6 +3498,21 @@ def LLVMIntrinsicCallOp : CIR_Op<"llvm.intrinsic"> {
 }
 
 //===----------------------------------------------------------------------===//
+// DeleteArrayOp
+//===----------------------------------------------------------------------===//
+
+def DeleteArrayOp : CIR_Op<"delete.array">,
+              Arguments<(ins CIR_PointerType:$address)> {
+  let summary = "Delete address representing an array";
+  let description = [{
+    `cir.delete.array` operation deletes an array. For example, `delete[] ptr;`
+    will be translated to `cir.delete.array %ptr`.
+  }];
+  let assemblyFormat = "$address `:` type($address) attr-dict";
+  let hasVerifier = 0;
+}
+
+//===----------------------------------------------------------------------===//
 // CallOp and TryCallOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -901,17 +901,23 @@ void CIRGenFunction::emitCXXDeleteExpr(const CXXDeleteExpr *E) {
     return;
   }
 
+  // In CodeGen:
   // We might be deleting a pointer to array.  If so, GEP down to the
   // first non-array element.
   // (this assumes that A(*)[3][7] is converted to [3 x [7 x %A]]*)
+  // In CIRGen: we handle this differently because the deallocation of
+  // array highly relates to the array cookies, which is ABI sensitive,
+  // we plan to handle it in LoweringPreparePass and the corresponding
+  // ABI part.
   if (DeleteTy->isConstantArrayType()) {
-    llvm_unreachable("NYI");
+    Ptr = Ptr;
   }
 
   assert(convertTypeForMem(DeleteTy) == Ptr.getElementType());
 
   if (E->isArrayForm()) {
-    llvm_unreachable("NYI");
+    builder.create<cir::DeleteArrayOp>(Ptr.getPointer().getLoc(),
+                                       Ptr.getPointer());
   } else {
     (void)EmitObjectDelete(*this, E, Ptr, DeleteTy);
   }

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1167,6 +1167,8 @@ void LoweringPreparePass::runOnOp(Operation *op) {
     lowerThreeWayCmpOp(threeWayCmp);
   } else if (auto vaArgOp = dyn_cast<VAArgOp>(op)) {
     lowerVAArgOp(vaArgOp);
+  } else if (auto deleteArrayOp = dyn_cast<DeleteArrayOp>(op)) {
+    lowerDeleteArrayOp(deleteArrayOp);
   } else if (auto getGlobal = dyn_cast<GlobalOp>(op)) {
     lowerGlobalOp(getGlobal);
   } else if (auto dynamicCast = dyn_cast<DynamicCastOp>(op)) {

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareCXXABI.h
@@ -32,6 +32,10 @@ public:
 
   virtual mlir::Value lowerVAArg(CIRBaseBuilderTy &builder, cir::VAArgOp op,
                                  const cir::CIRDataLayout &datalayout) = 0;
+
+  virtual mlir::Value
+  lowerDeleteArray(cir::CIRBaseBuilderTy &builder, cir::DeleteArrayOp op,
+                   const cir::CIRDataLayout &datalayout) = 0;
   virtual ~LoweringPrepareCXXABI() {}
 
   virtual mlir::Value lowerDynamicCast(CIRBaseBuilderTy &builder,

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.h
@@ -21,4 +21,16 @@ public:
                                cir::DynamicCastOp op) override;
   mlir::Value lowerVAArg(cir::CIRBaseBuilderTy &builder, cir::VAArgOp op,
                          const cir::CIRDataLayout &datalayout) override;
+
+  mlir::Value lowerDeleteArray(cir::CIRBaseBuilderTy &builder,
+                               cir::DeleteArrayOp op,
+                               const cir::CIRDataLayout &datalayout) override {
+    // Note: look at `CIRGenFunction::EmitCXXDeleteExpr(const CXXDeleteExpr *)`
+    // in CIRGenExprCXX.cpp.
+    // In traditional code gen, we need handle ABI related array cookie to
+    // generate codes to handle the expression to delete array. We need similar
+    // mechanism here for ItaniumCXXABI.
+    llvm_unreachable("NYI && Delete Array is not supported to be lowered in "
+                     "Itanium CXX ABI");
+  }
 };

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -164,4 +164,7 @@ public:
                                cir::DynamicCastOp op) override;
   mlir::Value lowerVAArg(cir::CIRBaseBuilderTy &builder, cir::VAArgOp op,
                          const cir::CIRDataLayout &datalayout) override;
+  mlir::Value lowerDeleteArray(cir::CIRBaseBuilderTy &builder,
+                               cir::DeleteArrayOp op,
+                               const cir::CIRDataLayout &datalayout) override;
 };

--- a/clang/test/CIR/CodeGen/delete-array.cpp
+++ b/clang/test/CIR/CodeGen/delete-array.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void test_delete_array(int *ptr) {
+  delete[] ptr;
+}
+
+// CHECK: cir.delete.array 


### PR DESCRIPTION
I am working on a clangir based solution to improve C++'s safety (https://discourse.llvm.org/t/rfc-a-clangir-based-safe-c/83245). This is similar with the previous analysis only approach I proposed, where we may not care about the lowered code. And this is what I described as layering problems in https://discourse.llvm.org/t/rfc-a-clangir-based-safe-c/83245

This is similar with the other issue proposed https://github.com/llvm/clangir/issues/1128. We'd better to emit the higher level operations and lowering/optimizing it later.

This is also inspired our handling method for VAArg, where we use ABI information to lower things during the passes. It gives me more confidence that I am doing things right.