### PR TITLE
[CIR][CIRGen] Remove -clangir-disable-emit-cxx-default

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -102,7 +102,6 @@ public:
   bool verifyModule();
 
   void emitDeferredDecls();
-  void emitDefaultMethods();
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -141,7 +141,6 @@ struct MissingFeatures {
   static bool shouldSplitConstantStore() { return false; }
   static bool shouldCreateMemCpyFromGlobal() { return false; }
   static bool shouldReverseUnaryCondOnBoolExpr() { return false; }
-  static bool fieldMemcpyizerBuildMemcpy() { return false; }
   static bool isTrivialCtorOrDtor() { return false; }
   static bool isMemcpyEquivalentSpecialMember() { return false; }
   static bool constructABIArgDirectExtend() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -174,6 +174,7 @@ struct MissingFeatures {
 
   // ABIInfo queries.
   static bool useTargetLoweringABIInfo() { return false; }
+  static bool isEmptyFieldForLayout() { return false; }
 
   // Misc
   static bool cacheRecordLayouts() { return false; }

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3062,10 +3062,6 @@ def clangir_disable_verifier : Flag<["-"], "clangir-disable-verifier">,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"ClangIR: Disable MLIR module verifier">,
   MarshallingInfoFlag<FrontendOpts<"ClangIRDisableCIRVerifier">>;
-def clangir_disable_emit_cxx_default : Flag<["-"], "clangir-disable-emit-cxx-default">,
-  Visibility<[ClangOption, CC1Option]>,
-  HelpText<"ClangIR: Disable emission of c++ default (compiler implemented) methods.">,
-  MarshallingInfoFlag<FrontendOpts<"ClangIRDisableEmitCXXDefault">>;
 def clangir_verify_diagnostics : Flag<["-"], "clangir-verify-diagnostics">,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"ClangIR: Enable diagnostic verification in MLIR, similar to clang's -verify">,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -433,9 +433,6 @@ public:
   /// Disable Clang IR (CIR) verifier
   unsigned ClangIRDisableCIRVerifier : 1;
 
-  /// Disable ClangIR emission for CXX default (compiler generated methods).
-  unsigned ClangIRDisableEmitCXXDefault : 1;
-
   /// Enable diagnostic verification for CIR
   unsigned ClangIRVerifyDiags : 1;
 
@@ -655,10 +652,9 @@ public:
         EmitPrettySymbolGraphs(false), GenReducedBMI(false),
         UseClangIRPipeline(false), ClangIRDirectLowering(false),
         ClangIRDisablePasses(false), ClangIRDisableCIRVerifier(false),
-        ClangIRDisableEmitCXXDefault(false), ClangIRLifetimeCheck(false),
-        ClangIRIdiomRecognizer(false), ClangIRLibOpt(false),
-        ClangIRAnalysisOnly(false), TimeTraceGranularity(500),
-        TimeTraceVerbose(false) {}
+        ClangIRLifetimeCheck(false), ClangIRIdiomRecognizer(false),
+        ClangIRLibOpt(false), ClangIRAnalysisOnly(false),
+        TimeTraceGranularity(500), TimeTraceVerbose(false) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -429,20 +429,11 @@ private:
       }
       return nullptr;
     } else if (CXXMemberCallExpr *MCE = dyn_cast<CXXMemberCallExpr>(S)) {
-      CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(MCE->getCalleeDecl());
-      if (!(MD && isMemcpyEquivalentSpecialMember(MD)))
-        return nullptr;
-      MemberExpr *IOA = dyn_cast<MemberExpr>(MCE->getImplicitObjectArgument());
-      if (!IOA)
-        return nullptr;
-      FieldDecl *Field = dyn_cast<FieldDecl>(IOA->getMemberDecl());
-      if (!Field || !isMemcpyableField(Field))
-        return nullptr;
-      MemberExpr *Arg0 = dyn_cast<MemberExpr>(MCE->getArg(0));
-      if (!Arg0 || Field != dyn_cast<FieldDecl>(Arg0->getMemberDecl()))
-        return nullptr;
-      return Field;
+      // We want to represent all calls explicitly for analysis purposes.
+      return nullptr;
     } else if (CallExpr *CE = dyn_cast<CallExpr>(S)) {
+      // TODO(cir): https://github.com/llvm/clangir/issues/1177: This can result
+      // in memcpys instead of calls to trivial member functions.
       FunctionDecl *FD = dyn_cast<FunctionDecl>(CE->getCalleeDecl());
       if (!FD || FD->getBuiltinID() != Builtin::BI__builtin_memcpy)
         return nullptr;

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2786,10 +2786,7 @@ cir::FuncOp CIRGenModule::GetOrCreateCIRFunction(
            FD = FD->getPreviousDecl()) {
         if (isa<CXXRecordDecl>(FD->getLexicalDeclContext())) {
           if (FD->doesThisDeclarationHaveABody()) {
-            if (isDefaultedMethod(FD))
-              addDefaultMethodsToEmit(GD.getWithDecl(FD));
-            else
-              addDeferredDeclToEmit(GD.getWithDecl(FD));
+            addDeferredDeclToEmit(GD.getWithDecl(FD));
             break;
           }
         }
@@ -2937,13 +2934,6 @@ void CIRGenModule::emitDeferred(unsigned recursionLimit) {
       assert(DeferredVTables.empty() && DeferredDeclsToEmit.empty());
     }
   }
-}
-
-void CIRGenModule::emitDefaultMethods() {
-  // Differently from DeferredDeclsToEmit, there's no recurrent use of
-  // DefaultMethodsToEmit, so use it directly for emission.
-  for (auto &D : DefaultMethodsToEmit)
-    emitGlobalDecl(D);
 }
 
 mlir::IntegerAttr CIRGenModule::getSize(CharUnits size) {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -566,14 +566,6 @@ public:
     DeferredDeclsToEmit.emplace_back(GD);
   }
 
