### PR TITLE
[CIR][CIRGen] Add padding to unions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -86,12 +86,12 @@ public:
   /// Create a identified and complete struct type.
   static StructType get(mlir::MLIRContext *context,
                         llvm::ArrayRef<mlir::Type> members,
-                        mlir::StringAttr name, bool packed, RecordKind kind,
+                        mlir::StringAttr name, bool packed, bool padded, RecordKind kind,
                         ASTRecordDeclInterface ast = {});
   static StructType
   getChecked(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
              mlir::MLIRContext *context, llvm::ArrayRef<mlir::Type> members,
-             mlir::StringAttr name, bool packed, RecordKind kind,
+             mlir::StringAttr name, bool packed, bool padded, RecordKind kind,
              ASTRecordDeclInterface ast = {});
 
   /// Create a identified and incomplete struct type.
@@ -104,18 +104,18 @@ public:
 
   /// Create a anonymous struct type (always complete).
   static StructType get(mlir::MLIRContext *context,
-                        llvm::ArrayRef<mlir::Type> members, bool packed,
-                        RecordKind kind, ASTRecordDeclInterface ast = {});
+                        llvm::ArrayRef<mlir::Type> members, bool packed, 
+                        bool padded, RecordKind kind, ASTRecordDeclInterface ast = {});
   static StructType
   getChecked(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
              mlir::MLIRContext *context, llvm::ArrayRef<mlir::Type> members,
-             bool packed, RecordKind kind, ASTRecordDeclInterface ast = {});
+             bool packed, bool padded, RecordKind kind, ASTRecordDeclInterface ast = {});
 
   /// Validate the struct about to be constructed.
   static llvm::LogicalResult
   verifyInvariants(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
                    llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                   bool incomplete, bool packed, StructType::RecordKind kind,
+                   bool incomplete, bool packed, bool padded,  StructType::RecordKind kind,
                    ASTRecordDeclInterface ast);
 
   // Parse/print methods.
@@ -130,6 +130,7 @@ public:
   StructType::RecordKind getKind() const;
   bool getIncomplete() const;
   bool getPacked() const;
+  bool getPadded() const;
   void dropAst();
 
   // Predicates
@@ -157,7 +158,7 @@ public:
   }
 
   /// Complete the struct type by mutating its members and attributes.
-  void complete(llvm::ArrayRef<mlir::Type> members, bool packed,
+  void complete(llvm::ArrayRef<mlir::Type> members, bool packed, bool isPadded,
                 ASTRecordDeclInterface ast = {});
 
   /// DataLayoutTypeInterface methods.
@@ -177,8 +178,7 @@ private:
   // FIXME: currently opaque because there's a cycle if CIRTypes.types include
   // from CIRAttrs.h. The implementation operates in terms of StructLayoutAttr
   // instead.
-  mutable mlir::Attribute layoutInfo;
-  bool isPadded(const mlir::DataLayout &dataLayout) const;
+  mutable mlir::Attribute layoutInfo;  
   void computeSizeAndAlignment(const mlir::DataLayout &dataLayout) const;
 };
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -86,8 +86,8 @@ public:
   /// Create a identified and complete struct type.
   static StructType get(mlir::MLIRContext *context,
                         llvm::ArrayRef<mlir::Type> members,
-                        mlir::StringAttr name, bool packed, bool padded, RecordKind kind,
-                        ASTRecordDeclInterface ast = {});
+                        mlir::StringAttr name, bool packed, bool padded,
+                        RecordKind kind, ASTRecordDeclInterface ast = {});
   static StructType
   getChecked(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
              mlir::MLIRContext *context, llvm::ArrayRef<mlir::Type> members,
@@ -104,19 +104,21 @@ public:
 
   /// Create a anonymous struct type (always complete).
   static StructType get(mlir::MLIRContext *context,
-                        llvm::ArrayRef<mlir::Type> members, bool packed, 
-                        bool padded, RecordKind kind, ASTRecordDeclInterface ast = {});
+                        llvm::ArrayRef<mlir::Type> members, bool packed,
+                        bool padded, RecordKind kind,
+                        ASTRecordDeclInterface ast = {});
   static StructType
   getChecked(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
              mlir::MLIRContext *context, llvm::ArrayRef<mlir::Type> members,
-             bool packed, bool padded, RecordKind kind, ASTRecordDeclInterface ast = {});
+             bool packed, bool padded, RecordKind kind,
+             ASTRecordDeclInterface ast = {});
 
   /// Validate the struct about to be constructed.
   static llvm::LogicalResult
   verifyInvariants(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
                    llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                   bool incomplete, bool packed, bool padded,  StructType::RecordKind kind,
-                   ASTRecordDeclInterface ast);
+                   bool incomplete, bool packed, bool padded,
+                   StructType::RecordKind kind, ASTRecordDeclInterface ast);
 
   // Parse/print methods.
   static constexpr llvm::StringLiteral getMnemonic() { return {"struct"}; }
@@ -178,8 +180,8 @@ private:
   // FIXME: currently opaque because there's a cycle if CIRTypes.types include
   // from CIRAttrs.h. The implementation operates in terms of StructLayoutAttr
   // instead.
-  mutable mlir::Attribute layoutInfo;  
-  //bool isPadded(const mlir::DataLayout &dataLayout) const;
+  mutable mlir::Attribute layoutInfo;
+  // bool isPadded(const mlir::DataLayout &dataLayout) const;
   void computeSizeAndAlignment(const mlir::DataLayout &dataLayout) const;
 };
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -181,7 +181,6 @@ private:
   // from CIRAttrs.h. The implementation operates in terms of StructLayoutAttr
   // instead.
   mutable mlir::Attribute layoutInfo;
-  // bool isPadded(const mlir::DataLayout &dataLayout) const;
   void computeSizeAndAlignment(const mlir::DataLayout &dataLayout) const;
 };
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -179,6 +179,7 @@ private:
   // from CIRAttrs.h. The implementation operates in terms of StructLayoutAttr
   // instead.
   mutable mlir::Attribute layoutInfo;  
+  //bool isPadded(const mlir::DataLayout &dataLayout) const;
   void computeSizeAndAlignment(const mlir::DataLayout &dataLayout) const;
 };
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
@@ -52,7 +52,7 @@ struct StructTypeStorage : public mlir::TypeStorage {
   ASTRecordDeclInterface ast;
 
   StructTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                    bool incomplete, bool packed, bool padded, 
+                    bool incomplete, bool packed, bool padded,
                     StructType::RecordKind kind, ASTRecordDeclInterface ast)
       : members(members), name(name), incomplete(incomplete), packed(packed),
         padded(padded), kind(kind), ast(ast) {}
