### PR TITLE
[CIR] Data member pointer comparison and casts

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -123,6 +123,7 @@ def CK_FloatComplexToIntegralComplex
 def CK_IntegralComplexCast : I32EnumAttrCase<"int_complex", 23>;
 def CK_IntegralComplexToFloatComplex
     : I32EnumAttrCase<"int_complex_to_float_complex", 24>;
+def CK_MemberPtrToBoolean : I32EnumAttrCase<"member_ptr_to_bool", 25>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
@@ -135,7 +136,7 @@ def CastKind : I32EnumAttr<
      CK_FloatComplexToReal, CK_IntegralComplexToReal, CK_FloatComplexToBoolean,
      CK_IntegralComplexToBoolean, CK_FloatComplexCast,
      CK_FloatComplexToIntegralComplex, CK_IntegralComplexCast,
-     CK_IntegralComplexToFloatComplex]> {
+     CK_IntegralComplexToFloatComplex, CK_MemberPtrToBoolean]> {
   let cppNamespace = "::cir";
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -530,6 +530,11 @@ LogicalResult cir::CastOp::verify() {
       return success();
     }
 
+    // Handle the data member pointer types.
+    if (mlir::isa<cir::DataMemberType>(srcType) &&
+        mlir::isa<cir::DataMemberType>(resType))
+      return success();
+
     // This is the only cast kind where we don't want vector types to decay
     // into the element type.
     if ((!mlir::isa<cir::VectorType>(getSrc().getType()) ||
@@ -703,6 +708,13 @@ LogicalResult cir::CastOp::verify() {
         !mlir::isa<cir::CIRFPTypeInterface>(resComplexTy.getElementTy()))
       return emitOpError()
              << "requires !cir.complex<!cir.float> type for result";
+    return success();
+  }
+  case cir::CastKind::member_ptr_to_bool: {
+    if (!mlir::isa<cir::DataMemberType>(srcType))
+      return emitOpError() << "requires !cir.data_member type for source";
+    if (!mlir::isa<cir::BoolType>(resType))
+      return emitOpError() << "requires !cir.bool type for result";
     return success();
   }
   }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -97,6 +97,19 @@ public:
   virtual mlir::Value
   lowerDerivedDataMember(cir::DerivedDataMemberOp op, mlir::Value loweredSrc,
                          mlir::OpBuilder &builder) const = 0;
+
+  virtual mlir::Value lowerDataMemberCmp(cir::CmpOp op, mlir::Value loweredLhs,
+                                         mlir::Value loweredRhs,
+                                         mlir::OpBuilder &builder) const = 0;
+
+  virtual mlir::Value
+  lowerDataMemberBitcast(cir::CastOp op, mlir::Type loweredDstTy,
+                         mlir::Value loweredSrc,
+                         mlir::OpBuilder &builder) const = 0;
+
+  virtual mlir::Value
+  lowerDataMemberToBoolCast(cir::CastOp op, mlir::Value loweredSrc,
+                            mlir::OpBuilder &builder) const = 0;
 };
 
 /// Creates an Itanium-family ABI.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1299,8 +1299,18 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
   }
   case cir::CastKind::bitcast: {
     auto dstTy = castOp.getType();
-    auto llvmSrcVal = adaptor.getOperands().front();
     auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+
+    if (mlir::isa<cir::DataMemberType>(castOp.getSrc().getType())) {
+      mlir::Value loweredResult = lowerMod->getCXXABI().lowerDataMemberBitcast(
+          castOp, llvmDstTy, src, rewriter);
+      rewriter.replaceOp(castOp, loweredResult);
+      return mlir::success();
+    }
+    if (mlir::isa<cir::MethodType>(castOp.getSrc().getType()))
+      llvm_unreachable("NYI");
+
+    auto llvmSrcVal = adaptor.getOperands().front();
     rewriter.replaceOpWithNewOp<mlir::LLVM::BitcastOp>(castOp, llvmDstTy,
                                                        llvmSrcVal);
     return mlir::success();
@@ -1322,6 +1332,16 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     auto llvmDstTy = getTypeConverter()->convertType(dstTy);
     rewriter.replaceOpWithNewOp<mlir::LLVM::AddrSpaceCastOp>(castOp, llvmDstTy,
                                                              llvmSrcVal);
+    break;
+  }
+  case cir::CastKind::member_ptr_to_bool: {
+    mlir::Value loweredResult;
+    if (mlir::isa<cir::MethodType>(castOp.getSrc().getType()))
+      llvm_unreachable("NYI");
+    else
+      loweredResult = lowerMod->getCXXABI().lowerDataMemberToBoolCast(
+          castOp, src, rewriter);
+    rewriter.replaceOp(castOp, loweredResult);
     break;
   }
   default: {
@@ -2902,6 +2922,14 @@ mlir::LogicalResult CIRToLLVMCmpOpLowering::matchAndRewrite(
     mlir::ConversionPatternRewriter &rewriter) const {
   auto type = cmpOp.getLhs().getType();
 
+  if (mlir::isa<cir::DataMemberType>(type)) {
+    assert(lowerMod && "lowering module is not available");
+    mlir::Value loweredResult = lowerMod->getCXXABI().lowerDataMemberCmp(
+        cmpOp, adaptor.getLhs(), adaptor.getRhs(), rewriter);
+    rewriter.replaceOp(cmpOp, loweredResult);
+    return mlir::success();
+  }
+
   // Lower to LLVM comparison op.
   // if (auto intTy = mlir::dyn_cast<cir::IntType>(type)) {
   if (mlir::isa<cir::IntType, mlir::IntegerType>(type)) {
@@ -4087,6 +4115,7 @@ void populateCIRToLLVMConversionPatterns(
                                           argsVarMap, patterns.getContext());
   patterns.add<
       // clang-format off
+      CIRToLLVMCastOpLowering,
       CIRToLLVMLoadOpLowering,
       CIRToLLVMStoreOpLowering,
       CIRToLLVMGlobalOpLowering,
@@ -4096,6 +4125,7 @@ void populateCIRToLLVMConversionPatterns(
   patterns.add<
       // clang-format off
       CIRToLLVMBaseDataMemberOpLowering,
+      CIRToLLVMCmpOpLowering,
       CIRToLLVMDerivedDataMemberOpLowering,
       CIRToLLVMGetRuntimeMemberOpLowering
       // clang-format on
@@ -4103,7 +4133,6 @@ void populateCIRToLLVMConversionPatterns(
   patterns.add<
       // clang-format off
       CIRToLLVMPtrStrideOpLowering,
-      CIRToLLVMCastOpLowering,
       CIRToLLVMInlineAsmOpLowering
       // clang-format on
       >(converter, patterns.getContext(), dataLayout);
@@ -4132,7 +4161,6 @@ void populateCIRToLLVMConversionPatterns(
       CIRToLLVMCallOpLowering,
       CIRToLLVMCatchParamOpLowering,
       CIRToLLVMClearCacheOpLowering,
-      CIRToLLVMCmpOpLowering,
       CIRToLLVMCmpThreeWayOpLowering,
       CIRToLLVMComplexCreateOpLowering,
       CIRToLLVMComplexImagOpLowering,

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -232,6 +232,7 @@ public:
 };
 
 class CIRToLLVMCastOpLowering : public mlir::OpConversionPattern<cir::CastOp> {
+  cir::LowerModule *lowerMod;
   mlir::DataLayout const &dataLayout;
 
   mlir::Type convertTy(mlir::Type ty) const;
@@ -239,9 +240,10 @@ class CIRToLLVMCastOpLowering : public mlir::OpConversionPattern<cir::CastOp> {
 public:
   CIRToLLVMCastOpLowering(const mlir::TypeConverter &typeConverter,
                           mlir::MLIRContext *context,
+                          cir::LowerModule *lowerModule,
                           mlir::DataLayout const &dataLayout)
-      : OpConversionPattern(typeConverter, context), dataLayout(dataLayout) {}
-  using mlir::OpConversionPattern<cir::CastOp>::OpConversionPattern;
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule),
+        dataLayout(dataLayout) {}
 
   mlir::LogicalResult
   matchAndRewrite(cir::CastOp op, OpAdaptor,
@@ -649,8 +651,15 @@ public:
 };
 
 class CIRToLLVMCmpOpLowering : public mlir::OpConversionPattern<cir::CmpOp> {
+  cir::LowerModule *lowerMod;
+
 public:
-  using mlir::OpConversionPattern<cir::CmpOp>::OpConversionPattern;
+  CIRToLLVMCmpOpLowering(const mlir::TypeConverter &typeConverter,
+                         mlir::MLIRContext *context,
+                         cir::LowerModule *lowerModule)
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {
+    setHasBoundedRewriteRecursion();
+  }
 
   mlir::LogicalResult
   matchAndRewrite(cir::CmpOp op, OpAdaptor,

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
@@ -70,3 +70,29 @@ auto derived_to_base_zero_offset(int Derived::*ptr) -> int Base1::* {
   // LLVM-NEXT: %[[#ret:]] = load i64, ptr %[[#ret_slot]]
   // LLVM-NEXT: ret i64 %[[#ret]]
 }
+
+struct Foo {
+  int a;
+};
+
+struct Bar {
+  int a;
+};
+
+bool to_bool(int Foo::*x) {
+  return x;
+}
+
+// CIR-LABEL: @_Z7to_boolM3Fooi
+//      CIR:   %[[#x:]] = cir.load %{{.+}} : !cir.ptr<!cir.data_member<!s32i in !ty_Foo>>, !cir.data_member<!s32i in !ty_Foo>
+// CIR-NEXT:   %{{.+}} = cir.cast(member_ptr_to_bool, %[[#x]] : !cir.data_member<!s32i in !ty_Foo>), !cir.bool
+//      CIR: }
+
+auto bitcast(int Foo::*x) {
+  return reinterpret_cast<int Bar::*>(x);
+}
+
+// CIR-LABEL: @_Z7bitcastM3Fooi
+//      CIR:   %[[#x:]] = cir.load %{{.+}} : !cir.ptr<!cir.data_member<!s32i in !ty_Foo>>, !cir.data_member<!s32i in !ty_Foo>
+// CIR-NEXT:   %{{.+}} = cir.cast(bitcast, %[[#x]] : !cir.data_member<!s32i in !ty_Foo>), !cir.data_member<!s32i in !ty_Bar>
+//      CIR: }

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cmp.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cmp.cpp
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
+
+struct Foo {
+  int a;
+};
+
+struct Bar {
+  int a;
+};
+
+bool eq(int Foo::*x, int Foo::*y) {
+  return x == y;
+}
+
+// CIR-LABEL: @_Z2eqM3FooiS0_
+//      CIR:   %[[#x:]] = cir.load %{{.+}} : !cir.ptr<!cir.data_member<!s32i in !ty_Foo>>, !cir.data_member<!s32i in !ty_Foo>
+// CIR-NEXT:   %[[#y:]] = cir.load %{{.+}} : !cir.ptr<!cir.data_member<!s32i in !ty_Foo>>, !cir.data_member<!s32i in !ty_Foo>
+// CIR-NEXT:   %{{.+}} = cir.cmp(eq, %[[#x]], %[[#y]]) : !cir.data_member<!s32i in !ty_Foo>, !cir.bool
+//      CIR: }
+
+// LLVM-LABEL: @_Z2eqM3FooiS0_
+//      LLVM:   %[[#x:]] = load i64, ptr %{{.+}}, align 8
+// LLVM-NEXT:   %[[#y:]] = load i64, ptr %{{.+}}, align 8
+// LLVM-NEXT:   %{{.+}} = icmp eq i64 %[[#x]], %[[#y]]
+//      LLVM: }
+
+bool ne(int Foo::*x, int Foo::*y) {
+  return x != y;
+}
+
+// CIR-LABEL: @_Z2neM3FooiS0_
+//      CIR:   %[[#x:]] = cir.load %{{.+}} : !cir.ptr<!cir.data_member<!s32i in !ty_Foo>>, !cir.data_member<!s32i in !ty_Foo>
+// CIR-NEXT:   %[[#y:]] = cir.load %{{.+}} : !cir.ptr<!cir.data_member<!s32i in !ty_Foo>>, !cir.data_member<!s32i in !ty_Foo>
+// CIR-NEXT:   %{{.+}} = cir.cmp(ne, %[[#x]], %[[#y]]) : !cir.data_member<!s32i in !ty_Foo>, !cir.bool
+//      CIR: }
+
+// LLVM-LABEL: @_Z2neM3FooiS0_
+//      LLVM:   %[[#x:]] = load i64, ptr %{{.+}}, align 8
+// LLVM-NEXT:   %[[#y:]] = load i64, ptr %{{.+}}, align 8
+// LLVM-NEXT:   %{{.+}} = icmp ne i64 %[[#x]], %[[#y]]
+//      LLVM: }


### PR DESCRIPTION
This PR adds CIRGen and LLVM lowering support for the following language features related to pointers to data members:

  - Comparisons between pointers to data members.
  - Casting from pointers to data members to boolean.
  - Reinterpret casts between pointers to data members.