### PR TITLE
[CIR] Fix tests with LLVM_LINK_LLVM_DYLIB

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -22,10 +22,12 @@ add_clang_library(TargetLowering
   DEPENDS
   clangBasic
 
+  LINK_COMPONENTS
+  TargetParser
+
   LINK_LIBS PUBLIC
 
   clangBasic
-  LLVMTargetParser
   MLIRIR
   MLIRPass
   MLIRDLTIDialect

--- a/clang/tools/cir-opt/CMakeLists.txt
+++ b/clang/tools/cir-opt/CMakeLists.txt
@@ -4,15 +4,25 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
-set(LIBS
-  ${dialect_libs}
-  ${conversion_libs}
+add_clang_tool(cir-opt
+  cir-opt.cpp
+  ${LIBS}
+)
+
+clang_target_link_libraries(cir-opt
+  PRIVATE
   clangCIR
   clangCIRLoweringThroughMLIR
   clangCIRLoweringDirectToLLVM
-  MLIRAnalysis
   MLIRCIR
   MLIRCIRTransforms
+)
+
+target_link_libraries(cir-opt
+  PRIVATE
+  ${dialect_libs}
+  ${conversion_libs}
+  MLIRAnalysis
   MLIRDialect
   MLIRIR
   MLIRMemRefDialect
@@ -23,13 +33,3 @@ set(LIBS
   MLIRTransforms
   MLIRTransformUtils
 )
-
-add_clang_tool(cir-opt
-  cir-opt.cpp
-
-  DEPENDS
-  ${LIBS}
-)
-
-target_link_libraries(cir-opt PRIVATE ${LIBS})
-llvm_update_compile_flags(cir-opt)

--- a/clang/tools/cir-opt/CMakeLists.txt
+++ b/clang/tools/cir-opt/CMakeLists.txt
@@ -6,7 +6,6 @@ include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
 add_clang_tool(cir-opt
   cir-opt.cpp
-  ${LIBS}
 )
 
 clang_target_link_libraries(cir-opt

--- a/clang/tools/cir-translate/CMakeLists.txt
+++ b/clang/tools/cir-translate/CMakeLists.txt
@@ -5,15 +5,24 @@ get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS)
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
-set(LIBS
+add_clang_tool(cir-translate
+  cir-translate.cpp
+)
+
+clang_target_link_libraries(cir-translate
+  PRIVATE
+  clangCIR
+  clangCIRLoweringDirectToLLVM
+  MLIRCIR
+  MLIRCIRTransforms
+)
+
+target_link_libraries(cir-translate
+  PRIVATE
   ${dialect_libs}
   ${conversion_libs}
   ${translation_libs}
-  clangCIR
-  clangCIRLoweringDirectToLLVM
   MLIRAnalysis
-  MLIRCIR
-  MLIRCIRTransforms
   MLIRDialect
   MLIRIR
   MLIROptLib
@@ -24,13 +33,3 @@ set(LIBS
   MLIRTranslateLib
   MLIRSupport
 )
-
-add_clang_tool(cir-translate
-  cir-translate.cpp
-
-  DEPENDS
-  ${LIBS}
-)
-
-target_link_libraries(cir-translate PRIVATE ${LIBS})
-llvm_update_compile_flags(cir-translate)


### PR DESCRIPTION
This option creates and links all tools against a single libLLVM shared
library (and the corresponding CLANG_LINK_CLANG_DYLIB option also gets
turned on by default). In order for this to work, we need to use
LINK_COMPONENTS instead of LINK_LIBS for all LLVM dependencies, and
clang_target_link_libraries for all Clang dependencies, so that they get
rewritten to use the dylib. Remove llvm_update_compile_flags while I'm
here, since the build macros handle that internally. Before this change,
we'd link against certain LLVM libraries both statically and
dynamically, leading to test failures from duplicate singletons.

The way this works for MLIR is fragile right now: MLIR can create its
own dylib as well but doesn't have build system support for linking
against that dylib. We end up folding the MLIR libraries into
libclang-cpp.so (because all Clang dependencies get pulled into it), but
MLIR tools still link the MLIR libraries statically. It'll still work,
but BUILD_SHARED_LIBS is possibly a better alternative for development.
Distributions like Fedora build their LLVM packages with
LLVM_LINK_LLVM_DYLIB, so we'll want to eventually have good MLIR support
for that setup too.
