### PR TITLE
[CIR][CIRGen][TBAA] Replace hardcoded TBAA names with getTBAAName

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -20,13 +20,18 @@ include "mlir/Interfaces/DataLayoutInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
 
+// Specify the TBAA name of CIR_type
+class TBAALoweringInfo {
+  string tbaaName = "";
+}
+
 //===----------------------------------------------------------------------===//
 // CIR Types
 //===----------------------------------------------------------------------===//
 
 class CIR_Type<string name, string typeMnemonic, list<Trait> traits = [],
                string baseCppClass = "::mlir::Type">
-    : TypeDef<CIR_Dialect, name, traits, baseCppClass> {
+    : TypeDef<CIR_Dialect, name, traits, baseCppClass>, TBAALoweringInfo {
   let mnemonic = typeMnemonic;
 }
 
@@ -162,6 +167,7 @@ class CIR_FloatType<string name, string mnemonic>
           ]> {}
 
 def CIR_Single : CIR_FloatType<"Single", "float"> {
+  let tbaaName = "float";
   let summary = "CIR single-precision float type";
   let description = [{
     Floating-point type that represents the `float` type in C/C++. Its
@@ -170,6 +176,7 @@ def CIR_Single : CIR_FloatType<"Single", "float"> {
 }
 
 def CIR_Double : CIR_FloatType<"Double", "double"> {
+  let tbaaName = "double";
   let summary = "CIR double-precision float type";
   let description = [{
     Floating-point type that represents the `double` type in C/C++. Its
@@ -206,6 +213,7 @@ def CIR_FP128 : CIR_FloatType<"FP128", "f128"> {
 }
 
 def CIR_LongDouble : CIR_FloatType<"LongDouble", "long_double"> {
+  let tbaaName = "long double";
   let summary = "CIR extended-precision float type";
   let description = [{
     Floating-point type that represents the `long double` type in C/C++.
@@ -263,7 +271,7 @@ def CIR_ComplexType : CIR_Type<"Complex", "complex",
 
 def CIR_PointerType : CIR_Type<"Pointer", "ptr",
     [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
-
+  let tbaaName = "any pointer";
   let summary = "CIR pointer type";
   let description = [{
     `CIR.ptr` is a type returned by any op generating a pointer in C++.
@@ -339,7 +347,7 @@ def CIR_DataMemberType : CIR_Type<"DataMember", "data_member",
 def CIR_BoolType :
     CIR_Type<"Bool", "bool",
              [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
-
+  let tbaaName = "bool";
   let summary = "CIR bool type";
   let description = [{
     `cir.bool` represent's C++ bool type.

--- a/clang/include/clang/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/include/clang/CIR/Dialect/IR/CMakeLists.txt
@@ -31,3 +31,7 @@ add_public_tablegen_target(MLIRCIREnumsGen)
 clang_tablegen(CIRBuiltinsLowering.inc -gen-cir-builtins-lowering
                SOURCE CIROps.td
                TARGET CIRBuiltinsLowering)
+
+clang_tablegen(CIRTBAANameLowering.inc -gen-cir-tbaa-name-lowering
+               SOURCE CIRTypes.td
+               TARGET CIRTBAANameLowering)

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -689,19 +689,18 @@ mlir::LLVM::TBAATypeDescriptorAttr getChar(mlir::MLIRContext *ctx) {
   return createScalarTypeNode(ctx, "omnipotent char", getRoot(ctx), 0);
 }
 
-// FIXME(cir): This should be moved and use tablegen approach
-// see https://github.com/llvm/clangir/pull/1220#discussion_r1889187867
+#define GET_TBAANAME_LOWERING_FUNCTIONS_DEF
+#include "clang/CIR/Dialect/IR/CIRTBAANameLowering.inc"
+#undef GET_TBAANAME_LOWERING_FUNCTIONS_DEF
+
 StringRef getTypeName(mlir::Type type) {
   return TypeSwitch<mlir::Type, StringRef>(type)
       .Case<cir::IntType>([](cir::IntType ty) { return ty.getTBAATypeName(); })
-      .Case<cir::SingleType>([](cir::SingleType) { return "float"; })
-      .Case<cir::DoubleType>([](cir::DoubleType) { return "double"; })
-      .Case<cir::FP80Type>([](cir::FP80Type) { return "f80"; })
-      .Case<cir::FP128Type>([](cir::FP128Type) { return "f128"; })
-      .Case<cir::LongDoubleType>(
-          [](cir::LongDoubleType) { return "long double"; })
-      .Case<cir::BoolType>([](cir::BoolType) { return "bool"; })
-      .Case<cir::PointerType>([](cir::PointerType) { return "any pointer"; })
+      .Case<
+#define GET_TBAANAME_LOWERING_LIST
+#include "clang/CIR/Dialect/IR/CIRTBAANameLowering.inc"
+#undef GET_TBAANAME_LOWERING_LIST
+          >([](auto ty) { return getTBAAName(ty); })
       .Default([](auto ty) {
         llvm::errs() << "unknown type: " << ty << "\n";
         return "unknown";

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -1099,5 +1099,9 @@ public:
 #include "clang/CIR/Dialect/IR/CIRBuiltinsLowering.inc"
 #undef GET_BUILTIN_LOWERING_CLASSES_DECLARE
 
+#define GET_TBAANAME_LOWERING_FUNCTIONS_DECLARE
+#include "clang/CIR/Dialect/IR/CIRTBAANameLowering.inc"
+#undef GET_TBAANAME_LOWERING_FUNCTIONS_DECLARE
+
 } // namespace direct
 } // namespace cir

--- a/clang/utils/TableGen/CIRLoweringEmitter.cpp
+++ b/clang/utils/TableGen/CIRLoweringEmitter.cpp
@@ -16,6 +16,10 @@ std::string ClassDeclaration;
 std::string ClassDefinitions;
 std::string ClassList;
 
+std::string TBAANameFunctionDeclaration;
+std::string TBAANameFunctionDefinitions;
+std::string TBAANameClassList;
+
 void GenerateLowering(const Record *Operation) {
   using namespace std::string_literals;
   std::string Name = Operation->getName().str();
@@ -68,6 +72,24 @@ CIR)C++" +
 
   ClassList += ", CIR" + Name + "Lowering\n";
 }
+
+void GenerateTBAANameLowering(const Record *def) {
+  using namespace std::string_literals;
+  std::string Name = def->getValueAsString("cppClassName").str();
+  std::string TBAAName = def->getValueAsString("tbaaName").str();
+  TBAANameFunctionDeclaration += "llvm::StringRef getTBAAName(cir::";
+  TBAANameFunctionDeclaration += Name + " ty);";
+  TBAANameFunctionDeclaration += "\n";
+  TBAANameFunctionDefinitions += "llvm::StringRef getTBAAName(cir::";
+  TBAANameFunctionDefinitions += Name + " ty) {";
+  TBAANameFunctionDefinitions += "  return \"" + TBAAName + "\";";
+  TBAANameFunctionDefinitions += "}";
+  TBAANameFunctionDefinitions += "\n";
+  TBAANameClassList += "\n";
+  TBAANameClassList += "cir::";
+  TBAANameClassList += Name;
+  TBAANameClassList += ", ";
+}
 } // namespace
 
 void clang::EmitCIRBuiltinsLowering(const RecordKeeper &Records,
@@ -84,4 +106,26 @@ void clang::EmitCIRBuiltinsLowering(const RecordKeeper &Records,
   OS << "#ifdef GET_BUILTIN_LOWERING_CLASSES_DEF\n"
      << ClassDefinitions << "\n#endif\n";
   OS << "#ifdef GET_BUILTIN_LOWERING_LIST\n" << ClassList << "\n#endif\n";
+}
+
+void clang::EmitCIRTBAANameLowering(const RecordKeeper &Records,
+                                    raw_ostream &OS) {
+  emitSourceFileHeader("Lowering of ClangIR TBAA Name", OS);
+
+  for (const auto *Builtin :
+       Records.getAllDerivedDefinitions("TBAALoweringInfo")) {
+    if (!Builtin->getValueAsString("tbaaName").empty())
+      GenerateTBAANameLowering(Builtin);
+  }
+
+  OS << "#ifdef GET_TBAANAME_LOWERING_FUNCTIONS_DECLARE\n"
+     << TBAANameFunctionDeclaration << "\n#endif\n";
+  OS << "#ifdef GET_TBAANAME_LOWERING_FUNCTIONS_DEF\n"
+     << TBAANameFunctionDefinitions << "\n#endif\n";
+  // remove last `, `
+  if (!TBAANameClassList.empty()) {
+    TBAANameClassList.resize(TBAANameClassList.size() - 2);
+  }
+  OS << "#ifdef GET_TBAANAME_LOWERING_LIST\n"
+     << TBAANameClassList << "\n#endif\n";
 }

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -26,6 +26,7 @@ enum ActionType {
   PrintRecords,
   DumpJSON,
   GenCIRBuiltinsLowering,
+  GenCIRTBAANameLowering,
   GenClangAttrClasses,
   GenClangAttrParserStringSwitches,
   GenClangAttrSubjectMatchRulesParserStringSwitches,
@@ -123,6 +124,8 @@ cl::opt<ActionType> Action(
         clEnumValN(GenCIRBuiltinsLowering, "gen-cir-builtins-lowering",
                    "Generate lowering of ClangIR builtins to equivalent LLVM "
                    "IR builtins"),
+        clEnumValN(GenCIRTBAANameLowering, "gen-cir-tbaa-name-lowering",
+                   "Generate lowering of ClangIR TBAA Name"),
         clEnumValN(GenClangAttrClasses, "gen-clang-attr-classes",
                    "Generate clang attribute clases"),
         clEnumValN(GenClangAttrParserStringSwitches,
@@ -330,6 +333,9 @@ bool ClangTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
     break;
   case GenCIRBuiltinsLowering:
     EmitCIRBuiltinsLowering(Records, OS);
+    break;
+  case GenCIRTBAANameLowering:
+    EmitCIRTBAANameLowering(Records, OS);
     break;
   case GenClangAttrClasses:
     EmitClangAttrClass(Records, OS);

--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -26,6 +26,8 @@ namespace clang {
 
 void EmitCIRBuiltinsLowering(const llvm::RecordKeeper &RK,
                              llvm::raw_ostream &OS);
+void EmitCIRTBAANameLowering(const llvm::RecordKeeper &RK,
+                             llvm::raw_ostream &OS);
 void EmitClangDeclContext(const llvm::RecordKeeper &RK, llvm::raw_ostream &OS);
 /**
   @param PriorizeIfSubclassOf These classes should be prioritized in the output.


### PR DESCRIPTION
This patch follows https://github.com/llvm/clangir/pull/1220#discussion_r1882808223 by augmenting `CIR_Type` with a new field, `tbaaName`. Specifically, it enables TableGen support for the `-gen-cir-tbaa-name-lowering` option, allowing for the generation of `getTBAAName` functions based on the `tbaaName`. This enhancement enables us to replace the hardcoded TBAA names in the `getTypeName` function with the newly generated `getTBAAName`.