### PR TITLE
[CIR][CUDA] Add initial support for name-mangling CUDA declarations

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -1639,9 +1639,9 @@ static void getTrivialDefaultFunctionAttributes(
   // TODO: NoThrow attribute should be added for other GPU modes CUDA, SYCL,
   // HIP, OpenMP offload.
   // AFAIK, neither of them support exceptions in device code.
-  if ((langOpts.CUDA && langOpts.CUDAIsDevice) || langOpts.SYCLIsDevice)
+  if (langOpts.SYCLIsDevice)
     llvm_unreachable("NYI");
-  if (langOpts.OpenCL) {
+  if (langOpts.OpenCL || (langOpts.CUDA && langOpts.CUDAIsDevice)) {
     auto noThrow = cir::NoThrowAttr::get(CGM.getBuilder().getContext());
     funcAttrs.set(noThrow.getMnemonic(), noThrow);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -348,7 +348,11 @@ mlir::Type CIRGenTypes::convertType(QualType T) {
 
   // For the device-side compilation, CUDA device builtin surface/texture types
   // may be represented in different types.
-  assert(!astContext.getLangOpts().CUDAIsDevice && "not implemented");
+  if (astContext.getLangOpts().CUDAIsDevice) {
+    if (Ty->isCUDADeviceBuiltinSurfaceType() ||
+        Ty->isCUDADeviceBuiltinTextureType())
+      llvm_unreachable("NYI");
+  }
 
   if (const auto *recordType = dyn_cast<RecordType>(T))
     return convertRecordDeclType(recordType->getDecl());

--- a/clang/test/CIR/CodeGen/CUDA/simple-device.cu
+++ b/clang/test/CIR/CodeGen/CUDA/simple-device.cu
@@ -1,0 +1,14 @@
+#include "../Inputs/cuda.h"
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -fcuda-is-device \
+// RUN:            -fclangir -emit-cir -o - %s | FileCheck %s
+
+// This shouldn't emit.
+__host__ void host_fn(int *a, int *b, int *c) {}
+
+// CHECK-NOT: cir.func @_Z7host_fnPiS_S_
+
+// This should emit as a normal C++ function.
+__device__ void device_fn(int* a, double b, float c) {}
+
+// CIR: cir.func @_Z9device_fnPidf


### PR DESCRIPTION
The name-mangling for normal CUDA device/host functions are typically the same as normal C++ functions. 

However, special care is taken when `-fgpu-rdc` is specified, which requires `__device__` function names to be unique across complication unit in order to avoid symbol collisions.