### PR TITLE
[CIR][CodeGen][LowerToLLVM] Fix llvm lowering of CIR `UnaryOpKind_Not`

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2302,7 +2302,7 @@ mlir::LogicalResult CIRToLLVMUnaryOpLowering::matchAndRewrite(
     }
     case cir::UnaryOpKind::Not: {
       // bit-wise compliment operator, implemented as an XOR with -1.
-      mlir::Value MinusOne;
+      mlir::Value minusOne;
       if (IsVector) {
         // Creating a vector object with all -1 values is easier said than
         // done. It requires a series of insertelement ops.
@@ -2310,20 +2310,20 @@ mlir::LogicalResult CIRToLLVMUnaryOpLowering::matchAndRewrite(
             getTypeConverter()->convertType(elementType);
         auto MinusOneInt = rewriter.create<mlir::LLVM::ConstantOp>(
             loc, llvmElementType, mlir::IntegerAttr::get(llvmElementType, -1));
-        MinusOne = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmType);
+        minusOne = rewriter.create<mlir::LLVM::UndefOp>(loc, llvmType);
         auto NumElements = mlir::dyn_cast<cir::VectorType>(type).getSize();
         for (uint64_t i = 0; i < NumElements; ++i) {
           mlir::Value indexValue = rewriter.create<mlir::LLVM::ConstantOp>(
               loc, rewriter.getI64Type(), i);
-          MinusOne = rewriter.create<mlir::LLVM::InsertElementOp>(
-              loc, MinusOne, MinusOneInt, indexValue);
+          minusOne = rewriter.create<mlir::LLVM::InsertElementOp>(
+              loc, minusOne, MinusOneInt, indexValue);
         }
       } else {
-        MinusOne = rewriter.create<mlir::LLVM::ConstantOp>(
+        minusOne = rewriter.create<mlir::LLVM::ConstantOp>(
             loc, llvmType, mlir::IntegerAttr::get(llvmType, -1));
       }
-      rewriter.replaceOpWithNewOp<mlir::LLVM::XOrOp>(op, llvmType, MinusOne,
-                                                     adaptor.getInput());
+      rewriter.replaceOpWithNewOp<mlir::LLVM::XOrOp>(
+          op, llvmType, adaptor.getInput(), minusOne);
       return mlir::success();
     }
     }

--- a/clang/test/CIR/CodeGen/vectype-ext.cpp
+++ b/clang/test/CIR/CodeGen/vectype-ext.cpp
@@ -134,7 +134,7 @@ void vector_int_test(int x) {
   vi4 n = ~a;
   // CIR: %{{[0-9]+}} = cir.unary(not, %{{[0-9]+}}) : !cir.vector<!s32i x 4>, !cir.vector<!s32i x 4>
   // LLVM:      %[[#VAL:]] = load <4 x i32>, ptr %{{[0-9]+}}, align 16
-  // LLVM-NEXT: %[[#RES:]] = xor <4 x i32> splat (i32 -1), %[[#VAL]]
+  // LLVM-NEXT: %[[#RES:]] = xor <4 x i32> %[[#VAL]], splat (i32 -1)
   // LLVM-NEXT: store <4 x i32> %[[#RES]], ptr %{{[0-9]+}}, align 16
 
   // TODO: Ternary conditional operator

--- a/clang/test/CIR/Lowering/unary-not.cir
+++ b/clang/test/CIR/Lowering/unary-not.cir
@@ -18,7 +18,7 @@ module {
 // MLIR: = llvm.mlir.constant(-1 : i32)
 // MLIR: = llvm.xor
 
-// LLVM: = xor i32 -1, %[[#]]
+// LLVM: = xor i32 %[[#]], -1
 
 
     cir.func @floatingPoint(%arg0: !cir.float, %arg1: !cir.double) {

--- a/clang/test/CIR/Lowering/vectype.cpp
+++ b/clang/test/CIR/Lowering/vectype.cpp
@@ -137,7 +137,7 @@ void vector_int_test(int x) {
   // CHECK: %[[#T101:]] = llvm.insertelement %[[#T94]], %[[#T99]][%[[#T100]] : i64] : vector<4xi32>
   // CHECK: %[[#T102:]] = llvm.mlir.constant(3 : i64) : i64
   // CHECK: %[[#T103:]] = llvm.insertelement %[[#T94]], %[[#T101]][%[[#T102]] : i64] : vector<4xi32>
-  // CHECK: %[[#T104:]] = llvm.xor %[[#T103]], %[[#T93]]  : vector<4xi32>
+  // CHECK: %[[#T104:]] = llvm.xor %[[#T93]], %[[#T103]]  : vector<4xi32>
   // CHECK: llvm.store %[[#T104]], %[[#T29:]] {alignment = 16 : i64} : vector<4xi32>, !llvm.ptr
 
   // Ternary conditional operator


### PR DESCRIPTION
Basically, for int type, the order of Ops is not the same as OG in the emitted LLVM IR. OG has constant as the second op position. See [OG's order ](https://godbolt.org/z/584jrWeYn).
