### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower `neon_vsubd_s64` and `neon_vsubd_u64`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -3785,7 +3785,7 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
     llvm_unreachable("NEON::BI__builtin_neon_vaddd_u64 NYI");
   case NEON::BI__builtin_neon_vsubd_s64:
   case NEON::BI__builtin_neon_vsubd_u64:
-    llvm_unreachable("NEON::BI__builtin_neon_vsubd_u64 NYI");
+    return builder.createSub(Ops[0], emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vqdmlalh_s16:
   case NEON::BI__builtin_neon_vqdmlslh_s16: {
     llvm_unreachable("NEON::BI__builtin_neon_vqdmlslh_s16 NYI");

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -9895,19 +9895,27 @@ poly16x8_t test_vmull_p8(poly8x8_t a, poly8x8_t b) {
 //   return vaddd_u64(a, b);
 // }
 
-// NYI-LABEL: @test_vsubd_s64(
-// NYI:   [[VSUBD_I:%.*]] = sub i64 %a, %b
-// NYI:   ret i64 [[VSUBD_I]]
-// int64_t test_vsubd_s64(int64_t a, int64_t b) {
-//   return vsubd_s64(a, b);
-// }
+int64_t test_vsubd_s64(int64_t a, int64_t b) {
+  return vsubd_s64(a, b);
 
-// NYI-LABEL: @test_vsubd_u64(
-// NYI:   [[VSUBD_I:%.*]] = sub i64 %a, %b
-// NYI:   ret i64 [[VSUBD_I]]
-// uint64_t test_vsubd_u64(uint64_t a, uint64_t b) {
-//   return vsubd_u64(a, b);
-// }
+  // CIR-LABEL: vsubd_s64
+  // CIR: [[v3:%.*]] = cir.binop(sub, [[v1:%.*]], [[v2:%.*]]) : !s64i
+
+  // LLVM-LABEL: @test_vsubd_s64(
+  // LLVM:   [[VSUBD_I:%.*]]  = sub i64 [[a:%.*]], [[b:%.*]]
+  // LLVM:   ret i64 [[VSUBD_I]]
+}
+
+uint64_t test_vsubd_u64(uint64_t a, uint64_t b) {
+  return vsubd_u64(a, b);
+
+  // CIR-LABEL: vsubd_u64
+  // CIR: [[v3:%.*]] = cir.binop(sub, [[v1:%.*]], [[v2:%.*]]) : !u64i
+
+  // LLVM-LABEL: @test_vsubd_u64(
+  // LLVM:   [[VSUBD_I:%.*]]  = sub i64 [[a:%.*]], [[b:%.*]]
+  // LLVM:   ret i64 [[VSUBD_I]]
+}
 
 // NYI-LABEL: @test_vqaddb_s8(
 // NYI:   [[TMP0:%.*]] = insertelement <8 x i8> poison, i8 %a, i64 0

--- a/clang/test/CIR/CodeGen/AArch64/neon.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon.c
@@ -9899,10 +9899,11 @@ int64_t test_vsubd_s64(int64_t a, int64_t b) {
   return vsubd_s64(a, b);
 
   // CIR-LABEL: vsubd_s64
-  // CIR: [[v3:%.*]] = cir.binop(sub, [[v1:%.*]], [[v2:%.*]]) : !s64i
+  // CIR: {{%.*}} = cir.binop(sub, {{%.*}}, {{%.*}}) : !s64i
 
-  // LLVM-LABEL: @test_vsubd_s64(
-  // LLVM:   [[VSUBD_I:%.*]]  = sub i64 [[a:%.*]], [[b:%.*]]
+  // LLVM-LABEL: @test_vsubd_s64
+  // LLVM-SAME: (i64 [[a:%.]], i64 [[b:%.]])
+  // LLVM:   [[VSUBD_I:%.*]]  = sub i64 [[a]], [[b]]
   // LLVM:   ret i64 [[VSUBD_I]]
 }
 
@@ -9910,10 +9911,11 @@ uint64_t test_vsubd_u64(uint64_t a, uint64_t b) {
   return vsubd_u64(a, b);
 
   // CIR-LABEL: vsubd_u64
-  // CIR: [[v3:%.*]] = cir.binop(sub, [[v1:%.*]], [[v2:%.*]]) : !u64i
+  // CIR: {{%.*}} = cir.binop(sub, {{%.*}}, {{%.*}}) : !u64i
 
-  // LLVM-LABEL: @test_vsubd_u64(
-  // LLVM:   [[VSUBD_I:%.*]]  = sub i64 [[a:%.*]], [[b:%.*]]
+  // LLVM-LABEL: @test_vsubd_u64
+  // LLVM-SAME: (i64 [[a:%.]], i64 [[b:%.]])
+  // LLVM:   [[VSUBD_I:%.*]]  = sub i64 [[a]], [[b]]
   // LLVM:   ret i64 [[VSUBD_I]]
 }
 


### PR DESCRIPTION
Lowering `neon_vsubd_s64` and `neon_vsubd_u64`

- [Clang CGBuiltin Implementation](https://github.com/llvm/clangir/blob/2b1a638ea07ca10c5727ea835bfbe17b881175cc/clang/lib/CodeGen/CGBuiltin.cpp#L12463-L12465)
- [vaddd_s64 Builtin definition](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsubd_s64)
- [vaddd_u64 Builtin definition](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsubd_u64)

