### PR TITLE
[CIR] Add support for GCC function attribute "const" and "pure"

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -652,10 +652,11 @@ public:
                            mlir::Type returnType = cir::VoidType(),
                            mlir::ValueRange operands = mlir::ValueRange(),
                            cir::CallingConv callingConv = cir::CallingConv::C,
+                           cir::SideEffect sideEffect = cir::SideEffect::All,
                            cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
 
-    cir::CallOp callOp =
-        create<cir::CallOp>(loc, callee, returnType, operands, callingConv);
+    cir::CallOp callOp = create<cir::CallOp>(loc, callee, returnType, operands,
+                                             callingConv, sideEffect);
 
     if (extraFnAttr) {
       callOp->setAttr("extra_attrs", extraFnAttr);
@@ -671,10 +672,11 @@ public:
   cir::CallOp createCallOp(mlir::Location loc, cir::FuncOp callee,
                            mlir::ValueRange operands = mlir::ValueRange(),
                            cir::CallingConv callingConv = cir::CallingConv::C,
+                           cir::SideEffect sideEffect = cir::SideEffect::All,
                            cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
     return createCallOp(loc, mlir::SymbolRefAttr::get(callee),
                         callee.getFunctionType().getReturnType(), operands,
-                        callingConv, extraFnAttr);
+                        callingConv, sideEffect, extraFnAttr);
   }
 
   cir::CallOp
@@ -682,21 +684,23 @@ public:
                        cir::FuncType fn_type,
                        mlir::ValueRange operands = mlir::ValueRange(),
                        cir::CallingConv callingConv = cir::CallingConv::C,
+                       cir::SideEffect sideEffect = cir::SideEffect::All,
                        cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
 
     llvm::SmallVector<mlir::Value, 4> resOperands({ind_target});
     resOperands.append(operands.begin(), operands.end());
 
     return createCallOp(loc, mlir::SymbolRefAttr(), fn_type.getReturnType(),
-                        resOperands, callingConv, extraFnAttr);
+                        resOperands, callingConv, sideEffect, extraFnAttr);
   }
 
   cir::CallOp createCallOp(mlir::Location loc, mlir::SymbolRefAttr callee,
                            mlir::ValueRange operands = mlir::ValueRange(),
                            cir::CallingConv callingConv = cir::CallingConv::C,
+                           cir::SideEffect sideEffect = cir::SideEffect::All,
                            cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
     return createCallOp(loc, callee, cir::VoidType(), operands, callingConv,
-                        extraFnAttr);
+                        sideEffect, extraFnAttr);
   }
 
   cir::CallOp
@@ -705,10 +709,11 @@ public:
                   mlir::Type returnType = cir::VoidType(),
                   mlir::ValueRange operands = mlir::ValueRange(),
                   cir::CallingConv callingConv = cir::CallingConv::C,
