### PR TITLE
[CIR] Add support for casting pointer-to-data-member values

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3280,6 +3280,58 @@ def DerivedClassAddrOp : CIR_Op<"derived_class_addr"> {
 }
 
 //===----------------------------------------------------------------------===//
+// BaseDataMemberOp & DerivedDataMemberOp
+//===----------------------------------------------------------------------===//
+
+def BaseDataMemberOp : CIR_Op<"base_data_member", [Pure]> {
+  let summary =
+    "Cast a derived class data member pointer to a base class data member "
+    "pointer";
+  let description = [{
+    The `cir.base_data_member` operation casts a data member pointer of type
+    `T Derived::*` to a data member pointer of type `T Base::*`, where `Base`
+    is an accessible non-ambiguous non-virtual base class of `Derived`.
+
+    The `offset` parameter gives the offset in bytes of the `Base` base class
+    subobject within a `Derived` object.
+  }];
+
+  let arguments = (ins CIR_DataMemberType:$src, IndexAttr:$offset);
+  let results = (outs CIR_DataMemberType:$result);
+
+  let assemblyFormat = [{
+    `(` $src `:` qualified(type($src)) `)`
+    `[` $offset `]` `->` qualified(type($result)) attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+def DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
+  let summary =
+    "Cast a base class data member pointer to a derived class data member "
+    "pointer";
+  let description = [{
+    The `cir.derived_data_member` operation casts a data member pointer of type
+    `T Base::*` to a data member pointer of type `T Derived::*`, where `Base`
+    is an accessible non-ambiguous non-virtual base class of `Derived`.
+
+    The `offset` parameter gives the offset in bytes of the `Base` base class
+    subobject within a `Derived` object.
+  }];
+
+  let arguments = (ins CIR_DataMemberType:$src, IndexAttr:$offset);
+  let results = (outs CIR_DataMemberType:$result);
+
+  let assemblyFormat = [{
+    `(` $src `:` qualified(type($src)) `)`
+    `[` $offset `]` `->` qualified(type($result)) attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // FuncOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -800,6 +800,32 @@ LogicalResult cir::DynamicCastOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// BaseDataMemberOp & DerivedDataMemberOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verifyDataMemberCast(Operation *op, mlir::Value src,
+                                          mlir::Type resultTy) {
+  // Let the operand type be T1 C1::*, let the result type be T2 C2::*.
+  // Verify that T1 and T2 are the same type.
+  auto inputMemberTy =
+      mlir::cast<cir::DataMemberType>(src.getType()).getMemberTy();
+  auto resultMemberTy = mlir::cast<cir::DataMemberType>(resultTy).getMemberTy();
+  if (inputMemberTy != resultMemberTy)
+    return op->emitOpError()
+           << "member types of the operand and the result do not match";
+
+  return mlir::success();
+}
+
+LogicalResult cir::BaseDataMemberOp::verify() {
+  return verifyDataMemberCast(getOperation(), getSrc(), getType());
+}
+
+LogicalResult cir::DerivedDataMemberOp::verify() {
+  return verifyDataMemberCast(getOperation(), getSrc(), getType());
+}
+
+//===----------------------------------------------------------------------===//
 // ComplexCreateOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -85,6 +85,18 @@ public:
   lowerGetRuntimeMember(cir::GetRuntimeMemberOp op, mlir::Type loweredResultTy,
                         mlir::Value loweredAddr, mlir::Value loweredMember,
                         mlir::OpBuilder &builder) const = 0;
+
+  /// Lower the given cir.base_data_member op to a sequence of more "primitive"
+  /// CIR operations that act on the ABI types.
+  virtual mlir::Value lowerBaseDataMember(cir::BaseDataMemberOp op,
+                                          mlir::Value loweredSrc,
+                                          mlir::OpBuilder &builder) const = 0;
+
+  /// Lower the given cir.derived_data_member op to a sequence of more
+  /// "primitive" CIR operations that act on the ABI types.
+  virtual mlir::Value
+  lowerDerivedDataMember(cir::DerivedDataMemberOp op, mlir::Value loweredSrc,
+                         mlir::OpBuilder &builder) const = 0;
 };
 
 /// Creates an Itanium-family ABI.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -914,6 +914,24 @@ mlir::LogicalResult CIRToLLVMDerivedClassAddrOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
+mlir::LogicalResult CIRToLLVMBaseDataMemberOpLowering::matchAndRewrite(
+    cir::BaseDataMemberOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult =
+      lowerMod->getCXXABI().lowerBaseDataMember(op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRToLLVMDerivedDataMemberOpLowering::matchAndRewrite(
+    cir::DerivedDataMemberOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult = lowerMod->getCXXABI().lowerDerivedDataMember(
+      op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
 static mlir::Value
 getValueForVTableSymbol(mlir::Operation *op,
                         mlir::ConversionPatternRewriter &rewriter,
@@ -1518,7 +1536,13 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
     mlir::ConversionPatternRewriter &rewriter) const {
   mlir::Attribute attr = op.getValue();
 
-  if (mlir::isa<cir::BoolType>(op.getType())) {
+  if (mlir::isa<mlir::IntegerType>(op.getType())) {
+    // Verified cir.const operations cannot actually be of these types, but the
+    // lowering pass may generate temporary cir.const operations with these
+    // types. This is OK since MLIR allows unverified operations to be alive
+    // during a pass as long as they don't live past the end of the pass.
+    attr = op.getValue();
+  } else if (mlir::isa<cir::BoolType>(op.getType())) {
     int value = (op.getValue() ==
                  cir::BoolAttr::get(getContext(),
                                     cir::BoolType::get(getContext()), true));
@@ -2412,11 +2436,12 @@ CIRToLLVMBinOpLowering::getIntOverflowFlag(cir::BinOp op) const {
 mlir::LogicalResult CIRToLLVMBinOpLowering::matchAndRewrite(
     cir::BinOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
-  assert((op.getLhs().getType() == op.getRhs().getType()) &&
+  assert((adaptor.getLhs().getType() == adaptor.getRhs().getType()) &&
          "inconsistent operands' types not supported yet");
+
   mlir::Type type = op.getRhs().getType();
-  assert((mlir::isa<cir::IntType, cir::CIRFPTypeInterface, cir::VectorType>(
-             type)) &&
+  assert((mlir::isa<cir::IntType, cir::CIRFPTypeInterface, cir::VectorType,
+                    mlir::IntegerType>(type)) &&
          "operand type not supported yet");
 
   auto llvmTy = getTypeConverter()->convertType(op.getType());
@@ -2427,29 +2452,32 @@ mlir::LogicalResult CIRToLLVMBinOpLowering::matchAndRewrite(
 
   switch (op.getKind()) {
   case cir::BinOpKind::Add:
-    if (mlir::isa<cir::IntType>(type))
+    if (mlir::isa<cir::IntType, mlir::IntegerType>(type))
       rewriter.replaceOpWithNewOp<mlir::LLVM::AddOp>(op, llvmTy, lhs, rhs,
                                                      getIntOverflowFlag(op));
     else
       rewriter.replaceOpWithNewOp<mlir::LLVM::FAddOp>(op, llvmTy, lhs, rhs);
     break;
   case cir::BinOpKind::Sub:
-    if (mlir::isa<cir::IntType>(type))
+    if (mlir::isa<cir::IntType, mlir::IntegerType>(type))
       rewriter.replaceOpWithNewOp<mlir::LLVM::SubOp>(op, llvmTy, lhs, rhs,
                                                      getIntOverflowFlag(op));
     else
       rewriter.replaceOpWithNewOp<mlir::LLVM::FSubOp>(op, llvmTy, lhs, rhs);
     break;
   case cir::BinOpKind::Mul:
-    if (mlir::isa<cir::IntType>(type))
+    if (mlir::isa<cir::IntType, mlir::IntegerType>(type))
       rewriter.replaceOpWithNewOp<mlir::LLVM::MulOp>(op, llvmTy, lhs, rhs,
                                                      getIntOverflowFlag(op));
     else
       rewriter.replaceOpWithNewOp<mlir::LLVM::FMulOp>(op, llvmTy, lhs, rhs);
     break;
   case cir::BinOpKind::Div:
-    if (auto ty = mlir::dyn_cast<cir::IntType>(type)) {
-      if (ty.isUnsigned())
+    if (mlir::isa<cir::IntType, mlir::IntegerType>(type)) {
+      auto isUnsigned = mlir::isa<cir::IntType>(type)
+                            ? mlir::cast<cir::IntType>(type).isUnsigned()
+                            : mlir::cast<mlir::IntegerType>(type).isUnsigned();
+      if (isUnsigned)
         rewriter.replaceOpWithNewOp<mlir::LLVM::UDivOp>(op, llvmTy, lhs, rhs);
       else
         rewriter.replaceOpWithNewOp<mlir::LLVM::SDivOp>(op, llvmTy, lhs, rhs);
@@ -2457,8 +2485,11 @@ mlir::LogicalResult CIRToLLVMBinOpLowering::matchAndRewrite(
       rewriter.replaceOpWithNewOp<mlir::LLVM::FDivOp>(op, llvmTy, lhs, rhs);
     break;
   case cir::BinOpKind::Rem:
-    if (auto ty = mlir::dyn_cast<cir::IntType>(type)) {
-      if (ty.isUnsigned())
+    if (mlir::isa<cir::IntType, mlir::IntegerType>(type)) {
+      auto isUnsigned = mlir::isa<cir::IntType>(type)
+                            ? mlir::cast<cir::IntType>(type).isUnsigned()
+                            : mlir::cast<mlir::IntegerType>(type).isUnsigned();
+      if (isUnsigned)
         rewriter.replaceOpWithNewOp<mlir::LLVM::URemOp>(op, llvmTy, lhs, rhs);
       else
         rewriter.replaceOpWithNewOp<mlir::LLVM::SRemOp>(op, llvmTy, lhs, rhs);
@@ -2642,9 +2673,12 @@ mlir::LogicalResult CIRToLLVMCmpOpLowering::matchAndRewrite(
   mlir::Value llResult;
 
   // Lower to LLVM comparison op.
-  if (auto intTy = mlir::dyn_cast<cir::IntType>(type)) {
-    auto kind =
-        convertCmpKindToICmpPredicate(cmpOp.getKind(), intTy.isSigned());
+  // if (auto intTy = mlir::dyn_cast<cir::IntType>(type)) {
+  if (mlir::isa<cir::IntType, mlir::IntegerType>(type)) {
+    auto isSigned = mlir::isa<cir::IntType>(type)
+                        ? mlir::cast<cir::IntType>(type).isSigned()
+                        : mlir::cast<mlir::IntegerType>(type).isSigned();
+    auto kind = convertCmpKindToICmpPredicate(cmpOp.getKind(), isSigned);
     llResult = rewriter.create<mlir::LLVM::ICmpOp>(
         cmpOp.getLoc(), kind, adaptor.getLhs(), adaptor.getRhs());
   } else if (auto ptrTy = mlir::dyn_cast<cir::PointerType>(type)) {
@@ -3848,9 +3882,15 @@ void populateCIRToLLVMConversionPatterns(
   patterns.add<CIRToLLVMAllocaOpLowering>(converter, dataLayout,
                                           stringGlobalsMap, argStringGlobalsMap,
                                           argsVarMap, patterns.getContext());
-  patterns.add<CIRToLLVMConstantOpLowering, CIRToLLVMGlobalOpLowering,
-               CIRToLLVMGetRuntimeMemberOpLowering>(
-      converter, patterns.getContext(), lowerModule);
+  patterns.add<
+      // clang-format off
+      CIRToLLVMBaseDataMemberOpLowering,
+      CIRToLLVMConstantOpLowering,
+      CIRToLLVMDerivedDataMemberOpLowering,
+      CIRToLLVMGetRuntimeMemberOpLowering,
+      CIRToLLVMGlobalOpLowering
+      // clang-format on
+      >(converter, patterns.getContext(), lowerModule);
   patterns.add<
       // clang-format off
       CIRToLLVMAbsOpLowering,

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -165,6 +165,36 @@ public:
                   mlir::ConversionPatternRewriter &) const override;
 };
 
+class CIRToLLVMBaseDataMemberOpLowering
+    : public mlir::OpConversionPattern<cir::BaseDataMemberOp> {
+  cir::LowerModule *lowerMod;
+
+public:
+  CIRToLLVMBaseDataMemberOpLowering(const mlir::TypeConverter &typeConverter,
+                                    mlir::MLIRContext *context,
+                                    cir::LowerModule *lowerModule)
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::BaseDataMemberOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
+class CIRToLLVMDerivedDataMemberOpLowering
+    : public mlir::OpConversionPattern<cir::DerivedDataMemberOp> {
+  cir::LowerModule *lowerMod;
+
+public:
+  CIRToLLVMDerivedDataMemberOpLowering(const mlir::TypeConverter &typeConverter,
+                                       mlir::MLIRContext *context,
+                                       cir::LowerModule *lowerModule)
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::DerivedDataMemberOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
 class CIRToLLVMVTTAddrPointOpLowering
     : public mlir::OpConversionPattern<cir::VTTAddrPointOp> {
 public:

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
@@ -1,0 +1,76 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
+
+struct Base1 {
+  int base1_data;
+};
+
+struct Base2 {
+  int base2_data;
+};
+
+struct Derived : Base1, Base2 {
+  int derived_data;
+};
+
+// CIR-LABEL:  @_Z15base_to_derivedM5Base2i
+// LLVM-LABEL: @_Z15base_to_derivedM5Base2i
+auto base_to_derived(int Base2::*ptr) -> int Derived::* {
+  return ptr;
+  // CIR: %{{.+}} = cir.derived_data_member(%{{.+}} : !cir.data_member<!s32i in !ty_Base2_>) [4] -> !cir.data_member<!s32i in !ty_Derived>
+
+  //      LLVM: %[[#src:]] = load i64, ptr %{{.+}}
+  // LLVM-NEXT: %[[#is_null:]] = icmp eq i64 %[[#src]], -1
+  // LLVM-NEXT: %[[#is_null_bool:]] = zext i1 %[[#is_null]] to i8
+  // LLVM-NEXT: %[[#adjusted:]] = add i64 %[[#src]], 4
+  // LLVM-NEXT: %[[#cond:]] = trunc i8 %[[#is_null_bool]] to i1
+  // LLVM-NEXT: %{{.+}} = select i1 %[[#cond]], i64 -1, i64 %[[#adjusted]]
+}
+
+// CIR-LABEL:  @_Z15derived_to_baseM7Derivedi
+// LLVM-LABEL: @_Z15derived_to_baseM7Derivedi
+auto derived_to_base(int Derived::*ptr) -> int Base2::* {
+  return static_cast<int Base2::*>(ptr);
+  // CIR: %{{.+}} = cir.base_data_member(%{{.+}} : !cir.data_member<!s32i in !ty_Derived>) [4] -> !cir.data_member<!s32i in !ty_Base2_>
+
+  //      LLVM: %[[#src:]] = load i64, ptr %{{.+}}
+  // LLVM-NEXT: %[[#is_null:]] = icmp eq i64 %[[#src]], -1
+  // LLVM-NEXT: %[[#is_null_bool:]] = zext i1 %[[#is_null]] to i8
+  // LLVM-NEXT: %[[#adjusted:]] = sub i64 %[[#src]], 4
+  // LLVM-NEXT: %[[#cond:]] = trunc i8 %[[#is_null_bool]] to i1
+  // LLVM-NEXT: %9 = select i1 %[[#cond]], i64 -1, i64 %[[#adjusted]]
+}
+
+// CIR-LABEL:  @_Z27base_to_derived_zero_offsetM5Base1i
+// LLVM-LABEL: @_Z27base_to_derived_zero_offsetM5Base1i
+auto base_to_derived_zero_offset(int Base1::*ptr) -> int Derived::* {
+  return ptr;
+  // CIR: %{{.+}} = cir.derived_data_member(%{{.+}} : !cir.data_member<!s32i in !ty_Base1_>) [0] -> !cir.data_member<!s32i in !ty_Derived>
+
+  // No LLVM instructions emitted for performing a zero-offset cast.
+  // LLVM-NEXT: %[[#src_slot:]] = alloca i64, i64 1
+  // LLVM-NEXT: %[[#ret_slot:]] = alloca i64, i64 1
+  // LLVM-NEXT: store i64 %{{.+}}, ptr %[[#src_slot]]
+  // LLVM-NEXT: %[[#temp:]] = load i64, ptr %[[#src_slot]]
+  // LLVM-NEXT: store i64 %[[#temp]], ptr %[[#ret_slot]]
+  // LLVM-NEXT: %[[#ret:]] = load i64, ptr %[[#ret_slot]]
+  // LLVM-NEXT: ret i64 %[[#ret]]
+}
+
+// CIR-LABEL:  @_Z27derived_to_base_zero_offsetM7Derivedi
+// LLVM-LABEL: @_Z27derived_to_base_zero_offsetM7Derivedi
+auto derived_to_base_zero_offset(int Derived::*ptr) -> int Base1::* {
+  return static_cast<int Base1::*>(ptr);
+  // CIR: %{{.+}} = cir.base_data_member(%{{.+}} : !cir.data_member<!s32i in !ty_Derived>) [0] -> !cir.data_member<!s32i in !ty_Base1_>
+
+  // No LLVM instructions emitted for performing a zero-offset cast.
+  // LLVM-NEXT: %[[#src_slot:]] = alloca i64, i64 1
+  // LLVM-NEXT: %[[#ret_slot:]] = alloca i64, i64 1
+  // LLVM-NEXT: store i64 %{{.+}}, ptr %[[#src_slot]]
+  // LLVM-NEXT: %[[#temp:]] = load i64, ptr %[[#src_slot]]
+  // LLVM-NEXT: store i64 %[[#temp]], ptr %[[#ret_slot]]
+  // LLVM-NEXT: %[[#ret:]] = load i64, ptr %[[#ret_slot]]
+  // LLVM-NEXT: ret i64 %[[#ret]]
+}


### PR DESCRIPTION
This PR adds support for base-to-derived and derived-to-base casts on pointer-to-data-member values.

Related to #973.