### PR TITLE
[CIR] Cleanup cir.scopes with a single cir.yield operation

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -62,7 +62,16 @@ struct RemoveEmptyScope : public OpRewritePattern<ScopeOp> {
   LogicalResult match(ScopeOp op) const final {
     // TODO: Remove this logic once CIR uses MLIR infrastructure to remove
     // trivially dead operations
-    return success(op.isEmpty());
+    if (op.isEmpty()) {
+      return success();
+    }
+
+    Region *region = op.getRegions().front();
+    if (region && region->getBlocks().front().getOperations().size() == 1) {
+      return success(isa<YieldOp>(region->getBlocks().front().front()));
+    }
+
+    return failure();
   }
 
   void rewrite(ScopeOp op, PatternRewriter &rewriter) const final {

--- a/clang/test/CIR/Transforms/merge-cleanups.cir
+++ b/clang/test/CIR/Transforms/merge-cleanups.cir
@@ -138,4 +138,13 @@ module  {
     cir.return %0 : !cir.ptr<!s32i, addrspace(target<2>)>
   }
 
+  // Should remove scope with only yield
+  cir.func @removeBlockWithScopeYeild(%arg0: !s32i) {
+    cir.scope {
+      cir.yield
+    }
+    cir.return
+  }
+  //      CHECK: cir.func @removeBlockWithScopeYeild
+  // CHECK-NEXT: cir.return
 }


### PR DESCRIPTION
Cleanup cir scope if it contains only yield operation

Fixes: #455