### PR TITLE
[CIR] Cleanup: convert from Clang type to CIR type

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -455,7 +455,7 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
         uint64_t InputSize = getContext().getTypeSize(InputTy);
         if (getContext().getTypeSize(OutputType) < InputSize) {
           // Form the asm to return the value as a larger integer or fp type.
-          ResultRegTypes.back() = ConvertType(InputTy);
+          ResultRegTypes.back() = convertType(InputTy);
         }
       }
       if (mlir::Type AdjTy = getTargetHooks().adjustInlineAsmType(
@@ -478,7 +478,7 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
       // Otherwise there will be a mis-match if the matrix is also an
       // input-argument which is represented as vector.
       if (isa<MatrixType>(OutExpr->getType().getCanonicalType()))
-        DestAddr = DestAddr.withElementType(ConvertType(OutExpr->getType()));
+        DestAddr = DestAddr.withElementType(convertType(OutExpr->getType()));
 
       ArgTypes.push_back(DestAddr.getType());
       ArgElemTypes.push_back(DestAddr.getElementType());

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -2135,7 +2135,7 @@ static mlir::Value emitArmLdrexNon128Intrinsic(unsigned int builtinID,
   // Get Instrinc call
   CIRGenBuilderTy &builder = cgf.getBuilder();
   QualType clangResTy = clangCallExpr->getType();
-  mlir::Type realResTy = cgf.ConvertType(clangResTy);
+  mlir::Type realResTy = cgf.convertType(clangResTy);
   // Return type of LLVM intrinsic is defined in Intrinsic<arch_type>.td,
   // which can be found under LLVM IR directory.
   mlir::Type funcResTy = builder.getSInt64Ty();
@@ -2347,7 +2347,7 @@ emitCommonNeonCallPattern0(CIRGenFunction &cgf, llvm::StringRef intrincsName,
   mlir::Value res =
       emitNeonCall(builder, std::move(argTypes), ops, intrincsName, funcResTy,
                    cgf.getLoc(e->getExprLoc()));
-  mlir::Type resultType = cgf.ConvertType(e->getType());
+  mlir::Type resultType = cgf.convertType(e->getType());
   return builder.createBitcast(res, resultType);
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -1610,7 +1610,7 @@ void CIRGenFunction::emitNonNullArgCheck(RValue RV, QualType ArgType,
 mlir::Value CIRGenFunction::emitVAArg(VAArgExpr *VE, Address &VAListAddr) {
   assert(!VE->isMicrosoftABI() && "NYI");
   auto loc = CGM.getLoc(VE->getExprLoc());
-  auto type = ConvertType(VE->getType());
+  auto type = convertType(VE->getType());
   auto vaList = emitVAListRef(VE->getSubExpr()).getPointer();
   return builder.create<cir::VAArgOp>(loc, type, vaList);
 }

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -582,7 +582,7 @@ Address CIRGenFunction::getAddressOfDirectBaseInCompleteClass(
     mlir::Location loc, Address This, const CXXRecordDecl *Derived,
     const CXXRecordDecl *Base, bool BaseIsVirtual) {
   // 'this' must be a pointer (in some address space) to Derived.
-  assert(This.getElementType() == ConvertType(Derived));
+  assert(This.getElementType() == convertType(Derived));
 
   // Compute the offset of the virtual base.
   CharUnits Offset;
@@ -592,7 +592,7 @@ Address CIRGenFunction::getAddressOfDirectBaseInCompleteClass(
   else
     Offset = Layout.getBaseClassOffset(Base);
 
-  return builder.createBaseClassAddr(loc, This, ConvertType(Base),
+  return builder.createBaseClassAddr(loc, This, convertType(Base),
                                      Offset.getQuantity(),
                                      /*assume_not_null=*/true);
 }
@@ -1591,7 +1591,7 @@ Address CIRGenFunction::getAddressOfDerivedClass(
 
   QualType derivedTy =
       getContext().getCanonicalType(getContext().getTagDeclType(derived));
-  mlir::Type derivedValueTy = ConvertType(derivedTy);
+  mlir::Type derivedValueTy = convertType(derivedTy);
   CharUnits nonVirtualOffset =
       CGM.getNonVirtualBaseClassOffset(derived, pathBegin, pathEnd);
 

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -262,7 +262,7 @@ CIRGenFunction::emitCoroutineBody(const CoroutineBodyStmt &S) {
 
   // Initialize address of coroutine frame to null
   auto astVoidPtrTy = CGM.getASTContext().VoidPtrTy;
-  auto allocaTy = getTypes().convertTypeForMem(astVoidPtrTy);
+  auto allocaTy = convertTypeForMem(astVoidPtrTy);
   Address coroFrame =
       CreateTempAlloca(allocaTy, getContext().getTypeAlignInChars(astVoidPtrTy),
                        openCurlyLoc, "__coro_frame_addr",

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -139,7 +139,7 @@ CIRGenFunction::emitAutoVarAlloca(const VarDecl &D,
       if (isEscapingByRef)
         llvm_unreachable("NYI");
 
-      mlir::Type allocaTy = getTypes().convertTypeForMem(Ty);
+      mlir::Type allocaTy = convertTypeForMem(Ty);
       CharUnits allocaAlignment = alignment;
       // Create the temp alloca and declare variable using it.
       mlir::Value addrVal;
@@ -482,7 +482,7 @@ CIRGenModule::getOrCreateStaticVarDecl(const VarDecl &D,
   if (D.hasAttr<CUDASharedAttr>() || D.hasAttr<LoaderUninitializedAttr>())
     llvm_unreachable("CUDA is NYI");
   else if (Ty.getAddressSpace() != LangAS::opencl_local)
-    Init = builder.getZeroInitAttr(getTypes().ConvertType(Ty));
+    Init = builder.getZeroInitAttr(convertType(Ty));
 
   cir::GlobalOp GV = builder.createVersionedGlobal(
       getModule(), getLoc(D.getLocation()), Name, LTy, false, Linkage, AS);
@@ -620,7 +620,7 @@ void CIRGenFunction::emitStaticVarDecl(const VarDecl &D,
 
   // Store into LocalDeclMap before generating initializer to handle
   // circular references.
-  mlir::Type elemTy = getTypes().convertTypeForMem(D.getType());
+  mlir::Type elemTy = convertTypeForMem(D.getType());
   setAddrOfLocalVar(&D, Address(addr, elemTy, alignment));
 
   // We can't have a VLA here, but we can have a pointer to a VLA,

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -173,8 +173,7 @@ static Address emitPointerWithAlignment(const Expr *expr,
             llvm_unreachable("NYI");
         }
 
-        auto ElemTy =
-            cgf.getTypes().convertTypeForMem(expr->getType()->getPointeeType());
+        auto ElemTy = cgf.convertTypeForMem(expr->getType()->getPointeeType());
         addr = cgf.getBuilder().createElementBitCast(
             cgf.getLoc(expr->getSourceRange()), addr, ElemTy);
         if (CE->getCastKind() == CK_AddressSpaceConversion) {
@@ -443,7 +442,7 @@ LValue CIRGenFunction::emitLValueForFieldInitialization(
                                      FieldIndex);
 
   // Make sure that the address is pointing to the right type.
-  auto memTy = getTypes().convertTypeForMem(FieldType);
+  auto memTy = convertTypeForMem(FieldType);
   V = builder.createElementBitCast(getLoc(Field->getSourceRange()), V, memTy);
 
   // TODO: Generate TBAA information that describes this access as a structure
@@ -887,7 +886,7 @@ void CIRGenFunction::emitStoreThroughBitfieldLValue(RValue Src, LValue Dst,
     llvm_unreachable("volatile bit-field is not implemented for the AACPS");
 
   const CIRGenBitFieldInfo &info = Dst.getBitFieldInfo();
-  mlir::Type resLTy = getTypes().convertTypeForMem(Dst.getType());
+  mlir::Type resLTy = convertTypeForMem(Dst.getType());
   Address ptr = Dst.getBitFieldAddress();
 
   const bool useVolatile =
@@ -919,7 +918,7 @@ static LValue emitGlobalVarDeclLValue(CIRGenFunction &CGF, const Expr *E,
   // as part of getAddrOfGlobalVar.
   auto V = CGF.CGM.getAddrOfGlobalVar(VD);
 
-  auto RealVarTy = CGF.getTypes().convertTypeForMem(VD->getType());
+  auto RealVarTy = CGF.convertTypeForMem(VD->getType());
   cir::PointerType realPtrTy = CGF.getBuilder().getPointerTo(
       RealVarTy, cast_if_present<cir::AddressSpaceAttr>(
                      cast<cir::PointerType>(V.getType()).getAddrSpace()));
@@ -986,9 +985,8 @@ static LValue emitFunctionDeclLValue(CIRGenFunction &CGF, const Expr *E,
   mlir::Value addr = CGF.getBuilder().create<cir::GetGlobalOp>(
       loc, ptrTy, funcOp.getSymName());
 
-  if (funcOp.getFunctionType() !=
-      CGF.CGM.getTypes().ConvertType(FD->getType())) {
-    fnTy = CGF.CGM.getTypes().ConvertType(FD->getType());
+  if (funcOp.getFunctionType() != CGF.convertType(FD->getType())) {
+    fnTy = CGF.convertType(FD->getType());
     ptrTy = cir::PointerType::get(CGF.getBuilder().getContext(), fnTy);
 
     addr = CGF.getBuilder().create<cir::CastOp>(addr.getLoc(), ptrTy,
@@ -1616,7 +1614,7 @@ Address CIRGenFunction::emitArrayToPointerDecay(const Expr *E,
 
   mlir::Value ptr = CGM.getBuilder().maybeBuildArrayDecay(
       CGM.getLoc(E->getSourceRange()), Addr.getPointer(),
-      getTypes().convertTypeForMem(EltType));
+      convertTypeForMem(EltType));
   return Address(ptr, Addr.getAlignment());
 }
 
@@ -1757,7 +1755,7 @@ static Address emitArraySubscriptPtr(
     assert(0 && "NYI");
   }
 
-  return Address(eltPtr, CGF.getTypes().convertTypeForMem(eltType), eltAlign);
+  return Address(eltPtr, CGF.convertTypeForMem(eltType), eltAlign);
 }
 
 LValue CIRGenFunction::emitArraySubscriptExpr(const ArraySubscriptExpr *E,
@@ -1992,7 +1990,7 @@ LValue CIRGenFunction::emitCastLValue(const CastExpr *E) {
     if (LV.isSimple()) {
       Address V = LV.getAddress();
       if (V.isValid()) {
-        auto T = getTypes().convertTypeForMem(E->getType());
+        auto T = convertTypeForMem(E->getType());
         if (V.getElementType() != T)
           LV.setAddress(
               builder.createElementBitCast(getLoc(E->getSourceRange()), V, T));
@@ -2036,8 +2034,8 @@ LValue CIRGenFunction::emitCastLValue(const CastExpr *E) {
         builder.getAddrSpaceAttr(E->getSubExpr()->getType().getAddressSpace());
     auto DestAS = builder.getAddrSpaceAttr(E->getType().getAddressSpace());
     mlir::Value V = getTargetHooks().performAddrSpaceCast(
-        *this, LV.getPointer(), SrcAS, DestAS, ConvertType(DestTy));
-    return makeAddrLValue(Address(V, getTypes().convertTypeForMem(E->getType()),
+        *this, LV.getPointer(), SrcAS, DestAS, convertType(DestTy));
+    return makeAddrLValue(Address(V, convertTypeForMem(E->getType()),
                                   LV.getAddress().getAlignment()),
                           E->getType(), LV.getBaseInfo(), LV.getTBAAInfo());
   }
@@ -2872,7 +2870,7 @@ mlir::Value CIRGenFunction::emitAlloca(StringRef name, QualType ty,
                                        mlir::Location loc, CharUnits alignment,
                                        bool insertIntoFnEntryBlock,
                                        mlir::Value arraySize) {
-  return emitAlloca(name, getCIRType(ty), loc, alignment,
+  return emitAlloca(name, convertType(ty), loc, alignment,
                     insertIntoFnEntryBlock, arraySize);
 }
 
@@ -3011,7 +3009,7 @@ Address CIRGenFunction::emitLoadOfReference(LValue refLVal, mlir::Location loc,
   CharUnits align =
       CGM.getNaturalTypeAlignment(pointeeType, pointeeBaseInfo, pointeeTBAAInfo,
                                   /* forPointeeType= */ true);
-  return Address(load, getTypes().convertTypeForMem(pointeeType), align);
+  return Address(load, convertTypeForMem(pointeeType), align);
 }
 
 LValue CIRGenFunction::emitLoadOfReferenceLValue(LValue RefLVal,
@@ -3046,9 +3044,8 @@ Address CIRGenFunction::CreateMemTemp(QualType Ty, CharUnits Align,
                                       mlir::Location Loc, const Twine &Name,
                                       Address *Alloca,
                                       mlir::OpBuilder::InsertPoint ip) {
-  Address Result =
-      CreateTempAlloca(getTypes().convertTypeForMem(Ty), Align, Loc, Name,
-                       /*ArraySize=*/nullptr, Alloca, ip);
+  Address Result = CreateTempAlloca(convertTypeForMem(Ty), Align, Loc, Name,
+                                    /*ArraySize=*/nullptr, Alloca, ip);
   if (Ty->isConstantMatrixType()) {
     assert(0 && "NYI");
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -528,7 +528,7 @@ void AggExprEmitter::emitArrayInit(Address DestPtr, cir::ArrayType AType,
         /*condBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
           auto currentElement = builder.createLoad(loc, tmpAddr);
-          mlir::Type boolTy = CGF.getCIRType(CGF.getContext().BoolTy);
+          mlir::Type boolTy = CGF.convertType(CGF.getContext().BoolTy);
           auto cmp = builder.create<cir::CmpOp>(loc, boolTy, cir::CmpOpKind::ne,
                                                 currentElement, end);
           builder.createCondition(cmp);
@@ -999,7 +999,7 @@ void AggExprEmitter::VisitCastExpr(CastExpr *E) {
 
     // GCC union extension
     QualType Ty = E->getSubExpr()->getType();
-    Address CastPtr = Dest.getAddress().withElementType(CGF.ConvertType(Ty));
+    Address CastPtr = Dest.getAddress().withElementType(CGF.convertType(Ty));
     emitInitializationToLValue(E->getSubExpr(),
                                CGF.makeAddrLValue(CastPtr, Ty));
     break;

--- a/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
@@ -389,7 +389,7 @@ mlir::Value ComplexExprEmitter::emitComplexToComplexCast(mlir::Value Val,
     llvm_unreachable("unexpected src type or dest type");
 
   return Builder.createCast(CGF.getLoc(Loc), CastOpKind, Val,
-                            CGF.ConvertType(DestType));
+                            CGF.convertType(DestType));
 }
 
 mlir::Value ComplexExprEmitter::emitScalarToComplexCast(mlir::Value Val,
@@ -405,7 +405,7 @@ mlir::Value ComplexExprEmitter::emitScalarToComplexCast(mlir::Value Val,
     llvm_unreachable("unexpected src type");
 
   return Builder.createCast(CGF.getLoc(Loc), CastOpKind, Val,
-                            CGF.ConvertType(DestType));
+                            CGF.convertType(DestType));
 }
 
 mlir::Value ComplexExprEmitter::emitCast(CastKind CK, Expr *Op,
@@ -830,7 +830,7 @@ LValue ComplexExprEmitter::emitBinAssignLValue(const BinaryOperator *E,
 mlir::Value
 ComplexExprEmitter::VisitImaginaryLiteral(const ImaginaryLiteral *IL) {
   auto Loc = CGF.getLoc(IL->getExprLoc());
-  auto Ty = mlir::cast<cir::ComplexType>(CGF.getCIRType(IL->getType()));
+  auto Ty = mlir::cast<cir::ComplexType>(CGF.convertType(IL->getType()));
   auto ElementTy = Ty.getElementTy();
 
   mlir::TypedAttr RealValueAttr;
@@ -865,7 +865,7 @@ mlir::Value ComplexExprEmitter::VisitInitListExpr(InitListExpr *E) {
   // Empty init list initializes to null
   assert(E->getNumInits() == 0 && "Unexpected number of inits");
   QualType Ty = E->getType()->castAs<ComplexType>()->getElementType();
-  return Builder.getZero(CGF.getLoc(E->getExprLoc()), CGF.ConvertType(Ty));
+  return Builder.getZero(CGF.getLoc(E->getExprLoc()), CGF.convertType(Ty));
 }
 
 mlir::Value CIRGenFunction::emitPromotedComplexExpr(const Expr *E,
@@ -879,7 +879,7 @@ mlir::Value CIRGenFunction::emitPromotedValue(mlir::Value result,
              mlir::cast<cir::ComplexType>(result.getType()).getElementTy()) &&
          "integral complex will never be promoted");
   return builder.createCast(cir::CastKind::float_complex, result,
-                            ConvertType(PromotionType));
+                            convertType(PromotionType));
 }
 
 mlir::Value CIRGenFunction::emitUnPromotedValue(mlir::Value result,
@@ -888,7 +888,7 @@ mlir::Value CIRGenFunction::emitUnPromotedValue(mlir::Value result,
              mlir::cast<cir::ComplexType>(result.getType()).getElementTy()) &&
          "integral complex will never be promoted");
   return builder.createCast(cir::CastKind::float_complex, result,
-                            ConvertType(UnPromotionType));
+                            convertType(UnPromotionType));
 }
 
 mlir::Value CIRGenFunction::emitComplexExpr(const Expr *E) {

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -569,9 +569,9 @@ public:
 
   mlir::Type convertTypeForMem(QualType T);
 
-  mlir::Type ConvertType(clang::QualType T);
-  mlir::Type ConvertType(const TypeDecl *T) {
-    return ConvertType(getContext().getTypeDeclType(T));
+  mlir::Type convertType(clang::QualType T);
+  mlir::Type convertType(const TypeDecl *T) {
+    return convertType(getContext().getTypeDeclType(T));
   }
 
   ///  Return the cir::TypeEvaluationKind of QualType \c T.
@@ -1113,8 +1113,6 @@ public:
 
   mlir::Value emitFromMemory(mlir::Value Value, clang::QualType Ty);
 
-  mlir::Type convertType(clang::QualType T);
-
   mlir::LogicalResult emitAsmStmt(const clang::AsmStmt &S);
 
   std::pair<mlir::Value, mlir::Type>
@@ -1240,8 +1238,6 @@ public:
                                      QualType PromotionType);
   mlir::Value emitPromotedValue(mlir::Value result, QualType PromotionType);
   mlir::Value emitUnPromotedValue(mlir::Value result, QualType PromotionType);
-
-  mlir::Type getCIRType(const clang::QualType &type);
 
   const CaseStmt *foldCaseStmt(const clang::CaseStmt &S, mlir::Type condType,
                                mlir::ArrayAttr &value, cir::CaseOpKind &kind);

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -1678,8 +1678,8 @@ CIRGenItaniumRTTIBuilder::GetAddrOfTypeName(mlir::Location loc, QualType Ty,
   // We know that the mangled name of the type starts at index 4 of the
   // mangled name of the typename, so we can just index into it in order to
   // get the mangled name of the type.
-  auto Init = builder.getString(
-      Name.substr(4), CGM.getTypes().ConvertType(CGM.getASTContext().CharTy));
+  auto Init = builder.getString(Name.substr(4),
+                                CGM.convertType(CGM.getASTContext().CharTy));
   auto Align =
       CGM.getASTContext().getTypeAlignInChars(CGM.getASTContext().CharTy);
 
@@ -1770,8 +1770,7 @@ static unsigned ComputeVMIClassTypeInfoFlags(const CXXRecordDecl *RD) {
 /// constraints, according to the Itanium C++ ABI, 2.9.5p5c.
 void CIRGenItaniumRTTIBuilder::BuildVMIClassTypeInfo(mlir::Location loc,
                                                      const CXXRecordDecl *RD) {
-  auto UnsignedIntLTy =
-      CGM.getTypes().ConvertType(CGM.getASTContext().UnsignedIntTy);
+  auto UnsignedIntLTy = CGM.convertType(CGM.getASTContext().UnsignedIntTy);
   // Itanium C++ ABI 2.9.5p6c:
   //   __flags is a word with flags describing details about the class
   //   structure, which may be referenced by using the __flags_masks
@@ -1815,7 +1814,7 @@ void CIRGenItaniumRTTIBuilder::BuildVMIClassTypeInfo(mlir::Location loc,
   if (TI.getTriple().isOSCygMing() &&
       TI.getPointerWidth(LangAS::Default) > TI.getLongWidth())
     OffsetFlagsTy = CGM.getASTContext().LongLongTy;
-  auto OffsetFlagsLTy = CGM.getTypes().ConvertType(OffsetFlagsTy);
+  auto OffsetFlagsLTy = CGM.convertType(OffsetFlagsTy);
 
   for (const auto &Base : RD->bases()) {
     // The __base_type member points to the RTTI for the base type.
@@ -2241,7 +2240,7 @@ void CIRGenItaniumCXXABI::emitThrow(CIRGenFunction &CGF,
   // Now allocate the exception object.
   auto &builder = CGF.getBuilder();
   QualType clangThrowType = E->getSubExpr()->getType();
-  auto throwTy = builder.getPointerTo(CGF.ConvertType(clangThrowType));
+  auto throwTy = builder.getPointerTo(CGF.convertType(clangThrowType));
   uint64_t typeSize =
       CGF.getContext().getTypeSizeInChars(clangThrowType).getQuantity();
   auto subExprLoc = CGF.getLoc(E->getSubExpr()->getSourceRange());
@@ -2407,7 +2406,7 @@ static cir::FuncOp getItaniumDynamicCastFn(CIRGenFunction &CGF) {
 
   mlir::Type VoidPtrTy = CGF.VoidPtrTy;
   mlir::Type RTTIPtrTy = CGF.getBuilder().getUInt8PtrTy();
-  mlir::Type PtrDiffTy = CGF.ConvertType(CGF.getContext().getPointerDiffType());
+  mlir::Type PtrDiffTy = CGF.convertType(CGF.getContext().getPointerDiffType());
 
   // TODO(cir): mark the function as nowind readonly.
 
@@ -2579,7 +2578,7 @@ static cir::DynamicCastInfoAttr emitDynamicCastInfo(CIRGenFunction &CGF,
   const CXXRecordDecl *destDecl = DestRecordTy->getAsCXXRecordDecl();
   auto offsetHint = computeOffsetHint(CGF.getContext(), srcDecl, destDecl);
 
-  mlir::Type ptrdiffTy = CGF.ConvertType(CGF.getContext().getPointerDiffType());
+  mlir::Type ptrdiffTy = CGF.convertType(CGF.getContext().getPointerDiffType());
   auto offsetHintAttr = cir::IntAttr::get(ptrdiffTy, offsetHint.getQuantity());
 
   return cir::DynamicCastInfoAttr::get(srcRtti, destRtti, runtimeFuncRef,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -584,7 +584,7 @@ public:
                           GlobalDecl aliasGD, cir::FuncOp aliasee,
                           cir::GlobalLinkageKind linkage);
 
-  mlir::Type getCIRType(const clang::QualType &type);
+  mlir::Type convertType(clang::QualType type);
 
   /// Set the visibility for the given global.
   void setGlobalVisibility(mlir::Operation *Op, const NamedDecl *D) const;

--- a/clang/lib/CIR/CodeGen/CIRGenOpenCL.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenCL.cpp
@@ -204,7 +204,7 @@ void CIRGenFunction::emitKernelMetadata(const FunctionDecl *FD,
   mlir::IntegerAttr intelReqdSubGroupSizeAttr;
 
   if (const VecTypeHintAttr *A = FD->getAttr<VecTypeHintAttr>()) {
-    mlir::Type typeHintValue = getTypes().ConvertType(A->getTypeHint());
+    mlir::Type typeHintValue = convertType(A->getTypeHint());
     vecTypeHintAttr = mlir::TypeAttr::get(typeHintValue);
     vecTypeHintSignedness =
         OpenCLKernelMetadataAttr::isSignedHint(typeHintValue);

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.h
@@ -112,8 +112,8 @@ class CIRGenTypes {
 
   llvm::SmallVector<const clang::RecordDecl *, 8> DeferredRecords;
 
-  /// Heper for ConvertType.
-  mlir::Type ConvertFunctionTypeInternal(clang::QualType FT);
+  /// Heper for convertType.
+  mlir::Type convertFunctionTypeInternal(clang::QualType FT);
 
 public:
   CIRGenTypes(CIRGenModule &cgm);
@@ -165,7 +165,7 @@ public:
   CIRGenCXXABI &getCXXABI() const { return TheCXXABI; }
 
   /// Convert type T into a mlir::Type.
-  mlir::Type ConvertType(clang::QualType T);
+  mlir::Type convertType(clang::QualType T);
 
   mlir::Type convertRecordDeclType(const clang::RecordDecl *recordDecl);
 

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -129,13 +129,13 @@ private:
       if (testIfIsVoidTy(it->type))
         it->info = cir::ABIArgInfo::getIgnore();
       else
-        it->info = cir::ABIArgInfo::getDirect(CGT.ConvertType(it->type));
+        it->info = cir::ABIArgInfo::getDirect(CGT.convertType(it->type));
     }
     auto RetTy = FI.getReturnType();
     if (testIfIsVoidTy(RetTy))
       FI.getReturnInfo() = cir::ABIArgInfo::getIgnore();
     else
-      FI.getReturnInfo() = cir::ABIArgInfo::getDirect(CGT.ConvertType(RetTy));
+      FI.getReturnInfo() = cir::ABIArgInfo::getDirect(CGT.convertType(RetTy));
 
     return;
   }
@@ -334,13 +334,13 @@ void X86_64ABIInfo::computeInfo(CIRGenFunctionInfo &FI) const {
     if (testIfIsVoidTy(it->type))
       it->info = cir::ABIArgInfo::getIgnore();
     else
-      it->info = cir::ABIArgInfo::getDirect(CGT.ConvertType(it->type));
+      it->info = cir::ABIArgInfo::getDirect(CGT.convertType(it->type));
   }
   auto RetTy = FI.getReturnType();
   if (testIfIsVoidTy(RetTy))
     FI.getReturnInfo() = cir::ABIArgInfo::getIgnore();
   else
-    FI.getReturnInfo() = cir::ABIArgInfo::getDirect(CGT.ConvertType(RetTy));
+    FI.getReturnInfo() = cir::ABIArgInfo::getDirect(CGT.convertType(RetTy));
 }
 
 /// GetINTEGERTypeAtOffset - The ABI specifies that a value should be passed in
@@ -397,7 +397,7 @@ cir::ABIArgInfo X86_64ABIInfo::classifyArgumentType(QualType Ty,
     ++neededInt;
 
     // Pick an 8-byte type based on the preferred type.
-    ResType = GetINTEGERTypeAtOffset(CGT.ConvertType(Ty), 0, Ty, 0);
+    ResType = GetINTEGERTypeAtOffset(CGT.convertType(Ty), 0, Ty, 0);
 
     // If we have a sign or zero extended integer, make sure to return Extend so
     // that the parameter gets the right LLVM IR attributes.
@@ -414,7 +414,7 @@ cir::ABIArgInfo X86_64ABIInfo::classifyArgumentType(QualType Ty,
     // register is used, the registers are taken in the order from %xmm0 to
     // %xmm7.
   case Class::SSE: {
-    mlir::Type CIRType = CGT.ConvertType(Ty);
+    mlir::Type CIRType = CGT.convertType(Ty);
     ResType = GetSSETypeAtOffset(CIRType, 0, Ty, 0);
     ++neededSSE;
     break;
@@ -527,7 +527,7 @@ cir::ABIArgInfo X86_64ABIInfo::classifyReturnType(QualType RetTy) const {
   // AMD64-ABI 3.2.3p4: Rule 3. If the class is INTEGER, the next available
   // register of the sequence %rax, %rdx is used.
   case Class::Integer:
-    ResType = GetINTEGERTypeAtOffset(CGT.ConvertType(RetTy), 0, RetTy, 0);
+    ResType = GetINTEGERTypeAtOffset(CGT.convertType(RetTy), 0, RetTy, 0);
 
     // If we have a sign or zero extended integer, make sure to return Extend so
     // that the parameter gets the right LLVM IR attributes.
@@ -547,7 +547,7 @@ cir::ABIArgInfo X86_64ABIInfo::classifyReturnType(QualType RetTy) const {
     // AMD64-ABI 3.2.3p4: Rule 4. If the class is SSE, the next available SSE
     // register of the sequence %xmm0, %xmm1 is used.
   case Class::SSE:
-    ResType = GetSSETypeAtOffset(CGT.ConvertType(RetTy), 0, RetTy, 0);
+    ResType = GetSSETypeAtOffset(CGT.convertType(RetTy), 0, RetTy, 0);
     break;
 
   default:


### PR DESCRIPTION
Class `CIRGenFunction` contained three identical functions that converted from a Clang AST type (`clang::QualType`) to a ClangIR type (`mlir::Type`): `convertType`, `ConvertType`, and `getCIRType`.  This embarrassment of duplication needed to be fixed, along with cleaning up other functions that convert from Clang types to ClangIR types.

The three functions `CIRGenFunction::ConvertType`, `CIRGenFunction::convertType`, and `CIRGenFunction::getCIRType` were combined into a single function `CIRGenFunction::convertType`.  Other functions were renamed as follows:
- `CIRGenTypes::ConvertType` to `CIRGenTypes::convertType`
- `CIRGenTypes::ConvertFunctionTypeInternal` to `CIRGenTypes::convertFunctionTypeInternal`
- `CIRGenModule::getCIRType` to `CIRGenModule::convertType`
- `ConstExprEmitter::ConvertType` to `ConstExprEmitter::convertType`
- `ScalarExprEmitter::ConvertType` to `ScalarExprEmitter::convertType`

Many cases of `getTypes().convertType(t)` and `getTypes().convertTypeForMem(t)` were changed to just `convertType(t)` and `convertTypeForMem(t)`, respectively, because the forwarding functions in `CIRGenModule` and `CIRGenFunction` make the explicit call to `getTypes()` unnecessary.