### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower neon_vaddlvq_s16

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -4291,11 +4291,16 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
   case NEON::BI__builtin_neon_vaddlvq_u8: {
     llvm_unreachable("NEON::BI__builtin_neon_vaddlvq_u8 NYI");
   }
-  case NEON::BI__builtin_neon_vaddlvq_u16: {
-    mlir::Type argTy = cir::VectorType::get(builder.getContext(), UInt16Ty, 8);
+  case NEON::BI__builtin_neon_vaddlvq_u16:
+    usgn = true;
+    [[fallthrough]];
+  case NEON::BI__builtin_neon_vaddlvq_s16: {
+    mlir::Type argTy = cir::VectorType::get(builder.getContext(),
+                                            usgn ? UInt16Ty : SInt16Ty, 8);
     llvm::SmallVector<mlir::Value, 1> argOps = {emitScalarExpr(E->getArg(0))};
-    return emitNeonCall(builder, {argTy}, argOps, "aarch64.neon.uaddlv",
-                        UInt32Ty, getLoc(E->getExprLoc()));
+    return emitNeonCall(builder, {argTy}, argOps,
+                        usgn ? "aarch64.neon.uaddlv" : "aarch64.neon.saddlv",
+                        usgn ? UInt32Ty : SInt32Ty, getLoc(E->getExprLoc()));
   }
   case NEON::BI__builtin_neon_vaddlv_s8: {
     llvm_unreachable("NEON::BI__builtin_neon_vaddlv_s8 NYI");
@@ -4305,9 +4310,6 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
   }
   case NEON::BI__builtin_neon_vaddlvq_s8: {
     llvm_unreachable("NEON::BI__builtin_neon_vaddlvq_s8 NYI");
-  }
-  case NEON::BI__builtin_neon_vaddlvq_s16: {
-    llvm_unreachable("NEON::BI__builtin_neon_vaddlvq_s16 NYI");
   }
   case NEON::BI__builtin_neon_vsri_n_v:
   case NEON::BI__builtin_neon_vsriq_n_v: {

--- a/clang/test/CIR/CodeGen/AArch64/neon-arith.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-arith.c
@@ -894,6 +894,17 @@ uint32_t test_vaddlvq_u16(uint16x8_t a) {
   // LLVM: ret i32 [[VADDLV_I]]
 }
 
+int32_t test_vaddlvq_s16(int16x8_t a) {
+  return vaddlvq_s16(a);
+
+  // CIR-LABEL: vaddlvq_s16
+  // CIR: cir.llvm.intrinsic "aarch64.neon.saddlv" {{%.*}}: (!cir.vector<!s16i x 8>) -> !s32i
+
+  // LLVM: {{.*}}test_vaddlvq_s16(<8 x i16>{{.*}}[[A:%.*]])
+  // LLVM: [[VADDLV_I:%.*]] = call i32 @llvm.aarch64.neon.saddlv.i32.v8i16(<8 x i16> [[A]])
+  // LLVM: ret i32 [[VADDLV_I]]
+}
+
 uint16_t test_vaddv_u16(uint16x4_t a) {
   return vaddv_u16(a);
 


### PR DESCRIPTION
Combined implementaiton with `neon_vaddlvq_u16`
[OG somehow implemented them separately but they are no different except signess and intrinsic name]
(https://github.com/llvm/clangir/blob/2b1a638ea07ca10c5727ea835bfbe17b881175cc/clang/lib/CodeGen/CGBuiltin.cpp#L13483)