### PR TITLE
[CIR] Put loop body in nested scopes

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -910,13 +910,9 @@ mlir::LogicalResult CIRGenFunction::emitForStmt(const ForStmt &S) {
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          // https://en.cppreference.com/w/cpp/language/for
-          // While in C++, the scope of the init-statement and the scope of
-          // statement are one and the same, in C the scope of statement is
-          // nested within the scope of init-statement.
-          bool useCurrentScope =
-              CGM.getASTContext().getLangOpts().CPlusPlus ? true : false;
-          if (emitStmt(S.getBody(), useCurrentScope).failed())
+          // The scope of the for loop body is nested within the scope of the
+          // for loop's init-statement and condition.
+          if (emitStmt(S.getBody(), /*useCurrentScope=*/false).failed())
             loopRes = mlir::failure();
           emitStopPoint(&S);
         },
@@ -973,7 +969,8 @@ mlir::LogicalResult CIRGenFunction::emitDoStmt(const DoStmt &S) {
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          if (emitStmt(S.getBody(), /*useCurrentScope=*/true).failed())
+          // The scope of the do-while loop body is a nested scope.
+          if (emitStmt(S.getBody(), /*useCurrentScope=*/false).failed())
             loopRes = mlir::failure();
           emitStopPoint(&S);
         });
