### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower SISD neon_vqrdmulhs_s32

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -2613,8 +2613,12 @@ mlir::Value CIRGenFunction::emitCommonNeonBuiltinExpr(
 
 static mlir::Value emitCommonNeonSISDBuiltinExpr(
     CIRGenFunction &cgf, const ARMVectorIntrinsicInfo &info,
-    llvm::SmallVectorImpl<mlir::Value> &args, const CallExpr *expr) {
+    llvm::SmallVectorImpl<mlir::Value> &ops, const CallExpr *expr) {
   unsigned builtinID = info.BuiltinID;
+  clang::CIRGen::CIRGenBuilderTy &builder = cgf.getBuilder();
+  mlir::Type resultTy = cgf.convertType(expr->getType());
+  mlir::Location loc = cgf.getLoc(expr->getExprLoc());
+
   switch (builtinID) {
   default:
     llvm::errs() << getAArch64SIMDIntrinsicString(builtinID) << " ";
@@ -2862,7 +2866,8 @@ static mlir::Value emitCommonNeonSISDBuiltinExpr(
   case NEON::BI__builtin_neon_vqrdmulhh_s16:
     llvm_unreachable(" neon_vqrdmulhh_s16 NYI ");
   case NEON::BI__builtin_neon_vqrdmulhs_s32:
-    llvm_unreachable(" neon_vqrdmulhs_s32 NYI ");
+    return emitNeonCall(builder, {resultTy, resultTy}, ops,
+                        "aarch64.neon.sqrdmulh", resultTy, loc);
   case NEON::BI__builtin_neon_vqrshlb_s8:
     llvm_unreachable(" neon_vqrshlb_s8 NYI ");
   case NEON::BI__builtin_neon_vqrshlb_u8:

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -10005,12 +10005,16 @@ poly16x8_t test_vmull_p8(poly8x8_t a, poly8x8_t b) {
 //   return vqrdmulhh_s16(a, b);
 // }
 
-// NYI-LABEL: @test_vqrdmulhs_s32(
-// NYI:   [[VQRDMULHS_S32_I:%.*]] = call i32 @llvm.aarch64.neon.sqrdmulh.i32(i32 %a, i32 %b)
-// NYI:   ret i32 [[VQRDMULHS_S32_I]]
-// int32_t test_vqrdmulhs_s32(int32_t a, int32_t b) {
-//   return vqrdmulhs_s32(a, b);
-// }
+int32_t test_vqrdmulhs_s32(int32_t a, int32_t b) {
+  return vqrdmulhs_s32(a, b);
+
+  // CIR-LABEL: vqrdmulhs_s32
+  // CIR: cir.llvm.intrinsic "aarch64.neon.sqrdmulh" {{%.*}}, {{%.*}} : (!s32i, !s32i) -> !s32i
+
+  // LLVM: {{.*}}test_vqrdmulhs_s32(i32{{.*}}[[a:%.*]], i32{{.*}}[[b:%.*]])
+  // LLVM:   [[VQRDMULHS_S32_I:%.*]] = call i32 @llvm.aarch64.neon.sqrdmulh.i32(i32 [[a]], i32 [[b]])
+  // LLVM:   ret i32 [[VQRDMULHS_S32_I]]
+}
 
 // NYI-LABEL: @test_vmulxs_f32(
 // NYI:   [[VMULXS_F32_I:%.*]] = call float @llvm.aarch64.neon.fmulx.f32(float %a, float %b)


### PR DESCRIPTION
 [OG's implementation ](https://github.com/llvm/clangir/blob/aaf38b30d31251f3411790820c5e1bf914393ddc/clang/lib/CodeGen/CGBuiltin.cpp#L7527) provides one common code to handle all neon SISD intrinsics. But IMHO, it entangles different things together which hurts readability.
Here, We start with simple easy-to-understand approach with specific case. And in the future, as we handle more intrinsics, we may come up with a few simple common patterns.