### PR TITLE
[CIR][CIRGen] Support Lambda capturing `this` object

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -232,7 +232,6 @@ struct MissingFeatures {
   static bool isPPC_FP128Ty() { return false; }
   static bool emitBinaryAtomicPostHasInvert() { return false; }
   static bool createLaunderInvariantGroup() { return false; }
-  static bool supportExplicitObjectMemberFunction() { return false; }
 
   // Inline assembly
   static bool asmGoto() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -232,6 +232,7 @@ struct MissingFeatures {
   static bool isPPC_FP128Ty() { return false; }
   static bool emitBinaryAtomicPostHasInvert() { return false; }
   static bool createLaunderInvariantGroup() { return false; }
+  static bool supportExplicitObjectMemberFunction() { return false; }
 
   // Inline assembly
   static bool asmGoto() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -962,7 +962,6 @@ LValue CIRGenFunction::emitLValueForLambdaField(const FieldDecl *field,
   }
   LValue lambdaLV;
   if (hasExplicitObjectParameter) {
-    assert(!MissingFeatures::supportExplicitObjectMemberFunction());
     llvm_unreachable("ExplicitObjectMemberFunction NYI");
   }
   QualType lambdaTagType = getContext().getTagDeclType(field->getParent());

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -960,14 +960,12 @@ LValue CIRGenFunction::emitLValueForLambdaField(const FieldDecl *field,
     assert(methD->getParent()->isLambda());
     assert(methD->getParent() == field->getParent());
   }
-  LValue lambdaLV;
-  if (hasExplicitObjectParameter) {
-    llvm_unreachable("ExplicitObjectMemberFunction NYI");
+  if (!hasExplicitObjectParameter) {
+    QualType lambdaTagType = getContext().getTagDeclType(field->getParent());
+    LValue lambdaLV = MakeNaturalAlignAddrLValue(thisValue, lambdaTagType);
+    return emitLValueForField(lambdaLV, field);
   }
-  QualType lambdaTagType = getContext().getTagDeclType(field->getParent());
-  lambdaLV = MakeNaturalAlignAddrLValue(thisValue, lambdaTagType);
-
-  return emitLValueForField(lambdaLV, field);
+  llvm_unreachable("ExplicitObjectMemberFunction NYI");
 }
 
 LValue CIRGenFunction::emitLValueForLambdaField(const FieldDecl *field) {

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -955,17 +955,19 @@ LValue CIRGenFunction::emitLValueForLambdaField(const FieldDecl *field,
                                                 mlir::Value thisValue) {
   bool hasExplicitObjectParameter = false;
   const auto *methD = dyn_cast_if_present<CXXMethodDecl>(CurCodeDecl);
+  LValue lambdaLV;
   if (methD) {
     hasExplicitObjectParameter = methD->isExplicitObjectMemberFunction();
     assert(methD->getParent()->isLambda());
     assert(methD->getParent() == field->getParent());
   }
-  if (!hasExplicitObjectParameter) {
+  if (hasExplicitObjectParameter) {
+    llvm_unreachable("ExplicitObjectMemberFunction NYI");
+  } else {
     QualType lambdaTagType = getContext().getTagDeclType(field->getParent());
-    LValue lambdaLV = MakeNaturalAlignAddrLValue(thisValue, lambdaTagType);
-    return emitLValueForField(lambdaLV, field);
+    lambdaLV = MakeNaturalAlignAddrLValue(thisValue, lambdaTagType);
   }
-  llvm_unreachable("ExplicitObjectMemberFunction NYI");
+  return emitLValueForField(lambdaLV, field);
 }
 
 LValue CIRGenFunction::emitLValueForLambdaField(const FieldDecl *field) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -928,7 +928,9 @@ void AggExprEmitter::VisitLambdaExpr(LambdaExpr *E) {
       ValueDecl *v = capture.getCapturedVar();
       fieldName = v->getName();
       CGF.getCIRGenModule().LambdaFieldToName[*CurField] = fieldName;
-    } else if (!capture.capturesThis()) {
+    } else if (capture.capturesThis()) {
+      CGF.getCIRGenModule().LambdaFieldToName[*CurField] = "this";
+    } else {
       llvm_unreachable("NYI");
     }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -928,7 +928,7 @@ void AggExprEmitter::VisitLambdaExpr(LambdaExpr *E) {
       ValueDecl *v = capture.getCapturedVar();
       fieldName = v->getName();
       CGF.getCIRGenModule().LambdaFieldToName[*CurField] = fieldName;
-    } else {
+    } else if (!capture.capturesThis()) {
       llvm_unreachable("NYI");
     }
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1679,8 +1679,11 @@ public:
   void initializeVTablePointer(mlir::Location loc, const VPtr &Vptr);
 
   AggValueSlot::Overlap_t getOverlapForFieldInit(const FieldDecl *FD);
-  LValue emitLValueForField(LValue Base, const clang::FieldDecl *Field);
+  LValue emitLValueForField(LValue base, const clang::FieldDecl *field);
   LValue emitLValueForBitField(LValue base, const FieldDecl *field);
+  LValue emitLValueForLambdaField(const FieldDecl *field);
+  LValue emitLValueForLambdaField(const FieldDecl *field,
+                                  mlir::Value thisValue);
 
   /// Like emitLValueForField, excpet that if the Field is a reference, this
   /// will return the address of the reference and not the address of the value

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -21,11 +21,9 @@ void fn() {
 // CHECK-NEXT:     %0 = cir.alloca !ty_anon2E0_, !cir.ptr<!ty_anon2E0_>, ["a"]
 //      CHECK:   cir.call @_ZZ2fnvENK3$_0clEv
 
-// LLVM: {{.*}}void @"_ZZ2fnvENK3$_0clEv"(ptr [[THIS:%.*]])
-// FIXME: argument attributes should be emmitted, and lambda's alignment
-// COM: LLVM: {{.*}} @"_ZZ2fnvENK3$_0clEv"(ptr noundef nonnull align 1 dereferenceable(1) [[THIS:%.*]]){{%.*}} align 2 {
+// LLVM-LABEL:  _ZZ2fnvENK3$_0clEv
 // LLVM: [[THIS_ADDR:%.*]] = alloca ptr, i64 1, align 8
-// LLVM: store ptr [[THIS]], ptr [[THIS_ADDR]], align 8
+// LLVM: store ptr {{%.*}}, ptr [[THIS_ADDR]], align 8
 // LLVM: [[THIS1:%.*]] = load ptr, ptr [[THIS_ADDR]], align 8
 // LLVM: ret void
 
@@ -56,11 +54,11 @@ void l0() {
 // CHECK: %8 = cir.load %7 : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK: cir.store %6, %8 : !s32i, !cir.ptr<!s32i>
 
-// CHECK: cir.func @_Z2l0v()
+// CHECK-LABEL: _Z2l0v
 
-// LLVM: {{.* }}void @"_ZZ2l0vENK3$_0clEv"(ptr [[THIS:%.*]])
+// LLVM-LABEL: _ZZ2l0vENK3$_0clEv
 // LLVM: [[THIS_ADDR:%.*]] = alloca ptr, i64 1, align 8
-// LLVM: store ptr [[THIS]], ptr [[THIS_ADDR]], align 8
+// LLVM: store ptr {{%.*}}, ptr [[THIS_ADDR]], align 8
 // LLVM: [[THIS1:%.*]] = load ptr, ptr [[THIS_ADDR]], align 8
 // LLVM: [[I:%.*]] = getelementptr %class.anon.2, ptr [[THIS1]], i32 0, i32 0
 // FIXME: getelementptr argument attributes should be emitted
@@ -94,7 +92,7 @@ auto g() {
   };
 }
 
-// CHECK: cir.func @_Z1gv() -> !ty_anon2E3_
+// CHECK-LABEL: @_Z1gv()
 // CHECK: %0 = cir.alloca !ty_anon2E3_, !cir.ptr<!ty_anon2E3_>, ["__retval"] {alignment = 8 : i64}
 // CHECK: %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK: %2 = cir.const #cir.int<12> : !s32i
@@ -123,7 +121,7 @@ auto g2() {
 }
 
 // Should be same as above because of NRVO
-// CHECK: cir.func @_Z2g2v() -> !ty_anon2E4_
+// CHECK-LABEL: @_Z2g2v()
 // CHECK-NEXT: %0 = cir.alloca !ty_anon2E4_, !cir.ptr<!ty_anon2E4_>, ["__retval", init] {alignment = 8 : i64}
 // CHECK-NEXT: %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK-NEXT: %2 = cir.const #cir.int<12> : !s32i
@@ -146,7 +144,7 @@ int f() {
   return g2()();
 }
 
-//      CHECK: cir.func @_Z1fv() -> !s32i
+// CHECK-LABEL: @_Z1fv()
 // CHECK-NEXT:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     %2 = cir.alloca !ty_anon2E4_, !cir.ptr<!ty_anon2E4_>, ["ref.tmp0"] {alignment = 8 : i64}
@@ -159,10 +157,10 @@ int f() {
 // CHECK-NEXT:   cir.return %1 : !s32i
 // CHECK-NEXT: }
 
-// LLVM: {{.*}}i32 @"_ZZ2g2vENK3$_0clEv"(ptr [[THIS:%.*]])
+// LLVM-LABEL: _ZZ2g2vENK3$_0clEv
 // LLVM: [[THIS_ADDR:%.*]] = alloca ptr, i64 1, align 8
 // LLVM: [[I_SAVE:%.*]] = alloca i32, i64 1, align 4
-// LLVM: store ptr [[THIS]], ptr [[THIS_ADDR]], align 8
+// LLVM: store ptr {{%.*}}, ptr [[THIS_ADDR]], align 8
 // LLVM: [[THIS1:%.*]] = load ptr, ptr [[THIS_ADDR]], align 8
 // LLVM: [[I:%.*]] = getelementptr %class.anon.4, ptr [[THIS1]], i32 0, i32 0
 // LLVM: [[TMP0:%.*]] = load ptr, ptr [[I]], align 8
@@ -204,7 +202,7 @@ int g3() {
 // lambda operator int (*)(int const&)()
 // CHECK:   cir.func internal private @_ZZ2g3vENK3$_0cvPFiRKiEEv
 
-// CHECK: cir.func @_Z2g3v() -> !s32i
+// CHECK-LABEL: @_Z2g3v()
 // CHECK:     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:     %1 = cir.alloca !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>>, ["fn", init] {alignment = 8 : i64}
 // CHECK:     %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["task", init] {alignment = 4 : i64}
@@ -233,16 +231,14 @@ int g3() {
 // CHECK:   }
 
 // lambda operator()
-// FIXME: argument attributes should be emitted
-// COM: LLVM: define internal noundef i32 @"_ZZ2g3vENK3$_0clERKi"(ptr noundef nonnull align 1 dereferenceable(1) {{%.*}}, ptr noundef nonnull align 4 dereferenceable(4){{%.*}}) #0 align 2
-// LLVM: {{.*}}i32 @"_ZZ2g3vENK3$_0clERKi"(ptr {{%.*}}, ptr {{%.*}})
+// LLVM-LABEL: _ZZ2g3vENK3$_0clERKi
 
 // lambda __invoke()
-// LLVM: {{.*}}i32 @"_ZZ2g3vEN3$_08__invokeERKi"(ptr [[i:%.*]])
+// LLVM-LABEL: _ZZ2g3vEN3$_08__invokeERKi
 // LLVM: [[i_addr:%.*]] = alloca ptr, i64 1, align 8
 // LLVM: [[ret_val:%.*]] = alloca i32, i64 1, align 4
 // LLVM: [[unused_capture:%.*]] = alloca %class.anon.5, i64 1, align 1
-// LLVM: store ptr [[i]], ptr [[i_addr]], align 8
+// LLVM: store ptr {{%.*}}, ptr [[i_addr]], align 8
 // LLVM: [[TMP0:%.*]] = load ptr, ptr [[i_addr]], align 8
 // FIXME: call and argument attributes should be emitted
 // COM: LLVM: [[CALL:%.*]] =  call noundef i32 @"_ZZ2g3vENK3$_0clERKi"(ptr noundef nonnull align 1 dereferenceable(1) [[unused_capture]], ptr noundef nonnull align 4 dereferenceable(4) [[TMP0]])
@@ -295,21 +291,21 @@ struct A {
   int bar() { return [this] { return a; }(); }
 };
 // A's default ctor
-// CHECK: cir.func linkonce_odr @_ZN1AC1Ev(%arg0: !cir.ptr<!ty_A>
+// CHECK-LABEL: _ZN1AC1Ev
 
 // lambda operator() in foo()
-// CHECK: cir.func lambda linkonce_odr @_ZZN1A3fooEvENKUlvE_clEv([[ARG:%.*]]: !cir.ptr<!ty_anon2E7_>
+// CHECK-LABEL: _ZZN1A3fooEvENKUlvE_clEv
 // CHECK: [[ARG_ADDR:%.*]] = cir.alloca !cir.ptr<!ty_anon2E7_>, !cir.ptr<!cir.ptr<!ty_anon2E7_>>, ["this", init] {alignment = 8 : i64}
-// CHECK: cir.store [[ARG]], [[ARG_ADDR]] : !cir.ptr<!ty_anon2E7_>, !cir.ptr<!cir.ptr<!ty_anon2E7_>>
+// CHECK: cir.store {{%.*}}, [[ARG_ADDR]] : !cir.ptr<!ty_anon2E7_>, !cir.ptr<!cir.ptr<!ty_anon2E7_>>
 // CHECK: [[CLS_ANNO7:%.*]] = cir.load [[ARG_ADDR]] : !cir.ptr<!cir.ptr<!ty_anon2E7_>>, !cir.ptr<!ty_anon2E7_>
-// CHECK: [[STRUCT_A:%.*]] = cir.get_member [[CLS_ANNO7]][0] {name = ""} : !cir.ptr<!ty_anon2E7_> -> !cir.ptr<!ty_A>
+// CHECK: [[STRUCT_A:%.*]] = cir.get_member [[CLS_ANNO7]][0] {name = "this"} : !cir.ptr<!ty_anon2E7_> -> !cir.ptr<!ty_A>
 // CHECK: [[a:%.*]] = cir.get_member [[STRUCT_A]][0] {name = "a"} : !cir.ptr<!ty_A> -> !cir.ptr<!s32i> loc(#loc70)
 // CHECK: cir.return {{%.*}} : !s32i
 
-// LLVM: define {{.*}}@_ZZN1A3fooEvENKUlvE_clEv(ptr{{.*}}[[ARG:%.*]])
+// LLVM-LABEL: @_ZZN1A3fooEvENKUlvE_clEv
 // LLVM: [[ARG_ADDR:%.*]]  = alloca ptr, i64 1, align 8
 // LLVM: [[RET:%.*]] = alloca i32, i64 1, align 4
-// LLVM: store ptr [[ARG]], ptr [[ARG_ADDR]], align 8
+// LLVM: store ptr {{%.*}}, ptr [[ARG_ADDR]], align 8
 // LLVM: [[CLS_ANNO7:%.*]] = load ptr, ptr [[ARG_ADDR]], align 8
 // LLVM: [[STRUCT_A:%.*]] = getelementptr %class.anon.7, ptr [[CLS_ANNO7]], i32 0, i32 0
 // LLVM: [[a:%.*]] = getelementptr %struct.A, ptr [[STRUCT_A]], i32 0, i32 0
@@ -319,7 +315,7 @@ struct A {
 // LLVM: ret i32 [[TMP1]]
 
 // A::foo()
-// CHECK: cir.func linkonce_odr @_ZN1A3fooEv(%arg0: !cir.ptr<!ty_A>{{.*}}-> !s32i
+// CHECK-LABEL: @_ZN1A3fooEv
 // CHECK: [[THIS_ARG:%.*]] = cir.alloca !ty_anon2E7_, !cir.ptr<!ty_anon2E7_>, ["ref.tmp0"] {alignment = 4 : i64}
 // CHECK: cir.call @_ZZN1A3fooEvENKUlvE_clEv([[THIS_ARG]]) : (!cir.ptr<!ty_anon2E7_>) -> !s32i
 
@@ -328,19 +324,19 @@ struct A {
 // LLVM: call i32 @_ZZN1A3fooEvENKUlvE_clEv(ptr [[this_in_foo]])
 
 // lambda operator() in bar()
-// CHECK: cir.func lambda linkonce_odr @_ZZN1A3barEvENKUlvE_clEv([[ARG2:%.*]]: !cir.ptr<!ty_anon2E8_>
+// CHECK-LABEL: _ZZN1A3barEvENKUlvE_clEv
 // CHECK: [[ARG2_ADDR:%.*]] = cir.alloca !cir.ptr<!ty_anon2E8_>, !cir.ptr<!cir.ptr<!ty_anon2E8_>>, ["this", init] {alignment = 8 : i64}
-// CHECK: cir.store [[ARG2]], [[ARG2_ADDR]] : !cir.ptr<!ty_anon2E8_>, !cir.ptr<!cir.ptr<!ty_anon2E8_>>
+// CHECK: cir.store {{%.*}}, [[ARG2_ADDR]] : !cir.ptr<!ty_anon2E8_>, !cir.ptr<!cir.ptr<!ty_anon2E8_>>
 // CHECK: [[CLS_ANNO8:%.*]] = cir.load [[ARG2_ADDR]] : !cir.ptr<!cir.ptr<!ty_anon2E8_>>, !cir.ptr<!ty_anon2E8_>
-// CHECK: [[STRUCT_A_PTR:%.*]] = cir.get_member [[CLS_ANNO8]][0] {name = ""} : !cir.ptr<!ty_anon2E8_> -> !cir.ptr<!cir.ptr<!ty_A>>
+// CHECK: [[STRUCT_A_PTR:%.*]] = cir.get_member [[CLS_ANNO8]][0] {name = "this"} : !cir.ptr<!ty_anon2E8_> -> !cir.ptr<!cir.ptr<!ty_A>>
 // CHECK: [[STRUCT_A:%.*]] = cir.load [[STRUCT_A_PTR]] : !cir.ptr<!cir.ptr<!ty_A>>, !cir.ptr<!ty_A>
 // CHECK: [[a:%.*]] = cir.get_member [[STRUCT_A]][0] {name = "a"} : !cir.ptr<!ty_A> -> !cir.ptr<!s32i> loc(#loc70)
 // CHECK: cir.return {{%.*}} : !s32i
 
-// LLVM: define {{.*}}@_ZZN1A3barEvENKUlvE_clEv(ptr{{.*}}[[ARG2:%.*]])
+// LLVM-LABEL: _ZZN1A3barEvENKUlvE_clEv
 // LLVM: [[ARG2_ADDR:%.*]]  = alloca ptr, i64 1, align 8
 // LLVM: [[RET:%.*]] = alloca i32, i64 1, align 4
-// LLVM: store ptr [[ARG2]], ptr [[ARG2_ADDR]], align 8
+// LLVM: store ptr {{%.*}}, ptr [[ARG2_ADDR]], align 8
 // LLVM: [[CLS_ANNO8:%.*]] = load ptr, ptr [[ARG2_ADDR]], align 8
 // LLVM: [[STRUCT_A_PTR:%.*]] = getelementptr %class.anon.8, ptr [[CLS_ANNO8]], i32 0, i32 0
 // LLVM: [[STRUCT_A:%.*]] = load ptr, ptr [[STRUCT_A_PTR]], align 8
@@ -351,7 +347,7 @@ struct A {
 // LLVM: ret i32 [[TMP1]]
 
 // A::bar()
-// CHECK: cir.func linkonce_odr @_ZN1A3barEv(%arg0: !cir.ptr<!ty_A>{{.*}}-> !s32i
+// CHECK-LABEL: _ZN1A3barEv
 // CHECK: [[THIS_ARG:%.*]] = cir.alloca !ty_anon2E8_, !cir.ptr<!ty_anon2E8_>, ["ref.tmp0"] {alignment = 8 : i64}
 // CHECK: cir.call @_ZZN1A3barEvENKUlvE_clEv([[THIS_ARG]])
 

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -9,7 +9,10 @@ void fn() {
   a();
 }
 
+//      CHECK-DAG: !ty_A = !cir.struct<struct "A" {!s32i}>
 //      CHECK: !ty_anon2E0_ = !cir.struct<class "anon.0" {!u8i}>
+//      CHECK-DAG: !ty_anon2E7_ = !cir.struct<class "anon.7" {!ty_A}>
+//      CHECK-DAG: !ty_anon2E8_ = !cir.struct<class "anon.8" {!cir.ptr<!ty_A>}>
 //  CHECK-DAG: module
 
 //      CHECK: cir.func lambda internal private @_ZZ2fnvENK3$_0clEv{{.*}}) extra
@@ -285,3 +288,92 @@ int g3() {
 // LLVM: store i32 [[tmp2]], ptr [[ret_val]], align 4
 // LLVM: [[tmp3:%.*]] = load i32, ptr [[ret_val]], align 4
 // LLVM: ret i32 [[tmp3]]
+
+struct A {
+  int a = 111;
+  int foo() { return [*this] { return a; }(); }
+  int bar() { return [this] { return a; }(); }
+};
+// A's default ctor
+// CHECK: cir.func linkonce_odr @_ZN1AC1Ev(%arg0: !cir.ptr<!ty_A>
+
+// lambda operator() in foo()
+// CHECK: cir.func lambda linkonce_odr @_ZZN1A3fooEvENKUlvE_clEv([[ARG:%.*]]: !cir.ptr<!ty_anon2E7_>
+// CHECK: [[ARG_ADDR:%.*]] = cir.alloca !cir.ptr<!ty_anon2E7_>, !cir.ptr<!cir.ptr<!ty_anon2E7_>>, ["this", init] {alignment = 8 : i64}
+// CHECK: cir.store [[ARG]], [[ARG_ADDR]] : !cir.ptr<!ty_anon2E7_>, !cir.ptr<!cir.ptr<!ty_anon2E7_>>
+// CHECK: [[CLS_ANNO7:%.*]] = cir.load [[ARG_ADDR]] : !cir.ptr<!cir.ptr<!ty_anon2E7_>>, !cir.ptr<!ty_anon2E7_>
+// CHECK: [[STRUCT_A:%.*]] = cir.get_member [[CLS_ANNO7]][0] {name = ""} : !cir.ptr<!ty_anon2E7_> -> !cir.ptr<!ty_A>
+// CHECK: [[a:%.*]] = cir.get_member [[STRUCT_A]][0] {name = "a"} : !cir.ptr<!ty_A> -> !cir.ptr<!s32i> loc(#loc70)
+// CHECK: cir.return {{%.*}} : !s32i
+
+// LLVM: define {{.*}}@_ZZN1A3fooEvENKUlvE_clEv(ptr{{.*}}[[ARG:%.*]])
+// LLVM: [[ARG_ADDR:%.*]]  = alloca ptr, i64 1, align 8
+// LLVM: [[RET:%.*]] = alloca i32, i64 1, align 4
+// LLVM: store ptr [[ARG]], ptr [[ARG_ADDR]], align 8
+// LLVM: [[CLS_ANNO7:%.*]] = load ptr, ptr [[ARG_ADDR]], align 8
+// LLVM: [[STRUCT_A:%.*]] = getelementptr %class.anon.7, ptr [[CLS_ANNO7]], i32 0, i32 0
+// LLVM: [[a:%.*]] = getelementptr %struct.A, ptr [[STRUCT_A]], i32 0, i32 0
+// LLVM: [[TMP0:%.*]] = load i32, ptr [[a]], align 4
+// LLVM: store i32 [[TMP0]], ptr [[RET]], align 4
+// LLVM: [[TMP1:%.*]] = load i32, ptr [[RET]], align 4
+// LLVM: ret i32 [[TMP1]]
+
+// A::foo()
+// CHECK: cir.func linkonce_odr @_ZN1A3fooEv(%arg0: !cir.ptr<!ty_A>{{.*}}-> !s32i
+// CHECK: [[THIS_ARG:%.*]] = cir.alloca !ty_anon2E7_, !cir.ptr<!ty_anon2E7_>, ["ref.tmp0"] {alignment = 4 : i64}
+// CHECK: cir.call @_ZZN1A3fooEvENKUlvE_clEv([[THIS_ARG]]) : (!cir.ptr<!ty_anon2E7_>) -> !s32i
+
+// LLVM-LABEL: _ZN1A3fooEv
+// LLVM: [[this_in_foo:%.*]] =  alloca %class.anon.7, i64 1, align 4
+// LLVM: call i32 @_ZZN1A3fooEvENKUlvE_clEv(ptr [[this_in_foo]])
+
+// lambda operator() in bar()
+// CHECK: cir.func lambda linkonce_odr @_ZZN1A3barEvENKUlvE_clEv([[ARG2:%.*]]: !cir.ptr<!ty_anon2E8_>
+// CHECK: [[ARG2_ADDR:%.*]] = cir.alloca !cir.ptr<!ty_anon2E8_>, !cir.ptr<!cir.ptr<!ty_anon2E8_>>, ["this", init] {alignment = 8 : i64}
+// CHECK: cir.store [[ARG2]], [[ARG2_ADDR]] : !cir.ptr<!ty_anon2E8_>, !cir.ptr<!cir.ptr<!ty_anon2E8_>>
+// CHECK: [[CLS_ANNO8:%.*]] = cir.load [[ARG2_ADDR]] : !cir.ptr<!cir.ptr<!ty_anon2E8_>>, !cir.ptr<!ty_anon2E8_>
+// CHECK: [[STRUCT_A_PTR:%.*]] = cir.get_member [[CLS_ANNO8]][0] {name = ""} : !cir.ptr<!ty_anon2E8_> -> !cir.ptr<!cir.ptr<!ty_A>>
+// CHECK: [[STRUCT_A:%.*]] = cir.load [[STRUCT_A_PTR]] : !cir.ptr<!cir.ptr<!ty_A>>, !cir.ptr<!ty_A>
+// CHECK: [[a:%.*]] = cir.get_member [[STRUCT_A]][0] {name = "a"} : !cir.ptr<!ty_A> -> !cir.ptr<!s32i> loc(#loc70)
+// CHECK: cir.return {{%.*}} : !s32i
+
+// LLVM: define {{.*}}@_ZZN1A3barEvENKUlvE_clEv(ptr{{.*}}[[ARG2:%.*]])
+// LLVM: [[ARG2_ADDR:%.*]]  = alloca ptr, i64 1, align 8
+// LLVM: [[RET:%.*]] = alloca i32, i64 1, align 4
+// LLVM: store ptr [[ARG2]], ptr [[ARG2_ADDR]], align 8
+// LLVM: [[CLS_ANNO8:%.*]] = load ptr, ptr [[ARG2_ADDR]], align 8
+// LLVM: [[STRUCT_A_PTR:%.*]] = getelementptr %class.anon.8, ptr [[CLS_ANNO8]], i32 0, i32 0
+// LLVM: [[STRUCT_A:%.*]] = load ptr, ptr [[STRUCT_A_PTR]], align 8
+// LLVM: [[a:%.*]] = getelementptr %struct.A, ptr [[STRUCT_A]], i32
+// LLVM: [[TMP0:%.*]] = load i32, ptr [[a]], align 4
+// LLVM: store i32 [[TMP0]], ptr [[RET]], align 4
+// LLVM: [[TMP1:%.*]] = load i32, ptr [[RET]], align 4
+// LLVM: ret i32 [[TMP1]]
+
+// A::bar()
+// CHECK: cir.func linkonce_odr @_ZN1A3barEv(%arg0: !cir.ptr<!ty_A>{{.*}}-> !s32i
+// CHECK: [[THIS_ARG:%.*]] = cir.alloca !ty_anon2E8_, !cir.ptr<!ty_anon2E8_>, ["ref.tmp0"] {alignment = 8 : i64}
+// CHECK: cir.call @_ZZN1A3barEvENKUlvE_clEv([[THIS_ARG]])
+
+// LLVM-LABEL: _ZN1A3barEv
+// LLVM: [[this_in_bar:%.*]] =  alloca %class.anon.8, i64 1, align 8
+// LLVM: call i32 @_ZZN1A3barEvENKUlvE_clEv(ptr [[this_in_bar]])
+
+int test_lambda_this1(){
+  struct A clsA;
+  int x = clsA.foo();
+  int y = clsA.bar();
+  return x+y;
+}
+
+// CHECK-LABEL: test_lambda_this1
+// Construct A
+// CHECK: cir.call @_ZN1AC1Ev([[A_THIS:%.*]]) : (!cir.ptr<!ty_A>) -> ()
+// CHECK: cir.call @_ZN1A3fooEv([[A_THIS]]) : (!cir.ptr<!ty_A>) -> !s32i
+// CHECK: cir.call @_ZN1A3barEv([[A_THIS]]) : (!cir.ptr<!ty_A>) -> !s32i
+
+// LLVM-LABEL: test_lambda_this1
+// LLVM: [[A_THIS:%.*]] = alloca %struct.A, i64 1, align 4
+// LLVM: call void @_ZN1AC1Ev(ptr [[A_THIS]])
+// LLVM: call i32 @_ZN1A3fooEv(ptr [[A_THIS]])
+// LLVM: call i32 @_ZN1A3barEv(ptr [[A_THIS]])

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -22,8 +22,9 @@ void fn() {
 //      CHECK:   cir.call @_ZZ2fnvENK3$_0clEv
 
 // LLVM-LABEL:  _ZZ2fnvENK3$_0clEv
+// LLVM-SAME: (ptr [[THIS:%.*]])
 // LLVM: [[THIS_ADDR:%.*]] = alloca ptr, i64 1, align 8
-// LLVM: store ptr {{%.*}}, ptr [[THIS_ADDR]], align 8
+// LLVM: store ptr [[THIS]], ptr [[THIS_ADDR]], align 8
 // LLVM: [[THIS1:%.*]] = load ptr, ptr [[THIS_ADDR]], align 8
 // LLVM: ret void
 
@@ -57,8 +58,9 @@ void l0() {
 // CHECK-LABEL: _Z2l0v
 
 // LLVM-LABEL: _ZZ2l0vENK3$_0clEv
+// LLVM-SAME: (ptr [[THIS:%.*]])
 // LLVM: [[THIS_ADDR:%.*]] = alloca ptr, i64 1, align 8
-// LLVM: store ptr {{%.*}}, ptr [[THIS_ADDR]], align 8
+// LLVM: store ptr [[THIS]], ptr [[THIS_ADDR]], align 8
 // LLVM: [[THIS1:%.*]] = load ptr, ptr [[THIS_ADDR]], align 8
 // LLVM: [[I:%.*]] = getelementptr %class.anon.2, ptr [[THIS1]], i32 0, i32 0
 // FIXME: getelementptr argument attributes should be emitted
@@ -158,9 +160,10 @@ int f() {
 // CHECK-NEXT: }
 
 // LLVM-LABEL: _ZZ2g2vENK3$_0clEv
+// LLVM-SAME: (ptr [[THIS:%.*]])
 // LLVM: [[THIS_ADDR:%.*]] = alloca ptr, i64 1, align 8
 // LLVM: [[I_SAVE:%.*]] = alloca i32, i64 1, align 4
-// LLVM: store ptr {{%.*}}, ptr [[THIS_ADDR]], align 8
+// LLVM: store ptr [[THIS]], ptr [[THIS_ADDR]], align 8
 // LLVM: [[THIS1:%.*]] = load ptr, ptr [[THIS_ADDR]], align 8
 // LLVM: [[I:%.*]] = getelementptr %class.anon.4, ptr [[THIS1]], i32 0, i32 0
 // LLVM: [[TMP0:%.*]] = load ptr, ptr [[I]], align 8
@@ -232,13 +235,17 @@ int g3() {
 
 // lambda operator()
 // LLVM-LABEL: _ZZ2g3vENK3$_0clERKi
+// FIXME: argument attributes should be emitted
+// COM: LLVM-SAME: (ptr noundef nonnull align 1 dereferenceable(1) {{%.*}}, 
+// COM: LLVM-SAME: ptr noundef nonnull align 4 dereferenceable(4){{%.*}}) #0 align 2
 
 // lambda __invoke()
 // LLVM-LABEL: _ZZ2g3vEN3$_08__invokeERKi
+// LLVM-SAME: (ptr [[i:%.*]])
 // LLVM: [[i_addr:%.*]] = alloca ptr, i64 1, align 8
 // LLVM: [[ret_val:%.*]] = alloca i32, i64 1, align 4
 // LLVM: [[unused_capture:%.*]] = alloca %class.anon.5, i64 1, align 1
-// LLVM: store ptr {{%.*}}, ptr [[i_addr]], align 8
+// LLVM: store ptr [[i]], ptr [[i_addr]], align 8
 // LLVM: [[TMP0:%.*]] = load ptr, ptr [[i_addr]], align 8
 // FIXME: call and argument attributes should be emitted
 // COM: LLVM: [[CALL:%.*]] =  call noundef i32 @"_ZZ2g3vENK3$_0clERKi"(ptr noundef nonnull align 1 dereferenceable(1) [[unused_capture]], ptr noundef nonnull align 4 dereferenceable(4) [[TMP0]])
@@ -295,17 +302,23 @@ struct A {
 
 // lambda operator() in foo()
 // CHECK-LABEL: _ZZN1A3fooEvENKUlvE_clEv
+// CHECK-SAME: ([[ARG:%.*]]: !cir.ptr<!ty_anon2E7_>
 // CHECK: [[ARG_ADDR:%.*]] = cir.alloca !cir.ptr<!ty_anon2E7_>, !cir.ptr<!cir.ptr<!ty_anon2E7_>>, ["this", init] {alignment = 8 : i64}
-// CHECK: cir.store {{%.*}}, [[ARG_ADDR]] : !cir.ptr<!ty_anon2E7_>, !cir.ptr<!cir.ptr<!ty_anon2E7_>>
+// CHECK: [[RETVAL_ADDR:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK: cir.store [[ARG]], [[ARG_ADDR]] : !cir.ptr<!ty_anon2E7_>, !cir.ptr<!cir.ptr<!ty_anon2E7_>>
 // CHECK: [[CLS_ANNO7:%.*]] = cir.load [[ARG_ADDR]] : !cir.ptr<!cir.ptr<!ty_anon2E7_>>, !cir.ptr<!ty_anon2E7_>
 // CHECK: [[STRUCT_A:%.*]] = cir.get_member [[CLS_ANNO7]][0] {name = "this"} : !cir.ptr<!ty_anon2E7_> -> !cir.ptr<!ty_A>
 // CHECK: [[a:%.*]] = cir.get_member [[STRUCT_A]][0] {name = "a"} : !cir.ptr<!ty_A> -> !cir.ptr<!s32i> loc(#loc70)
-// CHECK: cir.return {{%.*}} : !s32i
+// CHECK: [[TMP0:%.*]] = cir.load [[a]] : !cir.ptr<!s32i>, !s32i
+// CHECK: cir.store [[TMP0]], [[RETVAL_ADDR]] : !s32i, !cir.ptr<!s32i>
+// CHECK: [[RET_VAL:%.*]] = cir.load [[RETVAL_ADDR]] : !cir.ptr<!s32i>,
+// CHECK: cir.return [[RET_VAL]] : !s32i
 
 // LLVM-LABEL: @_ZZN1A3fooEvENKUlvE_clEv
+// LLVM-SAME: (ptr [[ARG:%.*]])
 // LLVM: [[ARG_ADDR:%.*]]  = alloca ptr, i64 1, align 8
 // LLVM: [[RET:%.*]] = alloca i32, i64 1, align 4
-// LLVM: store ptr {{%.*}}, ptr [[ARG_ADDR]], align 8
+// LLVM: store ptr [[ARG]], ptr [[ARG_ADDR]], align 8
 // LLVM: [[CLS_ANNO7:%.*]] = load ptr, ptr [[ARG_ADDR]], align 8
 // LLVM: [[STRUCT_A:%.*]] = getelementptr %class.anon.7, ptr [[CLS_ANNO7]], i32 0, i32 0
 // LLVM: [[a:%.*]] = getelementptr %struct.A, ptr [[STRUCT_A]], i32 0, i32 0
@@ -325,18 +338,24 @@ struct A {
 
 // lambda operator() in bar()
 // CHECK-LABEL: _ZZN1A3barEvENKUlvE_clEv
+// CHECK-SAME: ([[ARG2:%.*]]: !cir.ptr<!ty_anon2E8_>
 // CHECK: [[ARG2_ADDR:%.*]] = cir.alloca !cir.ptr<!ty_anon2E8_>, !cir.ptr<!cir.ptr<!ty_anon2E8_>>, ["this", init] {alignment = 8 : i64}
-// CHECK: cir.store {{%.*}}, [[ARG2_ADDR]] : !cir.ptr<!ty_anon2E8_>, !cir.ptr<!cir.ptr<!ty_anon2E8_>>
+// CHECK: [[RETVAL_ADDR:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK: cir.store [[ARG2]], [[ARG2_ADDR]] : !cir.ptr<!ty_anon2E8_>, !cir.ptr<!cir.ptr<!ty_anon2E8_>>
 // CHECK: [[CLS_ANNO8:%.*]] = cir.load [[ARG2_ADDR]] : !cir.ptr<!cir.ptr<!ty_anon2E8_>>, !cir.ptr<!ty_anon2E8_>
 // CHECK: [[STRUCT_A_PTR:%.*]] = cir.get_member [[CLS_ANNO8]][0] {name = "this"} : !cir.ptr<!ty_anon2E8_> -> !cir.ptr<!cir.ptr<!ty_A>>
 // CHECK: [[STRUCT_A:%.*]] = cir.load [[STRUCT_A_PTR]] : !cir.ptr<!cir.ptr<!ty_A>>, !cir.ptr<!ty_A>
 // CHECK: [[a:%.*]] = cir.get_member [[STRUCT_A]][0] {name = "a"} : !cir.ptr<!ty_A> -> !cir.ptr<!s32i> loc(#loc70)
-// CHECK: cir.return {{%.*}} : !s32i
+// CHECK: [[TMP0:%.*]] = cir.load [[a]] : !cir.ptr<!s32i>, !s32i
+// CHECK: cir.store [[TMP0]], [[RETVAL_ADDR]] : !s32i, !cir.ptr<!s32i>
+// CHECK: [[RET_VAL:%.*]] = cir.load [[RETVAL_ADDR]] : !cir.ptr<!s32i>
+// CHECK: cir.return [[RET_VAL]] : !s32i
 
 // LLVM-LABEL: _ZZN1A3barEvENKUlvE_clEv
+// LLVM-SAME: (ptr [[ARG2:%.*]])
 // LLVM: [[ARG2_ADDR:%.*]]  = alloca ptr, i64 1, align 8
 // LLVM: [[RET:%.*]] = alloca i32, i64 1, align 4
-// LLVM: store ptr {{%.*}}, ptr [[ARG2_ADDR]], align 8
+// LLVM: store ptr [[ARG2]], ptr [[ARG2_ADDR]], align 8
 // LLVM: [[CLS_ANNO8:%.*]] = load ptr, ptr [[ARG2_ADDR]], align 8
 // LLVM: [[STRUCT_A_PTR:%.*]] = getelementptr %class.anon.8, ptr [[CLS_ANNO8]], i32 0, i32 0
 // LLVM: [[STRUCT_A:%.*]] = load ptr, ptr [[STRUCT_A_PTR]], align 8


### PR DESCRIPTION
The PR should help us to get rid of NYI 
`NYI UNREACHABLE executed at clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp:899`
[Relevant OG code here](https://github.com/llvm/clangir/blob/7fb608d4d1b72c25a1739a1bd66c9024208819cb/clang/lib/CodeGen/CGExpr.cpp#L4767): 
I put `HasExplicitObjectParameter` support as a missing feature, which is a new C++23 feature. 

