### PR TITLE
[CIR][CIRGen] Support emitting memcpys for fields

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -174,6 +174,7 @@ struct MissingFeatures {
 
   // ABIInfo queries.
   static bool useTargetLoweringABIInfo() { return false; }
+  static bool isEmptyFieldForLayout() { return false; }
 
   // Misc
   static bool cacheRecordLayouts() { return false; }


### PR DESCRIPTION
Default assignment operator generation was failing because of memcpy
generation for fields being unsupported. Implement it following
CodeGen's example, as usual. Follow-ups will avoid emitting memcpys for
fields of trivial class types, and extend this to copy constructors as
well.

Fixes https://github.com/llvm/clangir/issues/1128