+                  cir::SideEffect sideEffect = cir::SideEffect::All,
                   cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
     cir::CallOp tryCallOp =
         create<cir::CallOp>(loc, callee, returnType, operands, callingConv,
-                            /*exception=*/getUnitAttr());
+                            sideEffect, /*exception=*/getUnitAttr());
     if (extraFnAttr) {
       tryCallOp->setAttr("extra_attrs", extraFnAttr);
     } else {
@@ -724,20 +729,22 @@ public:
   createTryCallOp(mlir::Location loc, cir::FuncOp callee,
                   mlir::ValueRange operands,
                   cir::CallingConv callingConv = cir::CallingConv::C,
+                  cir::SideEffect sideEffect = cir::SideEffect::All,
                   cir::ExtraFuncAttributesAttr extraFnAttr = {}) {
     return createTryCallOp(loc, mlir::SymbolRefAttr::get(callee),
                            callee.getFunctionType().getReturnType(), operands,
-                           callingConv, extraFnAttr);
+                           callingConv, sideEffect, extraFnAttr);
   }
 
   cir::CallOp
   createIndirectTryCallOp(mlir::Location loc, mlir::Value ind_target,
                           cir::FuncType fn_type, mlir::ValueRange operands,
-                          cir::CallingConv callingConv = cir::CallingConv::C) {
+                          cir::CallingConv callingConv = cir::CallingConv::C,
+                          cir::SideEffect sideEffect = cir::SideEffect::All) {
     llvm::SmallVector<mlir::Value, 4> resOperands({ind_target});
     resOperands.append(operands.begin(), operands.end());
     return createTryCallOp(loc, mlir::SymbolRefAttr(), fn_type.getReturnType(),
-                           resOperands, callingConv);
+                           resOperands, callingConv, sideEffect);
   }
 
   struct GetMethodResults {

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3574,6 +3574,39 @@ def DeleteArrayOp : CIR_Op<"delete.array">,
 // CallOp and TryCallOp
 //===----------------------------------------------------------------------===//
 
+def SE_All : I32EnumAttrCase<"All", 1, "all">;
+def SE_Pure : I32EnumAttrCase<"Pure", 2, "pure">;
+def SE_Const : I32EnumAttrCase<"Const", 3, "const">;
+
+def SideEffect : I32EnumAttr<
+    "SideEffect", "allowed side effects of a function",
+    [SE_All, SE_Pure, SE_Const]> {
+  let description = [{
+    The side effect attribute specifies the possible side effects of the callee
+    of a call operation. This is an enumeration attribute and all possible
+    enumerators are:
+
+    - all: The callee can have any side effects. This is the default if no side
+      effects are explicitly listed.
+    - pure: The callee may read data from memory, but it cannot write data to
+      memory. This has the same effect as the GNU C/C++ attribute
+      `__attribute__((pure))`.
+    - const: The callee may not read or write data from memory. This has the
+      same effect as the GNU C/C++ attribute `__attribute__((const))`.
+
+    Examples:
+
+    ```mlir
+    %0 = cir.const #cir.int<0> : !s32i
+    %1 = cir.const #cir.int<1> : !s32i
+    %2 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(all)
+    %2 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(pure)
+    %2 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(const)
+    ```
+  }];
+  let cppNamespace = "::cir";
+}
+
 class CIR_CallOp<string mnemonic, list<Trait> extra_traits = []> :
     Op<CIR_Dialect, mnemonic,
        !listconcat(extra_traits,
@@ -3624,6 +3657,7 @@ class CIR_CallOp<string mnemonic, list<Trait> extra_traits = []> :
     OptionalAttr<FlatSymbolRefAttr>:$callee,
     Variadic<CIR_AnyType>:$arg_ops,
     DefaultValuedAttr<CallingConv, "CallingConv::C">:$calling_conv,
+    DefaultValuedAttr<SideEffect, "SideEffect::All">:$side_effect,
     ExtraFuncAttr:$extra_attrs,
     OptionalAttr<ASTCallExprInterface>:$ast
   );
@@ -3676,12 +3710,15 @@ def CallOp : CIR_CallOp<"call", [NoRegionArguments]> {
     OpBuilder<(ins "mlir::SymbolRefAttr":$callee, "mlir::Type":$resType,
               CArg<"mlir::ValueRange", "{}">:$operands,
               CArg<"CallingConv", "CallingConv::C">:$callingConv,
+              CArg<"SideEffect", "SideEffect::All">:$sideEffect,
               CArg<"mlir::UnitAttr", "{}">:$exception), [{
       $_state.addOperands(operands);
       if (callee)
         $_state.addAttribute("callee", callee);
       $_state.addAttribute("calling_conv",
         CallingConvAttr::get($_builder.getContext(), callingConv));
+      $_state.addAttribute("side_effect",
+        SideEffectAttr::get($_builder.getContext(), sideEffect));
       if (exception)
         $_state.addAttribute("exception", exception);
       if (resType && !isa<VoidType>(resType))
@@ -3693,6 +3730,7 @@ def CallOp : CIR_CallOp<"call", [NoRegionArguments]> {
                "FuncType":$fn_type,
                CArg<"mlir::ValueRange", "{}">:$operands,
                CArg<"CallingConv", "CallingConv::C">:$callingConv,
+               CArg<"SideEffect", "SideEffect::All">:$sideEffect,
                CArg<"mlir::UnitAttr", "{}">:$exception), [{
       $_state.addOperands(ValueRange{ind_target});
       $_state.addOperands(operands);
@@ -3700,6 +3738,8 @@ def CallOp : CIR_CallOp<"call", [NoRegionArguments]> {
         $_state.addTypes(fn_type.getReturnType());
       $_state.addAttribute("calling_conv",
         CallingConvAttr::get($_builder.getContext(), callingConv));
+      $_state.addAttribute("side_effect",
+        SideEffectAttr::get($_builder.getContext(), sideEffect));
       if (exception)
         $_state.addAttribute("exception", exception);
       // Create region placeholder for potential cleanups.
@@ -3742,7 +3782,8 @@ def TryCallOp : CIR_CallOp<"try_call",
                CArg<"mlir::ValueRange", "{}">:$operands,
                CArg<"mlir::ValueRange", "{}">:$contOperands,
                CArg<"mlir::ValueRange", "{}">:$landingPadOperands,
-               CArg<"CallingConv", "CallingConv::C">:$callingConv), [{
+               CArg<"CallingConv", "CallingConv::C">:$callingConv,
+               CArg<"SideEffect", "SideEffect::All">:$sideEffect), [{
       $_state.addOperands(operands);
       if (callee)
         $_state.addAttribute("callee", callee);
@@ -3751,6 +3792,8 @@ def TryCallOp : CIR_CallOp<"try_call",
 
       $_state.addAttribute("calling_conv",
         CallingConvAttr::get($_builder.getContext(), callingConv));
+      $_state.addAttribute("side_effect",
+        SideEffectAttr::get($_builder.getContext(), sideEffect));
 
       // Handle branches
       $_state.addOperands(contOperands);
@@ -3771,7 +3814,8 @@ def TryCallOp : CIR_CallOp<"try_call",
                CArg<"mlir::ValueRange", "{}">:$operands,
                CArg<"mlir::ValueRange", "{}">:$contOperands,
                CArg<"mlir::ValueRange", "{}">:$landingPadOperands,
-               CArg<"CallingConv", "CallingConv::C">:$callingConv), [{
+               CArg<"CallingConv", "CallingConv::C">:$callingConv,
+               CArg<"SideEffect", "SideEffect::All">:$sideEffect), [{
       ::llvm::SmallVector<mlir::Value, 4> finalCallOperands({ind_target});
       finalCallOperands.append(operands.begin(), operands.end());
       $_state.addOperands(finalCallOperands);
@@ -3781,6 +3825,8 @@ def TryCallOp : CIR_CallOp<"try_call",
 
       $_state.addAttribute("calling_conv",
         CallingConvAttr::get($_builder.getContext(), callingConv));
+      $_state.addAttribute("side_effect",
+        SideEffectAttr::get($_builder.getContext(), sideEffect));
 
       // Handle branches
       $_state.addOperands(contOperands);
@@ -4187,7 +4233,7 @@ def MemCpyInlineOp : CIR_MemOp<"memcpy_inline"> {
     Given two CIR pointers, `src` and `dst`, `memcpy_inline` will copy `len`
     bytes from the memory pointed by `src` to the memory pointed by `dst`.
 
-    Unlike `cir.libc.memcpy`,  this Op guarantees that no external functions 
+    Unlike `cir.libc.memcpy`,  this Op guarantees that no external functions
     are called, and length of copied bytes is a constant.
 
     Examples:

--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
@@ -37,6 +37,9 @@ let cppNamespace = "::cir" in {
       InterfaceMethod<
           "Return the calling convention of the call operation",
           "cir::CallingConv", "getCallingConv", (ins)>,
+      InterfaceMethod<
+          "Return the side effects of the call operation",
+          "cir::SideEffect", "getSideEffect", (ins)>,
     ];
   }
 
@@ -50,20 +53,20 @@ let cppNamespace = "::cir" in {
       >,
       InterfaceMethod<"",
       "bool", "hasLocalLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{ 
-        return cir::isLocalLinkage($_op.getLinkage()); 
+      /*defaultImplementation=*/[{
+        return cir::isLocalLinkage($_op.getLinkage());
       }]
       >,
       InterfaceMethod<"",
       "bool", "hasExternalWeakLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{ 
-        return cir::isExternalWeakLinkage($_op.getLinkage()); 
+      /*defaultImplementation=*/[{
+        return cir::isExternalWeakLinkage($_op.getLinkage());
       }]
       >,
       InterfaceMethod<"",
       "bool", "isExternalLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{ 
-        return cir::isExternalLinkage($_op.getLinkage()); 
+      /*defaultImplementation=*/[{
+        return cir::isExternalLinkage($_op.getLinkage());
       }]
       >,
       InterfaceMethod<"",
@@ -87,8 +90,8 @@ let cppNamespace = "::cir" in {
       }]
       >,
     ];
-    let extraClassDeclaration = [{ 
-    bool hasDefaultVisibility();  
+    let extraClassDeclaration = [{
+    bool hasDefaultVisibility();
     bool canBenefitFromLocalAlias();
   }];
   }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2682,10 +2682,11 @@ void CIRGenModule::setCIRFunctionAttributes(GlobalDecl GD,
                                             cir::FuncOp func, bool isThunk) {
   // TODO(cir): More logic of constructAttributeList is needed.
   cir::CallingConv callingConv;
+  cir::SideEffect sideEffect;
 
   // Initialize PAL with existing attributes to merge attributes.
   mlir::NamedAttrList PAL{func.getExtraAttrs().getElements().getValue()};
-  constructAttributeList(func.getName(), info, GD, PAL, callingConv,
+  constructAttributeList(func.getName(), info, GD, PAL, callingConv, sideEffect,
                          /*AttrOnCallSite=*/false, isThunk);
   func.setExtraAttrsAttr(cir::ExtraFuncAttributesAttr::get(
       &getMLIRContext(), PAL.getDictionary(&getMLIRContext())));

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -317,7 +317,8 @@ public:
                               CIRGenCalleeInfo CalleeInfo,
                               mlir::NamedAttrList &Attrs,
                               cir::CallingConv &callingConv,
-                              bool AttrOnCallSite, bool IsThunk);
+                              cir::SideEffect &sideEffect, bool AttrOnCallSite,
+                              bool IsThunk);
 
   /// Helper function for getDefaultFunctionAttributes. Builds a set of function
   /// attributes which can be simply added to a function.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -711,6 +711,43 @@ mlir::LLVM::CConv convertCallingConv(cir::CallingConv callinvConv) {
   llvm_unreachable("Unknown calling convention");
 }
 
+void convertSideEffectForCall(mlir::Operation *callOp,
+                              cir::SideEffect sideEffect,
+                              mlir::LLVM::MemoryEffectsAttr &memoryEffect,
+                              bool &noUnwind, bool &willReturn) {
+  using mlir::LLVM::ModRefInfo;
+
+  switch (sideEffect) {
+  case cir::SideEffect::All:
+    memoryEffect = {};
+    noUnwind = false;
+    willReturn = false;
+    break;
+
+  case cir::SideEffect::Pure:
+    memoryEffect = mlir::LLVM::MemoryEffectsAttr::get(
+        callOp->getContext(), /*other=*/ModRefInfo::Ref,
+        /*argMem=*/ModRefInfo::Ref,
+        /*inaccessibleMem=*/ModRefInfo::Ref);
+    noUnwind = true;
+    willReturn = true;
+    break;
+
+  case cir::SideEffect::Const:
+    memoryEffect = mlir::LLVM::MemoryEffectsAttr::get(
+        callOp->getContext(), /*other=*/ModRefInfo::NoModRef,
+        /*argMem=*/ModRefInfo::NoModRef,
+        /*inaccessibleMem=*/ModRefInfo::NoModRef);
+    noUnwind = true;
+    willReturn = true;
+    break;
+
+  default:
+    callOp->emitError("unknown side effect");
+    break;
+  }
+}
+
 mlir::LogicalResult CIRToLLVMCopyOpLowering::matchAndRewrite(
     cir::CopyOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -1255,6 +1292,12 @@ rewriteToCallOrInvoke(mlir::Operation *op, mlir::ValueRange callOperands,
 
   auto cconv = convertCallingConv(callIf.getCallingConv());
 
+  mlir::LLVM::MemoryEffectsAttr memoryEffects;
+  bool noUnwind = false;
+  bool willReturn = false;
+  convertSideEffectForCall(op, callIf.getSideEffect(), memoryEffects, noUnwind,
+                           willReturn);
+
   mlir::LLVM::LLVMFunctionType llvmFnTy;
   if (calleeAttr) { // direct call
     auto fn =
@@ -1283,6 +1326,10 @@ rewriteToCallOrInvoke(mlir::Operation *op, mlir::ValueRange callOperands,
     auto newOp = rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
         op, llvmFnTy, calleeAttr, callOperands);
     newOp.setCConv(cconv);
+    if (memoryEffects)
+      newOp.setMemoryEffectsAttr(memoryEffects);
+    newOp.setNoUnwind(noUnwind);
+    newOp.setWillReturn(willReturn);
   }
   return mlir::success();
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -26,6 +26,11 @@ mlir::LLVM::Linkage convertLinkage(cir::GlobalLinkageKind linkage);
 
 mlir::LLVM::CConv convertCallingConv(cir::CallingConv callinvConv);
 
+void convertSideEffectForCall(mlir::Operation *callOp,
+                              cir::SideEffect sideEffect,
+                              mlir::LLVM::MemoryEffectsAttr &memoryEffect,
+                              bool &noUnwind, bool &willReturn);
+
 void buildCtorDtorList(
     mlir::ModuleOp module, mlir::StringRef globalXtorName,
     mlir::StringRef llvmXtorName,

--- a/clang/test/CIR/CodeGen/call-side-effect.cpp
+++ b/clang/test/CIR/CodeGen/call-side-effect.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
+
+[[gnu::pure]] int pure_func(int x);
+[[gnu::const]] int const_func(int x);
+
+int test(int x) {
+  int y1 = pure_func(x);
+  int y2 = const_func(x);
+  return y1 + y2;
+}
+
+// CIR-LABEL: @_Z4testi
+// CIR:   %{{.+}} = cir.call @_Z9pure_funci(%{{.+}}) : (!s32i) -> !s32i side_effect(pure)
+// CIR:   %{{.+}} = cir.call @_Z10const_funci(%{{.+}}) : (!s32i) -> !s32i side_effect(const)
+// CIR: }
+
+// LLVM-LABEL: @_Z4testi(i32 %0)
+// LLVM:   %{{.+}} = call i32 @_Z9pure_funci(i32 %{{.+}}) #[[#meta_pure:]]
+// LLVM:   %{{.+}} = call i32 @_Z10const_funci(i32 %{{.+}}) #[[#meta_const:]]
+// LLVM: }
+// LLVM: attributes #[[#meta_pure]] = { nounwind willreturn memory(read) }
+// LLVM: attributes #[[#meta_const]] = { nounwind willreturn memory(none) }

--- a/clang/test/CIR/IR/side-effect.cir
+++ b/clang/test/CIR/IR/side-effect.cir
@@ -1,0 +1,21 @@
+// RUN: cir-opt %s -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.func private @add(%arg0: !s32i, %arg1: !s32i) -> !s32i
+  cir.func @call_with_side_effect() {
+    %0 = cir.const #cir.int<0> : !s32i
+    %1 = cir.const #cir.int<1> : !s32i
+    %2 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(all)
+    %3 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(pure)
+    %4 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(const)
+    cir.return
+  }
+  // CHECK-LABEL: @call_with_side_effect()
+  //      CHECK:    %{{.+}} = cir.call @add(%{{.+}}, %{{.+}}) : (!s32i, !s32i) -> !s32i
+  // CHECK-NEXT:    %{{.+}} = cir.call @add(%{{.+}}, %{{.+}}) : (!s32i, !s32i) -> !s32i side_effect(pure)
+  // CHECK-NEXT:    %{{.+}} = cir.call @add(%{{.+}}, %{{.+}}) : (!s32i, !s32i) -> !s32i side_effect(const)
+  //      CHECK:  }
+}

--- a/clang/test/CIR/Lowering/call.cir
+++ b/clang/test/CIR/Lowering/call.cir
@@ -99,4 +99,23 @@ module {
   // LLVM-NEXT:   %2 = call i32 (i32, ...) %1(i32 0, i32 0)
   // LLVM-NEXT:   ret i32 %2
 
+  cir.func private @add(%arg0: !s32i, %arg1: !s32i) -> !s32i
+
+  cir.func @call_with_side_effect() {
+    %0 = cir.const #cir.int<0> : !s32i
+    %1 = cir.const #cir.int<1> : !s32i
+    %2 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(all)
+    %3 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(pure)
+    %4 = cir.call @add(%0, %1) : (!s32i, !s32i) -> !s32i side_effect(const)
+    cir.return
+  }
+
+  // LLVM: @call_with_side_effect
+  // LLVM:   %{{.+}} = call i32 @add(i32 0, i32 1)
+  // LLVM:   %{{.+}} = call i32 @add(i32 0, i32 1) #[[#pure:]]
+  // LLVM:   %{{.+}} = call i32 @add(i32 0, i32 1) #[[#const:]]
+  // LLVM: }
+  // LLVM: attributes #[[#pure]] = { nounwind willreturn memory(read) }
+  // LLVM: attributes #[[#const]] = { nounwind willreturn memory(none) }
+
 } // end module


### PR DESCRIPTION
This patch adds support for the following GCC function attributes:

  - `__attribute__((const))`
  - `__attribute__((pure))`

The side effect information is attached to the call operations during CIRGen. During LLVM lowering, these information is consumed to further emit appropriate LLVM metadata on LLVM call instructions.