### PR TITLE
Implement support for zero-initialized builtin type allocation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -532,6 +532,10 @@ public:
   // Constant creation helpers
   // -------------------------
   //
+  cir::ConstantOp getUInt8(uint8_t c, mlir::Location loc) {
+    auto uInt8Ty = getUInt8Ty();
+    return create<cir::ConstantOp>(loc, uInt8Ty, cir::IntAttr::get(uInt8Ty, c));
+  }
   cir::ConstantOp getSInt32(int32_t c, mlir::Location loc) {
     auto sInt32Ty = getSInt32Ty();
     return create<cir::ConstantOp>(loc, sInt32Ty,

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -991,25 +991,18 @@ void CIRGenFunction::emitNewArrayInitializer(
       if (!CCE->requiresZeroInitialization() || Ctor->getParent()->isEmpty())
         return;
 
-      if (TryMemsetInitialization())
-        return;
+      llvm_unreachable("NYI");
     }
 
     llvm_unreachable("NYI");
   }
 
   // If this is value-initialization, we can usually use memset.
-  ImplicitValueInitExpr IVIE(ElementType);
   if (isa<ImplicitValueInitExpr>(Init)) {
     if (TryMemsetInitialization())
       return;
-
-    // Switch to an ImplicitValueInitExpr for the element type. This handles
-    // only one case: multidimensional array new of pointers to members. In
-    // all other cases, we already have an initializer for the array element.
-    Init = &IVIE;
+    llvm_unreachable("NYI");
   }
-
   llvm_unreachable("NYI");
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -876,11 +876,97 @@ void CIRGenFunction::emitNewArrayInitializer(
   unsigned InitListElements = 0;
 
   const Expr *Init = E->getInitializer();
+  QualType::DestructionKind DtorKind = ElementType.isDestructedType();
   CleanupDeactivationScope deactivation(*this);
+  bool pushedCleanup = false;
+
+  CharUnits ElementSize = getContext().getTypeSizeInChars(ElementType);
+  CharUnits ElementAlign =
+      BeginPtr.getAlignment().alignmentOfArrayElement(ElementSize);
+
+  // Attempt to perform zero-initialization using memset.
+  auto TryMemsetInitialization = [&]() -> bool {
+    auto Loc = NumElements.getLoc();
+
+    // FIXME: If the type is a pointer-to-data-member under the Itanium ABI,
+    // we can initialize with a memset to -1.
+    if (!CGM.getTypes().isZeroInitializable(ElementType))
+      return false;
+
+    // Optimization: since zero initialization will just set the memory
+    // to all zeroes, generate a single memset to do it in one shot.
+
+    // Subtract out the size of any elements we've already initialized.
+    auto RemainingSize = AllocSizeWithoutCookie;
+    if (InitListElements) {
+      llvm_unreachable("NYI");
+    }
+
+    // Create the memset.
+    auto CastOp =
+        builder.createPtrBitcast(CurPtr.getPointer(), builder.getVoidTy());
+    builder.createMemSet(Loc, CastOp, builder.getUInt8(0, Loc), RemainingSize);
+    return true;
+  };
 
   const InitListExpr *ILE = dyn_cast<InitListExpr>(Init);
-  if (ILE) {
-    llvm_unreachable("NYI");
+  const CXXParenListInitExpr *CPLIE = nullptr;
+  const StringLiteral *SL = nullptr;
+  const ObjCEncodeExpr *OCEE = nullptr;
+  const Expr *IgnoreParen = nullptr;
+  if (!ILE) {
+    IgnoreParen = Init->IgnoreParenImpCasts();
+    CPLIE = dyn_cast<CXXParenListInitExpr>(IgnoreParen);
+    SL = dyn_cast<StringLiteral>(IgnoreParen);
+    OCEE = dyn_cast<ObjCEncodeExpr>(IgnoreParen);
+  }
+
+  // If the initializer is an initializer list, first do the explicit elements.
+  if (ILE || CPLIE || SL || OCEE) {
+    // Initializing from a (braced) string literal is a special case; the init
+    // list element does not initialize a (single) array element.
+    if ((ILE && ILE->isStringLiteralInit()) || SL || OCEE) {
+      llvm_unreachable("NYI");
+    }
+
+    ArrayRef<const Expr *> InitExprs =
+        ILE ? ILE->inits() : CPLIE->getInitExprs();
+    InitListElements = InitExprs.size();
+
+    // If this is a multi-dimensional array new, we will initialize multiple
+    // elements with each init list element.
+    QualType AllocType = E->getAllocatedType();
+    if (const ConstantArrayType *CAT = dyn_cast_or_null<ConstantArrayType>(
+            AllocType->getAsArrayTypeUnsafe())) {
+      llvm_unreachable("NYI");
+    }
+
+    // Enter a partial-destruction Cleanup if necessary.
+    if (DtorKind) {
+      llvm_unreachable("NYI");
+    }
+
+    CharUnits StartAlign = CurPtr.getAlignment();
+    for (const Expr *IE : InitExprs) {
+      llvm_unreachable("NYI");
+    }
+
+    // The remaining elements are filled with the array filler expression.
+    Init = ILE ? ILE->getArrayFiller() : CPLIE->getArrayFiller();
+
+    // Extract the initializer for the individual array elements by pulling
+    // out the array filler from all the nested initializer lists. This avoids
+    // generating a nested loop for the initialization.
+    while (Init && Init->getType()->isConstantArrayType()) {
+      auto *SubILE = dyn_cast<InitListExpr>(Init);
+      if (!SubILE)
+        break;
+      assert(SubILE->getNumInits() == 0 && "explicit inits in array filler?");
+      Init = SubILE->getArrayFiller();
+    }
+
+    // Switch back to initializing one base element at a time.
+    CurPtr = CurPtr.withElementType(BeginPtr.getElementType());
   }
 
   // If all elements have already been initialized, skip any further
@@ -905,10 +991,23 @@ void CIRGenFunction::emitNewArrayInitializer(
       if (!CCE->requiresZeroInitialization() || Ctor->getParent()->isEmpty())
         return;
 
-      llvm_unreachable("NYI");
+      if (TryMemsetInitialization())
+        return;
     }
 
     llvm_unreachable("NYI");
+  }
+
+  // If this is value-initialization, we can usually use memset.
+  ImplicitValueInitExpr IVIE(ElementType);
+  if (isa<ImplicitValueInitExpr>(Init)) {
+    if (TryMemsetInitialization())
+      return;
+
+    // Switch to an ImplicitValueInitExpr for the element type. This handles
+    // only one case: multidimensional array new of pointers to members. In
+    // all other cases, we already have an initializer for the array element.
+    Init = &IVIE;
   }
 
   llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -878,7 +878,6 @@ void CIRGenFunction::emitNewArrayInitializer(
   const Expr *Init = E->getInitializer();
   QualType::DestructionKind DtorKind = ElementType.isDestructedType();
   CleanupDeactivationScope deactivation(*this);
-  bool pushedCleanup = false;
 
   CharUnits ElementSize = getContext().getTypeSizeInChars(ElementType);
   CharUnits ElementAlign =

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -144,3 +144,25 @@ void t_constant_size_nontrivial2() {
 // CHECK:    cir.store %9, %0 : !cir.ptr<!ty_D>, !cir.ptr<!cir.ptr<!ty_D>>
 // CHECK:    cir.return
 // CHECK:  }
+
+void t_constant_size_memset_init() {
+  auto p = new int[16] {};
+}
+
+// In this test, NUM_ELEMENTS isn't used because no cookie is needed and there
+//   are no constructor calls needed.
+
+// CHECK:  cir.func @_Z27t_constant_size_memset_initv()
+// CHECK:    %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init] {alignment = 8 : i64}
+// CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<16> : !u64i
+// CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<64> : !u64i
+// CHECK:    %3 = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
+// CHECK:    %4 = cir.cast(bitcast, %3 : !cir.ptr<!void>), !cir.ptr<!s32i>
+// TODO: How can we avoid casting back to void* here?
+// CHECK:    %5 = cir.cast(bitcast, %4 : !cir.ptr<!s32i>), !cir.ptr<!void>
+// CHECK:    %6 = cir.const #cir.int<0> : !u8i
+// CHECK:    %7 = cir.cast(integral, %6 : !u8i), !s32i
+// CHECK:    cir.libc.memset %[[#ALLOCATION_SIZE]] bytes from %5 set to %7 : !cir.ptr<!void>, !s32i, !u64i
+// CHECK:    cir.store %4, %0 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
+// CHECK:    cir.return
+// CHECK:  }

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -153,16 +153,11 @@ void t_constant_size_memset_init() {
 //   are no constructor calls needed.
 
 // CHECK:  cir.func @_Z27t_constant_size_memset_initv()
-// CHECK:    %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init] {alignment = 8 : i64}
 // CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<16> : !u64i
 // CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<64> : !u64i
-// CHECK:    %3 = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
-// CHECK:    %4 = cir.cast(bitcast, %3 : !cir.ptr<!void>), !cir.ptr<!s32i>
-// TODO: How can we avoid casting back to void* here?
-// CHECK:    %5 = cir.cast(bitcast, %4 : !cir.ptr<!s32i>), !cir.ptr<!void>
-// CHECK:    %6 = cir.const #cir.int<0> : !u8i
-// CHECK:    %7 = cir.cast(integral, %6 : !u8i), !s32i
-// CHECK:    cir.libc.memset %[[#ALLOCATION_SIZE]] bytes from %5 set to %7 : !cir.ptr<!void>, !s32i, !u64i
-// CHECK:    cir.store %4, %0 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
-// CHECK:    cir.return
-// CHECK:  }
+// CHECK:    %[[#ALLOC_PTR:]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
+// CHECK:    %[[#ELEM_PTR:]] = cir.cast(bitcast, %[[#ALLOC_PTR]] : !cir.ptr<!void>), !cir.ptr<!s32i>
+// CHECK:    %[[#VOID_PTR:]] = cir.cast(bitcast, %[[#ELEM_PTR]] : !cir.ptr<!s32i>), !cir.ptr<!void>
+// CHECK:    %[[#ZERO:]] = cir.const #cir.int<0> : !u8i
+// CHECK:    %[[#ZERO_I32:]] = cir.cast(integral, %[[#ZERO]] : !u8i), !s32i
+// CHECK:    cir.libc.memset %[[#ALLOCATION_SIZE]] bytes from %[[#VOID_PTR]] set to %[[#ZERO_I32]] : !cir.ptr<!void>, !s32i, !u64i

--- a/clang/test/CIR/Lowering/new.cpp
+++ b/clang/test/CIR/Lowering/new.cpp
@@ -57,3 +57,13 @@ void t_constant_size_nontrivial2() {
 // LLVM:   store i64 3, ptr %[[COOKIE_PTR]], align 8
 // LLVM:   %[[ALLOCATED_PTR:.*]] = getelementptr i8, ptr %[[COOKIE_PTR]], i64 8
 // LLVM:   store ptr %[[ALLOCATED_PTR]], ptr %[[ALLOCA]], align 8
+
+void t_constant_size_memset_init() {
+  auto p = new int[16] {};
+}
+
+// LLVM: @_Z27t_constant_size_memset_initv()
+// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[ADDR:.*]] = call ptr @_Znam(i64 64)
+// LLVM:   call void @llvm.memset.p0.i64(ptr %[[ADDR]], i8 0, i64 64, i1 false)
+// LLVM:   store ptr %[[ADDR]], ptr %[[ALLOCA]], align 8


### PR DESCRIPTION
This handles initialization of array new allocations in the simple case
where the entire allocated memory block can be initialized with a memset
to zero.