@@ -1028,7 +1025,8 @@ mlir::LogicalResult CIRGenFunction::emitWhileStmt(const WhileStmt &S) {
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          if (emitStmt(S.getBody(), /*useCurrentScope=*/true).failed())
+          // The scope of the while loop body is a nested scope.
+          if (emitStmt(S.getBody(), /*useCurrentScope=*/false).failed())
             loopRes = mlir::failure();
           emitStopPoint(&S);
         });

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -967,13 +967,6 @@ void LifetimeCheckPass::classifyAndInitTypeCategories(mlir::Value addr,
                                                       mlir::Type t,
                                                       mlir::Location loc,
                                                       unsigned nestLevel) {
-  // The same alloca can be hit more than once when checking for dangling
-  // pointers out of subsequent loop iterations (e.g. second iteraton using
-  // pointer invalidated in the first run). Since we copy the pmap out to
-  // start those subsequent checks, make sure sure we skip existing alloca
-  // tracking.
-  if (getPmap().count(addr))
-    return;
   getPmap()[addr] = {};
 
   enum TypeCategory {

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -171,13 +171,16 @@ int jumpIntoLoop(int* ar) {
 // CHECK:  ^bb[[#BLK6]]:
 // CHECK:    cir.br ^bb[[#COND:]]
 // CHECK:  ^bb[[#COND]]:
-// CHECK:    cir.brcond {{.*}} ^bb[[#BODY]], ^bb[[#EXIT:]]
+// CHECK:    cir.brcond {{.*}} ^bb[[#BLK8:]], ^bb[[#EXIT:]]
+// CHECK:  ^bb[[#BLK8]]:
+// CHECK:    cir.br ^bb[[#BODY]]
 // CHECK:  ^bb[[#BODY]]: 
 // CHECK:    cir.br ^bb[[#COND]]
 // CHECK:  ^bb[[#EXIT]]:
 // CHECK:    cir.br ^bb[[#BLK7:]]
 // CHECK:  ^bb[[#BLK7]]:
 // CHECK:    cir.br ^bb[[#RETURN]]
+// CHECK: }
 
 
 
@@ -222,6 +225,7 @@ err:
 // CHECK:    cir.br ^bb[[#RETURN2:]]
 // CHECK:  ^bb[[#RETURN2]]:
 // CHECK:    cir.return 
+// CHECK:  }
   
 
 void flatLoopWithNoTerminatorInFront(int* ptr) {

--- a/clang/test/CIR/CodeGen/loop-scope.cpp
+++ b/clang/test/CIR/CodeGen/loop-scope.cpp
@@ -12,10 +12,13 @@ void l0(void) {
 // CPPSCOPE: cir.func @_Z2l0v()
 // CPPSCOPE-NEXT:   cir.scope {
 // CPPSCOPE-NEXT:     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
-// CPPSCOPE-NEXT:     %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["j", init] {alignment = 4 : i64}
-// CPPSCOPE-NEXT:     %2 = cir.const #cir.int<0> : !s32i
-// CPPSCOPE-NEXT:     cir.store %2, %0 : !s32i, !cir.ptr<!s32i>
+// CPPSCOPE-NEXT:     %1 = cir.const #cir.int<0> : !s32i
+// CPPSCOPE-NEXT:     cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
 // CPPSCOPE-NEXT:     cir.for : cond {
+
+//      CPPSCOPE:     } body {
+// CPPSCOPE-NEXT:       cir.scope {
+// CPPSCOPE-NEXT:         %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["j", init] {alignment = 4 : i64}
 
 // CSCOPE: cir.func @l0()
 // CSCOPE-NEXT: cir.scope {

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -25,10 +25,12 @@ void l1() {
 // CHECK-NEXT:   %6 = cir.cmp(lt, %4, %5) : !s32i, !cir.bool
 // CHECK-NEXT:   cir.condition(%6)
 // CHECK-NEXT: } body {
-// CHECK-NEXT:   %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:   %5 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:   %6 = cir.binop(add, %4, %5) nsw : !s32i
-// CHECK-NEXT:   cir.store %6, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:   cir.scope {
+// CHECK-NEXT:     %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:     %5 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:     %6 = cir.binop(add, %4, %5) nsw : !s32i
+// CHECK-NEXT:     cir.store %6, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:   }
 // CHECK-NEXT:   cir.yield
 // CHECK-NEXT: } step {
 // CHECK-NEXT:   %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
@@ -57,10 +59,12 @@ void l2(bool cond) {
 // CHECK-NEXT:       %3 = cir.load %0 : !cir.ptr<!cir.bool>, !cir.bool
 // CHECK-NEXT:       cir.condition(%3)
 // CHECK-NEXT:     } do {
-// CHECK-NEXT:       %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:       %4 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:       %5 = cir.binop(add, %3, %4) nsw : !s32i
-// CHECK-NEXT:       cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:       cir.scope {
+// CHECK-NEXT:         %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:         %4 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:         %5 = cir.binop(add, %3, %4) nsw : !s32i
+// CHECK-NEXT:         cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:       }
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
@@ -69,10 +73,12 @@ void l2(bool cond) {
 // CHECK-NEXT:       %[[#TRUE:]] = cir.const #true
 // CHECK-NEXT:       cir.condition(%[[#TRUE]])
 // CHECK-NEXT:     } do {
-// CHECK-NEXT:       %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:       %4 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:       %5 = cir.binop(add, %3, %4) nsw : !s32i
-// CHECK-NEXT:       cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:       cir.scope {
+// CHECK-NEXT:         %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:         %4 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:         %5 = cir.binop(add, %3, %4) nsw : !s32i
+// CHECK-NEXT:         cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:       }
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
@@ -82,10 +88,12 @@ void l2(bool cond) {
 // CHECK-NEXT:       %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
 // CHECK-NEXT:       cir.condition(%4)
 // CHECK-NEXT:     } do {
-// CHECK-NEXT:       %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:       %4 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:       %5 = cir.binop(add, %3, %4) nsw : !s32i
-// CHECK-NEXT:       cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:       cir.scope {
+// CHECK-NEXT:         %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:         %4 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:         %5 = cir.binop(add, %3, %4) nsw : !s32i
+// CHECK-NEXT:         cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:       }
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
@@ -106,10 +114,12 @@ void l3(bool cond) {
 // CHECK: cir.func @_Z2l3b
 // CHECK: cir.scope {
 // CHECK-NEXT:   cir.do {
-// CHECK-NEXT:     %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:     %4 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:     %5 = cir.binop(add, %3, %4) nsw : !s32i
-// CHECK-NEXT:     cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:     cir.scope {
+// CHECK-NEXT:       %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:       %4 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:       %5 = cir.binop(add, %3, %4) nsw : !s32i
+// CHECK-NEXT:       cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   } while {
 // CHECK-NEXT:     %[[#TRUE:]] = cir.load %0 : !cir.ptr<!cir.bool>, !cir.bool
@@ -118,10 +128,12 @@ void l3(bool cond) {
 // CHECK-NEXT: }
 // CHECK-NEXT: cir.scope {
 // CHECK-NEXT:   cir.do {
-// CHECK-NEXT:     %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:     %4 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:     %5 = cir.binop(add, %3, %4) nsw : !s32i
-// CHECK-NEXT:     cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:     cir.scope {
+// CHECK-NEXT:       %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:       %4 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:       %5 = cir.binop(add, %3, %4) nsw : !s32i
+// CHECK-NEXT:       cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   } while {
 // CHECK-NEXT:     %[[#TRUE:]] = cir.const #true
@@ -130,10 +142,12 @@ void l3(bool cond) {
 // CHECK-NEXT: }
 // CHECK-NEXT: cir.scope {
 // CHECK-NEXT:   cir.do {
-// CHECK-NEXT:     %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:     %4 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:     %5 = cir.binop(add, %3, %4) nsw : !s32i
-// CHECK-NEXT:     cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:     cir.scope {
+// CHECK-NEXT:       %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:       %4 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:       %5 = cir.binop(add, %3, %4) nsw : !s32i
+// CHECK-NEXT:       cir.store %5, %1 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:     }
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   } while {
 // CHECK-NEXT:     %3 = cir.const #cir.int<1> : !s32i
@@ -157,18 +171,19 @@ void l4() {
 // CHECK-NEXT:   %[[#TRUE:]] = cir.const #true
 // CHECK-NEXT:   cir.condition(%[[#TRUE]])
 // CHECK-NEXT: } do {
-// CHECK-NEXT:   %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:   %5 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:   %6 = cir.binop(add, %4, %5) nsw  : !s32i
-// CHECK-NEXT:   cir.store %6, %0 : !s32i, !cir.ptr<!s32i>
 // CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:     %10 = cir.load %0 : !cir.ptr<!s32i>, !s32i
-// CHECK-NEXT:     %11 = cir.const #cir.int<10> : !s32i
-// CHECK-NEXT:     %12 = cir.cmp(lt, %10, %11) : !s32i, !cir.bool
-// CHECK-NEXT:     cir.if %12 {
-// CHECK-NEXT:       cir.continue
+// CHECK-NEXT:     %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:     %5 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:     %6 = cir.binop(add, %4, %5) nsw  : !s32i
+// CHECK-NEXT:     cir.store %6, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:     cir.scope {
+// CHECK-NEXT:       %10 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:       %11 = cir.const #cir.int<10> : !s32i
+// CHECK-NEXT:       %12 = cir.cmp(lt, %10, %11) : !s32i, !cir.bool
+// CHECK-NEXT:       cir.if %12 {
+// CHECK-NEXT:         cir.continue
+// CHECK-NEXT:       }
 // CHECK-NEXT:     }
-// CHECK-NEXT:   }
 
 void l5() {
   do {
@@ -200,7 +215,10 @@ void l6() {
 // CHECK-NEXT:       %[[#TRUE:]] = cir.const #true
 // CHECK-NEXT:       cir.condition(%[[#TRUE]])
 // CHECK-NEXT:     } do {
-// CHECK-NEXT:       cir.return
+// CHECK-NEXT:       cir.scope {
+// CHECK-NEXT:         cir.return
+// CHECK-NEXT:       }
+// CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.return
@@ -215,15 +233,18 @@ void unreachable_after_break() {
 
 // CHECK-NEXT: cir.func @_Z23unreachable_after_breakv()
 // CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
 // CHECK-NEXT:     cir.for : cond {
-// CHECK-NEXT:       %1 = cir.const #true
-// CHECK-NEXT:       cir.condition(%1)
+// CHECK-NEXT:       %0 = cir.const #true
+// CHECK-NEXT:       cir.condition(%0)
 // CHECK-NEXT:     } body {
-// CHECK-NEXT:       cir.break
-// CHECK-NEXT:     ^bb1:  // no predecessors
-// CHECK-NEXT:       %1 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:       cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:       cir.scope {
+// CHECK-NEXT:         %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
+// CHECK-NEXT:         cir.break
+// CHECK-NEXT:       ^bb1:  // no predecessors
+// CHECK-NEXT:         %1 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:         cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:         cir.yield
+// CHECK-NEXT:       }
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     } step {
 // CHECK-NEXT:       cir.yield
@@ -241,15 +262,18 @@ void unreachable_after_continue() {
 
 // CHECK-NEXT: cir.func @_Z26unreachable_after_continuev()
 // CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
 // CHECK-NEXT:     cir.for : cond {
-// CHECK-NEXT:       %1 = cir.const #true
-// CHECK-NEXT:       cir.condition(%1)
+// CHECK-NEXT:       %0 = cir.const #true
+// CHECK-NEXT:       cir.condition(%0)
 // CHECK-NEXT:     } body {
-// CHECK-NEXT:       cir.continue
-// CHECK-NEXT:     ^bb1:  // no predecessors
-// CHECK-NEXT:       %1 = cir.const #cir.int<1> : !s32i
-// CHECK-NEXT:       cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:       cir.scope {
+// CHECK-NEXT:         %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
+// CHECK-NEXT:         cir.continue
+// CHECK-NEXT:       ^bb1:  // no predecessors
+// CHECK-NEXT:         %1 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:         cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:         cir.yield
+// CHECK-NEXT:       }
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     } step {
 // CHECK-NEXT:       cir.yield

--- a/clang/test/CIR/Lowering/ThroughMLIR/doWhile.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/doWhile.c
@@ -32,14 +32,16 @@ void nestedDoWhile() {
 // CHECK: memref.store %[[C0_I32_2]], %[[ALLOC1]][] : memref<i32>
 // CHECK: memref.alloca_scope {
 // CHECK:   scf.while : () -> () {
-// CHECK:     %[[VAR1:.+]] = memref.load %[[ALLOC1]][] : memref<i32>
-// CHECK:     %[[VAR2:.+]] = memref.load %[[ALLOC0]][] : memref<i32>
-// CHECK:     %[[ADD:.+]] = arith.addi %[[VAR2]], %[[VAR1]] : i32
-// CHECK:     memref.store %[[ADD]], %[[ALLOC0]][] : memref<i32>
-// CHECK:     %[[VAR3:.+]] = memref.load %[[ALLOC1]][] : memref<i32>
-// CHECK:     %[[C1_I32:.+]] = arith.constant 1 : i32
-// CHECK:     %[[ADD1:.+]] = arith.addi %[[VAR3]], %[[C1_I32]] : i32
-// CHECK:     memref.store %[[ADD1]], %[[ALLOC1]][] : memref<i32>
+// CHECK:     memref.alloca_scope {
+// CHECK:       %[[VAR1:.+]] = memref.load %[[ALLOC1]][] : memref<i32>
+// CHECK:       %[[VAR2:.+]] = memref.load %[[ALLOC0]][] : memref<i32>
+// CHECK:       %[[ADD:.+]] = arith.addi %[[VAR2]], %[[VAR1]] : i32
+// CHECK:       memref.store %[[ADD]], %[[ALLOC0]][] : memref<i32>
+// CHECK:       %[[VAR3:.+]] = memref.load %[[ALLOC1]][] : memref<i32>
+// CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32
+// CHECK:       %[[ADD1:.+]] = arith.addi %[[VAR3]], %[[C1_I32]] : i32
+// CHECK:       memref.store %[[ADD1]], %[[ALLOC1]][] : memref<i32>
+// CHECK:     }
 // CHECK:     %[[VAR4:.+]] = memref.load %[[ALLOC1]][] : memref<i32>
 // CHECK:     %[[C10_I32:.+]] = arith.constant 10 : i32
 // CHECK:     %[[CMP:.+]] = arith.cmpi sle, %[[VAR4]], %[[C10_I32]] : i32
@@ -60,28 +62,30 @@ void nestedDoWhile() {
 // CHECK:     %[[C0_I32:.+]] = arith.constant 0 : i32
 // CHECK:     memref.store %[[C0_I32]], %[[alloca]][] : memref<i32>
 // CHECK:     memref.alloca_scope  {
-// CHECK:       %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
 // CHECK:       scf.while : () -> () {
-// CHECK:         %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
-// CHECK:         %[[C1_I32:.+]] = arith.constant 1 : i32
-// CHECK:         %[[ONE:.+]] = arith.addi %[[ZERO]], %[[C1_I32]] : i32
-// CHECK:         memref.store %[[ONE]], %[[alloca]][] : memref<i32>
-// CHECK:         %[[C0_I32_1:.+]] = arith.constant 0 : i32
-// CHECK:         memref.store %[[C0_I32_1]], %[[alloca_0]][] : memref<i32>
-// CHECK:         memref.alloca_scope  {
-// CHECK:           scf.while : () -> () {
-// CHECK:             %[[EIGHT:.+]] = memref.load %[[alloca_0]][] : memref<i32>
-// CHECK:             %[[C2_I32_3:.+]] = arith.constant 2 : i32
-// CHECK:             %[[NINE:.+]] = arith.cmpi slt, %[[EIGHT]], %[[C2_I32_3]] : i32
-// CHECK:             %[[TWELVE:.+]] = arith.extui %[[NINE]] : i1 to i8
-// CHECK:             %[[THIRTEEN:.+]] = arith.trunci %[[TWELVE]] : i8 to i1
-// CHECK:             scf.condition(%[[THIRTEEN]])
-// CHECK:           } do {
-// CHECK:             %[[EIGHT]] = memref.load %[[alloca_0]][] : memref<i32>
-// CHECK:             %[[C1_I32_3:.+]] = arith.constant 1 : i32
-// CHECK:             %[[NINE]] = arith.addi %[[EIGHT]], %[[C1_I32_3]] : i32
-// CHECK:             memref.store %[[NINE]], %[[alloca_0]][] : memref<i32>
-// CHECK:             scf.yield
+// CHECK:         memref.alloca_scope {
+// CHECK:           %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+// CHECK:           %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+// CHECK:           %[[C1_I32:.+]] = arith.constant 1 : i32
+// CHECK:           %[[ONE:.+]] = arith.addi %[[ZERO]], %[[C1_I32]] : i32
+// CHECK:           memref.store %[[ONE]], %[[alloca]][] : memref<i32>
+// CHECK:           %[[C0_I32_1:.+]] = arith.constant 0 : i32
+// CHECK:           memref.store %[[C0_I32_1]], %[[alloca_0]][] : memref<i32>
+// CHECK:           memref.alloca_scope  {
+// CHECK:             scf.while : () -> () {
+// CHECK:               %[[EIGHT:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+// CHECK:               %[[C2_I32_3:.+]] = arith.constant 2 : i32
+// CHECK:               %[[NINE:.+]] = arith.cmpi slt, %[[EIGHT]], %[[C2_I32_3]] : i32
+// CHECK:               %[[TWELVE:.+]] = arith.extui %[[NINE]] : i1 to i8
+// CHECK:               %[[THIRTEEN:.+]] = arith.trunci %[[TWELVE]] : i8 to i1
+// CHECK:               scf.condition(%[[THIRTEEN]])
+// CHECK:             } do {
+// CHECK:               %[[EIGHT]] = memref.load %[[alloca_0]][] : memref<i32>
+// CHECK:               %[[C1_I32_3:.+]] = arith.constant 1 : i32
+// CHECK:               %[[NINE]] = arith.addi %[[EIGHT]], %[[C1_I32_3]] : i32
+// CHECK:               memref.store %[[NINE]], %[[alloca_0]][] : memref<i32>
+// CHECK:               scf.yield
+// CHECK:             }
 // CHECK:           }
 // CHECK:         }
 // CHECK:         %[[TWO:.+]] = memref.load %[[alloca]][] : memref<i32>

--- a/clang/test/CIR/Lowering/ThroughMLIR/while.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/while.c
@@ -32,10 +32,12 @@ void nestedWhile() {
 //CHECK:       %[[FIVE:.+]] = arith.trunci %[[FOUR:.+]] : i8 to i1
 //CHECK:       scf.condition(%[[FIVE]])
 //CHECK:     } do {
-//CHECK:       %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
-//CHECK:       %[[C1_I32:.+]] = arith.constant 1 : i32
-//CHECK:       %[[ONE:.+]] = arith.addi %0, %[[C1_I32:.+]] : i32
-//CHECK:       memref.store %[[ONE:.+]], %[[alloca]][] : memref<i32>
+//CHECK:       memref.alloca_scope {
+//CHECK:         %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+//CHECK:         %[[C1_I32:.+]] = arith.constant 1 : i32
+//CHECK:         %[[ONE:.+]] = arith.addi %0, %[[C1_I32:.+]] : i32
+//CHECK:         memref.store %[[ONE:.+]], %[[alloca]][] : memref<i32>
+//CHECK:       }
 //CHECK:       scf.yield
 //CHECK:     }
 //CHECK:  }
@@ -47,7 +49,6 @@ void nestedWhile() {
 //CHECK:   %[[C0_I32:.+]] = arith.constant 0 : i32
 //CHECK:   memref.store %[[C0_I32]], %[[alloca]][] : memref<i32>
 //CHECK:   memref.alloca_scope  {
-//CHECK:     %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
 //CHECK:     scf.while : () -> () {
 //CHECK:       %[[ZERO:.+]] = memref.load %alloca[] : memref<i32>
 //CHECK:       %[[C2_I32:.+]] = arith.constant 2 : i32
@@ -56,6 +57,8 @@ void nestedWhile() {
 //CHECK:       %[[FIVE:.+]] = arith.trunci %[[FOUR]] : i8 to i1
 //CHECK:       scf.condition(%[[FIVE]])
 //CHECK:     } do {
+//CHECK:       memref.alloca_scope {
+//CHECK:         %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
 //CHECK:         %[[C0_I32_1:.+]] = arith.constant 0 : i32
 //CHECK:         memref.store %[[C0_I32_1]], %[[alloca_0]][] : memref<i32>
 //CHECK:         memref.alloca_scope  {
@@ -78,9 +81,9 @@ void nestedWhile() {
 //CHECK:         %[[C1_I32:.+]] = arith.constant 1 : i32
 //CHECK:         %[[ONE]] = arith.addi %[[ZERO]], %[[C1_I32]] : i32
 //CHECK:         memref.store %[[ONE]], %[[alloca]][] : memref<i32>
-//CHECK:         scf.yield
 //CHECK:       }
+//CHECK:       scf.yield
 //CHECK:     }
-//CHECK:     return
 //CHECK:   }
+//CHECK:   return
 //CHECK: }

--- a/clang/test/CIR/Transforms/lifetime-loop.cpp
+++ b/clang/test/CIR/Transforms/lifetime-loop.cpp
@@ -8,7 +8,7 @@ void loop_basic_for() {
     *p = 42;
   }        // expected-note {{pointee 'x' invalidated at end of scope}}
   *p = 42; // expected-warning {{use of invalid pointer 'p'}}
-           // expected-remark@-1 {{pset => { nullptr, invalid, x }}}
+           // expected-remark@-1 {{pset => { nullptr, invalid }}}
 }
 
 void loop_basic_while() {
@@ -21,7 +21,7 @@ void loop_basic_while() {
     i = i + 1;
   }        // expected-note {{pointee 'x' invalidated at end of scope}}
   *p = 42; // expected-warning {{use of invalid pointer 'p'}}
-           // expected-remark@-1 {{pset => { nullptr, invalid, x }}}
+           // expected-remark@-1 {{pset => { nullptr, invalid }}}
 }
 
 void loop_basic_dowhile() {
@@ -34,7 +34,7 @@ void loop_basic_dowhile() {
     i = i + 1;
   } while (i < 10); // expected-note {{pointee 'x' invalidated at end of scope}}
   *p = 42;          // expected-warning {{use of invalid pointer 'p'}}
-                    // expected-remark@-1 {{pset => { nullptr, invalid, x }}}
+                    // expected-remark@-1 {{pset => { nullptr, invalid }}}
 }
 
 // p1179r1: 2.4.9.3

--- a/clang/test/CIR/Transforms/lifetime-loop.cpp
+++ b/clang/test/CIR/Transforms/lifetime-loop.cpp
@@ -8,7 +8,7 @@ void loop_basic_for() {
     *p = 42;
   }        // expected-note {{pointee 'x' invalidated at end of scope}}
   *p = 42; // expected-warning {{use of invalid pointer 'p'}}
-           // expected-remark@-1 {{pset => { nullptr, invalid }}}
+           // expected-remark@-1 {{pset => { nullptr, invalid, x }}}
 }
 
 void loop_basic_while() {
@@ -21,7 +21,7 @@ void loop_basic_while() {
     i = i + 1;
   }        // expected-note {{pointee 'x' invalidated at end of scope}}
   *p = 42; // expected-warning {{use of invalid pointer 'p'}}
-           // expected-remark@-1 {{pset => { nullptr, invalid }}}
+           // expected-remark@-1 {{pset => { nullptr, invalid, x }}}
 }
 
 void loop_basic_dowhile() {
@@ -34,7 +34,7 @@ void loop_basic_dowhile() {
     i = i + 1;
   } while (i < 10); // expected-note {{pointee 'x' invalidated at end of scope}}
   *p = 42;          // expected-warning {{use of invalid pointer 'p'}}
-                    // expected-remark@-1 {{pset => { nullptr, invalid }}}
+                    // expected-remark@-1 {{pset => { nullptr, invalid, x }}}
 }
 
 // p1179r1: 2.4.9.3


### PR DESCRIPTION
This PR puts for-loop body, while-loop body, and do-while-loop body in nested scopes. Allocas in the loop body are now push down to the nested scope.

Resolve #1218 .