### PR TITLE
[CIR] Introduce a new dir in tests for known crashes to fix

### DIFF
--- a/clang/test/CIR/crashes/copy-on-catch.cpp
+++ b/clang/test/CIR/crashes/copy-on-catch.cpp
@@ -1,5 +1,7 @@
-// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s
-// -o %t.cir XFAIL: *
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s -o %t.cir -fcxx-exceptions -fexceptions | FileCheck %s
+// XFAIL: *
+
+// CHECK: cir.func
 
 struct E {};
 E e;

--- a/clang/test/CIR/crashes/copy-on-catch.cpp
+++ b/clang/test/CIR/crashes/copy-on-catch.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-cir %s
+// -o %t.cir XFAIL: *
+
+struct E {};
+E e;
+
+void throws() { throw e; }
+
+void bar() {
+  try {
+    throws();
+  } catch (E e) {
+  }
+}


### PR DESCRIPTION
We figure it would be nice to have a common place with all our known
crashes that is tracked by git and is actively verified whether or not
we can now support the crashes by lit. It can act as our source of truth
for known failures and also being potential good first tasks for new
developers.

Add a simple test case of a known crash that involves copying a struct
in a catch.