@@ -72,16 +72,15 @@ struct StructTypeStorage : public mlir::TypeStorage {
   static llvm::hash_code hashKey(const KeyTy &key) {
     if (key.name)
       return llvm::hash_combine(key.name, key.kind);
-    return llvm::hash_combine(key.members, key.incomplete, key.packed, 
+    return llvm::hash_combine(key.members, key.incomplete, key.packed,
                               key.padded, key.kind, key.ast);
   }
 
   static StructTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
                                       const KeyTy &key) {
-    return new (allocator.allocate<StructTypeStorage>())
-        StructTypeStorage(allocator.copyInto(key.members), key.name,
-                          key.incomplete, key.packed, key.padded, 
-                          key.kind, key.ast);
+    return new (allocator.allocate<StructTypeStorage>()) StructTypeStorage(
+        allocator.copyInto(key.members), key.name, key.incomplete, key.packed,
+        key.padded, key.kind, key.ast);
   }
 
   /// Mutates the members and attributes an identified struct.
@@ -100,8 +99,8 @@ struct StructTypeStorage : public mlir::TypeStorage {
     // Mutation of complete structs are allowed if they change nothing.
     if (!incomplete)
       return mlir::success((this->members == members) &&
-                           (this->packed == packed) && (this->padded == padded) &&
-                           (this->ast == ast));
+                           (this->packed == packed) &&
+                           (this->padded == padded) && (this->ast == ast));
 
     // Mutate incomplete struct.
     this->members = allocator.copyInto(members);

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
@@ -32,31 +32,33 @@ struct StructTypeStorage : public mlir::TypeStorage {
     mlir::StringAttr name;
     bool incomplete;
     bool packed;
+    bool padded;
     StructType::RecordKind kind;
     ASTRecordDeclInterface ast;
 
     KeyTy(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-          bool incomplete, bool packed, StructType::RecordKind kind,
-          ASTRecordDeclInterface ast)
+          bool incomplete, bool packed, bool padded,
+          StructType::RecordKind kind, ASTRecordDeclInterface ast)
         : members(members), name(name), incomplete(incomplete), packed(packed),
-          kind(kind), ast(ast) {}
+          padded(padded), kind(kind), ast(ast) {}
   };
 
   llvm::ArrayRef<mlir::Type> members;
   mlir::StringAttr name;
   bool incomplete;
   bool packed;
+  bool padded;
   StructType::RecordKind kind;
   ASTRecordDeclInterface ast;
 
   StructTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                    bool incomplete, bool packed, StructType::RecordKind kind,
-                    ASTRecordDeclInterface ast)
+                    bool incomplete, bool packed, bool padded, 
+                    StructType::RecordKind kind, ASTRecordDeclInterface ast)
       : members(members), name(name), incomplete(incomplete), packed(packed),
-        kind(kind), ast(ast) {}
+        padded(padded), kind(kind), ast(ast) {}
 
   KeyTy getAsKey() const {
-    return KeyTy(members, name, incomplete, packed, kind, ast);
+    return KeyTy(members, name, incomplete, packed, padded, kind, ast);
   }
 
   bool operator==(const KeyTy &key) const {
@@ -64,21 +66,22 @@ struct StructTypeStorage : public mlir::TypeStorage {
       return (name == key.name) && (kind == key.kind);
     return (members == key.members) && (name == key.name) &&
            (incomplete == key.incomplete) && (packed == key.packed) &&
-           (kind == key.kind) && (ast == key.ast);
+           (padded == key.padded) && (kind == key.kind) && (ast == key.ast);
   }
 
   static llvm::hash_code hashKey(const KeyTy &key) {
     if (key.name)
       return llvm::hash_combine(key.name, key.kind);
-    return llvm::hash_combine(key.members, key.incomplete, key.packed, key.kind,
-                              key.ast);
+    return llvm::hash_combine(key.members, key.incomplete, key.packed, 
+                              key.padded, key.kind, key.ast);
   }
 
   static StructTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
                                       const KeyTy &key) {
     return new (allocator.allocate<StructTypeStorage>())
         StructTypeStorage(allocator.copyInto(key.members), key.name,
-                          key.incomplete, key.packed, key.kind, key.ast);
+                          key.incomplete, key.packed, key.padded, 
+                          key.kind, key.ast);
   }
 
   /// Mutates the members and attributes an identified struct.