-  // After HandleTranslation finishes, differently from DeferredDeclsToEmit,
-  // DefaultMethodsToEmit is only called after a set of CIR passes run. See
-  // addDefaultMethodsToEmit usage for examples.
-  std::vector<clang::GlobalDecl> DefaultMethodsToEmit;
-  void addDefaultMethodsToEmit(clang::GlobalDecl GD) {
-    DefaultMethodsToEmit.emplace_back(GD);
-  }
-
   std::pair<cir::FuncType, cir::FuncOp> getAddrAndTypeOfCXXStructor(
       clang::GlobalDecl GD, const CIRGenFunctionInfo *FnInfo = nullptr,
       cir::FuncType FnType = nullptr, bool Dontdefer = false,
@@ -717,9 +709,6 @@ public:
 
   /// Helper for `emitDeferred` to apply actual codegen.
   void emitGlobalDecl(clang::GlobalDecl &D);
-
-  /// Build default methods not emitted before this point.
-  void emitDefaultMethods();
 
   const llvm::Triple &getTriple() const { return target.getTriple(); }
 

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -123,8 +123,6 @@ void CIRGenerator::HandleInlineFunctionDefinition(FunctionDecl *D) {
     CGM->AddDeferredUnusedCoverageMapping(D);
 }
 
-void CIRGenerator::emitDefaultMethods() { CGM->emitDefaultMethods(); }
-
 void CIRGenerator::emitDeferredDecls() {
   if (DeferredInlineMemberFuncDefs.empty())
     return;

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -261,10 +261,6 @@ public:
     case CIRGenAction::OutputType::EmitCIR:
     case CIRGenAction::OutputType::EmitCIRFlat:
       if (outputStream && mlirMod) {
-        // Emit remaining defaulted C++ methods
-        if (!feOptions.ClangIRDisableEmitCXXDefault)
-          gen->emitDefaultMethods();
-
         // FIXME: we cannot roundtrip prettyForm=true right now.
         mlir::OpPrintingFlags flags;
         flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3055,9 +3055,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_clangir_disable_verifier))
     Opts.ClangIRDisableCIRVerifier = true;
 
-  if (Args.hasArg(OPT_clangir_disable_emit_cxx_default))
-    Opts.ClangIRDisableEmitCXXDefault = true;
-
   if (Args.hasArg(OPT_clangir_verify_diagnostics))
     Opts.ClangIRVerifyDiags = true;
 

--- a/clang/test/CIR/CodeGen/assign-operator.cpp
+++ b/clang/test/CIR/CodeGen/assign-operator.cpp
@@ -1,9 +1,6 @@
 // RUN: %clang_cc1 -std=c++17 -mconstructor-aliases -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-// RUN: %clang_cc1 -std=c++17 -mconstructor-aliases -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -clangir-disable-emit-cxx-default %s -o %t-disable.cir
-// RUN: FileCheck --input-file=%t-disable.cir %s --check-prefix=DISABLE
-
 int strlen(char const *);
 
 struct String {
@@ -40,9 +37,6 @@ struct String {
   // CHECK:   cir.return
   // CHECK: }
 
-  // DISABLE: cir.func linkonce_odr @_ZN10StringViewC2ERK6String
-  // DISABLE-NEXT:   %0 = cir.alloca !cir.ptr<!ty_StringView>, !cir.ptr<!cir.ptr<!ty_StringView>>, ["this", init] {alignment = 8 : i64}
-
   // StringView::operator=(StringView&&)
   //
   // CHECK: cir.func linkonce_odr @_ZN10StringViewaSEOS_
@@ -61,9 +55,6 @@ struct String {
   // CHECK:   %8 = cir.load %2 : !cir.ptr<!cir.ptr<!ty_StringView>>
   // CHECK:   cir.return %8 : !cir.ptr<!ty_StringView>
   // CHECK: }
-
-  // DISABLE: cir.func private @_ZN10StringViewaSEOS_
-  // DISABLE-NEXT: cir.func @main()
 };
 
 struct StringView {
@@ -179,8 +170,6 @@ struct Trivial {
 // CHECK-NEXT:    %[[#OTHER_I_CAST:]] = cir.cast(bitcast, %[[#OTHER_I]] : !cir.ptr<!s32i>), !cir.ptr<!void>
 // CHECK-NEXT:    cir.libc.memcpy %[[#MEMCPY_SIZE]] bytes from %[[#OTHER_I_CAST]] to %[[#THIS_I_CAST]]
 // CHECK-NEXT:    cir.store %[[#THIS_LOAD]], %[[#RETVAL]]
-// CHECK-NEXT:    cir.br ^bb1
-// CHECK-NEXT:  ^bb1:
 // CHECK-NEXT:    %[[#RETVAL_LOAD:]] = cir.load %[[#RETVAL]]
 // CHECK-NEXT:    cir.return %[[#RETVAL_LOAD]]
 // CHECK-NEXT:  }

--- a/clang/test/CIR/CodeGen/copy-constructor.cpp
+++ b/clang/test/CIR/CodeGen/copy-constructor.cpp
@@ -33,3 +33,55 @@ struct HasScalarArrayMember {
 // LLVM-NEXT:    call void @llvm.memcpy.p0.p0.i32(ptr %[[#THIS_ARR]], ptr %[[#OTHER_ARR]], i32 16, i1 false)
 // LLVM-NEXT:    ret void
 HasScalarArrayMember::HasScalarArrayMember(const HasScalarArrayMember &) = default;
+
+struct Trivial { int *i; };
+struct ManyMembers {
+  int i;
+  int j;
+  Trivial k;
+  int l[1];
+  int m[2];
+  Trivial n;
+  int &o;
+  int *p;
+};
+
+// CIR-LABEL: cir.func linkonce_odr @_ZN11ManyMembersC2ERKS_(
+// CIR:         %[[#THIS_LOAD:]] = cir.load %[[#]]
+// CIR-NEXT:    %[[#THIS_I:]] = cir.get_member %[[#THIS_LOAD]][0] {name = "i"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER:]]
+// CIR-NEXT:    %[[#OTHER_I:]] = cir.get_member %[[#OTHER_LOAD]][0] {name = "i"}
+// CIR-NEXT:    %[[#MEMCPY_SIZE:]] = cir.const #cir.int<8>
+// CIR-NEXT:    %[[#THIS_I_CAST:]] = cir.cast(bitcast, %[[#THIS_I]] : !cir.ptr<!s32i>), !cir.ptr<!void>
+// CIR-NEXT:    %[[#OTHER_I_CAST:]] = cir.cast(bitcast, %[[#OTHER_I]] : !cir.ptr<!s32i>), !cir.ptr<!void>
+// CIR-NEXT:    cir.libc.memcpy %[[#MEMCPY_SIZE]] bytes from %[[#OTHER_I_CAST]] to %[[#THIS_I_CAST]]
+// CIR-NEXT:    %[[#THIS_K:]] = cir.get_member %[[#THIS_LOAD]][2] {name = "k"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER]]
+// CIR-NEXT:    %[[#OTHER_K:]] = cir.get_member %[[#OTHER_LOAD]][2] {name = "k"}
+// CIR-NEXT:    cir.call @_ZN7TrivialC1ERKS_(%[[#THIS_K]], %[[#OTHER_K]])
+// CIR-NEXT:    %[[#THIS_L:]] = cir.get_member %[[#THIS_LOAD]][3] {name = "l"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER]]
+// CIR-NEXT:    %[[#OTHER_L:]] = cir.get_member %[[#OTHER_LOAD]][3] {name = "l"}
+// CIR-NEXT:    %[[#MEMCPY_SIZE:]] = cir.const #cir.int<12>
+// CIR-NEXT:    %[[#THIS_L_CAST:]] = cir.cast(bitcast, %[[#THIS_L]] : !cir.ptr<!cir.array<!s32i x 1>>), !cir.ptr<!void>
+// CIR-NEXT:    %[[#OTHER_L_CAST:]] = cir.cast(bitcast, %[[#OTHER_L]] : !cir.ptr<!cir.array<!s32i x 1>>), !cir.ptr<!void>
+// CIR-NEXT:    cir.libc.memcpy %[[#MEMCPY_SIZE]] bytes from %[[#OTHER_L_CAST]] to %[[#THIS_L_CAST]]
+// CIR-NEXT:    %[[#THIS_N:]] = cir.get_member %[[#THIS_LOAD]][5] {name = "n"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER]]
+// CIR-NEXT:    %[[#OTHER_N:]] = cir.get_member %[[#OTHER_LOAD]][5] {name = "n"}
+// CIR-NEXT:    cir.call @_ZN7TrivialC1ERKS_(%[[#THIS_N]], %[[#OTHER_N]])
+// CIR-NEXT:    %[[#THIS_O:]] = cir.get_member %[[#THIS_LOAD]][6] {name = "o"}
+// CIR-NEXT:    %[[#OTHER_LOAD:]] = cir.load %[[#OTHER]]
+// CIR-NEXT:    %[[#OTHER_O:]] = cir.get_member %[[#OTHER_LOAD]][6] {name = "o"}
+// CIR-NEXT:    %[[#MEMCPY_SIZE:]] = cir.const #cir.int<16>
+// CIR-NEXT:    %[[#THIS_O_CAST:]] = cir.cast(bitcast, %[[#THIS_O]] : !cir.ptr<!cir.ptr<!s32i>>), !cir.ptr<!void>
+// CIR-NEXT:    %[[#OTHER_O_CAST:]] = cir.cast(bitcast, %[[#OTHER_O]] : !cir.ptr<!cir.ptr<!s32i>>), !cir.ptr<!void>
+// CIR-NEXT:    cir.libc.memcpy %[[#MEMCPY_SIZE]] bytes from %[[#OTHER_O_CAST]] to %[[#THIS_O_CAST]]
+// CIR-NEXT:    cir.return
+// CIR-NEXT:  }
+
+// CIR-LABEL: cir.func @_Z6doCopyR11ManyMembers(
+// CIR:         cir.call @_ZN11ManyMembersC1ERKS_(
+ManyMembers doCopy(ManyMembers &src) {
+  return src;
+}

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -clangir-disable-emit-cxx-default -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 namespace std {

--- a/clang/test/CIR/CodeGen/default-methods.cpp
+++ b/clang/test/CIR/CodeGen/default-methods.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
+
+// We should emit and call both implicit operator= functions.
+struct S {
+  struct T {
+    int x;
+  } t;
+};
+
+// CIR-LABEL: cir.func linkonce_odr @_ZN1S1TaSERKS0_({{.*}} {
+// CIR-LABEL: cir.func linkonce_odr @_ZN1SaSERKS_(
+// CIR:         cir.call @_ZN1S1TaSERKS0_(
+// CIR-LABEL: cir.func @_Z1fR1SS0_(
+// CIR:         cir.call @_ZN1SaSERKS_(
+
+// LLVM-LABEL: define linkonce_odr ptr @_ZN1S1TaSERKS0_(
+// LLVM-LABEL: define linkonce_odr ptr @_ZN1SaSERKS_(
+// LLVM:         call ptr @_ZN1S1TaSERKS0_(
+// LLVM-LABEL: define dso_local void @_Z1fR1SS0_(
+// LLVM:         call ptr @_ZN1SaSERKS_(
+void f(S &s1, S &s2) { s1 = s2; }

--- a/clang/test/CIR/CodeGen/delete.cpp
+++ b/clang/test/CIR/CodeGen/delete.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -clangir-disable-emit-cxx-default -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 typedef __typeof(sizeof(int)) size_t;

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -clangir-disable-emit-cxx-default -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 typedef enum {

--- a/clang/test/CIR/CodeGen/dtors-scopes.cpp
+++ b/clang/test/CIR/CodeGen/dtors-scopes.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -clangir-disable-emit-cxx-default -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -std=c++20 -fclangir -emit-cir %s -o %t2.cir
 // RUN: FileCheck --input-file=%t2.cir %s --check-prefix=DTOR_BODY

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -clangir-disable-emit-cxx-default -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 enum class EFMode { Always, Verbose };

--- a/clang/test/CIR/CodeGen/libcall.cpp
+++ b/clang/test/CIR/CodeGen/libcall.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -clangir-disable-emit-cxx-default -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 typedef __builtin_va_list va_list;

--- a/clang/test/CIR/CodeGen/move.cpp
+++ b/clang/test/CIR/CodeGen/move.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -clangir-disable-emit-cxx-default -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 namespace std {

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -clangir-disable-emit-cxx-default -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include "std-cxx.h"

--- a/clang/test/CIR/CodeGen/nrvo.cpp
+++ b/clang/test/CIR/CodeGen/nrvo.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -clangir-disable-emit-cxx-default -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include "std-cxx.h"

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -clangir-disable-emit-cxx-default -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include "std-cxx.h"

--- a/clang/test/CIR/CodeGen/std-array.cpp
+++ b/clang/test/CIR/CodeGen/std-array.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -clangir-disable-emit-cxx-default -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include "std-cxx.h"

--- a/clang/test/CIR/CodeGen/std-find.cpp
+++ b/clang/test/CIR/CodeGen/std-find.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -clangir-disable-emit-cxx-default -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include "std-cxx.h"

--- a/clang/test/CIR/CodeGen/vector.cpp
+++ b/clang/test/CIR/CodeGen/vector.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -clangir-disable-emit-cxx-default -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include "std-cxx.h"

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -clangir-disable-emit-cxx-default -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -mconstructor-aliases -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -fno-rtti -mconstructor-aliases -clangir-disable-emit-cxx-default -emit-cir %s -o %t2.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -fclangir -fno-rtti -mconstructor-aliases -emit-cir %s -o %t2.cir
 // RUN: FileCheck --input-file=%t2.cir --check-prefix=RTTI_DISABLED %s
 
 class A

--- a/clang/test/CIR/Transforms/lib-opt-find.cpp
+++ b/clang/test/CIR/Transforms/lib-opt-find.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -clangir-disable-emit-cxx-default -fclangir -fclangir-idiom-recognizer -fclangir-lib-opt -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -fclangir -fclangir-idiom-recognizer -fclangir-lib-opt -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include "std-cxx.h"

--- a/clang/test/CIR/Transforms/lifetime-check-agg.cpp
+++ b/clang/test/CIR/Transforms/lifetime-check-agg.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -clangir-disable-emit-cxx-default -fclangir-lifetime-check="history=all;remarks=all" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -fclangir-lifetime-check="history=all;remarks=all" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir-analysis-only -fclangir-lifetime-check="history=all;remarks=all" %s -clangir-verify-diagnostics -emit-obj -o /dev/null
 
 typedef enum SType {

--- a/clang/test/CIR/Transforms/lifetime-check-owner.cpp
+++ b/clang/test/CIR/Transforms/lifetime-check-owner.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fclangir-lifetime-check="history=all;remarks=all;history_limit=1" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
 
-struct [[gsl::Owner(int)]] MyIntOwner {
+struct [[gsl::Owner(int)]] MyIntOwner { // expected-remark {{pset => { fn_arg:0 }}}
   int val;
   MyIntOwner(int v) : val(v) {}
   void changeInt(int i);
@@ -8,7 +8,7 @@ struct [[gsl::Owner(int)]] MyIntOwner {
   int read() const;
 };
 
-struct [[gsl::Pointer(int)]] MyIntPointer {
+struct [[gsl::Pointer(int)]] MyIntPointer { // expected-remark {{pset => { fn_arg:0 }}}
   int *ptr;
   MyIntPointer(int *p = nullptr) : ptr(p) {}
   MyIntPointer(const MyIntOwner &);

--- a/clang/test/CIR/Transforms/lifetime-check-range-for-vector.cpp
+++ b/clang/test/CIR/Transforms/lifetime-check-range-for-vector.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -mconstructor-aliases -fclangir -clangir-disable-emit-cxx-default -fclangir-lifetime-check="history=all" -fclangir-skip-system-headers -clangir-verify-diagnostics -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -mconstructor-aliases -fclangir -fclangir-lifetime-check="history=all" -fclangir-skip-system-headers -clangir-verify-diagnostics -emit-cir %s -o %t.cir
 
 #include "std-cxx.h"
 

--- a/clang/test/CIR/Transforms/lifetime-check-string.cpp
+++ b/clang/test/CIR/Transforms/lifetime-check-string.cpp
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -clangir-disable-emit-cxx-default -fclangir-lifetime-check="history=all;remarks=all" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -fclangir-lifetime-check="history=all;remarks=all" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
 
 int strlen(char const *);
 
-struct [[gsl::Owner(char *)]] String {
+struct [[gsl::Owner(char *)]] String { // expected-remark {{pset => { fn_arg:0 }}}
   long size;
   long capacity;
   const char *storage;
@@ -11,7 +11,7 @@ struct [[gsl::Owner(char *)]] String {
   String(char const *s) : size{strlen(s)}, capacity{size}, storage{s} {}
 };
 
-struct [[gsl::Pointer(int)]] StringView {
+struct [[gsl::Pointer(int)]] StringView { // expected-remark {{pset => { fn_arg:0 }}}
   long size;
   const char *storage;
   char operator[](int);

--- a/clang/test/CIR/Transforms/lifetime-fn-args.cpp
+++ b/clang/test/CIR/Transforms/lifetime-fn-args.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -clangir-disable-emit-cxx-default -fclangir-lifetime-check="history=all;remarks=all" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -fclangir-lifetime-check="history=all;remarks=all" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
 
 struct A {
   void* ctx;

--- a/clang/test/CIR/Transforms/lifetime-null-passing.cpp
+++ b/clang/test/CIR/Transforms/lifetime-null-passing.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -clangir-disable-emit-cxx-default -fclangir-lifetime-check="history=all" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -fclangir-lifetime-check="history=all" -clangir-verify-diagnostics -emit-cir %s -o %t.cir
 
 class _j {};
 typedef _j* jobj;

--- a/clang/test/CIR/Transforms/lifetime-this.cpp
+++ b/clang/test/CIR/Transforms/lifetime-this.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -mconstructor-aliases -fclangir -clangir-disable-emit-cxx-default -fclangir-lifetime-check="history=all;remarks=all" -fclangir-skip-system-headers -clangir-verify-diagnostics -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -I%S/../Inputs -mconstructor-aliases -fclangir -fclangir-lifetime-check="history=all;remarks=all" -fclangir-skip-system-headers -clangir-verify-diagnostics -emit-cir %s -o %t.cir
 
 #include "std-cxx.h"
 


### PR DESCRIPTION
This is a leftover from when ClangIR was initially focused on analysis
and could ignore default method generation. We now handle default
methods and should generate them in all cases. This fixes several bugs:
- Default methods weren't emitted when emitting LLVM, only CIR.
- Default methods only referenced by other default methods weren't
  emitted.