### PR TITLE
[CIR][CIRGen][Builtin] Support __builtin_elementwise_abs with vector of floating type

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -330,9 +330,6 @@ struct MissingFeatures {
 
   //-- Other missing features
 
-  // We need to extend fpUnaryOPs to support vector types.
-  static bool fpUnaryOPsSupportVectorType() { return false; }
-
   // We need to track the parent record types that represent a field
   // declaration. This is necessary to determine the layout of a class.
   static bool fieldDeclAbstraction() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1309,10 +1309,12 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     mlir::Type cirTy = ConvertType(E->getArg(0)->getType());
     bool isIntTy = cir::isIntOrIntVectorTy(cirTy);
     if (!isIntTy) {
-      if (cir::isAnyFloatingPointType(cirTy)) {
+      mlir::Type eltTy = cirTy;
+      if (mlir::isa<cir::VectorType>(cirTy))
+        eltTy = mlir::cast<cir::VectorType>(cirTy).getEltType();
+      if (mlir::isa<cir::SingleType, cir::DoubleType>(eltTy)) {
         return emitUnaryFPBuiltin<cir::FAbsOp>(*this, *E);
       }
-      assert(!MissingFeatures::fpUnaryOPsSupportVectorType());
       llvm_unreachable("unsupported type for BI__builtin_elementwise_abs");
     }
     mlir::Value arg = emitScalarExpr(E->getArg(0));

--- a/clang/test/CIR/CodeGen/builtins-elementwise.c
+++ b/clang/test/CIR/CodeGen/builtins-elementwise.c
@@ -5,8 +5,11 @@
 // RUN: FileCheck  --check-prefix=LLVM --input-file=%t.ll %s
 
 typedef int vint4 __attribute__((ext_vector_type(4)));
+typedef float vfloat4 __attribute__((ext_vector_type(4)));
+typedef double vdouble4 __attribute__((ext_vector_type(4)));
 
-void test_builtin_elementwise_abs(vint4 vi4, int i, float f, double d) {
+void test_builtin_elementwise_abs(vint4 vi4, int i, float f, double d, 
+                                  vfloat4 vf4, vdouble4  vd4) {
     // CIR-LABEL: test_builtin_elementwise_abs
     // LLVM-LABEL: test_builtin_elementwise_abs
     // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.float
@@ -24,4 +27,12 @@ void test_builtin_elementwise_abs(vint4 vi4, int i, float f, double d) {
     // CIR: {{%.*}} = cir.abs {{%.*}} : !s32
     // LLVM: {{%.*}} = call i32 @llvm.abs.i32(i32 {{%.*}}, i1 false)
     i = __builtin_elementwise_abs(i);
+
+    // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.float x 4>
+    // LLVM: {{%.*}} = call <4 x float> @llvm.fabs.v4f32(<4 x float> {{%.*}})
+    vf4 = __builtin_elementwise_abs(vf4);
+
+    // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.double x 4>
+    // LLVM: {{%.*}} = call <4 x double> @llvm.fabs.v4f64(<4 x double> {{%.*}})
+    vd4 = __builtin_elementwise_abs(vd4);
 }


### PR DESCRIPTION
[PR1132](https://github.com/llvm/clangir/pull/1132) implements missing feature `fpUnaryOPsSupportVectorType`, so revisit this code.

One another thing changed is that I stopped using `cir::isAnyFloatingPointType` as it contains types like long double and FP80 which are not supported by the [builtin's signature](https://clang.llvm.org/docs/LanguageExtensions.html#vector-builtins) 