### PR TITLE
[CIR][CIRGen] Emit memcpys for copy constructors

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -141,7 +141,6 @@ struct MissingFeatures {
   static bool shouldSplitConstantStore() { return false; }
   static bool shouldCreateMemCpyFromGlobal() { return false; }
   static bool shouldReverseUnaryCondOnBoolExpr() { return false; }
-  static bool fieldMemcpyizerBuildMemcpy() { return false; }
   static bool isTrivialCtorOrDtor() { return false; }
   static bool isMemcpyEquivalentSpecialMember() { return false; }
   static bool constructABIArgDirectExtend() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -174,6 +174,7 @@ struct MissingFeatures {
 
   // ABIInfo queries.
   static bool useTargetLoweringABIInfo() { return false; }
+  static bool isEmptyFieldForLayout() { return false; }
 
   // Misc
   static bool cacheRecordLayouts() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -429,20 +429,11 @@ private:
       }
       return nullptr;
     } else if (CXXMemberCallExpr *MCE = dyn_cast<CXXMemberCallExpr>(S)) {
-      CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(MCE->getCalleeDecl());
-      if (!(MD && isMemcpyEquivalentSpecialMember(MD)))
-        return nullptr;
-      MemberExpr *IOA = dyn_cast<MemberExpr>(MCE->getImplicitObjectArgument());
-      if (!IOA)
-        return nullptr;
-      FieldDecl *Field = dyn_cast<FieldDecl>(IOA->getMemberDecl());
-      if (!Field || !isMemcpyableField(Field))
-        return nullptr;
-      MemberExpr *Arg0 = dyn_cast<MemberExpr>(MCE->getArg(0));
-      if (!Arg0 || Field != dyn_cast<FieldDecl>(Arg0->getMemberDecl()))
-        return nullptr;
-      return Field;
+      // We want to represent all calls explicitly for analysis purposes.
+      return nullptr;
     } else if (CallExpr *CE = dyn_cast<CallExpr>(S)) {
+      // TODO(cir): https://github.com/llvm/clangir/issues/1177: This can result
+      // in memcpys instead of calls to trivial member functions.
       FunctionDecl *FD = dyn_cast<FunctionDecl>(CE->getCalleeDecl());
       if (!FD || FD->getBuiltinID() != Builtin::BI__builtin_memcpy)
         return nullptr;

--- a/clang/test/CIR/CodeGen/copy-constructor.cpp
+++ b/clang/test/CIR/CodeGen/copy-constructor.cpp
@@ -33,3 +33,55 @@ struct HasScalarArrayMember {
 // LLVM-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr %[[#THIS_ARR]], ptr %[[#OTHER_ARR]], i32 16, i1 false)
 // LLVM-NEXT:    ret void
 HasScalarArrayMember::HasScalarArrayMember(const HasScalarArrayMember &) = default;
+
+struct Trivial { int *i; };
+struct ManyMembers {
+  int i;
+  int j;
+  Trivial k;
+  int l[1];
+  int m[2];
+  Trivial n;
+  int &o;
+  int *p;
+};
+
+// CIR-LABEL: cir.func linkonce_odr @_ZN11ManyMembersC2ERKS_(
+// CIR:         %[[#THIS_LOAD:]] = cir.load %[[#]]
+// CIR-NEXT:    %[[#THIS_I:]] = cir.get_member %[[#THIS_LOAD]][0] {name = "i"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER:]]
+// CIR-NEXT:    %[[#OTHER_I:]] = cir.get_member %[[#OTHER_LOAD]][0] {name = "i"}
+// CIR-NEXT:    %[[#MEMCPY_SIZE:]] = cir.const #cir.int<8>
+// CIR-NEXT:    %[[#THIS_I_CAST:]] = cir.cast(bitcast, %[[#THIS_I]] : !cir.ptr<!s32i>), !cir.ptr<!void>
+// CIR-NEXT:    %[[#OTHER_I_CAST:]] = cir.cast(bitcast, %[[#OTHER_I]] : !cir.ptr<!s32i>), !cir.ptr<!void>
+// CIR-NEXT:    cir.libc.memcpy %[[#MEMCPY_SIZE]] bytes from %[[#OTHER_I_CAST]] to %[[#THIS_I_CAST]]
+// CIR-NEXT:    %[[#THIS_K:]] = cir.get_member %[[#THIS_LOAD]][2] {name = "k"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER]]
+// CIR-NEXT:    %[[#OTHER_K:]] = cir.get_member %[[#OTHER_LOAD]][2] {name = "k"}
+// CIR-NEXT:    cir.call @_ZN7TrivialC1ERKS_(%[[#THIS_K]], %[[#OTHER_K]])
+// CIR-NEXT:    %[[#THIS_L:]] = cir.get_member %[[#THIS_LOAD]][3] {name = "l"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER]]
+// CIR-NEXT:    %[[#OTHER_L:]] = cir.get_member %[[#OTHER_LOAD]][3] {name = "l"}
+// CIR-NEXT:    %[[#MEMCPY_SIZE:]] = cir.const #cir.int<12>
+// CIR-NEXT:    %[[#THIS_L_CAST:]] = cir.cast(bitcast, %[[#THIS_L]] : !cir.ptr<!cir.array<!s32i x 1>>), !cir.ptr<!void>
+// CIR-NEXT:    %[[#OTHER_L_CAST:]] = cir.cast(bitcast, %[[#OTHER_L]] : !cir.ptr<!cir.array<!s32i x 1>>), !cir.ptr<!void>
+// CIR-NEXT:    cir.libc.memcpy %[[#MEMCPY_SIZE]] bytes from %[[#OTHER_L_CAST]] to %[[#THIS_L_CAST]]
+// CIR-NEXT:    %[[#THIS_N:]] = cir.get_member %[[#THIS_LOAD]][5] {name = "n"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER]]
+// CIR-NEXT:    %[[#OTHER_N:]] = cir.get_member %[[#OTHER_LOAD]][5] {name = "n"}
+// CIR-NEXT:    cir.call @_ZN7TrivialC1ERKS_(%[[#THIS_N]], %[[#OTHER_N]])
+// CIR-NEXT:    %[[#THIS_O:]] = cir.get_member %[[#THIS_LOAD]][6] {name = "o"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER]]
+// CIR-NEXT:    %[[#OTHER_O:]] = cir.get_member %[[#OTHER_LOAD]][6] {name = "o"}
+// CIR-NEXT:    %[[#MEMCPY_SIZE:]] = cir.const #cir.int<16>
+// CIR-NEXT:    %[[#THIS_O_CAST:]] = cir.cast(bitcast, %[[#THIS_O]] : !cir.ptr<!cir.ptr<!s32i>>), !cir.ptr<!void>
+// CIR-NEXT:    %[[#OTHER_O_CAST:]] = cir.cast(bitcast, %[[#OTHER_O]] : !cir.ptr<!cir.ptr<!s32i>>), !cir.ptr<!void>
+// CIR-NEXT:    cir.libc.memcpy %[[#MEMCPY_SIZE]] bytes from %[[#OTHER_O_CAST]] to %[[#THIS_O_CAST]]
+// CIR-NEXT:    cir.return
+// CIR-NEXT:  }
+
+// CIR-LABEL: cir.func @_Z6doCopyR11ManyMembers(
+// CIR:         cir.call @_ZN11ManyMembersC1ERKS_(
+ManyMembers doCopy(ManyMembers &src) {
+  return src;
+}


### PR DESCRIPTION
CodeGen does so for trivial record types as well as non-record types; we
only do it for non-record types.