### PR TITLE
[CIR][CIRGen] Handle NYI in CIRGenModule::tryEmitBaseDestructorAsAlias

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3531,6 +3531,16 @@ class CIR_CallOp<string mnemonic, list<Trait> extra_traits = []> :
 
     bool isIndirect() { return !getCallee(); }
     mlir::Value getIndirectCall();
+
+    void setArg(unsigned index, mlir::Value value) {
+      if (!isIndirect()) {
+        setOperand(index, value);
+        return;
+      }
+
+      // For indirect call, the operand list is shifted by one.
+      setOperand(index + 1, value);
+    }
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -155,7 +155,7 @@ bool CIRGenModule::tryEmitBaseDestructorAsAlias(const CXXDestructorDecl *D) {
   // symbol reference from another TU. The other TU must also mark the
   // referenced symbol as weak, which we cannot rely on.
   if (cir::isWeakForLinker(Linkage) && getTriple().isOSBinFormatCOFF()) {
-    assert(false && "please sent a PR with a test and remove this.\n");
+    llvm_unreachable("please sent a PR with a test and remove this.\n");
     return true;
   }
 
@@ -171,7 +171,7 @@ bool CIRGenModule::tryEmitBaseDestructorAsAlias(const CXXDestructorDecl *D) {
   // output the alias both for weak_odr and linkonce_odr, but that
   // requires explicit comdat support in the IL.
   if (cir::isWeakForLinker(TargetLinkage)) {
-    assert(false && "please sent a PR with a test and remove this.\n");
+    llvm_unreachable("please sent a PR with a test and remove this.\n");
     return true;
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -145,7 +145,8 @@ bool CIRGenModule::tryEmitBaseDestructorAsAlias(const CXXDestructorDecl *D) {
     // members with attribute "AlwaysInline" and expect no reference to
     // be generated. It is desirable to reenable this optimisation after
     // corresponding LLVM changes.
-    llvm_unreachable("NYI");
+    addReplacement(MangledName, Aliasee);
+    return false;
   }
 
   // If we have a weak, non-discardable alias (weak, weak_odr), like an
@@ -154,7 +155,8 @@ bool CIRGenModule::tryEmitBaseDestructorAsAlias(const CXXDestructorDecl *D) {
   // symbol reference from another TU. The other TU must also mark the
   // referenced symbol as weak, which we cannot rely on.
   if (cir::isWeakForLinker(Linkage) && getTriple().isOSBinFormatCOFF()) {
-    llvm_unreachable("NYI");
+    assert(false && "please sent a PR with a test and remove this.\n");
+    return true;
   }
 
   // If we don't have a definition for the destructor yet or the definition
@@ -168,8 +170,10 @@ bool CIRGenModule::tryEmitBaseDestructorAsAlias(const CXXDestructorDecl *D) {
   // different COMDATs in different TUs. Another option would be to
   // output the alias both for weak_odr and linkonce_odr, but that
   // requires explicit comdat support in the IL.
-  if (cir::isWeakForLinker(TargetLinkage))
-    llvm_unreachable("NYI");
+  if (cir::isWeakForLinker(TargetLinkage)) {
+    assert(false && "please sent a PR with a test and remove this.\n");
+    return true;
+  }
 
   // Create the alias with no name.
   emitAliasForGlobal(MangledName, Entry, AliasDecl, Aliasee, Linkage);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3193,6 +3193,39 @@ void CIRGenModule::addReplacement(StringRef Name, mlir::Operation *Op) {
   Replacements[Name] = Op;
 }
 
+void CIRGenModule::replacePointerTypeArgs(cir::FuncOp OldF, cir::FuncOp NewF) {
+  auto optionalUseRange = OldF.getSymbolUses(theModule);
+  if (!optionalUseRange)
+    return;
+
+  for (auto U : *optionalUseRange) {
+    // FIXME: Handling TryCallOp here once they have the same base op.
+    auto Call = mlir::dyn_cast<cir::CallOp>(U.getUser());
+    if (!Call)
+      continue;
+
+    auto ArgOps = Call.getArgOps();
+    auto FuncArgTypes = NewF.getFunctionType().getInputs();
+    for (unsigned I = 0; I < FuncArgTypes.size(); I++) {
+      if (ArgOps[I].getType() == FuncArgTypes[I])
+        continue;
+
+      auto argPointerTy = mlir::dyn_cast<cir::PointerType>(ArgOps[I].getType());
+      auto funcArgPointerTy = mlir::dyn_cast<cir::PointerType>(FuncArgTypes[I]);
+
+      // If we can't solve it, leave it for the verifier to bail out.
+      if (!argPointerTy || !funcArgPointerTy)
+        continue;
+
+      mlir::OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPoint(Call);
+      auto castedArg =
+          builder.createBitcast(Call.getLoc(), ArgOps[I], funcArgPointerTy);
+      Call.setArg(I, castedArg);
+    }
+  }
+}
+
 void CIRGenModule::applyReplacements() {
   for (auto &I : Replacements) {
     StringRef MangledName = I.first();
@@ -3204,6 +3237,10 @@ void CIRGenModule::applyReplacements() {
     auto OldF = cast<cir::FuncOp>(Entry);
     auto NewF = dyn_cast<cir::FuncOp>(Replacement);
     assert(NewF && "not implemented");
+
+    // LLVM has opaque pointer but CIR not. So we may have to handle these
+    // different pointer types when performing replacement.
+    replacePointerTypeArgs(OldF, NewF);
 
     // Replace old with new, but keep the old order.
     if (OldF.replaceAllSymbolUses(NewF.getSymNameAttr(), theModule).failed())

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3199,7 +3199,7 @@ void CIRGenModule::replacePointerTypeArgs(cir::FuncOp OldF, cir::FuncOp NewF) {
     return;
 
   for (auto U : *optionalUseRange) {
-    // FIXME: Handling TryCallOp here once they have the same base op.
+    // CallTryOp only shows up after FlattenCFG.
     auto Call = mlir::dyn_cast<cir::CallOp>(U.getUser());
     if (!Call)
       continue;

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -871,6 +871,11 @@ private:
   /// Call replaceAllUsesWith on all pairs in Replacements.
   void applyReplacements();
 
+  /// A helper function to replace all uses of OldF to NewF that replace
+  /// the type of pointer arguments. This is not needed to tradtional
+  /// pipeline since LLVM has opaque pointers but CIR not.
+  void replacePointerTypeArgs(cir::FuncOp OldF, cir::FuncOp NewF);
+
   void setNonAliasAttributes(GlobalDecl GD, mlir::Operation *GV);
   /// Map source language used to a CIR attribute.
   cir::SourceLanguage getCIRSourceLanguage();

--- a/clang/test/CIR/CodeGen/dtor-alias.cpp
+++ b/clang/test/CIR/CodeGen/dtor-alias.cpp
@@ -1,0 +1,18 @@
+// FIXME: Remove of -clangir-disable-passes may trigger a memory safe bug in CIR internally during
+// lowering
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu \
+// RUN:   -mconstructor-aliases -fclangir -emit-cir %s -o %t.cir \
+// RUN:   -clangir-disable-passes -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir
+
+namespace {
+struct A {
+  ~A() {}
+};
+
+struct B : public A {};
+}
+
+B x;
+
+// CHECK: cir.call @_ZN12_GLOBAL__N_11AD2Ev({{.*}}) : (!cir.ptr<!ty_28anonymous_namespace293A3AA>) -> ()


### PR DESCRIPTION
This removes some NYI in CIRGenModule::tryEmitBaseDestructorAsAlias and similar to https://github.com/llvm/clangir/pull/1179, use `assert(false)` to tell devs to add test.

It is slightly verbose due to the difference between LLVM and CIR's type system. LLVM's pointer are opaque types while CIR's pointer are typed. So we need to handle these pointers when transforming the generated cir.