### PR TITLE
[CIR][cir-translate] Support specifying target for `cir-translate`

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -231,6 +231,7 @@ struct MissingFeatures {
   static bool isPPC_FP128Ty() { return false; }
   static bool emitBinaryAtomicPostHasInvert() { return false; }
   static bool createLaunderInvariantGroup() { return false; }
+  static bool supportNonLinuxOSTriples() { return false; }
 
   // Inline assembly
   static bool asmGoto() { return false; }

--- a/clang/test/CIR/Lowering/address-space.cir
+++ b/clang/test/CIR/Lowering/address-space.cir
@@ -1,12 +1,9 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o %t.ll
+// RUN: cir-translate %s -cir-to-llvmir --target spirv64-unknown-unknown --disable-cc-lowering -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 
-module attributes {
-  cir.triple = "spirv64-unknown-unknown",
-  dlti.dl_spec = #dlti.dl_spec<i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, "dlti.endianness" = "little", "dlti.global_memory_space" = 1 : ui64>
-} {
+module {
   cir.global external addrspace(offload_global) @addrspace1 = #cir.int<1> : !s32i
   // LLVM: @addrspace1 = addrspace(1) global i32
 

--- a/clang/test/CIR/Lowering/data-member.cir
+++ b/clang/test/CIR/Lowering/data-member.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt -cir-to-llvm -o - %s | FileCheck -check-prefix=MLIR %s
-// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o - %s  | FileCheck -check-prefix=LLVM %s
+// RUN: cir-translate -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o - %s  | FileCheck -check-prefix=LLVM %s
 
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
@@ -7,7 +7,7 @@
 
 module @test attributes {
   cir.triple = "x86_64-unknown-linux-gnu",
-  llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  dlti.dl_spec = #dlti.dl_spec<i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">
 } {
   cir.global external @pt_member = #cir.data_member<1> : !cir.data_member<!s32i in !structT>
   // MLIR: llvm.mlir.global external @pt_member(4 : i64) {addr_space = 0 : i32} : i64

--- a/clang/test/CIR/Lowering/exceptions.cir
+++ b/clang/test/CIR/Lowering/exceptions.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o %t.ll
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
@@ -8,7 +8,7 @@
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-module @"try-catch.cpp" attributes {cir.lang = #cir.lang<cxx>, cir.sob = #cir.signed_overflow_behavior<undefined>, cir.triple = "x86_64-unknown-linux-gnu", dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>, #dlti.dl_entry<"dlti.endianness", "little">>} {
+module @"try-catch.cpp" attributes {cir.lang = #cir.lang<cxx>, cir.sob = #cir.signed_overflow_behavior<undefined>} {
   cir.global "private" constant external @_ZTIi : !cir.ptr<!u8i>
   cir.global "private" constant external @_ZTIPKc : !cir.ptr<!u8i>
   cir.func private @_Z8divisionii(!s32i, !s32i) -> !cir.double

--- a/clang/test/CIR/Tools/cir-translate-target-option/has-triple-and-data-layout.cir
+++ b/clang/test/CIR/Tools/cir-translate-target-option/has-triple-and-data-layout.cir
@@ -1,0 +1,24 @@
+// RUN: cir-translate --cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering %s -o %t.x86.ll
+// RUN: FileCheck %s -input-file %t.x86.ll -check-prefix=X86
+// RUN: cir-translate --cir-to-llvmir --target spirv64-unknown-unknown --disable-cc-lowering %s -o %t.spirv64.ll
+// RUN: FileCheck %s -input-file %t.spirv64.ll -check-prefix=SPIRV64
+// RUN: cir-translate --cir-to-llvmir --disable-cc-lowering %s -o %t.default.ll
+// RUN: FileCheck %s -input-file %t.default.ll -check-prefix=DEFAULT
+
+module attributes {
+  cir.triple = "spirv64-unknown-unknown",
+  dlti.dl_spec = #dlti.dl_spec<"dlti.global_memory_space" = 7 : ui64>
+} {
+  cir.func @foo() {
+    cir.return
+  }
+}
+
+// X86-NOT: target datalayout = "G7"
+// X86-DAG: target triple = "x86_64-unknown-linux-gnu"
+
+// SPIRV64-NOT: target datalayout = "G7"
+// SPIRV64-DAG: target triple = "spirv64-unknown-unknown"
+
+// DEFAULT-DAG: target datalayout = "G7"
+// DEFAULT-DAG: target triple = "spirv64-unknown-unknown"

--- a/clang/test/CIR/Tools/cir-translate-target-option/has-triple-no-data-layout.cir
+++ b/clang/test/CIR/Tools/cir-translate-target-option/has-triple-no-data-layout.cir
@@ -1,0 +1,23 @@
+// RUN: cir-translate --cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering %s -o %t.x86.ll
+// RUN: FileCheck %s -input-file %t.x86.ll -check-prefix=X86
+// RUN: cir-translate --cir-to-llvmir --target spirv64-unknown-unknown --disable-cc-lowering %s -o %t.spirv64.ll
+// RUN: FileCheck %s -input-file %t.spirv64.ll -check-prefix=SPIRV64
+// RUN: cir-translate --cir-to-llvmir --disable-cc-lowering %s -o %t.default.ll
+// RUN: FileCheck %s -input-file %t.default.ll -check-prefix=DEFAULT
+
+module attributes {
+  cir.triple = "spirv64-unknown-unknown"
+} {
+  cir.func @foo() {
+    cir.return
+  }
+}
+
+// X86-DAG: target triple = "x86_64-unknown-linux-gnu"
+// X86-DAG: target datalayout = "{{.*}}"
+
+// SPIRV64-DAG: target triple = "spirv64-unknown-unknown"
+// SPIRV64-DAG: target datalayout = "{{.*}}"
+
+// DEFAULT-DAG: target triple = "spirv64-unknown-unknown"
+// DEFAULT-DAG: target datalayout = "{{.*}}"

--- a/clang/test/CIR/Tools/cir-translate-target-option/no-triple-has-data-layout.cir
+++ b/clang/test/CIR/Tools/cir-translate-target-option/no-triple-has-data-layout.cir
@@ -1,0 +1,23 @@
+// RUN: cir-translate --cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering %s -o %t.x86.ll
+// RUN: FileCheck %s -input-file %t.x86.ll -check-prefix=X86
+// RUN: cir-translate --cir-to-llvmir --target spirv64-unknown-unknown --disable-cc-lowering %s -o %t.spirv64.ll
+// RUN: FileCheck %s -input-file %t.spirv64.ll -check-prefix=SPIRV64
+// RUN: cir-translate --cir-to-llvmir --disable-cc-lowering %s -o %t.default.ll
+// RUN: FileCheck %s -input-file %t.default.ll -check-prefix=DEFAULT
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<"dlti.global_memory_space" = 7 : ui64>
+} {
+  cir.func @foo() {
+    cir.return
+  }
+}
+
+// X86-NOT: target datalayout = "G7"
+// X86-DAG: target triple = "x86_64-unknown-linux-gnu"
+
+// SPIRV64-NOT: target datalayout = "G7"
+// SPIRV64-DAG: target triple = "spirv64-unknown-unknown"
+
+// DEFAULT-NOT: target datalayout = "G7"
+// DEFAULT-DAG: target triple = "x86_64-unknown-linux-gnu"

--- a/clang/test/CIR/Tools/cir-translate-target-option/no-triple-no-data-layout.cir
+++ b/clang/test/CIR/Tools/cir-translate-target-option/no-triple-no-data-layout.cir
@@ -1,0 +1,21 @@
+// RUN: cir-translate --cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering %s -o %t.x86.ll
+// RUN: FileCheck %s -input-file %t.x86.ll -check-prefix=X86
+// RUN: cir-translate --cir-to-llvmir --target spirv64-unknown-unknown --disable-cc-lowering %s -o %t.spirv64.ll
+// RUN: FileCheck %s -input-file %t.spirv64.ll -check-prefix=SPIRV64
+// RUN: cir-translate --cir-to-llvmir --disable-cc-lowering %s -o %t.default.ll
+// RUN: FileCheck %s -input-file %t.default.ll -check-prefix=DEFAULT
+
+module {
+  cir.func @foo() {
+    cir.return
+  }
+}
+
+// X86-DAG: target triple = "x86_64-unknown-linux-gnu"
+// X86-DAG: target datalayout = "{{.*}}"
+
+// SPIRV64-DAG: target triple = "spirv64-unknown-unknown"
+// SPIRV64-DAG: target datalayout = "{{.*}}"
+
+// DEFAULT-DAG: target triple = "x86_64-unknown-linux-gnu"
+// DEFAULT-DAG: target datalayout = "{{.*}}"

--- a/clang/test/CIR/Tools/cir-translate-target-option/value-invalid.cir
+++ b/clang/test/CIR/Tools/cir-translate-target-option/value-invalid.cir
@@ -1,0 +1,9 @@
+// RUN: not cir-translate --cir-to-llvmir --target foobar --disable-cc-lowering %s 2>&1 | FileCheck %s -check-prefix=INVALID
+
+module {
+  cir.func @foo() {
+    cir.return
+  }
+}
+
+// INVALID: error: invalid target triple 'foobar'

--- a/clang/test/CIR/Tools/cir-translate-triple.cir
+++ b/clang/test/CIR/Tools/cir-translate-triple.cir
@@ -1,10 +1,7 @@
-// RUN: cir-translate --cir-to-llvmir --disable-cc-lowering %s -o %t.ll
+// RUN: cir-translate --cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering %s -o %t.ll
 // RUN: FileCheck %s -input-file %t.ll -check-prefix=LLVM
 
-module attributes {
-  cir.triple = "x86_64-unknown-linux-gnu",
-  dlti.dl_spec = #dlti.dl_spec<i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">
-} {
+module {
   cir.func @foo() {
     cir.return
   }

--- a/clang/tools/cir-translate/cir-translate.cpp
+++ b/clang/tools/cir-translate/cir-translate.cpp
@@ -13,14 +13,22 @@
 
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/InitAllTranslations.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/LLVMIR/Dialect/All.h"
+#include "mlir/Target/LLVMIR/Import.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 #include "mlir/Tools/mlir-translate/Translation.h"
+
 #include "llvm/IR/Module.h"
+#include "llvm/TargetParser/Host.h"
+
+#include "clang/Basic/TargetInfo.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/MissingFeatures.h"
 
 namespace cir {
 namespace direct {
@@ -30,6 +38,103 @@ extern std::unique_ptr<llvm::Module> lowerDirectlyFromCIRToLLVMIR(
     bool disableVerifier = false, bool disableCCLowering = false,
     bool disableDebugInfo = false);
 } // namespace direct
+
+namespace {
+
+std::string determineDataLayoutByTriple(llvm::StringRef rawTriple) {
+  llvm::Triple triple(rawTriple);
+  // Data layout is fully determined by the target triple. Here we only pass the
+  // triple to get the data layout.
+  clang::TargetOptions targetOptions;
+  targetOptions.Triple = rawTriple;
+  // FIXME: AllocateTarget is a big deal. Better make it a global state.
+  auto targetInfo =
+      clang::targets::AllocateTarget(llvm::Triple(rawTriple), targetOptions);
+  if (!targetInfo) {
+    llvm::errs() << "error: invalid target triple '" << rawTriple << "'\n";
+    exit(1);
+  }
+  return targetInfo->getDataLayoutString();
+}
+
+/// The goal of this option is to ensure that the triple and data layout specs
+/// are always available in the ClangIR module. With this requirement met, the
+/// behavior of this option is designed to be as intuitive as possible, as shown
+/// in the table below:
+///
+/// +--------+--------+-------------+-----------------+-----------------------+
+/// | Option | Triple | Data Layout | Behavior Triple | Behavior Data Layout  |
+/// +========+========+=============+=================+=======================+
+/// | T      | T      | T           | Overwrite       | Derive from triple    |
+/// | T      | T      | F           | Overwrite       | Derive from triple    |
+/// | T      | F      | T           | Overwrite       | Derive from triple    |
+/// | T      | F      | F           | Overwrite       | Derive from triple    |
+/// | F      | T      | T           |                 |                       |
+/// | F      | T      | F           |                 | Derive from triple    |
+/// | F      | F      | T           | Set default     | Derive from triple    |
+/// | F      | F      | F           | Set default     | Derive from triple    |
+/// +--------+--------+-------------+-----------------+-----------------------+
+llvm::cl::opt<std::string>
+    targetTripleOption("target",
+                       llvm::cl::desc("Specify a default target triple when "
+                                      "it's not available in the module"),
+                       llvm::cl::init(""));
+
+std::string prepareCIRModuleTriple(mlir::ModuleOp mod) {
+  std::string triple = targetTripleOption;
+
+  // Treat "" as the default target machine.
+  if (triple.empty()) {
+    // FIXME: Use `llvm::sys::getDefaultTargetTriple()` in the future. Currently
+    // ClangIR does not support OS like Windows, which may lead to CI failure.
+    assert(!cir::MissingFeatures::supportNonLinuxOSTriples());
+    triple = "x86_64-unknown-linux-gnu";
+  }
+
+  mod->setAttr(cir::CIRDialect::getTripleAttrName(),
+               mlir::StringAttr::get(mod.getContext(), triple));
+  return triple;
+}
+
+void prepareCIRModuleDataLayout(mlir::ModuleOp mod, llvm::StringRef triple) {
+  auto *context = mod.getContext();
+
+  // Set up DLTI spec depending on the target triple.
+  std::string layoutString = determineDataLayoutByTriple(triple);
+
+  // Registered dialects may not be loaded yet, ensure they are.
+  context->loadDialect<mlir::DLTIDialect, mlir::LLVM::LLVMDialect>();
+
+  mlir::DataLayoutSpecInterface dlSpec =
+      mlir::translateDataLayout(llvm::DataLayout(layoutString), context);
+  mod->setAttr(mlir::DLTIDialect::kDataLayoutAttrName, dlSpec);
+}
+
+/// Prepare requirements like cir.triple and data layout.
+void prepareCIRModuleForTranslation(mlir::ModuleOp mod) {
+  auto modTriple = mod->getAttrOfType<mlir::StringAttr>(
+      cir::CIRDialect::getTripleAttrName());
+  auto modDataLayout = mod->getAttr(mlir::DLTIDialect::kDataLayoutAttrName);
+  bool hasTargetOption = targetTripleOption.getNumOccurrences() > 0;
+
+  // Skip the situation where nothing should be done.
+  if (!hasTargetOption && modTriple && modDataLayout)
+    return;
+
+  std::string triple;
+
+  if (!hasTargetOption && modTriple) {
+    // Do nothing if it's already set.
+    triple = modTriple.getValue();
+  } else {
+    // Otherwise, overwrite or set default.
+    triple = prepareCIRModuleTriple(mod);
+  }
+
+  // If the data layout is not set, derive it from the triple.
+  prepareCIRModuleDataLayout(mod, triple);
+}
+} // namespace
 } // namespace cir
 
 void registerToLLVMTranslation() {
@@ -41,9 +146,11 @@ void registerToLLVMTranslation() {
   mlir::TranslateFromMLIRRegistration registration(
       "cir-to-llvmir", "Translate CIR to LLVMIR",
       [](mlir::Operation *op, mlir::raw_ostream &output) {
+        auto cirModule = llvm::dyn_cast<mlir::ModuleOp>(op);
+        cir::prepareCIRModuleForTranslation(cirModule);
         llvm::LLVMContext llvmContext;
         auto llvmModule = cir::direct::lowerDirectlyFromCIRToLLVMIR(
-            llvm::dyn_cast<mlir::ModuleOp>(op), llvmContext,
+            cirModule, llvmContext,
             /*disableVerifier=*/false, disableCCLowering);
         if (!llvmModule)
           return mlir::failure();


### PR DESCRIPTION
This PR adds a new command line option `--target` to our tool `cir-translate`. The concrete behaviour of it also depends on the triple and data layout in the CIR module. See the table in code comments for details.

The default triple is `x86_64-unknown-linux-gnu` currently.

Some tests are updated with triple and DLTI attribute eliminated (replaced by an option in RUN line). But still some tests remain unchanged, primarily because they uses `cir-opt` instead.