### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower neon_vset_lane_f64

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -3687,9 +3687,14 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
     // at the moment, the implementation should be the same as above
     // vset_lane or vsetq_lane intrinsics
     llvm_unreachable("NEON::BI__builtin_neon_vsetq_lane_bf16 NYI");
-  case NEON::BI__builtin_neon_vset_lane_f64:
-    // The vector type needs a cast for the v1f64 variant.
-    llvm_unreachable("NEON::BI__builtin_neon_vset_lane_f64 NYI");
+
+  case NEON::BI__builtin_neon_vset_lane_f64: {
+    Ops.push_back(emitScalarExpr(E->getArg(2)));
+    Ops[1] = builder.createBitcast(
+        Ops[1], cir::VectorType::get(&getMLIRContext(), DoubleTy, 1));
+    return builder.create<cir::VecInsertOp>(getLoc(E->getExprLoc()), Ops[1],
+                                            Ops[0], Ops[2]);
+  }
   case NEON::BI__builtin_neon_vsetq_lane_f64: {
     Ops.push_back(emitScalarExpr(E->getArg(2)));
     Ops[1] = builder.createBitcast(
@@ -3697,7 +3702,6 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
     return builder.create<cir::VecInsertOp>(getLoc(E->getExprLoc()), Ops[1],
                                             Ops[0], Ops[2]);
   }
-
   case NEON::BI__builtin_neon_vget_lane_i8:
   case NEON::BI__builtin_neon_vdupb_lane_i8:
     Ops[0] = builder.createBitcast(

--- a/clang/test/CIR/CodeGen/AArch64/neon-misc.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-misc.c
@@ -137,15 +137,27 @@ float32x4_t test_vsetq_lane_f32(float32_t a, float32x4_t b) {
 // LLVM: [[INTRN_RES:%.*]] = insertelement <4 x float> [[B]], float [[A]], i32 3
 // LLVM: ret <4 x float> [[INTRN_RES]]
 
-float64x2_t test_vsetq_land_f64(float64_t a, float64x2_t b) {
+float64x1_t test_vset_lane_f64(float64_t a, float64x1_t b) {
+  return vset_lane_f64(a, b, 0);
+}
+
+// CIR-LABEL: test_vset_lane_f64
+// CIR: [[IDX:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR: {{%.*}} = cir.vec.insert {{%.*}}, {{%.*}}[[[IDX]] : !s32i] : !cir.vector<!cir.double x 1>
+
+// LLVM: {{.*}}test_vset_lane_f64(double{{.*}}[[A:%.*]], <1 x double>{{.*}}[[B:%.*]])
+// LLVM: [[INTRN_RES:%.*]] = insertelement <1 x double> [[B]], double [[A]], i32 0
+// LLVM: ret <1 x double> [[INTRN_RES]]
+
+float64x2_t test_vsetq_lane_f64(float64_t a, float64x2_t b) {
   return vsetq_lane_f64(a, b, 0);
 }
 
-// CIR-LABEL: test_vsetq_land_f64
+// CIR-LABEL: test_vsetq_lane_f64
 // CIR: [[IDX:%.*]] = cir.const #cir.int<0> : !s32i
 // CIR: {{%.*}} = cir.vec.insert {{%.*}}, {{%.*}}[[[IDX]] : !s32i] : !cir.vector<!cir.double x 2>
 
-// LLVM: {{.*}}test_vsetq_land_f64(double{{.*}}[[A:%.*]], <2 x double>{{.*}}[[B:%.*]])
+// LLVM: {{.*}}test_vsetq_lane_f64(double{{.*}}[[A:%.*]], <2 x double>{{.*}}[[B:%.*]])
 // LLVM: [[INTRN_RES:%.*]] = insertelement <2 x double> [[B]], double [[A]], i32 0
 // LLVM: ret <2 x double> [[INTRN_RES]]
 


### PR DESCRIPTION
Lowering Neon `vset_lane_f64`

References:
[Clang CGBuiltin Implementation](https://github.com/llvm/clangir/blob/2b1a638ea07ca10c5727ea835bfbe17b881175cc/clang/lib/CodeGen/CGBuiltin.cpp#L12342)
[Builtin definition](https://developer.arm.com/architectures/instruction-sets/intrinsics/vset_lane_f64)