### PR TITLE
[CIR][CodeGen] fixes access to globals with bitfields

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -814,6 +814,13 @@ void CIRGenModule::replaceGlobal(cir::GlobalOp Old, cir::GlobalOp New) {
           auto UseOpResultValue = GGO.getAddr();
           UseOpResultValue.setType(
               cir::PointerType::get(&getMLIRContext(), NewTy));
+
+          mlir::OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPointAfter(UserOp);
+          mlir::Type ptrTy = builder.getPointerTo(OldTy);
+          mlir::Value cast =
+              builder.createBitcast(GGO->getLoc(), UseOpResultValue, ptrTy);
+          UseOpResultValue.replaceAllUsesExcept(cast, {cast.getDefiningOp()});
         }
       }
     }

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -54,6 +54,7 @@ typedef struct {
 } U;
 
 // CHECK: !ty_D = !cir.struct<struct "D" {!u16i, !s32i}>
+// CHECK: !ty_G = !cir.struct<struct "G" {!u16i, !s32i} #cir.record.decl.ast>
 // CHECK: !ty_T = !cir.struct<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
 // CHECK: !ty_anon2E0_ = !cir.struct<struct "anon.0" {!u32i} #cir.record.decl.ast>
 // CHECK: !ty_anon_struct = !cir.struct<struct  {!u8i, !u8i, !s32i}>
@@ -128,4 +129,21 @@ void createU() {
 // CHECK:   cir.store %2, %1 : !ty_anon_struct, !cir.ptr<!ty_anon_struct>
 void createD() {
   D d = {1,2,3};
+}
+
+typedef struct {
+  int x : 15;
+  int y ;
+} G;
+
+// CHECK: cir.global external @g = #cir.const_struct<{#cir.int<133> : !u8i, #cir.int<127> : !u8i, #cir.int<254> : !s32i}> : !ty_anon_struct 
+G g = { -123, 254UL};
+
+// CHECK: cir.func {{.*@get_y}}
+// CHECK:   %[[V1:.*]] = cir.get_global @g : !cir.ptr<!ty_anon_struct>
+// CHECK:   %[[V2:.*]] = cir.cast(bitcast, %[[V1]] : !cir.ptr<!ty_anon_struct>), !cir.ptr<!ty_G>
+// CHECK:   %[[V3:.*]] = cir.get_member %[[V2]][1] {name = "y"} : !cir.ptr<!ty_G> -> !cir.ptr<!s32i>
+// CHECK:   cir.load %[[V3]] : !cir.ptr<!s32i>, !s32i
+int get_y() {
+  return g.y;
 }


### PR DESCRIPTION
This PR adds a bitcast when we rewrite globals type. Previously we just set a new type and it worked. 
But recently I started to test ClangIR with CSmith in order to find some run time bugs and faced with the next problem.

```
typedef struct {
    int x : 15;   
    uint8_t y;
} S;

S g = { -12, 254};

int main() {    
    printf("%d\n", g.y);
    return 0;
}

```
The output for this program is  ... 127 but not 254!
The reason is that first global var is created with the type of struct `S`, then `get_member` operation is generated with index `1` 
and then after, the type of the global is rewritten - I assume because of the anon struct created on the right side in the initialization.
But the `get_member` operation still wants to access to the field at index `1` and get a wrong byte. 
If we change the `y` type to `int` we will fail on the verification stage. But in the example above it's a run time error!

This is why I suggest to add a bitcast once we have to rewrite the global type.
