### PR TITLE
[CIR][CIRGen][Builtin][Neon] Lower vabsh_f16

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -3554,8 +3554,10 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
   switch (BuiltinID) {
   default:
     break;
-  case NEON::BI__builtin_neon_vabsh_f16:
-    llvm_unreachable("NEON::BI__builtin_neon_vabsh_f16 NYI");
+  case NEON::BI__builtin_neon_vabsh_f16: {
+    Ops.push_back(emitScalarExpr(E->getArg(0)));
+    return builder.create<cir::FAbsOp>(getLoc(E->getExprLoc()), Ops);
+  }
   case NEON::BI__builtin_neon_vaddq_p128: {
     llvm_unreachable("NEON::BI__builtin_neon_vaddq_p128 NYI");
   }

--- a/clang/test/CIR/CodeGen/AArch64/neon-fp16.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-fp16.c
@@ -19,12 +19,16 @@
 
 #include <arm_fp16.h>
 
-// NYI-LABEL: test_vabsh_f16
-// NYI:  [[ABS:%.*]] =  call half @llvm.fabs.f16(half %a)
-// NYI:  ret half [[ABS]]
-// float16_t test_vabsh_f16(float16_t a) {
-//   return vabsh_f16(a);
-// }
+// CIR-LABEL: vabsh_f16
+// CIR: {{%.*}}  = cir.fabs {{%.*}} : !cir.f16
+//
+// LLVM-LABEL: test_vabsh_f16
+// LLVM-SAME: (half [[a:%.]])
+// LLVM:  [[ABS:%.*]] =  call half @llvm.fabs.f16(half [[a]])
+// LLVM:  ret half [[ABS]]
+float16_t test_vabsh_f16(float16_t a) {
+  return vabsh_f16(a);
+}
 
 // NYI-LABEL: test_vceqzh_f16
 // NYI:  [[TMP1:%.*]] = fcmp oeq half %a, 0xH0000


### PR DESCRIPTION
Lower `vabsh_f16`

CG: https://github.com/llvm/clangir/blob/25b269e5fed544e1da37b72bc32315c0ae0c5aa6/clang/lib/CodeGen/CGBuiltin.cpp#L11975-L11977