### PR TITLE
[CIR][CodeGen] Propagate alignment information in createLoad

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -838,7 +838,9 @@ public:
 
     return create<cir::LoadOp>(
         loc, addr.getElementType(), addr.getPointer(), /*isDeref=*/false,
-        /*is_volatile=*/isVolatile, /*alignment=*/mlir::IntegerAttr{},
+        /*is_volatile=*/isVolatile,
+        /*alignment=*/
+        getI64IntegerAttr(addr.getAlignment().getAsAlign().value()),
         /*mem_order=*/cir::MemOrderAttr{}, /*tbaa=*/mlir::ArrayAttr{});
   }
 


### PR DESCRIPTION
This had been left unimplemented all along but surely should be
propagated forward from the alignment in the address.
