### PR TITLE
[CIR]fix `cir.std.initializer_list` validate issue for struct type initlist

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3854,7 +3854,9 @@ LogicalResult cir::StdInitializerListOp::verify() {
     return emitOpError("first member type of std::initializer_list must be "
                        "'!cir.ptr', but provided ")
            << resultType.getMembers()[0];
-  auto expectedType = memberPtr.getPointee();
+  mlir::Type expectedType = memberPtr.getPointee();
+  if (mlir::dyn_cast<cir::StructType>(expectedType))
+    expectedType = memberPtr;
   for (const mlir::Value &arg : getArgs())
     if (expectedType != arg.getType())
       return emitOpError("arg type must be ")

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3854,9 +3854,10 @@ LogicalResult cir::StdInitializerListOp::verify() {
     return emitOpError("first member type of std::initializer_list must be "
                        "'!cir.ptr', but provided ")
            << resultType.getMembers()[0];
-  mlir::Type expectedType = memberPtr.getPointee();
-  if (mlir::dyn_cast<cir::StructType>(expectedType))
-    expectedType = memberPtr;
+  const mlir::Type templateType = memberPtr.getPointee();
+  const mlir::Type expectedType =
+      mlir::isa<cir::StructType, cir::ArrayType>(templateType) ? memberPtr
+                                                               : templateType;
   for (const mlir::Value &arg : getArgs())
     if (expectedType != arg.getType())
       return emitOpError("arg type must be ")

--- a/clang/test/CIR/CodeGen/initlist-array.cpp
+++ b/clang/test/CIR/CodeGen/initlist-array.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s -o %t.cir -clangir-disable-passes
+// RUN: FileCheck --check-prefix=BEFORE --input-file=%t.cir %s
+
+namespace std {
+template <class b> class initializer_list {
+  const b *array_start;
+  const b *array_end;
+};
+
+} // namespace std
+
+void f(std::initializer_list<int[2]>);
+void test() {
+  f({{1,2},{1,2}});
+}
+
+// BEFORE: [[INITLIST_TYPE:!.*]] = !cir.struct<class "std::initializer_list<int[2]>" {!cir.ptr<!cir.array<!s32i x 2>>, !cir.ptr<!cir.array<!s32i x 2>>} #cir.record.decl.ast>
+// BEFORE: %0 = cir.alloca !ty_std3A3Ainitializer_list3Cint5B25D3E, !cir.ptr<!ty_std3A3Ainitializer_list3Cint5B25D3E>, ["agg.tmp0"] {alignment = 8 : i64}
+// BEFORE: %1 = cir.alloca !cir.array<!s32i x 2>, !cir.ptr<!cir.array<!s32i x 2>>, ["agg.tmp1"] {alignment = 4 : i64}
+// BEFORE: %2 = cir.alloca !cir.array<!s32i x 2>, !cir.ptr<!cir.array<!s32i x 2>>, ["agg.tmp2"] {alignment = 4 : i64}
+// ignore cir for array initialization
+// BEFORE: cir.std.initializer_list %0 (%1, %2 : !cir.ptr<!cir.array<!s32i x 2>>, !cir.ptr<!cir.array<!s32i x 2>>) : !cir.ptr<[[INITLIST_TYPE]]>

--- a/clang/test/CIR/CodeGen/initlist-record.cpp
+++ b/clang/test/CIR/CodeGen/initlist-record.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s -o %t.cir -clangir-disable-passes
+// RUN: FileCheck --check-prefix=BEFORE --input-file=%t.cir %s
+
+namespace std {
+template <class b> class initializer_list {
+  const b *array_start;
+  const b *array_end;
+};
+
+} // namespace std
+
+struct A {};
+void f(std::initializer_list<A>);
+void test() {
+  f({A{},{}});
+}
+
+// BEFORE: [[INITLIST_TYPE:!.*]] = !cir.struct<class "std::initializer_list<A>" {!cir.ptr<!ty_A>, !cir.ptr<!ty_A>} #cir.record.decl.ast>
+// BEFORE: %0 = cir.alloca [[INITLIST_TYPE]], !cir.ptr<[[INITLIST_TYPE]]>, ["agg.tmp0"] {alignment = 8 : i64}
+// BEFORE: %1 = cir.alloca !ty_A, !cir.ptr<!ty_A>, ["agg.tmp1"] {alignment = 1 : i64}
+// BEFORE: %2 = cir.alloca !ty_A, !cir.ptr<!ty_A>, ["agg.tmp2"] {alignment = 1 : i64}
+// BEFORE: cir.std.initializer_list %0 (%1, %2 : !cir.ptr<!ty_A>, !cir.ptr<!ty_A>) : !cir.ptr<[[INITLIST_TYPE]]>
+// BEFORE: %3 = cir.load %0 : !cir.ptr<[[INITLIST_TYPE]]>, [[INITLIST_TYPE]]
+// BEFORE: cir.call @_Z1fSt16initializer_listI1AE(%3) : ([[INITLIST_TYPE]]) -> ()


### PR DESCRIPTION
cir test is missing because `StructType::getPreferredAlignment` is still NYI