### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower `neon_vaddd_s64` and `neon_vaddd_u64`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -3782,7 +3782,7 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
   }
   case NEON::BI__builtin_neon_vaddd_s64:
   case NEON::BI__builtin_neon_vaddd_u64:
-    llvm_unreachable("NEON::BI__builtin_neon_vaddd_u64 NYI");
+    return builder.createAdd(Ops[0], emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vsubd_s64:
   case NEON::BI__builtin_neon_vsubd_u64:
     llvm_unreachable("NEON::BI__builtin_neon_vsubd_u64 NYI");

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -9885,10 +9885,11 @@ int64_t test_vaddd_s64(int64_t a, int64_t b) {
   return vaddd_s64(a, b);
 
   // CIR-LABEL: vaddd_s64
-  // CIR: [[v3:%.*]] = cir.binop(add, [[v1:%.*]], [[v2:%.*]]) : !s64i
+  // CIR: {{%.*}} = cir.binop(add, {{%.*}}, {{%.*}}) : !s64i
 
-  // LLVM-LABEL: @test_vaddd_s64(
-  // LLVM:   [[VADDD_I:%.*]]  = add i64 [[a:%.*]], [[b:%.*]]
+  // LLVM-LABEL: @test_vaddd_s64
+  // LLVM-SAME: (i64 [[a:%.]], i64 [[b:%.]])
+  // LLVM:   [[VADDD_I:%.*]]  = add i64 [[a]], [[b]]
   // LLVM:   ret i64 [[VADDD_I]]
 }
 
@@ -9896,10 +9897,11 @@ uint64_t test_vaddd_u64(uint64_t a, uint64_t b) {
    return vaddd_u64(a, b);
 
   // CIR-LABEL: vaddd_u64
-  // CIR: [[v3:%.*]] = cir.binop(add, [[v1:%.*]], [[v2:%.*]]) : !u64i
+  // CIR: {{%.*}} = cir.binop(add, {{%.*}}, {{%.*}}) : !u64i
 
-  // LLVM-LABEL: @test_vaddd_u64(
-  // LLVM:   [[VADDD_I:%.*]]  = add i64 [[a:%.*]], [[b:%.*]]
+  // LLVM-LABEL: @test_vaddd_u64
+  // LLVM-SAME: (i64 [[a:%.]], i64 [[b:%.]])
+  // LLVM:   [[VADDD_I:%.*]]  = add i64 [[a]], [[b]]
   // LLVM:   ret i64 [[VADDD_I]]
 }
 

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -9881,19 +9881,27 @@ poly16x8_t test_vmull_p8(poly8x8_t a, poly8x8_t b) {
 //   return vmull_high_p8(a, b);
 // }
 
-// NYI-LABEL: @test_vaddd_s64(
-// NYI:   [[VADDD_I:%.*]] = add i64 %a, %b
-// NYI:   ret i64 [[VADDD_I]]
-// int64_t test_vaddd_s64(int64_t a, int64_t b) {
-//   return vaddd_s64(a, b);
-// }
+int64_t test_vaddd_s64(int64_t a, int64_t b) {
+  return vaddd_s64(a, b);
 
-// NYI-LABEL: @test_vaddd_u64(
-// NYI:   [[VADDD_I:%.*]] = add i64 %a, %b
-// NYI:   ret i64 [[VADDD_I]]
-// uint64_t test_vaddd_u64(uint64_t a, uint64_t b) {
-//   return vaddd_u64(a, b);
-// }
+  // CIR-LABEL: vaddd_s64
+  // CIR: [[v3:%.*]] = cir.binop(add, [[v1:%.*]], [[v2:%.*]]) : !s64i
+
+  // LLVM-LABEL: @test_vaddd_s64(
+  // LLVM:   [[VADDD_I:%.*]]  = add i64 [[a:%.*]], [[b:%.*]]
+  // LLVM:   ret i64 [[VADDD_I]]
+}
+
+uint64_t test_vaddd_u64(uint64_t a, uint64_t b) {
+   return vaddd_u64(a, b);
+
+  // CIR-LABEL: vaddd_u64
+  // CIR: [[v3:%.*]] = cir.binop(add, [[v1:%.*]], [[v2:%.*]]) : !u64i
+
+  // LLVM-LABEL: @test_vaddd_u64(
+  // LLVM:   [[VADDD_I:%.*]]  = add i64 [[a:%.*]], [[b:%.*]]
+  // LLVM:   ret i64 [[VADDD_I]]
+}
 
 // NYI-LABEL: @test_vsubd_s64(
 // NYI:   [[VSUBD_I:%.*]] = sub i64 %a, %b


### PR DESCRIPTION
Lowering Neon `vaddd_s64` and `vaddd_u64`

- [Clang CGBuiltin Implementation](https://github.com/llvm/clangir/blob/2b1a638ea07ca10c5727ea835bfbe17b881175cc/clang/lib/CodeGen/CGBuiltin.cpp#L12460-L12462)
- [vaddd_s64 Builtin definition](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddd_s64)
- [vaddd_u64 Builtin definition](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddd_u64)

