### PR TITLE
[CIR][CIRGen] Match skeleton for setCIRFunctionAttributesForDefinition

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -371,6 +371,13 @@ struct MissingFeatures {
   static bool setVisibilityFromDLLStorageClass() { return false; }
   static bool mustTailCallUndefinedGlobals() { return false; }
 
+  //-- Missing parts of the setCIRFunctionAttributesForDefinition skeleton.
+  static bool stackProtector() { return false; }
+  static bool optimizeForSize() { return false; }
+  static bool minSize() { return false; }
+  static bool setFunctionAlignment() { return false; }
+  static bool memberFunctionPointerTypeMetadata() { return false; }
+
   //-- Other missing features
 
   // We need to track the parent record types that represent a field


### PR DESCRIPTION
Match `CodeGenModule::SetLLVMFunctionAttributesForDefinition` so that we
can see what's missing and have a good base to build upon.
