### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower neon_vsetq_lane_f64

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -3690,9 +3690,13 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
   case NEON::BI__builtin_neon_vset_lane_f64:
     // The vector type needs a cast for the v1f64 variant.
     llvm_unreachable("NEON::BI__builtin_neon_vset_lane_f64 NYI");
-  case NEON::BI__builtin_neon_vsetq_lane_f64:
-    // The vector type needs a cast for the v2f64 variant.
-    llvm_unreachable("NEON::BI__builtin_neon_vsetq_lane_f64 NYI");
+  case NEON::BI__builtin_neon_vsetq_lane_f64: {
+    Ops.push_back(emitScalarExpr(E->getArg(2)));
+    Ops[1] = builder.createBitcast(
+        Ops[1], cir::VectorType::get(&getMLIRContext(), DoubleTy, 2));
+    return builder.create<cir::VecInsertOp>(getLoc(E->getExprLoc()), Ops[1],
+                                            Ops[0], Ops[2]);
+  }
 
   case NEON::BI__builtin_neon_vget_lane_i8:
   case NEON::BI__builtin_neon_vdupb_lane_i8:

--- a/clang/test/CIR/CodeGen/AArch64/neon-misc.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-misc.c
@@ -146,7 +146,7 @@ float64x2_t test_vsetq_land_f64(float64_t a, float64x2_t b) {
 // CIR: {{%.*}} = cir.vec.insert {{%.*}}, {{%.*}}[[[IDX]] : !s32i] : !cir.vector<!cir.double x 2>
 
 // LLVM: {{.*}}test_vsetq_land_f64(double{{.*}}[[A:%.*]], <2 x double>{{.*}}[[B:%.*]])
-// : [[INTRN_RES:%.*]] = insertelement <2 x double> [[B]], double [[A]], i32 1
+// LLVM: [[INTRN_RES:%.*]] = insertelement <2 x double> [[B]], double [[A]], i32 0
 // LLVM: ret <2 x double> [[INTRN_RES]]
 
 uint8_t test_vget_lane_u8(uint8x8_t a) {

--- a/clang/test/CIR/CodeGen/AArch64/neon-misc.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-misc.c
@@ -137,6 +137,18 @@ float32x4_t test_vsetq_lane_f32(float32_t a, float32x4_t b) {
 // LLVM: [[INTRN_RES:%.*]] = insertelement <4 x float> [[B]], float [[A]], i32 3
 // LLVM: ret <4 x float> [[INTRN_RES]]
 
+float64x2_t test_vsetq_land_f64(float64_t a, float64x2_t b) {
+  return vsetq_lane_f64(a, b, 0);
+}
+
+// CIR-LABEL: test_vsetq_land_f64
+// CIR: [[IDX:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR: {{%.*}} = cir.vec.insert {{%.*}}, {{%.*}}[[[IDX]] : !s32i] : !cir.vector<!cir.double x 2>
+
+// LLVM: {{.*}}test_vsetq_land_f64(double{{.*}}[[A:%.*]], <2 x double>{{.*}}[[B:%.*]])
+// : [[INTRN_RES:%.*]] = insertelement <2 x double> [[B]], double [[A]], i32 1
+// LLVM: ret <2 x double> [[INTRN_RES]]
+
 uint8_t test_vget_lane_u8(uint8x8_t a) {
   return vget_lane_u8(a, 7);
 }


### PR DESCRIPTION
Lowering Neon `vsetq_lane_f64`

References:
[Clang CGBuiltin Implementation](https://github.com/llvm/clangir/blob/2b1a638ea07ca10c5727ea835bfbe17b881175cc/clang/lib/CodeGen/CGBuiltin.cpp#L12348)
[Builtin definition](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsetq_lane_f64)