### PR TITLE
[CIR][CIRGen] Implement array cookie ABI for AppleARM64 targets

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -364,9 +364,9 @@ public:
 class CIRGenARMCXXABI : public CIRGenItaniumCXXABI {
 public:
   CIRGenARMCXXABI(CIRGenModule &CGM) : CIRGenItaniumCXXABI(CGM) {
-      // TODO(cir): When implemented, /*UseARMMethodPtrABI=*/true,
-      //                              /*UseARMGuardVarABI=*/true) {}
-      assert(!cir::MissingFeatures::appleArm64CXXABI());
+    // TODO(cir): When implemented, /*UseARMMethodPtrABI=*/true,
+    //                              /*UseARMGuardVarABI=*/true) {}
+    assert(!cir::MissingFeatures::appleArm64CXXABI());
   }
   CharUnits getArrayCookieSizeImpl(QualType elementType) override;
   Address initializeArrayCookie(CIRGenFunction &CGF, Address NewPtr,

--- a/clang/test/CIR/CodeGen/applearm64-array-cookies.cpp
+++ b/clang/test/CIR/CodeGen/applearm64-array-cookies.cpp
@@ -11,24 +11,19 @@ void t_constant_size_nontrivial() {
 }
 
 // CHECK:  cir.func @_Z26t_constant_size_nontrivialv()
-// CHECK:    %0 = cir.alloca !cir.ptr<!ty_C>, !cir.ptr<!cir.ptr<!ty_C>>, ["p", init] {alignment = 8 : i64}
 // CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<3> : !u64i
 // CHECK:    %[[#SIZE_WITHOUT_COOKIE:]] = cir.const #cir.int<3> : !u64i
 // CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<19> : !u64i
-// CHECK:    %4 = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
-// CHECK:    %5 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!u64i>
+// CHECK:    %[[#ALLOC_PTR:]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
+// CHECK:    %[[#COOKIE_PTR:]] = cir.cast(bitcast, %[[#ALLOC_PTR]] : !cir.ptr<!void>), !cir.ptr<!u64i>
 // CHECK:    %[[#ELEMENT_SIZE:]] = cir.const #cir.int<1> : !u64i
-// CHECK:    cir.store %[[#ELEMENT_SIZE]], %5 : !u64i, !cir.ptr<!u64i>
+// CHECK:    cir.store %[[#ELEMENT_SIZE]], %[[#COOKIE_PTR]] : !u64i, !cir.ptr<!u64i>
 // CHECK:    %[[#SECOND_COOKIE_OFFSET:]] = cir.const #cir.int<1> : !s32i
-// CHECK:    %8 = cir.ptr_stride(%5 : !cir.ptr<!u64i>, %[[#SECOND_COOKIE_OFFSET]] : !s32i), !cir.ptr<!u64i>
-// CHECK:    cir.store %[[#NUM_ELEMENTS]], %8 : !u64i, !cir.ptr<!u64i>
+// CHECK:    %[[#COOKIE_PTR2:]] = cir.ptr_stride(%[[#COOKIE_PTR]] : !cir.ptr<!u64i>, %[[#SECOND_COOKIE_OFFSET]] : !s32i), !cir.ptr<!u64i>
+// CHECK:    cir.store %[[#NUM_ELEMENTS]], %[[#COOKIE_PTR2]] : !u64i, !cir.ptr<!u64i>
 // CHECK:    %[[#COOKIE_SIZE:]] = cir.const #cir.int<16> : !s32i
-// CHECK:    %10 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!u8i>
-// CHECK:    %11 = cir.ptr_stride(%10 : !cir.ptr<!u8i>, %[[#COOKIE_SIZE]] : !s32i), !cir.ptr<!u8i>
-// CHECK:    %12 = cir.cast(bitcast, %11 : !cir.ptr<!u8i>), !cir.ptr<!ty_C>
-// CHECK:    cir.store %12, %0 : !cir.ptr<!ty_C>, !cir.ptr<!cir.ptr<!ty_C>>
-// CHECK:    cir.return
-// CHECK:  }
+// CHECK:    %[[#ALLOC_AS_I8:]] = cir.cast(bitcast, %[[#ALLOC_PTR]] : !cir.ptr<!void>), !cir.ptr<!u8i>
+// CHECK:    cir.ptr_stride(%[[#ALLOC_AS_I8]] : !cir.ptr<!u8i>, %[[#COOKIE_SIZE]] : !s32i), !cir.ptr<!u8i>
 
 class D {
   public:
@@ -44,21 +39,16 @@ void t_constant_size_nontrivial2() {
 // an initializer.
 
 // CHECK:  cir.func @_Z27t_constant_size_nontrivial2v()
-// CHECK:    %0 = cir.alloca !cir.ptr<!ty_D>, !cir.ptr<!cir.ptr<!ty_D>>, ["p", init] {alignment = 8 : i64}
 // CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<3> : !u64i
 // CHECK:    %[[#SIZE_WITHOUT_COOKIE:]] = cir.const #cir.int<12> : !u64i
 // CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<28> : !u64i
-// CHECK:    %4 = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
-// CHECK:    %5 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!u64i>
+// CHECK:    %[[#ALLOC_PTR:]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
+// CHECK:    %[[#COOKIE_PTR:]] = cir.cast(bitcast, %[[#ALLOC_PTR]] : !cir.ptr<!void>), !cir.ptr<!u64i>
 // CHECK:    %[[#ELEMENT_SIZE:]] = cir.const #cir.int<4> : !u64i
-// CHECK:    cir.store %[[#ELEMENT_SIZE]], %5 : !u64i, !cir.ptr<!u64i>
+// CHECK:    cir.store %[[#ELEMENT_SIZE]], %[[#COOKIE_PTR]] : !u64i, !cir.ptr<!u64i>
 // CHECK:    %[[#SECOND_COOKIE_OFFSET:]] = cir.const #cir.int<1> : !s32i
-// CHECK:    %8 = cir.ptr_stride(%5 : !cir.ptr<!u64i>, %[[#SECOND_COOKIE_OFFSET]] : !s32i), !cir.ptr<!u64i>
-// CHECK:    cir.store %[[#NUM_ELEMENTS]], %8 : !u64i, !cir.ptr<!u64i>
+// CHECK:    %[[#COOKIE_PTR2:]] = cir.ptr_stride(%[[#COOKIE_PTR]] : !cir.ptr<!u64i>, %[[#SECOND_COOKIE_OFFSET]] : !s32i), !cir.ptr<!u64i>
+// CHECK:    cir.store %[[#NUM_ELEMENTS]], %[[#COOKIE_PTR2]] : !u64i, !cir.ptr<!u64i>
 // CHECK:    %[[#COOKIE_SIZE:]] = cir.const #cir.int<16> : !s32i
-// CHECK:    %10 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!u8i>
-// CHECK:    %11 = cir.ptr_stride(%10 : !cir.ptr<!u8i>, %[[#COOKIE_SIZE]] : !s32i), !cir.ptr<!u8i>
-// CHECK:    %12 = cir.cast(bitcast, %11 : !cir.ptr<!u8i>), !cir.ptr<!ty_D>
-// CHECK:    cir.store %12, %0 : !cir.ptr<!ty_D>, !cir.ptr<!cir.ptr<!ty_D>>
-// CHECK:    cir.return
-// CHECK:  }
+// CHECK:    %[[#ALLOC_AS_I8:]] = cir.cast(bitcast, %[[#ALLOC_PTR]] : !cir.ptr<!void>), !cir.ptr<!u8i>
+// CHECK:    cir.ptr_stride(%[[#ALLOC_AS_I8]] : !cir.ptr<!u8i>, %[[#COOKIE_SIZE]] : !s32i), !cir.ptr<!u8i>

--- a/clang/test/CIR/CodeGen/applearm64-array-cookies.cpp
+++ b/clang/test/CIR/CodeGen/applearm64-array-cookies.cpp
@@ -1,0 +1,64 @@
+// RUN: %clang_cc1 -std=c++20 -triple=arm64e-apple-darwin -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+class C {
+  public:
+    ~C();
+};
+
+void t_constant_size_nontrivial() {
+  auto p = new C[3];
+}
+
+// CHECK:  cir.func @_Z26t_constant_size_nontrivialv()
+// CHECK:    %0 = cir.alloca !cir.ptr<!ty_C>, !cir.ptr<!cir.ptr<!ty_C>>, ["p", init] {alignment = 8 : i64}
+// CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<3> : !u64i
+// CHECK:    %[[#SIZE_WITHOUT_COOKIE:]] = cir.const #cir.int<3> : !u64i
+// CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<19> : !u64i
+// CHECK:    %4 = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
+// CHECK:    %5 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!u64i>
+// CHECK:    %[[#ELEMENT_SIZE:]] = cir.const #cir.int<1> : !u64i
+// CHECK:    cir.store %[[#ELEMENT_SIZE]], %5 : !u64i, !cir.ptr<!u64i>
+// CHECK:    %[[#SECOND_COOKIE_OFFSET:]] = cir.const #cir.int<1> : !s32i
+// CHECK:    %8 = cir.ptr_stride(%5 : !cir.ptr<!u64i>, %[[#SECOND_COOKIE_OFFSET]] : !s32i), !cir.ptr<!u64i>
+// CHECK:    cir.store %[[#NUM_ELEMENTS]], %8 : !u64i, !cir.ptr<!u64i>
+// CHECK:    %[[#COOKIE_SIZE:]] = cir.const #cir.int<16> : !s32i
+// CHECK:    %10 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!u8i>
+// CHECK:    %11 = cir.ptr_stride(%10 : !cir.ptr<!u8i>, %[[#COOKIE_SIZE]] : !s32i), !cir.ptr<!u8i>
+// CHECK:    %12 = cir.cast(bitcast, %11 : !cir.ptr<!u8i>), !cir.ptr<!ty_C>
+// CHECK:    cir.store %12, %0 : !cir.ptr<!ty_C>, !cir.ptr<!cir.ptr<!ty_C>>
+// CHECK:    cir.return
+// CHECK:  }
+
+class D {
+  public:
+    int x;
+    ~D();
+};
+
+void t_constant_size_nontrivial2() {
+  auto p = new D[3];
+}
+
+// In this test SIZE_WITHOUT_COOKIE isn't used, but it would be if there were
+// an initializer.
+
+// CHECK:  cir.func @_Z27t_constant_size_nontrivial2v()
+// CHECK:    %0 = cir.alloca !cir.ptr<!ty_D>, !cir.ptr<!cir.ptr<!ty_D>>, ["p", init] {alignment = 8 : i64}
+// CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<3> : !u64i
+// CHECK:    %[[#SIZE_WITHOUT_COOKIE:]] = cir.const #cir.int<12> : !u64i
+// CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<28> : !u64i
+// CHECK:    %4 = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
+// CHECK:    %5 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!u64i>
+// CHECK:    %[[#ELEMENT_SIZE:]] = cir.const #cir.int<4> : !u64i
+// CHECK:    cir.store %[[#ELEMENT_SIZE]], %5 : !u64i, !cir.ptr<!u64i>
+// CHECK:    %[[#SECOND_COOKIE_OFFSET:]] = cir.const #cir.int<1> : !s32i
+// CHECK:    %8 = cir.ptr_stride(%5 : !cir.ptr<!u64i>, %[[#SECOND_COOKIE_OFFSET]] : !s32i), !cir.ptr<!u64i>
+// CHECK:    cir.store %[[#NUM_ELEMENTS]], %8 : !u64i, !cir.ptr<!u64i>
+// CHECK:    %[[#COOKIE_SIZE:]] = cir.const #cir.int<16> : !s32i
+// CHECK:    %10 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!u8i>
+// CHECK:    %11 = cir.ptr_stride(%10 : !cir.ptr<!u8i>, %[[#COOKIE_SIZE]] : !s32i), !cir.ptr<!u8i>
+// CHECK:    %12 = cir.cast(bitcast, %11 : !cir.ptr<!u8i>), !cir.ptr<!ty_D>
+// CHECK:    cir.store %12, %0 : !cir.ptr<!ty_D>, !cir.ptr<!cir.ptr<!ty_D>>
+// CHECK:    cir.return
+// CHECK:  }

--- a/clang/test/CIR/Lowering/applearm64-new.cpp
+++ b/clang/test/CIR/Lowering/applearm64-new.cpp
@@ -17,13 +17,11 @@ void t_constant_size_nontrivial() {
 //       missing "inbounds"
 
 // LLVM: @_Z26t_constant_size_nontrivialv()
-// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
 // LLVM:   %[[COOKIE_PTR:.*]] = call ptr @_Znam(i64 19)
 // LLVM:   store i64 1, ptr %[[COOKIE_PTR]], align 8
 // LLVM:   %[[NUM_ELEMENTS_PTR:.*]] = getelementptr i64, ptr %[[COOKIE_PTR]], i64 1
 // LLVM:   store i64 3, ptr %[[NUM_ELEMENTS_PTR]], align 8
 // LLVM:   %[[ALLOCATED_PTR:.*]] = getelementptr i8, ptr %[[COOKIE_PTR]], i64 16
-// LLVM:   store ptr %[[ALLOCATED_PTR]], ptr %[[ALLOCA]], align 8
 
 class D {
   public:
@@ -36,10 +34,8 @@ void t_constant_size_nontrivial2() {
 }
 
 // LLVM: @_Z27t_constant_size_nontrivial2v()
-// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
 // LLVM:   %[[COOKIE_PTR:.*]] = call ptr @_Znam(i64 28)
 // LLVM:   store i64 4, ptr %[[COOKIE_PTR]], align 8
 // LLVM:   %[[NUM_ELEMENTS_PTR:.*]] = getelementptr i64, ptr %[[COOKIE_PTR]], i64 1
 // LLVM:   store i64 3, ptr %[[NUM_ELEMENTS_PTR]], align 8
 // LLVM:   %[[ALLOCATED_PTR:.*]] = getelementptr i8, ptr %[[COOKIE_PTR]], i64 16
-// LLVM:   store ptr %[[ALLOCATED_PTR]], ptr %[[ALLOCA]], align 8

--- a/clang/test/CIR/Lowering/applearm64-new.cpp
+++ b/clang/test/CIR/Lowering/applearm64-new.cpp
@@ -1,0 +1,45 @@
+// RUN: %clang_cc1 -triple=arm64e-apple-darwin -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+class C {
+  public:
+    ~C();
+};
+
+void t_constant_size_nontrivial() {
+  auto p = new C[3];
+}
+
+// Note: The below differs from the IR emitted by clang without -fclangir in
+//       several respects. (1) The alloca here has an extra "i64 1"
+//       (2) The operator new call is missing "noalias noundef nonnull" on
+//       the call and "noundef" on the argument, (3) The getelementptr is
+//       missing "inbounds"
+
+// LLVM: @_Z26t_constant_size_nontrivialv()
+// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[COOKIE_PTR:.*]] = call ptr @_Znam(i64 19)
+// LLVM:   store i64 1, ptr %[[COOKIE_PTR]], align 8
+// LLVM:   %[[NUM_ELEMENTS_PTR:.*]] = getelementptr i64, ptr %[[COOKIE_PTR]], i64 1
+// LLVM:   store i64 3, ptr %[[NUM_ELEMENTS_PTR]], align 8
+// LLVM:   %[[ALLOCATED_PTR:.*]] = getelementptr i8, ptr %[[COOKIE_PTR]], i64 16
+// LLVM:   store ptr %[[ALLOCATED_PTR]], ptr %[[ALLOCA]], align 8
+
+class D {
+  public:
+    int x;
+    ~D();
+};
+
+void t_constant_size_nontrivial2() {
+  auto p = new D[3];
+}
+
+// LLVM: @_Z27t_constant_size_nontrivial2v()
+// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[COOKIE_PTR:.*]] = call ptr @_Znam(i64 28)
+// LLVM:   store i64 4, ptr %[[COOKIE_PTR]], align 8
+// LLVM:   %[[NUM_ELEMENTS_PTR:.*]] = getelementptr i64, ptr %[[COOKIE_PTR]], i64 1
+// LLVM:   store i64 3, ptr %[[NUM_ELEMENTS_PTR]], align 8
+// LLVM:   %[[ALLOCATED_PTR:.*]] = getelementptr i8, ptr %[[COOKIE_PTR]], i64 16
+// LLVM:   store ptr %[[ALLOCATED_PTR]], ptr %[[ALLOCA]], align 8


### PR DESCRIPTION
This change introduces CIRGenCXXABI subclasses for ARM and AppleARM64 and implements ARM CXXABI handling for array cookies.