### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower neon_vqadds_s32

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -419,13 +419,15 @@ public:
   }
 
   mlir::Value createSub(mlir::Value lhs, mlir::Value rhs, bool hasNUW = false,
-                        bool hasNSW = false) {
+                        bool hasNSW = false, bool saturated = false) {
     auto op = create<cir::BinOp>(lhs.getLoc(), lhs.getType(),
                                  cir::BinOpKind::Sub, lhs, rhs);
     if (hasNUW)
       op.setNoUnsignedWrap(true);
     if (hasNSW)
       op.setNoSignedWrap(true);
+    if (saturated)
+      op.setSaturated(true);
     return op;
   }
 

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -438,13 +438,15 @@ public:
   }
 
   mlir::Value createAdd(mlir::Value lhs, mlir::Value rhs, bool hasNUW = false,
-                        bool hasNSW = false) {
+                        bool hasNSW = false, bool saturated = false) {
     auto op = create<cir::BinOp>(lhs.getLoc(), lhs.getType(),
                                  cir::BinOpKind::Add, lhs, rhs);
     if (hasNUW)
       op.setNoUnsignedWrap(true);
     if (hasNSW)
       op.setNoSignedWrap(true);
+    if (saturated)
+      op.setSaturated(true);
     return op;
   }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1192,12 +1192,14 @@ def BinOp : CIR_Op<"binop", [Pure,
   let arguments = (ins Arg<BinOpKind, "binop kind">:$kind,
                        CIR_AnyType:$lhs, CIR_AnyType:$rhs,
                        UnitAttr:$no_unsigned_wrap,
-                       UnitAttr:$no_signed_wrap);
+                       UnitAttr:$no_signed_wrap,
+                       UnitAttr:$saturated);
 
   let assemblyFormat = [{
     `(` $kind `,` $lhs `,` $rhs  `)`
     (`nsw` $no_signed_wrap^)?
     (`nuw` $no_unsigned_wrap^)?
+    (`sat` $saturated^)?
     `:` type($lhs) attr-dict
   }];
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -2834,7 +2834,7 @@ static mlir::Value emitCommonNeonSISDBuiltinExpr(
   case NEON::BI__builtin_neon_vqaddh_u16:
     llvm_unreachable(" neon_vqaddh_u16 NYI ");
   case NEON::BI__builtin_neon_vqadds_s32:
-    return builder.createAdd(ops[0], ops[1], true, true, true);
+    return builder.createAdd(ops[0], ops[1], false, false, true);
   case NEON::BI__builtin_neon_vqadds_u32:
     llvm_unreachable(" neon_vqadds_u32 NYI ");
   case NEON::BI__builtin_neon_vqdmulhh_s16:
@@ -2983,7 +2983,7 @@ static mlir::Value emitCommonNeonSISDBuiltinExpr(
   case NEON::BI__builtin_neon_vqsubh_u16:
     llvm_unreachable(" neon_vqsubh_u16 NYI ");
   case NEON::BI__builtin_neon_vqsubs_s32:
-    llvm_unreachable(" neon_vqsubs_s32 NYI ");
+    return builder.createSub(ops[0], ops[1], false, false, true);
   case NEON::BI__builtin_neon_vqsubs_u32:
     llvm_unreachable(" neon_vqsubs_u32 NYI ");
   case NEON::BI__builtin_neon_vrecped_f64:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -2834,7 +2834,7 @@ static mlir::Value emitCommonNeonSISDBuiltinExpr(
   case NEON::BI__builtin_neon_vqaddh_u16:
     llvm_unreachable(" neon_vqaddh_u16 NYI ");
   case NEON::BI__builtin_neon_vqadds_s32:
-    llvm_unreachable(" neon_vqadds_s32 NYI ");
+    return builder.createAdd(ops[0], ops[1], true, true, true);
   case NEON::BI__builtin_neon_vqadds_u32:
     llvm_unreachable(" neon_vqadds_u32 NYI ");
   case NEON::BI__builtin_neon_vqdmulhh_s16:

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3785,6 +3785,7 @@ LogicalResult cir::AtomicFetch::verify() {
 
 LogicalResult cir::BinOp::verify() {
   bool noWrap = getNoUnsignedWrap() || getNoSignedWrap();
+  bool saturated = getSaturated();
 
   if (!isa<cir::IntType>(getType()) && noWrap)
     return emitError()
@@ -3794,9 +3795,15 @@ LogicalResult cir::BinOp::verify() {
                    getKind() == cir::BinOpKind::Sub ||
                    getKind() == cir::BinOpKind::Mul;
 
+  bool saturatedOps =
+      getKind() == cir::BinOpKind::Add || getKind() == cir::BinOpKind::Sub;
+
   if (noWrap && !noWrapOps)
     return emitError() << "The nsw/nuw flags are applicable to opcodes: 'add', "
                           "'sub' and 'mul'";
+  if (saturated && !saturatedOps)
+    return emitError() << "The saturated flag is applicable to opcodes: 'add' "
+                          "and 'sub'";
 
   bool complexOps =
       getKind() == cir::BinOpKind::Add || getKind() == cir::BinOpKind::Sub;

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3804,6 +3804,9 @@ LogicalResult cir::BinOp::verify() {
   if (saturated && !saturatedOps)
     return emitError() << "The saturated flag is applicable to opcodes: 'add' "
                           "and 'sub'";
+  if (noWrap && saturated)
+    return emitError() << "The nsw/nuw flags and the saturated flag are "
+                          "mutually exclusive";
 
   bool complexOps =
       getKind() == cir::BinOpKind::Add || getKind() == cir::BinOpKind::Sub;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2452,6 +2452,12 @@ CIRToLLVMBinOpLowering::getIntOverflowFlag(cir::BinOp op) const {
   return mlir::LLVM::IntegerOverflowFlags::none;
 }
 
+static bool isIntTypeUnSigned(mlir::Type type) {
+  return mlir::isa<cir::IntType>(type)
+             ? mlir::cast<cir::IntType>(type).isUnsigned()
+             : mlir::cast<mlir::IntegerType>(type).isUnsigned();
+}
+
 mlir::LogicalResult CIRToLLVMBinOpLowering::matchAndRewrite(
     cir::BinOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -2471,58 +2477,70 @@ mlir::LogicalResult CIRToLLVMBinOpLowering::matchAndRewrite(
 
   switch (op.getKind()) {
   case cir::BinOpKind::Add:
-    if (mlir::isa<cir::IntType, mlir::IntegerType>(type))
+    if (mlir::isa<cir::IntType, mlir::IntegerType>(type)) {
+      if (op.getSaturated()) {
+        if (isIntTypeUnSigned(type)) {
+          rewriter.replaceOpWithNewOp<mlir::LLVM::UAddSat>(op, lhs, rhs);
+          break;
+        }
+        rewriter.replaceOpWithNewOp<mlir::LLVM::SAddSat>(op, lhs, rhs);
+        break;
+      }
       rewriter.replaceOpWithNewOp<mlir::LLVM::AddOp>(op, llvmTy, lhs, rhs,
                                                      getIntOverflowFlag(op));
-    else
-      rewriter.replaceOpWithNewOp<mlir::LLVM::FAddOp>(op, llvmTy, lhs, rhs);
+    } else
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FAddOp>(op, lhs, rhs);
     break;
   case cir::BinOpKind::Sub:
-    if (mlir::isa<cir::IntType, mlir::IntegerType>(type))
+    if (mlir::isa<cir::IntType, mlir::IntegerType>(type)) {
+      if (op.getSaturated()) {
+        if (isIntTypeUnSigned(type)) {
+          rewriter.replaceOpWithNewOp<mlir::LLVM::USubSat>(op, lhs, rhs);
+          break;
+        }
+        rewriter.replaceOpWithNewOp<mlir::LLVM::SSubSat>(op, lhs, rhs);
+        break;
+      }
       rewriter.replaceOpWithNewOp<mlir::LLVM::SubOp>(op, llvmTy, lhs, rhs,
                                                      getIntOverflowFlag(op));
-    else
-      rewriter.replaceOpWithNewOp<mlir::LLVM::FSubOp>(op, llvmTy, lhs, rhs);
+    } else
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FSubOp>(op, lhs, rhs);
     break;
   case cir::BinOpKind::Mul:
     if (mlir::isa<cir::IntType, mlir::IntegerType>(type))
       rewriter.replaceOpWithNewOp<mlir::LLVM::MulOp>(op, llvmTy, lhs, rhs,
                                                      getIntOverflowFlag(op));
     else
-      rewriter.replaceOpWithNewOp<mlir::LLVM::FMulOp>(op, llvmTy, lhs, rhs);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FMulOp>(op, lhs, rhs);
     break;
   case cir::BinOpKind::Div:
     if (mlir::isa<cir::IntType, mlir::IntegerType>(type)) {
-      auto isUnsigned = mlir::isa<cir::IntType>(type)
-                            ? mlir::cast<cir::IntType>(type).isUnsigned()
-                            : mlir::cast<mlir::IntegerType>(type).isUnsigned();
+      auto isUnsigned = isIntTypeUnSigned(type);
       if (isUnsigned)
-        rewriter.replaceOpWithNewOp<mlir::LLVM::UDivOp>(op, llvmTy, lhs, rhs);
+        rewriter.replaceOpWithNewOp<mlir::LLVM::UDivOp>(op, lhs, rhs);
       else
-        rewriter.replaceOpWithNewOp<mlir::LLVM::SDivOp>(op, llvmTy, lhs, rhs);
+        rewriter.replaceOpWithNewOp<mlir::LLVM::SDivOp>(op, lhs, rhs);
     } else
-      rewriter.replaceOpWithNewOp<mlir::LLVM::FDivOp>(op, llvmTy, lhs, rhs);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FDivOp>(op, lhs, rhs);
     break;
   case cir::BinOpKind::Rem:
     if (mlir::isa<cir::IntType, mlir::IntegerType>(type)) {
-      auto isUnsigned = mlir::isa<cir::IntType>(type)
-                            ? mlir::cast<cir::IntType>(type).isUnsigned()
-                            : mlir::cast<mlir::IntegerType>(type).isUnsigned();
+      auto isUnsigned = isIntTypeUnSigned(type);
       if (isUnsigned)
-        rewriter.replaceOpWithNewOp<mlir::LLVM::URemOp>(op, llvmTy, lhs, rhs);
+        rewriter.replaceOpWithNewOp<mlir::LLVM::URemOp>(op, lhs, rhs);
       else
-        rewriter.replaceOpWithNewOp<mlir::LLVM::SRemOp>(op, llvmTy, lhs, rhs);
+        rewriter.replaceOpWithNewOp<mlir::LLVM::SRemOp>(op, lhs, rhs);
     } else
-      rewriter.replaceOpWithNewOp<mlir::LLVM::FRemOp>(op, llvmTy, lhs, rhs);
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FRemOp>(op, lhs, rhs);
     break;
   case cir::BinOpKind::And:
-    rewriter.replaceOpWithNewOp<mlir::LLVM::AndOp>(op, llvmTy, lhs, rhs);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::AndOp>(op, lhs, rhs);
     break;
   case cir::BinOpKind::Or:
-    rewriter.replaceOpWithNewOp<mlir::LLVM::OrOp>(op, llvmTy, lhs, rhs);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::OrOp>(op, lhs, rhs);
     break;
   case cir::BinOpKind::Xor:
-    rewriter.replaceOpWithNewOp<mlir::LLVM::XOrOp>(op, llvmTy, lhs, rhs);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::XOrOp>(op, lhs, rhs);
     break;
   }
 

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -9754,7 +9754,7 @@ int32_t test_vqadds_s32(int32_t a, int32_t b) {
   return vqadds_s32(a, b);
 
   // CIR: vqadds_s32
-  // CIR: cir.binop(add, {{%.*}}, {{%.*}}) nsw nuw sat : !s32i
+  // CIR: cir.binop(add, {{%.*}}, {{%.*}}) sat : !s32i
 
   // LLVM:{{.*}}test_vqadds_s32(i32{{.*}}[[a:%.*]], i32{{.*}}[[b:%.*]])
   // LLVM:   [[VQADDS_S32_I:%.*]] = call i32 @llvm.sadd.sat.i32(i32 [[a]], i32 [[b]])
@@ -9825,9 +9825,16 @@ int32_t test_vqadds_s32(int32_t a, int32_t b) {
 // NYI-LABEL: @test_vqsubs_s32(
 // NYI:   [[VQSUBS_S32_I:%.*]] = call i32 @llvm.aarch64.neon.sqsub.i32(i32 %a, i32 %b)
 // NYI:   ret i32 [[VQSUBS_S32_I]]
-// int32_t test_vqsubs_s32(int32_t a, int32_t b) {
-//   return vqsubs_s32(a, b);
-// }
+int32_t test_vqsubs_s32(int32_t a, int32_t b) {
+  return vqsubs_s32(a, b);
+
+  // CIR: vqsubs_s32
+  // CIR: cir.binop(sub, {{%.*}}, {{%.*}}) sat : !s32i
+
+  // LLVM:{{.*}}test_vqsubs_s32(i32{{.*}}[[a:%.*]], i32{{.*}}[[b:%.*]])
+  // LLVM:   [[VQSUBS_S32_I:%.*]] = call i32 @llvm.ssub.sat.i32(i32 [[a]], i32 [[b]])
+  // LLVM:   ret i32 [[VQSUBS_S32_I]]
+}
 
 // NYI-LABEL: @test_vqsubd_s64(
 // NYI:   [[VQSUBD_S64_I:%.*]] = call i64 @llvm.aarch64.neon.sqsub.i64(i64 %a, i64 %b)

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -9750,12 +9750,16 @@ poly16x8_t test_vmull_p8(poly8x8_t a, poly8x8_t b) {
 //   return vqaddh_s16(a, b);
 // }
 
-// NYI-LABEL: @test_vqadds_s32(
-// NYI:   [[VQADDS_S32_I:%.*]] = call i32 @llvm.aarch64.neon.sqadd.i32(i32 %a, i32 %b)
-// NYI:   ret i32 [[VQADDS_S32_I]]
-// int32_t test_vqadds_s32(int32_t a, int32_t b) {
-//   return vqadds_s32(a, b);
-// }
+int32_t test_vqadds_s32(int32_t a, int32_t b) {
+  return vqadds_s32(a, b);
+
+  // CIR: vqadds_s32
+  // CIR: cir.binop(add, {{%.*}}, {{%.*}}) nsw nuw sat : !s32i
+
+  // LLVM:{{.*}}test_vqadds_s32(i32{{.*}}[[a:%.*]], i32{{.*}}[[b:%.*]])
+  // LLVM:   [[VQADDS_S32_I:%.*]] = call i32 @llvm.sadd.sat.i32(i32 [[a]], i32 [[b]])
+  // LLVM:   ret i32 [[VQADDS_S32_I]]
+}
 
 // NYI-LABEL: @test_vqaddd_s64(
 // NYI:   [[VQADDD_S64_I:%.*]] = call i64 @llvm.aarch64.neon.sqadd.i64(i64 %a, i64 %b)

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1091,6 +1091,15 @@ cir.func @bad_binop_for_nowrap(%x: !u32i, %y: !u32i) {
 
 // -----
 
+!u32i = !cir.int<u, 32>
+
+cir.func @bad_binop_for_saturated(%x: !u32i, %y: !u32i) {
+  // expected-error@+1 {{The saturated flag is applicable to opcodes: 'add' and 'sub'}}
+  %0 = cir.binop(div, %x, %y) sat : !u32i
+}
+
+// -----
+
 !s32i = !cir.int<s, 32>
 
 module {

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1102,6 +1102,24 @@ cir.func @bad_binop_for_saturated(%x: !u32i, %y: !u32i) {
 
 !s32i = !cir.int<s, 32>
 
+cir.func @no_nsw_for_saturated(%x: !s32i, %y: !s32i) {
+  // expected-error@+1 {{The nsw/nuw flags and the saturated flag are mutually exclusive}}
+  %0 = cir.binop(add, %x, %y) nsw sat : !s32i
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+
+cir.func @no_nuw_for_saturated(%x: !s32i, %y: !s32i) {
+  // expected-error@+1 {{The nsw/nuw flags and the saturated flag are mutually exclusive}}
+  %0 = cir.binop(add, %x, %y) nuw sat : !s32i
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+
 module {
   cir.global "private" external @batata : !s32i
   cir.func @f35() {

--- a/clang/test/CIR/Lowering/binop-signed-int.cir
+++ b/clang/test/CIR/Lowering/binop-signed-int.cir
@@ -58,6 +58,10 @@ module {
     %33 = cir.load %1 : !cir.ptr<!s32i>, !s32i
     %34 = cir.binop(or, %32, %33) : !s32i
     // CHECK: = llvm.or
+    %35 = cir.binop(add, %32, %33) sat: !s32i
+    // CHECK: = llvm.intr.sadd.sat{{.*}}(i32, i32) -> i32
+    %36 = cir.binop(sub, %32, %33) sat: !s32i
+    // CHECK: = llvm.intr.ssub.sat{{.*}}(i32, i32) -> i32 
     cir.store %34, %2 : !s32i, !cir.ptr<!s32i>
     cir.return
   }

--- a/clang/test/CIR/Lowering/binop-unsigned-int.cir
+++ b/clang/test/CIR/Lowering/binop-unsigned-int.cir
@@ -49,6 +49,8 @@ module {
     %33 = cir.load %1 : !cir.ptr<!u32i>, !u32i
     %34 = cir.binop(or, %32, %33) : !u32i
     cir.store %34, %2 : !u32i, !cir.ptr<!u32i>
+    %35 = cir.binop(add, %32, %33) sat: !u32i
+    %36 = cir.binop(sub, %32, %33) sat: !u32i  
     cir.return
   }
 }
@@ -62,7 +64,8 @@ module {
 // MLIR: = llvm.shl
 // MLIR: = llvm.and
 // MLIR: = llvm.xor
-// MLIR: = llvm.or
+// MLIR: = llvm.intr.uadd.sat{{.*}}(i32, i32) -> i32
+// MLIR: = llvm.intr.usub.sat{{.*}}(i32, i32) -> i32 
 
 // LLVM: = mul i32
 // LLVM: = udiv i32
@@ -74,3 +77,5 @@ module {
 // LLVM: = and i32
 // LLVM: = xor i32
 // LLVM: = or i32
+// LLVM: = call i32 @llvm.uadd.sat.i32
+// LLVM: = call i32 @llvm.usub.sat.i32


### PR DESCRIPTION
This can't be simply implemented by our CIR Add via LLVM::AddOp, as i[t's saturated add.](https://godbolt.org/z/MxqGrj6fP)
