### PR TITLE
[CIR] Fix build due to deprecated interfaces

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3638,8 +3638,8 @@ class CIR_CallOp<string mnemonic, list<Trait> extra_traits = []> :
     void setCalleeFromCallable(::mlir::CallInterfaceCallable callee) {
       if (auto calling =
               (*this)->getAttrOfType<mlir::SymbolRefAttr>(getCalleeAttrName()))
-        (*this)->setAttr(getCalleeAttrName(), callee.get<mlir::SymbolRefAttr>());
-      setOperand(0, callee.get<mlir::Value>());
+        (*this)->setAttr(getCalleeAttrName(), mlir::cast<mlir::SymbolRefAttr>(callee));
+      setOperand(0, mlir::cast<mlir::Value>(callee));
     }
 
     bool isIndirect() { return !getCallee(); }

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -1053,7 +1053,7 @@ void CIRGenFunction::emitCallArgs(
     const auto *MD = mlir::dyn_cast<const ObjCMethodDecl *>(Prototype.P);
     assert(!MD && "ObjCMethodDecl NYI");
 
-    const auto *FPT = Prototype.P.get<const FunctionProtoType *>();
+    const auto *FPT = mlir::cast<const FunctionProtoType *>(Prototype.P);
     IsVariadic = FPT->isVariadic();
     ExplicitCC = FPT->getExtInfo().getCC();
     ArgTypes.assign(FPT->param_type_begin() + ParamsToSkip,

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1456,8 +1456,8 @@ mlir::Attribute ConstantLValueEmitter::tryEmit() {
   // Convert to the appropriate type; this could be an lvalue for
   // an integer. FIXME: performAddrSpaceCast
   if (mlir::isa<cir::PointerType>(destTy)) {
-    if (value.is<mlir::Attribute>())
-      return value.get<mlir::Attribute>();
+    if (auto attr = mlir::dyn_cast<mlir::Attribute>(value))
+      return attr;
     llvm_unreachable("NYI");
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenValue.h
+++ b/clang/lib/CIR/CodeGen/CIRGenValue.h
@@ -70,8 +70,9 @@ public:
   /// Return the mlir::Value of the address of the aggregate.
   Address getAggregateAddress() const {
     assert(isAggregate() && "Not an aggregate!");
-    auto align = reinterpret_cast<uintptr_t>(V2.getPointer().get<int *>()) >>
-                 AggAlignShift;
+    auto align =
+        reinterpret_cast<uintptr_t>(mlir::cast<int *>(V2.getPointer())) >>
+        AggAlignShift;
     return Address(V1.getPointer(), ElementType,
                    clang::CharUnits::fromQuantity(align));
   }

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
@@ -23,10 +23,10 @@ ConstantInitBuilderBase::ConstantInitBuilderBase(CIRGenModule &CGM)
 
 mlir::Type ConstantInitFuture::getType() const {
   assert(Data && "dereferencing null future");
-  if (Data.is<mlir::Attribute>()) {
-    auto attr = mlir::dyn_cast<mlir::TypedAttr>(Data.get<mlir::Attribute>());
-    assert(attr && "expected typed attribute");
-    return attr.getType();
+  if (auto attr = mlir::dyn_cast<mlir::Attribute>(Data)) {
+    auto typedAttr = mlir::dyn_cast<mlir::TypedAttr>(attr);
+    assert(typedAttr && "expected typed attribute");
+    return typedAttr.getType();
   } else {
     llvm_unreachable("Only sypport typed attributes here");
   }
@@ -42,8 +42,8 @@ void ConstantInitFuture::abandon() {
 
 void ConstantInitFuture::installInGlobal(cir::GlobalOp GV) {
   assert(Data && "installing null future");
-  if (Data.is<mlir::Attribute>()) {
-    CIRGenModule::setInitializer(GV, Data.get<mlir::Attribute>());
+  if (auto attr = mlir::dyn_cast<mlir::Attribute>(Data)) {
+    CIRGenModule::setInitializer(GV, attr);
   } else {
     llvm_unreachable("NYI");
     // auto &builder = *Data.get<ConstantInitBuilderBase *>();

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -784,8 +784,8 @@ OpFoldResult cir::CastOp::fold(FoldAdaptor adaptor) {
       // create a new attribute that's capable of representing the source.
       llvm::SmallVector<mlir::OpFoldResult, 1> foldResults;
       auto foldOrder = getSrc().getDefiningOp()->fold(foldResults);
-      if (foldOrder.succeeded() && foldResults[0].is<mlir::Attribute>())
-        return foldResults[0].get<mlir::Attribute>();
+      if (foldOrder.succeeded() && mlir::isa<mlir::Attribute>(foldResults[0]))
+        return mlir::cast<mlir::Attribute>(foldResults[0]);
       return {};
     }
     case cir::CastKind::bitcast:

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -526,11 +526,11 @@ static Location getEndLocForHist(Region *R) {
 
 static Location getEndLocForHist(LifetimeCheckPass::LexicalScopeContext &lsc) {
   assert(!lsc.parent.isNull() && "shouldn't be null");
-  if (lsc.parent.is<Region *>())
-    return getEndLocForHist(lsc.parent.get<Region *>());
-  assert(lsc.parent.is<Operation *>() &&
+  if (auto r = mlir::dyn_cast<Region *>(lsc.parent))
+    return getEndLocForHist(r);
+  assert(mlir::isa<Operation *>(lsc.parent) &&
          "Only support operation beyond this point");
-  return getEndLocForHist(lsc.parent.get<Operation *>());
+  return getEndLocForHist(mlir::cast<Operation *>(lsc.parent));
 }
 
 void LifetimeCheckPass::killInPset(mlir::Value ptrKey, const State &s,

--- a/clang/test/CodeGenOpenCL/printf.cl
+++ b/clang/test/CodeGenOpenCL/printf.cl
@@ -4,7 +4,6 @@
 // RUN: %clang_cc1 -no-enable-noundef-analysis -cl-std=CL3.0 -cl-ext=-__opencl_c_fp64,-cl_khr_fp64 -triple spir-unknown-unknown -disable-llvm-passes -emit-llvm -o - %s | FileCheck -check-prefixes=NOFP64,ALL %s
 // RUN: %clang_cc1 -no-enable-noundef-analysis -cl-std=clc++2021 -cl-ext=+__opencl_c_fp64,+cl_khr_fp64 -triple spir-unknown-unknown -disable-llvm-passes -emit-llvm -o - %s | FileCheck -check-prefixes=FP64,ALL %s
 // RUN: %clang_cc1 -no-enable-noundef-analysis -cl-std=clc++2021 -cl-ext=-__opencl_c_fp64,-cl_khr_fp64 -triple spir-unknown-unknown -disable-llvm-passes -emit-llvm -o - %s | FileCheck -check-prefixes=NOFP64,ALL %s
-// XFAIL: *
 
 typedef __attribute__((ext_vector_type(2))) float float2;
 typedef __attribute__((ext_vector_type(2))) half half2;


### PR DESCRIPTION
- After abba01adad5dfc54f781357d924c8021c9306615, 'is' and 'get' interfaces are deprecated even though not removed yet. However, it causes warnings and triggers build failures if that warnings are treated as errors.