### PR TITLE
[CIR][CIRGen] Fixes function calls with return values and cleanup stage

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -901,7 +901,7 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &CallInfo,
           assert(Results.size() <= 1 && "multiple returns NYI");
           assert(Results[0].getType() == RetCIRTy && "Bitcast support NYI");
 
-          mlir::Region *region region = builder.getBlock()->getParent();
+          mlir::Region *region = builder.getBlock()->getParent();
           if (region != theCall->getParentRegion()) {
             Address DestPtr = ReturnValue.getValue();
 

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -901,12 +901,12 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &CallInfo,
           assert(Results.size() <= 1 && "multiple returns NYI");
           assert(Results[0].getType() == RetCIRTy && "Bitcast support NYI");
 
-          auto region = builder.getBlock()->getParent();
+          mlir::Region *region region = builder.getBlock()->getParent();
           if (region != theCall->getParentRegion()) {
             Address DestPtr = ReturnValue.getValue();
 
             if (!DestPtr.isValid())
-              DestPtr = CreateMemTemp(RetTy, callLoc, "tmp");
+              DestPtr = CreateMemTemp(RetTy, callLoc, "tmp.try.call.res");
 
             return getRValueThroughMemory(callLoc, builder, Results[0],
                                           DestPtr);

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -552,8 +552,7 @@ static cir::CIRCallOpInterface emitCallLikeOp(
 }
 
 static RValue getRValueThroughMemory(mlir::Location loc,
-                                     CIRGenBuilderTy &builder,
-                                     mlir::Value val,
+                                     CIRGenBuilderTy &builder, mlir::Value val,
                                      Address addr) {
   auto ip = builder.saveInsertionPoint();
   builder.setInsertionPointAfterValue(val);

--- a/clang/test/CIR/CodeGen/try-catch-dtors.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-dtors.cpp
@@ -324,7 +324,7 @@ void bar() {
 // CIR-LABEL: @_Z3barv
 // CIR:  %[[V0:.*]] = cir.alloca !ty_A, !cir.ptr<!ty_A>, ["a"] {alignment = 1 : i64}
 // CIR:  %[[V1:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init] {alignment = 4 : i64}
-// CIR:  %[[V2:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["tmp"] {alignment = 4 : i64}
+// CIR:  %[[V2:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["tmp.try.call.res"] {alignment = 4 : i64}
 // CIR:  cir.try synthetic cleanup {
 // CIR:    %[[V4:.*]] = cir.call exception @_Z3foov() : () -> !s32i cleanup {
 // CIR:      cir.call @_ZN1AD2Ev(%[[V0]]) : (!cir.ptr<!ty_A>) -> () extra(#fn_attr)

--- a/clang/test/CIR/CodeGen/try-catch-dtors.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-dtors.cpp
@@ -308,3 +308,34 @@ void yo2(bool x) {
 // CIR:   } catch [type #cir.all {
 // CIR:     cir.catch_param -> !cir.ptr<!void>
 // CIR:   }]
+
+
+int foo() { return 42; }
+
+struct A {
+  ~A() {}
+};
+
+void bar() {
+  A a;
+  int b = foo();
+}
+
+// CIR-LABEL: @_Z3barv
+// CIR:  %[[V0:.*]] = cir.alloca !ty_A, !cir.ptr<!ty_A>, ["a"] {alignment = 1 : i64}
+// CIR:  %[[V1:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init] {alignment = 4 : i64}
+// CIR:  %[[V2:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["tmp"] {alignment = 4 : i64}
+// CIR:  cir.try synthetic cleanup {
+// CIR:    %[[V4:.*]] = cir.call exception @_Z3foov() : () -> !s32i cleanup {
+// CIR:      cir.call @_ZN1AD2Ev(%[[V0]]) : (!cir.ptr<!ty_A>) -> () extra(#fn_attr)
+// CIR:      cir.yield
+// CIR:    }
+// CIR:    cir.store %[[V4]], %[[V2]] : !s32i, !cir.ptr<!s32i>
+// CIR:    cir.yield
+// CIR:  } catch [#cir.unwind {
+// CIR:    cir.resume
+// CIR:  }]
+// CIR:  %[[V3:.*]] = cir.load %[[V2]] : !cir.ptr<!s32i>, !s32i
+// CIR:  cir.store %[[V3]], %[[V1]] : !s32i, !cir.ptr<!s32i>
+// CIR:  cir.call @_ZN1AD2Ev(%[[V0]]) : (!cir.ptr<!ty_A>) -> () extra(#fn_attr)
+// CIR:  cir.return


### PR DESCRIPTION
#### The Problem
Let's take a look at the following code:
```
struct A {
~A() {}
};

int foo() { return 42; }
void bar() {
  A a;
  int b = foo(); 
}
```
The call to `foo` guarded by the synthetic `tryOp` looks approximately like the following:
```
cir.try synthetic cleanup {
   %2 = cir.call exception @_Z3foov() : () -> !s32i cleanup {
      cir.call @_ZN1AD1Ev(%0) : (!cir.ptr<!ty_A>) -> () extra(#fn_attr1)   // call to destructor of 'A'
      cir.yield
    } 
    cir.yield
} catch [#cir.unwind {
    cir.resume 
}] 
cir.store %2, %1: !s32i, !cir.ptr<!s32i>  // CIR verification error
```
The result of the `foo` call is in the `try` region - and is not accessible from the outside, so the code generation fails with 
`operand #0 does not dominate its use` .

#### Solution
So we have several options how to handle this properly. 
1. We may intpoduce a new operation here, like `TryCall` but probably more high level one, e.g. introduce the `InvokeOp`.  
2. Also, we may add the result to `TryOp`.
3. The fast fix that is implemented in this PR is a temporary `alloca` where we store the call result right in the try region. And the result of the whole `emitCall` is a `load` from the temp `alloca`.  

So this PR is both the request for changes and an open discussion as well - how to handle this properly. So far I choose the third approach. If it's ok - I will need to create one more PR with a similar fix for the aggregated results or update this one. 