@@ -89,7 +92,7 @@ struct StructTypeStorage : public mlir::TypeStorage {
   /// change the struct.
   llvm::LogicalResult mutate(mlir::TypeStorageAllocator &allocator,
                              llvm::ArrayRef<mlir::Type> members, bool packed,
-                             ASTRecordDeclInterface ast) {
+                             bool padded, ASTRecordDeclInterface ast) {
     // Anonymous structs cannot mutate.
     if (!name)
       return llvm::failure();
@@ -97,12 +100,14 @@ struct StructTypeStorage : public mlir::TypeStorage {
     // Mutation of complete structs are allowed if they change nothing.
     if (!incomplete)
       return mlir::success((this->members == members) &&
-                           (this->packed == packed) && (this->ast == ast));
+                           (this->packed == packed) && (this->padded == padded) &&
+                           (this->ast == ast));
 
     // Mutate incomplete struct.
     this->members = allocator.copyInto(members);
     this->packed = packed;
     this->ast = ast;
+    this->padded = padded;
 
     incomplete = false;
     return llvm::success();

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -620,7 +620,7 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
   else if (ResultRegTypes.size() > 1) {
     auto sname = builder.getUniqueAnonRecordName();
     ResultType =
-        builder.getCompleteStructTy(ResultRegTypes, sname, false, nullptr);
+        builder.getCompleteStructTy(ResultRegTypes, sname, false, false, nullptr);
   }
 
   bool HasSideEffect = S.isVolatile() || S.getNumOutputs() == 0;

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -619,8 +619,8 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
     ResultType = ResultRegTypes[0];
   else if (ResultRegTypes.size() > 1) {
     auto sname = builder.getUniqueAnonRecordName();
-    ResultType =
-        builder.getCompleteStructTy(ResultRegTypes, sname, false, false, nullptr);
+    ResultType = builder.getCompleteStructTy(ResultRegTypes, sname, false,
+                                             false, nullptr);
   }
 
   bool HasSideEffect = S.isVolatile() || S.getNumOutputs() == 0;

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -194,9 +194,9 @@ public:
 
     // Struct type not specified: create anon struct type from members.
     if (!structTy)
-      structTy =
-          getType<cir::StructType>(members, packed, padded, cir::StructType::Struct,
-                                   /*ast=*/nullptr);
+      structTy = getType<cir::StructType>(members, packed, padded,
+                                          cir::StructType::Struct,
+                                          /*ast=*/nullptr);
 
     // Return zero or anonymous constant struct.
     if (isZero)
@@ -436,8 +436,7 @@ public:
 
   /// Get a CIR anonymous struct type.
   cir::StructType getAnonStructTy(llvm::ArrayRef<mlir::Type> members,
-                                  bool packed = false,
-                                  bool padded = false,
+                                  bool packed = false, bool padded = false,
                                   const clang::RecordDecl *ast = nullptr) {
     cir::ASTRecordDeclAttr astAttr = nullptr;
     auto kind = cir::StructType::RecordKind::Struct;
@@ -491,8 +490,8 @@ public:
     }
 
     // Create or get the struct.
-    auto type =
-        getType<cir::StructType>(members, nameAttr, packed, padded, kind, astAttr);
+    auto type = getType<cir::StructType>(members, nameAttr, packed, padded,
+                                         kind, astAttr);
 
     // Complete an incomplete struct or ensure the existing complete struct
     // matches the requested attributes.
@@ -503,8 +502,7 @@ public:
 
   cir::StructType
   getCompleteStructType(mlir::ArrayAttr fields, bool packed = false,
-                        bool padded = false,
-                        llvm::StringRef name = "",
+                        bool padded = false, llvm::StringRef name = "",
                         const clang::RecordDecl *ast = nullptr) {
     llvm::SmallVector<mlir::Type, 8> members;
     for (auto &attr : fields) {

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -178,6 +178,7 @@ public:
 
   mlir::Attribute getConstStructOrZeroAttr(mlir::ArrayAttr arrayAttr,
                                            bool packed = false,
+                                           bool padded = false,
                                            mlir::Type type = {}) {
     llvm::SmallVector<mlir::Type, 8> members;
     auto structTy = mlir::dyn_cast<cir::StructType>(type);
@@ -194,7 +195,7 @@ public:
     // Struct type not specified: create anon struct type from members.
     if (!structTy)
       structTy =
-          getType<cir::StructType>(members, packed, cir::StructType::Struct,
+          getType<cir::StructType>(members, packed, padded, cir::StructType::Struct,
                                    /*ast=*/nullptr);
 
     // Return zero or anonymous constant struct.
@@ -205,6 +206,7 @@ public:
 
   cir::ConstStructAttr getAnonConstStruct(mlir::ArrayAttr arrayAttr,
                                           bool packed = false,
+                                          bool padded = false,
                                           mlir::Type ty = {}) {
     llvm::SmallVector<mlir::Type, 4> members;
     for (auto &f : arrayAttr) {
@@ -214,7 +216,7 @@ public:
     }
 
     if (!ty)
-      ty = getAnonStructTy(members, packed);
+      ty = getAnonStructTy(members, packed, padded);
 
     auto sTy = mlir::dyn_cast<cir::StructType>(ty);
     assert(sTy && "expected struct type");
@@ -435,6 +437,7 @@ public:
   /// Get a CIR anonymous struct type.
   cir::StructType getAnonStructTy(llvm::ArrayRef<mlir::Type> members,
                                   bool packed = false,
+                                  bool padded = false,
                                   const clang::RecordDecl *ast = nullptr) {
     cir::ASTRecordDeclAttr astAttr = nullptr;
     auto kind = cir::StructType::RecordKind::Struct;
@@ -442,7 +445,7 @@ public:
       astAttr = getAttr<cir::ASTRecordDeclAttr>(ast);
       kind = getRecordKind(ast->getTagKind());
     }
-    return getType<cir::StructType>(members, packed, kind, astAttr);
+    return getType<cir::StructType>(members, packed, padded, kind, astAttr);
   }
 
   /// Get a CIR record kind from a AST declaration tag.
@@ -477,6 +480,7 @@ public:
   /// it with a different set of attributes, this method will crash.
   cir::StructType getCompleteStructTy(llvm::ArrayRef<mlir::Type> members,
                                       llvm::StringRef name, bool packed,
+                                      bool padded,
                                       const clang::RecordDecl *ast) {
     const auto nameAttr = getStringAttr(name);
     cir::ASTRecordDeclAttr astAttr = nullptr;
@@ -488,17 +492,18 @@ public:
 
     // Create or get the struct.
     auto type =
-        getType<cir::StructType>(members, nameAttr, packed, kind, astAttr);
+        getType<cir::StructType>(members, nameAttr, packed, padded, kind, astAttr);
 
     // Complete an incomplete struct or ensure the existing complete struct
     // matches the requested attributes.
-    type.complete(members, packed, astAttr);
+    type.complete(members, packed, padded, astAttr);
 
     return type;
   }
 
   cir::StructType
   getCompleteStructType(mlir::ArrayAttr fields, bool packed = false,
+                        bool padded = false,
                         llvm::StringRef name = "",
                         const clang::RecordDecl *ast = nullptr) {
     llvm::SmallVector<mlir::Type, 8> members;
@@ -508,9 +513,9 @@ public:
     }
 
     if (name.empty())
-      return getAnonStructTy(members, packed, ast);
+      return getAnonStructTy(members, packed, padded, ast);
     else
-      return getCompleteStructTy(members, name, packed, ast);
+      return getCompleteStructTy(members, name, packed, padded, ast);
   }
 
   cir::ArrayType getArrayType(mlir::Type eltType, unsigned size) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -385,6 +385,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   CharUnits AlignedSize = Size.alignTo(Align);
 
   bool Packed = false;
+  bool Padded = false;
   ArrayRef<mlir::Attribute> UnpackedElems = Elems;
 
   llvm::SmallVector<mlir::Attribute, 32> UnpackedElemStorage;
@@ -435,17 +436,17 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   auto &builder = CGM.getBuilder();
   auto arrAttr = mlir::ArrayAttr::get(builder.getContext(),
                                       Packed ? PackedElems : UnpackedElems);
+  
   auto strType = builder.getCompleteStructType(arrAttr, Packed);
-
   if (auto desired = dyn_cast<cir::StructType>(DesiredTy))
     if (desired.isLayoutIdentical(strType))
       strType = desired;
 
-  return builder.getConstStructOrZeroAttr(arrAttr, Packed, strType);
+  return builder.getConstStructOrZeroAttr(arrAttr, Packed, Padded, strType);
 }
 
 void ConstantAggregateBuilder::condense(CharUnits Offset,
-                                        mlir::Type DesiredTy) {
+                                        mlir::Type DesiredTy) {  
   CharUnits Size = getSize(DesiredTy);
 
   std::optional<size_t> FirstElemToReplace = splitAt(Offset);
@@ -520,6 +521,9 @@ private:
   bool ApplyZeroInitPadding(const ASTRecordLayout &Layout, unsigned FieldNo,
                             const FieldDecl &Field, bool AllowOverwrite,
                             CharUnits &SizeSoFar, bool &ZeroFieldSize);
+
+  bool ApplyZeroInitPadding(const ASTRecordLayout &Layout, bool AllowOverwrite,
+                            CharUnits SizeSoFar);
 
   mlir::Attribute Finalize(QualType Ty);
 };
@@ -715,6 +719,10 @@ bool ConstStructBuilder::Build(InitListExpr *ILE, bool AllowOverwrite) {
     }
   }
 
+  if (ZeroInitPadding && !ApplyZeroInitPadding(Layout, AllowOverwrite, SizeSoFar))
+    return false;
+
+
   return true;
 }
 
@@ -850,6 +858,19 @@ bool ConstStructBuilder::ApplyZeroInitPadding(
     }
     ZeroFieldSize = Info.Size == 0;
   }
+  return true;
+}
+
+bool ConstStructBuilder::ApplyZeroInitPadding(const ASTRecordLayout &Layout,
+                                           bool AllowOverwrite,
+                                           CharUnits SizeSoFar) {
+  CharUnits TotalSize = Layout.getSize();
+  if (SizeSoFar < TotalSize) {
+      if (!AppendBytes(SizeSoFar, computePadding(CGM, TotalSize - SizeSoFar),
+                     AllowOverwrite))
+      return false;
+  }
+  SizeSoFar = TotalSize;
   return true;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -436,7 +436,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   auto &builder = CGM.getBuilder();
   auto arrAttr = mlir::ArrayAttr::get(builder.getContext(),
                                       Packed ? PackedElems : UnpackedElems);
-  
+
   auto strType = builder.getCompleteStructType(arrAttr, Packed);
   if (auto desired = dyn_cast<cir::StructType>(DesiredTy))
     if (desired.isLayoutIdentical(strType))
@@ -446,7 +446,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
 }
 
 void ConstantAggregateBuilder::condense(CharUnits Offset,
-                                        mlir::Type DesiredTy) {  
+                                        mlir::Type DesiredTy) {
   CharUnits Size = getSize(DesiredTy);
 
   std::optional<size_t> FirstElemToReplace = splitAt(Offset);
@@ -719,9 +719,9 @@ bool ConstStructBuilder::Build(InitListExpr *ILE, bool AllowOverwrite) {
     }
   }
 
