### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower neon_vaddlvq_u16

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -4254,7 +4254,10 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
     llvm_unreachable("NEON::BI__builtin_neon_vaddlvq_u8 NYI");
   }
   case NEON::BI__builtin_neon_vaddlvq_u16: {
-    llvm_unreachable("NEON::BI__builtin_neon_vaddlvq_u16 NYI");
+    mlir::Type argTy = cir::VectorType::get(builder.getContext(), UInt16Ty, 8);
+    llvm::SmallVector<mlir::Value, 1> argOps = {emitScalarExpr(E->getArg(0))};
+    return emitNeonCall(builder, {argTy}, argOps, "aarch64.neon.uaddlv",
+                        UInt32Ty, getLoc(E->getExprLoc()));
   }
   case NEON::BI__builtin_neon_vaddlv_s8: {
     llvm_unreachable("NEON::BI__builtin_neon_vaddlv_s8 NYI");

--- a/clang/test/CIR/CodeGen/AArch64/neon-arith.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-arith.c
@@ -882,3 +882,14 @@ float64x2_t test_vabsq_f64(float64x2_t a) {
   // LLVM: [[VABS_F:%.*]] = call <2 x double> @llvm.fabs.v2f64(<2 x double> [[a]])
   // LLVM: ret <2 x double> [[VABS_F]]
 }
+
+uint32_t test_vaddlvq_u16(uint16x8_t a) {
+  return vaddlvq_u16(a);
+
+  // CIR-LABEL: vaddlvq_u16
+  // CIR: cir.llvm.intrinsic "aarch64.neon.uaddlv" {{%.*}}: (!cir.vector<!u16i x 8>) -> !u32i
+
+  // LLVM: {{.*}}test_vaddlvq_u16(<8 x i16>{{.*}}[[A:%.*]])
+  // LLVM: [[VADDLV_I:%.*]] = call i32 @llvm.aarch64.neon.uaddlv.i32.v8i16(<8 x i16> [[A]])
+  // LLVM: ret i32 [[VADDLV_I]]
+}


### PR DESCRIPTION
[OG's implementation here](https://github.com/llvm/clangir/blob/1b052dac90f8d070aafc2034e13ae3e88552d58a/clang/lib/CodeGen/CGBuiltin.cpp#L13432)
[OG's test here](https://github.com/llvm/clangir/blob/1b052dac90f8d070aafc2034e13ae3e88552d58a/clang/test/CodeGen/AArch64/neon-across.c#L41)