### PR TITLE
[CIR] LLVM lowering support for pointers to member functions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -573,6 +573,16 @@ def MethodAttr : CIR_Attr<"Method", "method", [TypedAttrInterface]> {
   let hasCustomAssemblyFormat = 1;
 
   let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    bool isNull() const {
+      return !getSymbol().has_value() && !getVtableOffset().has_value();
+    }
+
+    bool isVirtual() const {
+      return getVtableOffset().has_value();
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2851,6 +2851,64 @@ def GetMemberOp : CIR_Op<"get_member"> {
 }
 
 //===----------------------------------------------------------------------===//
+// ExtractMemberOp
+//===----------------------------------------------------------------------===//
+
+def ExtractMemberOp : CIR_Op<"extract_member", [Pure]> {
+  let summary = "Extract the value of a member of a struct value";
+  let description = [{
+    The `cir.extract_member` operation extracts the value of a particular member
+    from the input record. Unlike `cir.get_member` which derives pointers, this
+    operation operates on values. It takes a value of record type, and extract
+    the value of the specified record member from the input record value.
+
+    Currently `cir.extract_member` does not work on unions.
+
+    Example:
+
+    ```mlir
+    // Suppose we have a struct with multiple members.
+    !s32i = !cir.int<s, 32>
+    !s8i = !cir.int<s, 32>
+    !struct_ty = !cir.struct<"struct.Bar" {!s32i, !s8i}>
+
+    // And suppose we have a value of the struct type.
+    %0 = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s8i}> : !struct_ty
+
+    // Extract the value of the second member of the struct.
+    %1 = cir.extract_member %0[1] : !struct_ty -> !s8i
+    ```
+  }];
+
+  let arguments = (ins CIR_StructType:$record, IndexAttr:$index_attr);
+  let results = (outs CIR_AnyType:$result);
+
+  let assemblyFormat = [{
+    $record `[` $index_attr `]` attr-dict
+    `:` qualified(type($record)) `->` qualified(type($result))
+  }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$type, "mlir::Value":$record, "uint64_t":$index), [{
+      mlir::APInt fieldIdx(64, index);
+      build($_builder, $_state, type, record, fieldIdx);
+    }]>,
+    OpBuilder<(ins "mlir::Value":$record, "uint64_t":$index), [{
+      auto recordTy = mlir::cast<cir::StructType>(record.getType());
+      mlir::Type memberTy = recordTy.getMembers()[index];
+      build($_builder, $_state, memberTy, record, index);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Get the index of the struct member being accessed.
+    uint64_t getIndex() { return getIndexAttr().getZExtValue(); }
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // GetRuntimeMemberOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -70,6 +70,9 @@ struct MissingFeatures {
   static bool tbaaPointer() { return false; }
   static bool emitNullabilityCheck() { return false; }
   static bool ptrAuth() { return false; }
+  static bool emitCFICheck() { return false; }
+  static bool emitVFEInfo() { return false; }
+  static bool emitWPDInfo() { return false; }
 
   // GNU vectors are done, but other kinds of vectors haven't been implemented.
   static bool scalableVectors() { return false; }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3578,6 +3578,22 @@ LogicalResult cir::GetMemberOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ExtractMemberOp Definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult cir::ExtractMemberOp::verify() {
+  auto recordTy = mlir::cast<cir::StructType>(getRecord().getType());
+  if (recordTy.getKind() == cir::StructType::Union)
+    return emitError()
+           << "cir.extract_member currently does not work on unions";
+  if (recordTy.getMembers().size() <= getIndex())
+    return emitError() << "member index out of bounds";
+  if (recordTy.getMembers()[getIndex()] != getType())
+    return emitError() << "member type mismatch";
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // GetRuntimeMemberOp Definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -72,6 +72,12 @@ public:
   lowerDataMemberType(cir::DataMemberType type,
                       const mlir::TypeConverter &typeConverter) const = 0;
 
+  /// Lower the given member function pointer type to its ABI type. The returned
+  /// type is also a CIR type.
+  virtual mlir::Type
+  lowerMethodType(cir::MethodType type,
+                  const mlir::TypeConverter &typeConverter) const = 0;
+
   /// Lower the given data member pointer constant to a constant of the ABI
   /// type. The returned constant is represented as an attribute as well.
   virtual mlir::TypedAttr
@@ -79,12 +85,26 @@ public:
                           const mlir::DataLayout &layout,
                           const mlir::TypeConverter &typeConverter) const = 0;
 
+  /// Lower the given member function pointer constant to a constant of the ABI
+  /// type. The returned constant is represented as an attribute as well.
+  virtual mlir::TypedAttr
+  lowerMethodConstant(cir::MethodAttr attr, const mlir::DataLayout &layout,
+                      const mlir::TypeConverter &typeConverter) const = 0;
+
   /// Lower the given cir.get_runtime_member op to a sequence of more
   /// "primitive" CIR operations that act on the ABI types.
   virtual mlir::Operation *
   lowerGetRuntimeMember(cir::GetRuntimeMemberOp op, mlir::Type loweredResultTy,
                         mlir::Value loweredAddr, mlir::Value loweredMember,
                         mlir::OpBuilder &builder) const = 0;
+
+  /// Lower the given cir.get_method op to a sequence of more "primitive" CIR
+  /// operations that act on the ABI types. The lowered result values will be
+  /// stored in the given loweredResults array.
+  virtual void
+  lowerGetMethod(cir::GetMethodOp op, mlir::Value (&loweredResults)[2],
+                 mlir::Value loweredMethod, mlir::Value loweredObjectPtr,
+                 mlir::ConversionPatternRewriter &rewriter) const = 0;
 
   /// Lower the given cir.base_data_member op to a sequence of more "primitive"
   /// CIR operations that act on the ABI types.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -33,15 +33,28 @@ namespace {
 class ItaniumCXXABI : public CIRCXXABI {
 
 protected:
+  enum class VTableComponentLayout {
+    /// Components in the vtable are pointers to other structs/functions.
+    Pointer,
+
+    /// Components in the vtable are relative offsets between the vtable and the
+    /// other structs/functions.
+    Relative,
+  };
+
   bool UseARMMethodPtrABI;
   bool UseARMGuardVarABI;
   bool Use32BitVTableOffsetABI;
+  VTableComponentLayout VTComponentLayout;
 
 public:
-  ItaniumCXXABI(LowerModule &LM, bool UseARMMethodPtrABI = false,
-                bool UseARMGuardVarABI = false)
+  ItaniumCXXABI(
+      LowerModule &LM, bool UseARMMethodPtrABI = false,
+      bool UseARMGuardVarABI = false,
+      VTableComponentLayout VTComponentLayout = VTableComponentLayout::Pointer)
       : CIRCXXABI(LM), UseARMMethodPtrABI(UseARMMethodPtrABI),
-        UseARMGuardVarABI(UseARMGuardVarABI), Use32BitVTableOffsetABI(false) {}
+        UseARMGuardVarABI(UseARMGuardVarABI), Use32BitVTableOffsetABI(false),
+        VTComponentLayout(VTComponentLayout) {}
 
   bool classifyReturnType(LowerFunctionInfo &FI) const override;
 
@@ -57,14 +70,26 @@ public:
   lowerDataMemberType(cir::DataMemberType type,
                       const mlir::TypeConverter &typeConverter) const override;
 
+  mlir::Type
+  lowerMethodType(cir::MethodType type,
+                  const mlir::TypeConverter &typeConverter) const override;
+
   mlir::TypedAttr lowerDataMemberConstant(
       cir::DataMemberAttr attr, const mlir::DataLayout &layout,
       const mlir::TypeConverter &typeConverter) const override;
+
+  mlir::TypedAttr
+  lowerMethodConstant(cir::MethodAttr attr, const mlir::DataLayout &layout,
+                      const mlir::TypeConverter &typeConverter) const override;
 
   mlir::Operation *
   lowerGetRuntimeMember(cir::GetRuntimeMemberOp op, mlir::Type loweredResultTy,
                         mlir::Value loweredAddr, mlir::Value loweredMember,
                         mlir::OpBuilder &builder) const override;
+
+  void lowerGetMethod(cir::GetMethodOp op, mlir::Value (&loweredResults)[2],
+                      mlir::Value loweredMethod, mlir::Value loweredObjectPtr,
+                      mlir::ConversionPatternRewriter &rewriter) const override;
 
   mlir::Value lowerBaseDataMember(cir::BaseDataMemberOp op,
                                   mlir::Value loweredSrc,
@@ -101,10 +126,7 @@ bool ItaniumCXXABI::classifyReturnType(LowerFunctionInfo &FI) const {
   return false;
 }
 
-static mlir::Type getABITypeForDataMember(LowerModule &lowerMod) {
-  // Itanium C++ ABI 2.3:
-  //   A pointer to data member is an offset from the base address of
-  //   the class object containing it, represented as a ptrdiff_t
+static cir::IntType getPtrDiffCIRTy(LowerModule &lowerMod) {
   const clang::TargetInfo &target = lowerMod.getTarget();
   clang::TargetInfo::IntType ptrdiffTy =
       target.getPtrDiffType(clang::LangAS::Default);
@@ -115,7 +137,32 @@ static mlir::Type getABITypeForDataMember(LowerModule &lowerMod) {
 
 mlir::Type ItaniumCXXABI::lowerDataMemberType(
     cir::DataMemberType type, const mlir::TypeConverter &typeConverter) const {
-  return getABITypeForDataMember(LM);
+  // Itanium C++ ABI 2.3.1:
+  //   A data member pointer is represented as the data member's offset in bytes
+  //   from the address point of an object of the base type, as a ptrdiff_t.
+  return getPtrDiffCIRTy(LM);
+}
+
+mlir::Type
+ItaniumCXXABI::lowerMethodType(cir::MethodType type,
+                               const mlir::TypeConverter &typeConverter) const {
+  // Itanium C++ ABI 2.3.2:
+  //    In all representations, the basic ABI properties of member function
+  //    pointer types are those of the following class, where fnptr_t is the
+  //    appropriate function-pointer type for a member function of this type:
+  //
+  //    struct {
+  //      fnptr_t ptr;
+  //      ptrdiff_t adj;
+  //    };
+
+  cir::IntType ptrdiffCIRTy = getPtrDiffCIRTy(LM);
+
+  // Note that clang CodeGen emits struct{ptrdiff_t, ptrdiff_t} for member
+  // function pointers. Let's follow this approach.
+  return cir::StructType::get(type.getContext(), {ptrdiffCIRTy, ptrdiffCIRTy},
+                              /*packed=*/false, /*padded=*/false,
+                              cir::StructType::Struct);
 }
 
 mlir::TypedAttr ItaniumCXXABI::lowerDataMemberConstant(
@@ -139,6 +186,72 @@ mlir::TypedAttr ItaniumCXXABI::lowerDataMemberConstant(
   return cir::IntAttr::get(abiTy, memberOffset);
 }
 
+mlir::TypedAttr ItaniumCXXABI::lowerMethodConstant(
+    cir::MethodAttr attr, const mlir::DataLayout &layout,
+    const mlir::TypeConverter &typeConverter) const {
+  cir::IntType ptrdiffCIRTy = getPtrDiffCIRTy(LM);
+  auto loweredMethodTy = mlir::cast<cir::StructType>(
+      lowerMethodType(attr.getType(), typeConverter));
+
+  auto zero = cir::IntAttr::get(ptrdiffCIRTy, 0);
+
+  // Itanium C++ ABI 2.3.2:
+  //   In all representations, the basic ABI properties of member function
+  //   pointer types are those of the following class, where fnptr_t is the
+  //   appropriate function-pointer type for a member function of this type:
+  //
+  //   struct {
+  //     fnptr_t ptr;
+  //     ptrdiff_t adj;
+  //   };
+
+  if (attr.isNull()) {
+    // Itanium C++ ABI 2.3.2:
+    //
+    //   In the standard representation, a null member function pointer is
+    //   represented with ptr set to a null pointer. The value of adj is
+    //   unspecified for null member function pointers.
+    //
+    // clang CodeGen emits struct{null, null} for null member function pointers.
+    // Let's do the same here.
+    return cir::ConstStructAttr::get(
+        loweredMethodTy, mlir::ArrayAttr::get(attr.getContext(), {zero, zero}));
+  }
+
+  if (attr.isVirtual()) {
+    if (UseARMMethodPtrABI) {
+      // ARM C++ ABI 3.2.1:
+      //   This ABI specifies that adj contains twice the this
+      //   adjustment, plus 1 if the member function is virtual. The
+      //   least significant bit of adj then makes exactly the same
+      //   discrimination as the least significant bit of ptr does for
+      //   Itanium.
+      llvm_unreachable("ARM method ptr abi NYI");
+    }
+
+    // Itanium C++ ABI 2.3.2:
+    //
+    //   In the standard representation, a member function pointer for a
+    //   virtual function is represented with ptr set to 1 plus the function's
+    //   v-table entry offset (in bytes), converted to a function pointer as if
+    //   by reinterpret_cast<fnptr_t>(uintfnptr_t(1 + offset)), where
+    //   uintfnptr_t is an unsigned integer of the same size as fnptr_t.
+    auto ptr =
+        cir::IntAttr::get(ptrdiffCIRTy, 1 + attr.getVtableOffset().value());
+    return cir::ConstStructAttr::get(
+        loweredMethodTy, mlir::ArrayAttr::get(attr.getContext(), {ptr, zero}));
+  }
+
+  // Itanium C++ ABI 2.3.2:
+  //
+  //   A member function pointer for a non-virtual member function is
+  //   represented with ptr set to a pointer to the function, using the base
+  //   ABI's representation of function pointers.
+  auto ptr = cir::GlobalViewAttr::get(ptrdiffCIRTy, attr.getSymbol().value());
+  return cir::ConstStructAttr::get(
+      loweredMethodTy, mlir::ArrayAttr::get(attr.getContext(), {ptr, zero}));
+}
+
 mlir::Operation *ItaniumCXXABI::lowerGetRuntimeMember(
     cir::GetRuntimeMemberOp op, mlir::Type loweredResultTy,
     mlir::Value loweredAddr, mlir::Value loweredMember,
@@ -152,6 +265,171 @@ mlir::Operation *ItaniumCXXABI::lowerGetRuntimeMember(
       op.getLoc(), bytePtrTy, objectBytesPtr, loweredMember);
   return builder.create<CastOp>(op.getLoc(), op.getType(), CastKind::bitcast,
                                 memberBytesPtr);
+}
+
+void ItaniumCXXABI::lowerGetMethod(
+    cir::GetMethodOp op, mlir::Value (&loweredResults)[2],
+    mlir::Value loweredMethod, mlir::Value loweredObjectPtr,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  // In the Itanium and ARM ABIs, method pointers have the form:
+  //   struct { ptrdiff_t ptr; ptrdiff_t adj; } memptr;
+  //
+  // In the Itanium ABI:
+  //  - method pointers are virtual if (memptr.ptr & 1) is nonzero
+  //  - the this-adjustment is (memptr.adj)
+  //  - the virtual offset is (memptr.ptr - 1)
+  //
+  // In the ARM ABI:
+  //  - method pointers are virtual if (memptr.adj & 1) is nonzero
+  //  - the this-adjustment is (memptr.adj >> 1)
+  //  - the virtual offset is (memptr.ptr)
+  // ARM uses 'adj' for the virtual flag because Thumb functions
+  // may be only single-byte aligned.
+  //
+  // If the member is virtual, the adjusted 'this' pointer points
+  // to a vtable pointer from which the virtual offset is applied.
+  //
+  // If the member is non-virtual, memptr.ptr is the address of
+  // the function to call.
+
+  mlir::Value &callee = loweredResults[0];
+  mlir::Value &adjustedThis = loweredResults[1];
+  mlir::Type calleePtrTy = op.getCallee().getType();
+
+  cir::IntType ptrdiffCIRTy = getPtrDiffCIRTy(LM);
+  mlir::Value ptrdiffOne = rewriter.create<cir::ConstantOp>(
+      op.getLoc(), cir::IntAttr::get(ptrdiffCIRTy, 1));
+
+  mlir::Value adj = rewriter.create<cir::ExtractMemberOp>(
+      op.getLoc(), ptrdiffCIRTy, loweredMethod, 1);
+  if (UseARMMethodPtrABI)
+    llvm_unreachable("ARM method ptr abi NYI");
+
+  // Apply the adjustment to the 'this' pointer.
+  mlir::Type thisVoidPtrTy = cir::PointerType::get(
+      cir::VoidType::get(rewriter.getContext()),
+      mlir::cast<cir::PointerType>(op.getObject().getType()).getAddrSpace());
+  mlir::Value thisVoidPtr = rewriter.create<cir::CastOp>(
+      op.getLoc(), thisVoidPtrTy, cir::CastKind::bitcast, loweredObjectPtr);
+  adjustedThis = rewriter.create<cir::PtrStrideOp>(op.getLoc(), thisVoidPtrTy,
+                                                   thisVoidPtr, adj);
+
+  // Load the "ptr" field of the member function pointer and determine if it
+  // points to a virtual function.
+  mlir::Value methodPtrField = rewriter.create<cir::ExtractMemberOp>(
+      op.getLoc(), ptrdiffCIRTy, loweredMethod, 0);
+  mlir::Value virtualBit = rewriter.create<cir::BinOp>(
+      op.getLoc(), cir::BinOpKind::And, methodPtrField, ptrdiffOne);
+  mlir::Value isVirtual;
+  if (UseARMMethodPtrABI)
+    llvm_unreachable("ARM method ptr abi NYI");
+  else
+    isVirtual = rewriter.create<cir::CmpOp>(op.getLoc(), cir::CmpOpKind::eq,
+                                            virtualBit, ptrdiffOne);
+
+  assert(!MissingFeatures::emitCFICheck());
+  assert(!MissingFeatures::emitVFEInfo());
+  assert(!MissingFeatures::emitWPDInfo());
+
+  // See their original definitions in
+  // ItaniumCXXABI::EmitLoadOfMemberFunctionPointer in file
+  // clang/lib/CodeGen/ItaniumCXXABI.cpp.
+  bool shouldEmitCFICheck = false;
+  bool shouldEmitVFEInfo =
+      LM.getContext().getCodeGenOpts().VirtualFunctionElimination;
+  bool shouldEmitWPDInfo = LM.getContext().getCodeGenOpts().WholeProgramVTables;
+
+  mlir::Block *currBlock = rewriter.getInsertionBlock();
+  mlir::Block *continueBlock =
+      rewriter.splitBlock(currBlock, rewriter.getInsertionPoint());
+  continueBlock->addArgument(calleePtrTy, op.getLoc());
+
+  mlir::Block *virtualBlock = rewriter.createBlock(continueBlock);
+  mlir::Block *nonVirtualBlock = rewriter.createBlock(continueBlock);
+  rewriter.setInsertionPointToEnd(currBlock);
+  rewriter.create<cir::BrCondOp>(op.getLoc(), isVirtual, virtualBlock,
+                                 nonVirtualBlock);
+
+  auto buildVirtualBranch = [&] {
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(virtualBlock);
+
+    // Load vtable pointer.
+    // Note that vtable pointer always point to the global address space.
+    auto vtablePtrTy = cir::PointerType::get(
+        rewriter.getContext(),
+        cir::IntType::get(rewriter.getContext(), 8, true));
+    auto vtablePtrPtrTy = cir::PointerType::get(
+        rewriter.getContext(), vtablePtrTy,
+        mlir::cast<cir::PointerType>(op.getObject().getType()).getAddrSpace());
+    auto vtablePtrPtr = rewriter.create<cir::CastOp>(
+        op.getLoc(), vtablePtrPtrTy, cir::CastKind::bitcast, loweredObjectPtr);
+    mlir::Value vtablePtr = rewriter.create<cir::LoadOp>(
+        op.getLoc(), vtablePtrPtr, /*isDeref=*/false, /*isVolatile=*/false,
+        /*alignment=*/mlir::IntegerAttr(), /*mem_order=*/cir::MemOrderAttr(),
+        /*tbaa=*/mlir::ArrayAttr());
+
+    // Get the vtable offset.
+    mlir::Value vtableOffset = methodPtrField;
+    if (!UseARMMethodPtrABI)
+      vtableOffset = rewriter.create<cir::BinOp>(
+          op.getLoc(), cir::BinOpKind::Sub, vtableOffset, ptrdiffOne);
+    if (Use32BitVTableOffsetABI)
+      llvm_unreachable("NYI");
+
+    if (shouldEmitCFICheck || shouldEmitVFEInfo || shouldEmitWPDInfo)
+      llvm_unreachable("NYI");
+
+    // Apply the offset to the vtable pointer and get the pointer to the target
+    // virtual function. Then load that pointer to get the callee.
+    mlir::Value funcPtr;
+    if (shouldEmitVFEInfo)
+      llvm_unreachable("NYI");
+    else {
+      if (shouldEmitCFICheck || shouldEmitWPDInfo)
+        llvm_unreachable("NYI");
+
+      if (VTComponentLayout == VTableComponentLayout::Relative)
+        llvm_unreachable("NYI");
+      else {
+        mlir::Value vfpAddr = rewriter.create<cir::PtrStrideOp>(
+            op.getLoc(), vtablePtrTy, vtablePtr, vtableOffset);
+        auto vfpPtrTy =
+            cir::PointerType::get(rewriter.getContext(), calleePtrTy);
+        mlir::Value vfpPtr = rewriter.create<cir::CastOp>(
+            op.getLoc(), vfpPtrTy, cir::CastKind::bitcast, vfpAddr);
+        funcPtr = rewriter.create<cir::LoadOp>(
+            op.getLoc(), vfpPtr, /*isDeref=*/false, /*isVolatile=*/false,
+            /*alignment=*/mlir::IntegerAttr(),
+            /*mem_order=*/cir::MemOrderAttr(),
+            /*tbaa=*/mlir::ArrayAttr());
+      }
+    }
+
+    if (shouldEmitCFICheck)
+      llvm_unreachable("NYI");
+
+    rewriter.create<cir::BrOp>(op.getLoc(), continueBlock, funcPtr);
+  };
+
+  auto buildNonVirtualBranch = [&] {
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(nonVirtualBlock);
+
+    mlir::Value funcPtr = rewriter.create<cir::CastOp>(
+        op.getLoc(), calleePtrTy, cir::CastKind::int_to_ptr, methodPtrField);
+
+    if (shouldEmitCFICheck)
+      llvm_unreachable("NYI");
+
+    rewriter.create<cir::BrOp>(op.getLoc(), continueBlock, funcPtr);
+  };
+
+  buildVirtualBranch();
+  buildNonVirtualBranch();
+
+  rewriter.setInsertionPointToStart(continueBlock);
+  callee = continueBlock->getArgument(0);
 }
 
 static mlir::Value lowerDataMemberCast(mlir::Operation *op,
@@ -213,7 +491,7 @@ ItaniumCXXABI::lowerDataMemberToBoolCast(cir::CastOp op, mlir::Value loweredSrc,
                                          mlir::OpBuilder &builder) const {
   // Itanium C++ ABI 2.3:
   //   A NULL pointer is represented as -1.
-  auto nullAttr = cir::IntAttr::get(getABITypeForDataMember(LM), -1);
+  auto nullAttr = cir::IntAttr::get(getPtrDiffCIRTy(LM), -1);
   auto nullValue = builder.create<cir::ConstantOp>(op.getLoc(), nullAttr);
   return builder.create<cir::CmpOp>(op.getLoc(), cir::CmpOpKind::ne, loweredSrc,
                                     nullValue);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -882,6 +882,31 @@ public:
                   mlir::ConversionPatternRewriter &) const override;
 };
 
+class CIRToLLVMExtractMemberOpLowering
+    : public mlir::OpConversionPattern<cir::ExtractMemberOp> {
+public:
+  using mlir::OpConversionPattern<cir::ExtractMemberOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::ExtractMemberOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
+class CIRToLLVMGetMethodOpLowering
+    : public mlir::OpConversionPattern<cir::GetMethodOp> {
+  cir::LowerModule *lowerMod;
+
+public:
+  CIRToLLVMGetMethodOpLowering(const mlir::TypeConverter &typeConverter,
+                               mlir::MLIRContext *context,
+                               cir::LowerModule *lowerModule)
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::GetMethodOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
 class CIRToLLVMGetRuntimeMemberOpLowering
     : public mlir::OpConversionPattern<cir::GetRuntimeMemberOp> {
   cir::LowerModule *lowerMod;

--- a/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
 
 struct Foo {
   void m1(int);
@@ -15,6 +17,10 @@ auto make_non_virtual() -> void (Foo::*)(int) {
 //       CHECK:   %{{.+}} = cir.const #cir.method<@_ZN3Foo2m1Ei> : !cir.method<!cir.func<(!s32i)> in !ty_Foo>
 //       CHECK: }
 
+// LLVM-LABEL: @_Z16make_non_virtualv
+//       LLVM:   store { i64, i64 } { i64 ptrtoint (ptr @_ZN3Foo2m1Ei to i64), i64 0 }, ptr %{{.+}}
+//       LLVM: }
+
 auto make_virtual() -> void (Foo::*)(int) {
   return &Foo::m3;
 }
@@ -23,6 +29,10 @@ auto make_virtual() -> void (Foo::*)(int) {
 //       CHECK:   %{{.+}} = cir.const #cir.method<vtable_offset = 8> : !cir.method<!cir.func<(!s32i)> in !ty_Foo>
 //       CHECK: }
 
+// LLVM-LABEL: @_Z12make_virtualv
+//       LLVM:   store { i64, i64 } { i64 9, i64 0 }, ptr %{{.+}}
+//       LLVM: }
+
 auto make_null() -> void (Foo::*)(int) {
   return nullptr;
 }
@@ -30,6 +40,10 @@ auto make_null() -> void (Foo::*)(int) {
 // CHECK-LABEL: cir.func @_Z9make_nullv() -> !cir.method<!cir.func<(!s32i)> in !ty_Foo>
 //       CHECK:   %{{.+}} = cir.const #cir.method<null> : !cir.method<!cir.func<(!s32i)> in !ty_Foo>
 //       CHECK: }
+
+// LLVM-LABEL: @_Z9make_nullv
+//       LLVM:   store { i64, i64 } zeroinitializer, ptr %{{.+}}
+//       LLVM: }
 
 void call(Foo *obj, void (Foo::*func)(int), int arg) {
   (obj->*func)(arg);
@@ -40,3 +54,27 @@ void call(Foo *obj, void (Foo::*func)(int), int arg) {
 //  CHECK-NEXT:   %[[#ARG:]] = cir.load %{{.+}} : !cir.ptr<!s32i>, !s32i
 //  CHECK-NEXT:   cir.call %[[CALLEE]](%[[THIS]], %[[#ARG]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>, !cir.ptr<!void>, !s32i) -> ()
 //       CHECK: }
+
+// LLVM-LABEL: @_Z4callP3FooMS_FviEi
+//      LLVM:    %[[#obj:]] = load ptr, ptr %{{.+}}
+// LLVM-NEXT:    %[[#memfn_ptr:]] = load { i64, i64 }, ptr %{{.+}}
+// LLVM-NEXT:    %[[#this_adj:]] = extractvalue { i64, i64 } %[[#memfn_ptr]], 1
+// LLVM-NEXT:    %[[#adjusted_this:]] = getelementptr i8, ptr %[[#obj]], i64 %[[#this_adj]]
+// LLVM-NEXT:    %[[#ptr_field:]] = extractvalue { i64, i64 } %[[#memfn_ptr]], 0
+// LLVM-NEXT:    %[[#virt_bit:]] = and i64 %[[#ptr_field]], 1
+// LLVM-NEXT:    %[[#is_virt:]] = icmp eq i64 %[[#virt_bit]], 1
+// LLVM-NEXT:    br i1 %[[#is_virt]], label %[[#block_virt:]], label %[[#block_non_virt:]]
+//      LLVM:  [[#block_virt]]:
+// LLVM-NEXT:    %[[#vtable_ptr:]] = load ptr, ptr %[[#obj]]
+// LLVM-NEXT:    %[[#vtable_offset:]] = sub i64 %[[#ptr_field]], 1
+// LLVM-NEXT:    %[[#vfp_ptr:]] = getelementptr i8, ptr %[[#vtable_ptr]], i64 %[[#vtable_offset]]
+// LLVM-NEXT:    %[[#vfp:]] = load ptr, ptr %[[#vfp_ptr]]
+// LLVM-NEXT:    br label %[[#block_continue:]]
+//      LLVM:  [[#block_non_virt]]:
+// LLVM-NEXT:    %[[#func_ptr:]] = inttoptr i64 %[[#ptr_field]] to ptr
+// LLVM-NEXT:    br label %[[#block_continue]]
+//      LLVM:  [[#block_continue]]:
+// LLVM-NEXT:    %[[#callee_ptr:]] = phi ptr [ %[[#func_ptr]], %[[#block_non_virt]] ], [ %[[#vfp]], %[[#block_virt]] ]
+// LLVM-NEXT:    %[[#arg:]] = load i32, ptr %{{.+}}
+// LLVM-NEXT:    call void %[[#callee_ptr]](ptr %[[#adjusted_this]], i32 %[[#arg]])
+//      LLVM: }

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -24,6 +24,21 @@ module {
     cir.return
   }
 
+  // CHECK-LABEL: @test_value
+  cir.func @test_value() {
+    %0 = cir.const #cir.const_struct<{#cir.int<1> : !u8i, #cir.int<2> : !s32i}> : !ty_S
+    //      CHECK: %[[#v0:]] = llvm.mlir.undef : !llvm.struct<"struct.S", (i8, i32)>
+    // CHECK-NEXT: %[[#v1:]] = llvm.mlir.constant(1 : i8) : i8
+    // CHECK-NEXT: %[[#v2:]] = llvm.insertvalue %[[#v1]], %[[#v0]][0] : !llvm.struct<"struct.S", (i8, i32)>
+    // CHECK-NEXT: %[[#v3:]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-NEXT: %[[#v4:]] = llvm.insertvalue %[[#v3]], %[[#v2]][1] : !llvm.struct<"struct.S", (i8, i32)>
+    %1 = cir.extract_member %0[0] : !ty_S -> !u8i
+    // CHECK-NEXT: %{{.+}} = llvm.extractvalue %[[#v4]][0] : !llvm.struct<"struct.S", (i8, i32)>
+    %2 = cir.extract_member %0[1] : !ty_S -> !s32i
+    // CHECK-NEXT: %{{.+}} = llvm.extractvalue %[[#v4]][1] : !llvm.struct<"struct.S", (i8, i32)>
+    cir.return
+  }
+
   cir.func @shouldConstInitLocalStructsWithConstStructAttr() {
     %0 = cir.alloca !ty_S2A, !cir.ptr<!ty_S2A>, ["s"] {alignment = 4 : i64}
     %1 = cir.const #cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S2A


### PR DESCRIPTION
This PR adds support for LLVM lowering of pointers to member functions. The lowering is ABI-specific and this patch only considers Itanium ABI.

Itanium ABI lowers pointers to member functions to a struct with two fields of type `ptrdiff_t`. To extract fields from such aggregate values, this PR includes a new operation `cir.extract_member` to accomplish this.