-  if (ZeroInitPadding && !ApplyZeroInitPadding(Layout, AllowOverwrite, SizeSoFar))
+  if (ZeroInitPadding &&
+      !ApplyZeroInitPadding(Layout, AllowOverwrite, SizeSoFar))
     return false;
-
 
   return true;
 }
@@ -862,11 +862,11 @@ bool ConstStructBuilder::ApplyZeroInitPadding(
 }
 
 bool ConstStructBuilder::ApplyZeroInitPadding(const ASTRecordLayout &Layout,
-                                           bool AllowOverwrite,
-                                           CharUnits SizeSoFar) {
+                                              bool AllowOverwrite,
+                                              CharUnits SizeSoFar) {
   CharUnits TotalSize = Layout.getSize();
   if (SizeSoFar < TotalSize) {
-      if (!AppendBytes(SizeSoFar, computePadding(CGM, TotalSize - SizeSoFar),
+    if (!AppendBytes(SizeSoFar, computePadding(CGM, TotalSize - SizeSoFar),
                      AllowOverwrite))
       return false;
   }

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -238,7 +238,7 @@ CIRRecordLowering::CIRRecordLowering(CIRGenTypes &cirGenTypes,
       astRecordLayout{cirGenTypes.getContext().getASTRecordLayout(recordDecl)},
       dataLayout{cirGenTypes.getModule().getModule()},
       IsZeroInitializable(true), IsZeroInitializableAsBase(true),
-      isPacked{isPacked} {}
+      isPacked{isPacked}, isPadded{false} {}
 
 void CIRRecordLowering::setBitFieldInfo(const FieldDecl *FD,
                                         CharUnits StartOffset,

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -197,8 +197,10 @@ struct CIRRecordLowering final {
   void fillOutputFields();
 
   void appendPaddingBytes(CharUnits Size) {
-    if (!Size.isZero())
+    if (!Size.isZero()) {
       fieldTypes.push_back(getByteArrayType(Size));
+      isPadded = 1;    
+    }
   }
 
   CIRGenTypes &cirGenTypes;
@@ -219,6 +221,7 @@ struct CIRRecordLowering final {
   bool IsZeroInitializable : 1;
   bool IsZeroInitializableAsBase : 1;
   bool isPacked : 1;
+  bool isPadded : 1;
 
 private:
   CIRRecordLowering(const CIRRecordLowering &) = delete;
@@ -366,7 +369,7 @@ void CIRRecordLowering::lowerUnion() {
   if (LayoutSize < getSize(StorageType))
     StorageType = getByteArrayType(LayoutSize);
   // NOTE(cir): Defer padding calculations to the lowering process.
-  // appendPaddingBytes(LayoutSize - getSize(StorageType));
+  appendPaddingBytes(LayoutSize - getSize(StorageType));
   // Set packed if we need it.
   if (LayoutSize % getAlignment(StorageType))
     isPacked = true;
@@ -680,6 +683,7 @@ void CIRRecordLowering::insertPadding() {
   }
   if (Padding.empty())
     return;
+  isPadded = 1;
   // Add the padding to the Members list and sort it.
   for (std::vector<std::pair<CharUnits, CharUnits>>::const_iterator
            Pad = Padding.begin(),
@@ -706,7 +710,8 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *D, cir::StructType *Ty) {
       baseBuilder.lower(/*NonVirtualBaseType=*/true);
       auto baseIdentifier = getRecordTypeName(D, ".base");
       BaseTy = Builder.getCompleteStructTy(
-          baseBuilder.fieldTypes, baseIdentifier, baseBuilder.isPacked, D);
+          baseBuilder.fieldTypes, baseIdentifier, baseBuilder.isPacked, baseBuilder.isPadded, 
+          D);
       // TODO(cir): add something like addRecordTypeName
 
       // BaseTy and Ty must agree on their packedness for getCIRFieldNo to work
@@ -720,7 +725,7 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *D, cir::StructType *Ty) {
   // signifies that the type is no longer opaque and record layout is complete,
   // but we may need to recursively layout D while laying D out as a base type.
   auto astAttr = cir::ASTRecordDeclAttr::get(Ty->getContext(), D);
-  Ty->complete(builder.fieldTypes, builder.isPacked, astAttr);
+  Ty->complete(builder.fieldTypes, builder.isPacked, builder.isPadded, astAttr);
 
   auto RL = std::make_unique<CIRGenRecordLayout>(
       Ty ? *Ty : cir::StructType{}, BaseTy ? BaseTy : cir::StructType{},

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -199,7 +199,7 @@ struct CIRRecordLowering final {
   void appendPaddingBytes(CharUnits Size) {
     if (!Size.isZero()) {
       fieldTypes.push_back(getByteArrayType(Size));
-      isPadded = 1;    
+      isPadded = 1;
     }
   }
 
@@ -709,9 +709,9 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *D, cir::StructType *Ty) {
       CIRRecordLowering baseBuilder(*this, D, /*Packed=*/builder.isPacked);
       baseBuilder.lower(/*NonVirtualBaseType=*/true);
       auto baseIdentifier = getRecordTypeName(D, ".base");
-      BaseTy = Builder.getCompleteStructTy(
-          baseBuilder.fieldTypes, baseIdentifier, baseBuilder.isPacked, baseBuilder.isPadded, 
-          D);
+      BaseTy = Builder.getCompleteStructTy(baseBuilder.fieldTypes,
+                                           baseIdentifier, baseBuilder.isPacked,
+                                           baseBuilder.isPadded, D);
       // TODO(cir): add something like addRecordTypeName
 
       // BaseTy and Ty must agree on their packedness for getCIRFieldNo to work

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -212,16 +212,18 @@ llvm::TypeSize CIRDataLayout::getTypeSizeInBits(mlir::Type Ty) const {
 
     // FIXME(cir): CIR struct's data layout implementation doesn't do a good job
     // of handling unions particularities. We should have a separate union type.
-    if (structTy.isUnion()) {
-      auto largestMember = structTy.getLargestMember(layout);
-      return llvm::TypeSize::getFixed(layout.getTypeSizeInBits(largestMember));
-    }
+    // if (structTy.isUnion()) {
+    //   auto largestMember = structTy.getLargestMember(layout);
+    //   return llvm::TypeSize::getFixed(layout.getTypeSizeInBits(largestMember));
+    // }
 
     // FIXME(cir): We should be able to query the size of a struct directly to
     // its data layout implementation instead of requiring a separate
     // StructLayout object.
     // Get the layout annotation... which is lazily created on demand.
-    return getStructLayout(structTy)->getSizeInBits();
+    return structTy.getTypeSizeInBits(layout, {});
+    
+    //return getStructLayout(structTy)->getSizeInBits();
   }
 
   // FIXME(cir): This does not account for different address spaces, and relies

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -209,22 +209,9 @@ llvm::TypeSize CIRDataLayout::getTypeSizeInBits(mlir::Type Ty) const {
          "Cannot getTypeInfo() on a type that is unsized!");
 
   if (auto structTy = llvm::dyn_cast<cir::StructType>(Ty)) {
-
     // FIXME(cir): CIR struct's data layout implementation doesn't do a good job
     // of handling unions particularities. We should have a separate union type.
-    // if (structTy.isUnion()) {
-    //   auto largestMember = structTy.getLargestMember(layout);
-    //   return
-    //   llvm::TypeSize::getFixed(layout.getTypeSizeInBits(largestMember));
-    // }
-
-    // FIXME(cir): We should be able to query the size of a struct directly to
-    // its data layout implementation instead of requiring a separate
-    // StructLayout object.
-    // Get the layout annotation... which is lazily created on demand.
     return structTy.getTypeSizeInBits(layout, {});
-
-    // return getStructLayout(structTy)->getSizeInBits();
   }
 
   // FIXME(cir): This does not account for different address spaces, and relies

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -214,7 +214,8 @@ llvm::TypeSize CIRDataLayout::getTypeSizeInBits(mlir::Type Ty) const {
     // of handling unions particularities. We should have a separate union type.
     // if (structTy.isUnion()) {
     //   auto largestMember = structTy.getLargestMember(layout);
-    //   return llvm::TypeSize::getFixed(layout.getTypeSizeInBits(largestMember));
+    //   return
+    //   llvm::TypeSize::getFixed(layout.getTypeSizeInBits(largestMember));
     // }
 
     // FIXME(cir): We should be able to query the size of a struct directly to
@@ -222,8 +223,8 @@ llvm::TypeSize CIRDataLayout::getTypeSizeInBits(mlir::Type Ty) const {
     // StructLayout object.
     // Get the layout annotation... which is lazily created on demand.
     return structTy.getTypeSizeInBits(layout, {});
-    
-    //return getStructLayout(structTy)->getSizeInBits();
+
+    // return getStructLayout(structTy)->getSizeInBits();
   }
 
   // FIXME(cir): This does not account for different address spaces, and relies

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -35,6 +35,7 @@
 #include "llvm/Support/MathExtras.h"
 #include <cassert>
 #include <optional>
+#include <iostream>
 
 using cir::MissingFeatures;
 
@@ -128,6 +129,7 @@ Type StructType::parse(mlir::AsmParser &parser) {
   const auto loc = parser.getCurrentLocation();
   const auto eLoc = parser.getEncodedSourceLoc(loc);
   bool packed = false;
+  bool padded = false;
   RecordKind kind;
   auto *context = parser.getContext();
 
@@ -172,6 +174,9 @@ Type StructType::parse(mlir::AsmParser &parser) {
 
   if (parser.parseOptionalKeyword("packed").succeeded())
     packed = true;
+  
+  if (parser.parseOptionalKeyword("padded").succeeded())
+    padded = true;
 
   // Parse record members or lack thereof.
   bool incomplete = true;
@@ -200,13 +205,13 @@ Type StructType::parse(mlir::AsmParser &parser) {
   if (name && incomplete) { // Identified & incomplete
     type = getChecked(eLoc, context, name, kind);
   } else if (name && !incomplete) { // Identified & complete
-    type = getChecked(eLoc, context, membersRef, name, packed, kind);
+    type = getChecked(eLoc, context, membersRef, name, packed, padded, kind);
     // If the record has a self-reference, its type already exists in a
     // incomplete state. In this case, we must complete it.
     if (mlir::cast<StructType>(type).isIncomplete())
-      mlir::cast<StructType>(type).complete(membersRef, packed, ast);
+      mlir::cast<StructType>(type).complete(membersRef, packed, padded, ast);
   } else if (!name && !incomplete) { // anonymous & complete
-    type = getChecked(eLoc, context, membersRef, packed, kind);
+    type = getChecked(eLoc, context, membersRef, packed, padded, kind);
   } else { // anonymous & incomplete
     parser.emitError(loc, "anonymous structs must be complete");
     return {};
@@ -247,6 +252,9 @@ void StructType::print(mlir::AsmPrinter &printer) const {
   if (getPacked())
     printer << "packed ";
 
+  if (getPadded())
+    printer << "padded ";
+
   if (isIncomplete()) {
     printer << "incomplete";
   } else {
@@ -266,7 +274,7 @@ void StructType::print(mlir::AsmPrinter &printer) const {
 mlir::LogicalResult StructType::verifyInvariants(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
     llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name, bool incomplete,
-    bool packed, cir::StructType::RecordKind kind, ASTRecordDeclInterface ast) {
+    bool packed, bool padded, cir::StructType::RecordKind kind, ASTRecordDeclInterface ast) {
   if (name && name.getValue().empty()) {
     emitError() << "identified structs cannot have an empty name";
     return mlir::failure();
@@ -276,24 +284,24 @@ mlir::LogicalResult StructType::verifyInvariants(
 
 void StructType::dropAst() { getImpl()->ast = nullptr; }
 StructType StructType::get(::mlir::MLIRContext *context, ArrayRef<Type> members,
-                           StringAttr name, bool packed, RecordKind kind,
+                           StringAttr name, bool packed, bool padded, RecordKind kind,
                            ASTRecordDeclInterface ast) {
-  return Base::get(context, members, name, /*incomplete=*/false, packed, kind,
+  return Base::get(context, members, name, /*incomplete=*/false, packed, padded, kind,
                    ast);
 }
 
 StructType StructType::getChecked(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     ::mlir::MLIRContext *context, ArrayRef<Type> members, StringAttr name,
-    bool packed, RecordKind kind, ASTRecordDeclInterface ast) {
+    bool packed, bool padded, RecordKind kind, ASTRecordDeclInterface ast) {
   return Base::getChecked(emitError, context, members, name,
-                          /*incomplete=*/false, packed, kind, ast);
+                          /*incomplete=*/false, packed, padded, kind, ast);
 }
 
 StructType StructType::get(::mlir::MLIRContext *context, StringAttr name,
                            RecordKind kind) {
   return Base::get(context, /*members=*/ArrayRef<Type>{}, name,
-                   /*incomplete=*/true, /*packed=*/false, kind,
+                   /*incomplete=*/true, /*packed=*/false, /*padded=*/false, kind,
                    /*ast=*/ASTRecordDeclInterface{});
 }
 
@@ -301,23 +309,24 @@ StructType StructType::getChecked(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     ::mlir::MLIRContext *context, StringAttr name, RecordKind kind) {
   return Base::getChecked(emitError, context, ArrayRef<Type>{}, name,
-                          /*incomplete=*/true, /*packed=*/false, kind,
+                          /*incomplete=*/true, /*packed=*/false, /*padded=*/false, kind,
                           ASTRecordDeclInterface{});
 }
 
 StructType StructType::get(::mlir::MLIRContext *context, ArrayRef<Type> members,
-                           bool packed, RecordKind kind,
+                           bool packed, bool padded, RecordKind kind,
                            ASTRecordDeclInterface ast) {
   return Base::get(context, members, StringAttr{}, /*incomplete=*/false, packed,
-                   kind, ast);
+                   padded, kind, ast);
 }
 
 StructType StructType::getChecked(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     ::mlir::MLIRContext *context, ArrayRef<Type> members, bool packed,
-    RecordKind kind, ASTRecordDeclInterface ast) {
+    bool padded, RecordKind kind, ASTRecordDeclInterface ast) {
   return Base::getChecked(emitError, context, members, StringAttr{},
-                          /*incomplete=*/false, packed, kind, ast);
+                          /*incomplete=*/false, packed, padded,
+                           kind, ast);
 }
 
 ::llvm::ArrayRef<mlir::Type> StructType::getMembers() const {
@@ -332,15 +341,17 @@ bool StructType::getIncomplete() const { return getImpl()->incomplete; }
 
 bool StructType::getPacked() const { return getImpl()->packed; }
 
+bool StructType::getPadded() const { return getImpl()->padded; }
+
 cir::StructType::RecordKind StructType::getKind() const {
   return getImpl()->kind;
 }
 
 ASTRecordDeclInterface StructType::getAst() const { return getImpl()->ast; }
 
-void StructType::complete(ArrayRef<Type> members, bool packed,
+void StructType::complete(ArrayRef<Type> members, bool packed, bool padded,
                           ASTRecordDeclInterface ast) {
-  if (mutate(members, packed, ast).failed())
+  if (mutate(members, packed, padded, ast).failed())
     llvm_unreachable("failed to complete struct");
 }
 
@@ -481,11 +492,11 @@ StructType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
   llvm_unreachable("NYI");
 }
 
-bool StructType::isPadded(const ::mlir::DataLayout &dataLayout) const {
-  if (!layoutInfo)
-    computeSizeAndAlignment(dataLayout);
-  return mlir::cast<cir::StructLayoutAttr>(layoutInfo).getPadded();
-}
+// bool StructType::isPadded(const ::mlir::DataLayout &dataLayout) const {
+//   if (!layoutInfo)
+//     computeSizeAndAlignment(dataLayout);
+//   return mlir::cast<cir::StructLayoutAttr>(layoutInfo).getPadded();
+// }
 
 uint64_t StructType::getElementOffset(const ::mlir::DataLayout &dataLayout,
                                       unsigned idx) const {
@@ -506,6 +517,7 @@ void StructType::computeSizeAndAlignment(
 
   // This is a similar algorithm to LLVM's StructLayout.
   unsigned structSize = 0;
+  unsigned lastMemberSize = 0;
   llvm::Align structAlignment{1};
   bool isPadded = false;
   unsigned numElements = getNumElements();
@@ -547,13 +559,16 @@ void StructType::computeSizeAndAlignment(
     memberOffsets.push_back(mlir::IntegerAttr::get(
         mlir::IntegerType::get(getContext(), 32), structSize));
 
+    lastMemberSize = dataLayout.getTypeSize(ty);
     // Consume space for this data item
-    structSize += dataLayout.getTypeSize(ty);
+    structSize += lastMemberSize;    
   }
 
   // For unions, the size and aligment is that of the largest element.
   if (isUnion()) {
     structSize = largestMemberSize;
+    if (getPadded())
+      structSize += lastMemberSize;    
     isPadded = false;
   } else {
     // Add padding to the end of the struct so that it could be put in an array
@@ -1044,7 +1059,8 @@ static mlir::Type getMethodLayoutType(mlir::MLIRContext *ctx) {
   // TODO: consider member function pointer layout in other ABIs
   auto voidPtrTy = cir::PointerType::get(cir::VoidType::get(ctx));
   mlir::Type fields[2]{voidPtrTy, voidPtrTy};
-  return cir::StructType::get(ctx, fields, /*packed=*/false,
+  return cir::StructType::get(ctx, fields, /*packed=*/false, 
+                              /*padded=*/false, 
                               cir::StructType::Struct);
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -492,12 +492,6 @@ StructType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
   llvm_unreachable("NYI");
 }
 
-// bool StructType::isPadded(const ::mlir::DataLayout &dataLayout) const {
-//   if (!layoutInfo)
-//     computeSizeAndAlignment(dataLayout);
-//   return mlir::cast<cir::StructLayoutAttr>(layoutInfo).getPadded();
-// }
-
 uint64_t StructType::getElementOffset(const ::mlir::DataLayout &dataLayout,
                                       unsigned idx) const {
   assert(idx < getMembers().size() && "access not valid");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareX86CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareX86CXXABI.cpp
@@ -300,7 +300,7 @@ mlir::Value LoweringPrepareX86CXXABI::lowerVAArgX86_64(
             ? cast<StructType>(ai.getCoerceToType())
             : StructType::get(
                   Context, {DoubleType::get(Context), DoubleType::get(Context)},
-                  /*packed=*/false, StructType::Struct);
+                  /*packed=*/false, /*padded=*/false, StructType::Struct);
     cir::PointerType addrTy = builder.getPointerTo(ty);
     mlir::Value tmp = builder.createAlloca(loc, addrTy, ty, "tmp",
                                            CharUnits::fromQuantity(tyAlign));

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/X86.cpp
@@ -487,7 +487,7 @@ static mlir::Type GetX86_64ByValArgumentPair(mlir::Type lo, mlir::Type hi,
   }
 
   auto result = StructType::get(lo.getContext(), {lo, hi}, /*packed=*/false,
-                                StructType::Struct);
+                                /*padded=*/false, StructType::Struct);
 
   // Verify that the second element is at an 8-byte offset.
   assert(td.getStructLayout(result)->getElementOffset(1) == 8 &&

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4343,16 +4343,20 @@ void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
     switch (type.getKind()) {
     case cir::StructType::Class:
       // TODO(cir): This should be properly validated.
-    case cir::StructType::Struct:
+    case cir::StructType::Struct:    
       for (auto ty : type.getMembers())
         llvmMembers.push_back(convertTypeForMemory(converter, dataLayout, ty));
       break;
     // Unions are lowered as only the largest member.
-    case cir::StructType::Union: {
+    case cir::StructType::Union: {      
       auto largestMember = type.getLargestMember(dataLayout);
       if (largestMember)
         llvmMembers.push_back(
             convertTypeForMemory(converter, dataLayout, largestMember));
+      if (type.getPadded()) {
+        auto last = *type.getMembers().rbegin();
+        llvmMembers.push_back(convertTypeForMemory(converter, dataLayout, last));
+      }
       break;
     }
     }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4343,19 +4343,20 @@ void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
     switch (type.getKind()) {
     case cir::StructType::Class:
       // TODO(cir): This should be properly validated.
-    case cir::StructType::Struct:    
+    case cir::StructType::Struct:
       for (auto ty : type.getMembers())
         llvmMembers.push_back(convertTypeForMemory(converter, dataLayout, ty));
       break;
     // Unions are lowered as only the largest member.
-    case cir::StructType::Union: {      
+    case cir::StructType::Union: {
       auto largestMember = type.getLargestMember(dataLayout);
       if (largestMember)
         llvmMembers.push_back(
             convertTypeForMemory(converter, dataLayout, largestMember));
       if (type.getPadded()) {
         auto last = *type.getMembers().rbegin();
-        llvmMembers.push_back(convertTypeForMemory(converter, dataLayout, last));
+        llvmMembers.push_back(
+            convertTypeForMemory(converter, dataLayout, last));
       }
       break;
     }

--- a/clang/test/CIR/CodeGen/agg-init2.cpp
+++ b/clang/test/CIR/CodeGen/agg-init2.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-// CHECK: !ty_Zero = !cir.struct<struct "Zero" {!u8i}>
+// CHECK: !ty_Zero = !cir.struct<struct "Zero" padded {!u8i}>
 
 struct Zero {
   void yolo();

--- a/clang/test/CIR/CodeGen/call-via-class-member-funcptr.cpp
+++ b/clang/test/CIR/CodeGen/call-via-class-member-funcptr.cpp
@@ -16,7 +16,7 @@ public:
 const char *f::b() { return g.b(h); }
 void fn1() { f f1; }
 
-// CIR: ty_a = !cir.struct<class "a" {!u8i} #cir.record.decl.ast>
+// CIR: ty_a = !cir.struct<class "a" padded {!u8i} #cir.record.decl.ast>
 // CIR: ty_f = !cir.struct<class "f" {!ty_a}>
 
 // CIR: cir.global external @h = #cir.int<0>

--- a/clang/test/CIR/CodeGen/conditional-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/conditional-cleanup.cpp
@@ -23,11 +23,11 @@ namespace test7 {
   }
 }
 
-// CIR-DAG: ![[A:.*]] = !cir.struct<struct "test7::A" {!u8i}
-// CIR-DAG: ![[B:.*]] = !cir.struct<struct "test7::B" {!u8i}
+// CIR-DAG: ![[A:.*]] = !cir.struct<struct "test7::A" padded {!u8i}
+// CIR-DAG: ![[B:.*]] = !cir.struct<struct "test7::B" padded {!u8i}
 
-// CIR_EH-DAG: ![[A:.*]] = !cir.struct<struct "test7::A" {!u8i}
-// CIR_EH-DAG: ![[B:.*]] = !cir.struct<struct "test7::B" {!u8i}
+// CIR_EH-DAG: ![[A:.*]] = !cir.struct<struct "test7::A" padded {!u8i}
+// CIR_EH-DAG: ![[B:.*]] = !cir.struct<struct "test7::B" padded {!u8i}
 
 // CIR-LABEL: _ZN5test74testEv
 // CIR:   %[[RET_VAL:.*]] = cir.alloca !cir.ptr<![[B]]>, !cir.ptr<!cir.ptr<![[B]]>>, ["__retval"] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -126,13 +126,13 @@ co_invoke_fn co_invoke;
 
 }} // namespace folly::coro
 
-// CHECK-DAG: ![[IntTask:.*]] = !cir.struct<struct "folly::coro::Task<int>" {!u8i}>
-// CHECK-DAG: ![[VoidTask:.*]] = !cir.struct<struct "folly::coro::Task<void>" {!u8i}>
-// CHECK-DAG: ![[VoidPromisse:.*]] = !cir.struct<struct "folly::coro::Task<void>::promise_type" {!u8i}>
-// CHECK-DAG: ![[CoroHandleVoid:.*]] = !cir.struct<struct "std::coroutine_handle<void>" {!u8i}>
-// CHECK-DAG: ![[CoroHandlePromise:ty_.*]]  = !cir.struct<struct "std::coroutine_handle<folly::coro::Task<void>::promise_type>" {!u8i}>
-// CHECK-DAG: ![[StdString:.*]] = !cir.struct<struct "std::string" {!u8i}>
-// CHECK-DAG: ![[SuspendAlways:.*]] = !cir.struct<struct "std::suspend_always" {!u8i}>
+// CHECK-DAG: ![[IntTask:.*]] = !cir.struct<struct "folly::coro::Task<int>" padded {!u8i}>
+// CHECK-DAG: ![[VoidTask:.*]] = !cir.struct<struct "folly::coro::Task<void>" padded {!u8i}>
+// CHECK-DAG: ![[VoidPromisse:.*]] = !cir.struct<struct "folly::coro::Task<void>::promise_type" padded {!u8i}>
+// CHECK-DAG: ![[CoroHandleVoid:.*]] = !cir.struct<struct "std::coroutine_handle<void>" padded {!u8i}>
+// CHECK-DAG: ![[CoroHandlePromise:ty_.*]]  = !cir.struct<struct "std::coroutine_handle<folly::coro::Task<void>::promise_type>" padded {!u8i}>
+// CHECK-DAG: ![[StdString:.*]] = !cir.struct<struct "std::string" padded {!u8i}>
+// CHECK-DAG: ![[SuspendAlways:.*]] = !cir.struct<struct "std::suspend_always" padded {!u8i}>
 
 // CHECK: module {{.*}} {
 // CHECK-NEXT: cir.global external @_ZN5folly4coro9co_invokeE = #cir.zero : !ty_folly3A3Acoro3A3Aco_invoke_fn

--- a/clang/test/CIR/CodeGen/global-new.cpp
+++ b/clang/test/CIR/CodeGen/global-new.cpp
@@ -12,7 +12,7 @@
 struct e { e(int); };
 e *g = new e(0);
 
-// CIR_BEFORE: ![[ty:.*]] = !cir.struct<struct "e" {!u8i}
+// CIR_BEFORE: ![[ty:.*]] = !cir.struct<struct "e" padded {!u8i}
 
 // CIR_BEFORE: cir.global external @g = ctor : !cir.ptr<![[ty]]> {
 // CIR_BEFORE:     %[[GlobalAddr:.*]] = cir.get_global @g : !cir.ptr<!cir.ptr<![[ty]]>>

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -10,7 +10,7 @@ void fn() {
 }
 
 //      CHECK-DAG: !ty_A = !cir.struct<struct "A" {!s32i}>
-//      CHECK: !ty_anon2E0_ = !cir.struct<class "anon.0" {!u8i}>
+//      CHECK: !ty_anon2E0_ = !cir.struct<class "anon.0" padded {!u8i}>
 //      CHECK-DAG: !ty_anon2E7_ = !cir.struct<class "anon.7" {!ty_A}>
 //      CHECK-DAG: !ty_anon2E8_ = !cir.struct<class "anon.8" {!cir.ptr<!ty_A>}>
 //  CHECK-DAG: module

--- a/clang/test/CIR/CodeGen/move.cpp
+++ b/clang/test/CIR/CodeGen/move.cpp
@@ -16,7 +16,7 @@ struct string {
 
 } // std namespace
 
-// CHECK: ![[StdString:ty_.*]] = !cir.struct<struct "std::string" {!u8i}>
+// CHECK: ![[StdString:ty_.*]] = !cir.struct<struct "std::string" padded {!u8i}>
 
 std::string getstr();
 void emplace(std::string &&s);

--- a/clang/test/CIR/CodeGen/new-null.cpp
+++ b/clang/test/CIR/CodeGen/new-null.cpp
@@ -39,7 +39,7 @@ void *operator new[](size_t, void*, bool) throw();
 
 namespace test15 {
   struct A { A(); ~A(); };
-  // CIR-DAG:   ![[TEST15A:.*]] = !cir.struct<struct "test15::A" {!u8i}
+  // CIR-DAG:   ![[TEST15A:.*]] = !cir.struct<struct "test15::A" padded {!u8i}
 
   void test0a(void *p) {
     new (p) A();

--- a/clang/test/CIR/CodeGen/packed-structs.c
+++ b/clang/test/CIR/CodeGen/packed-structs.c
@@ -23,8 +23,8 @@ typedef struct {
 
 
 // CIR: !ty_A = !cir.struct<struct "A" packed {!s32i, !s8i}>
-// CIR: !ty_C = !cir.struct<struct "C" packed {!s32i, !s8i, !u8i}>
-// CIR: !ty_D = !cir.struct<struct "D" packed {!s8i, !u8i, !s32i}
+// CIR: !ty_C = !cir.struct<struct "C" packed padded {!s32i, !s8i, !u8i}>
+// CIR: !ty_D = !cir.struct<struct "D" packed padded {!s8i, !u8i, !s32i}
 // CIR: !ty_F = !cir.struct<struct "F" packed {!s64i, !s8i}
 // CIR: !ty_E = !cir.struct<struct "E" packed {!ty_D
 // CIR: !ty_G = !cir.struct<struct "G" {!ty_F

--- a/clang/test/CIR/CodeGen/paren-list-init.cpp
+++ b/clang/test/CIR/CodeGen/paren-list-init.cpp
@@ -13,10 +13,10 @@ struct S1 {
   Vec v;
 };
 
-// CIR-DAG: ![[VecType:.*]] = !cir.struct<struct "Vec" {!u8i}>
+// CIR-DAG: ![[VecType:.*]] = !cir.struct<struct "Vec" padded {!u8i}>
 // CIR-DAG: ![[S1:.*]] = !cir.struct<struct "S1" {![[VecType]]}>
 
-// CIR_EH-DAG: ![[VecType:.*]] = !cir.struct<struct "Vec" {!u8i}>
+// CIR_EH-DAG: ![[VecType:.*]] = !cir.struct<struct "Vec" padded {!u8i}>
 // CIR_EH-DAG: ![[S1:.*]] = !cir.struct<struct "S1" {![[VecType]]}>
 
 template <int I>

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -38,9 +38,13 @@ void shouldConstInitStructs(void) {
 // CHECK: cir.func @shouldConstInitStructs
   struct Foo f = {1, 2, {3, 4}};
   // CHECK: %[[#V0:]] = cir.alloca !ty_Foo, !cir.ptr<!ty_Foo>, ["f"] {alignment = 4 : i64}
-  // CHECK: %[[#V1:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_Foo>), !cir.ptr<!ty_anon_struct> l
-  // CHECK: %[[#V2:]] = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>, #cir.const_struct<{#cir.int<3> : !s32i, #cir.int<4> : !s8i}> : !ty_Bar}> : !ty_anon_struct
-  // CHECK: cir.store %[[#V2]], %[[#V1]] : !ty_anon_struct, !cir.ptr<!ty_anon_struct>
+  // CHECK: %[[#V1:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_Foo>), !cir.ptr<!ty_anon_struct1>
+  // CHECK: %[[#V2:]] = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s8i,
+  // CHECK-SAME:        #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>,
+  // CHECK-SAME:        #cir.const_struct<{#cir.int<3> : !s32i, #cir.int<4> : !s8i,
+  // CHECK-SAME:        #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>}>
+  // CHECK-SAME:        : !ty_anon_struct}> : !ty_anon_struct1
+  // CHECK: cir.store %[[#V2]], %[[#V1]] : !ty_anon_struct1, !cir.ptr<!ty_anon_struct1>
 }
 
 // Should zero-initialize uninitialized global structs.

--- a/clang/test/CIR/CodeGen/try-catch-dtors.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-dtors.cpp
@@ -20,10 +20,10 @@ void yo() {
   }
 }
 
-// CIR-DAG: ![[VecTy:.*]] = !cir.struct<struct "Vec" {!u8i}>
+// CIR-DAG: ![[VecTy:.*]] = !cir.struct<struct "Vec" padded {!u8i}>
 // CIR-DAG: ![[S1:.*]] = !cir.struct<struct "S1" {![[VecTy]]}>
 
-// CIR_FLAT-DAG: ![[VecTy:.*]] = !cir.struct<struct "Vec" {!u8i}>
+// CIR_FLAT-DAG: ![[VecTy:.*]] = !cir.struct<struct "Vec" padded {!u8i}>
 // CIR_FLAT-DAG: ![[S1:.*]] = !cir.struct<struct "S1" {![[VecTy]]}>
 
 // CIR: cir.scope {

--- a/clang/test/CIR/CodeGen/union-padding.c
+++ b/clang/test/CIR/CodeGen/union-padding.c
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s
+
+typedef union {    
+   short f0;
+   signed   f1 : 11;
+   unsigned f2 : 2;
+   signed   f3 : 5;
+} U;
+
+static U g1[2] = {{65534UL}, {65534UL}};
+static short *g2[1] = {&g1[1].f0};
+static short **g3 = &g2[0];
+
+short use() {
+  U u;
+  return **g3;
+}
+// CHECK:       !ty_U = !cir.struct<union "U" padded {!s16i, !u16i, !u8i, !u8i, !cir.array<!u8i x 2>}>
+// CHECK:       !ty_anon_struct = !cir.struct<struct  {!s16i, !cir.array<!u8i x 2>}>
+
+// CHECK:       @g3 = #cir.global_view<@g2> : !cir.ptr<!cir.ptr<!s16i>>
+// CHECK:       @g2 = #cir.const_array<[#cir.global_view<@g1, [1 : i32]> : !cir.ptr<!s16i>]> : !cir.array<!cir.ptr<!s16i> x 1> 
+
+// CHECK:       @g1 = 
+// CHECK-SAME:    #cir.const_array<[
+// CHECK-SAME:      #cir.const_struct<{#cir.int<-2> : !s16i, 
+// CHECK-SAME:      #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>}> : !ty_anon_struct, 
+// CHECK-SAME:      #cir.const_struct<{#cir.int<-2> : !s16i,
+// CHECK-SAME:      #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>}> : !ty_anon_struct
+// CHECK-SAME:    ]> : !cir.array<!ty_anon_struct x 2>
+
+


### PR DESCRIPTION
This PR adds padding for union type, which is necessary in some cases (e.g. proper offset computation for an element of an array).

The previous discussion is here #1281 

The idea is to add a notion about padding in the `StructType`  in the same fashion as it's done for packed structures - as a bool argument in the constructor.

Now we can compute the proper union type size as a size of the largest element + size of padding type.

There are some downsides though - I had to add this `padded` word in many places.  So take a look please!
There are many tests fixed and one new - `union-padding`



