### PR TITLE
[CIR] Implement partial initialization for array new

### DIFF
--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -161,3 +161,31 @@ void t_constant_size_memset_init() {
 // CHECK:    %[[#ZERO:]] = cir.const #cir.int<0> : !u8i
 // CHECK:    %[[#ZERO_I32:]] = cir.cast(integral, %[[#ZERO]] : !u8i), !s32i
 // CHECK:    cir.libc.memset %[[#ALLOCATION_SIZE]] bytes from %[[#VOID_PTR]] set to %[[#ZERO_I32]] : !cir.ptr<!void>, !s32i, !u64i
+
+void t_constant_size_partial_init() {
+  auto p = new int[16] { 1, 2, 3 };
+}
+
+// CHECK:  cir.func @_Z28t_constant_size_partial_initv()
+// CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<16> : !u64i
+// CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<64> : !u64i
+// CHECK:    %[[#ALLOC_PTR:]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
+// CHECK:    %[[#ELEM_0_PTR:]] = cir.cast(bitcast, %[[#ALLOC_PTR]] : !cir.ptr<!void>), !cir.ptr<!s32i>
+// CHECK:    %[[#CONST_ONE:]] = cir.const #cir.int<1> : !s32i
+// CHECK:    cir.store %[[#CONST_ONE]], %[[#ELEM_0_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[#OFFSET:]] = cir.const #cir.int<1> : !s32i
+// CHECK:    %[[#ELEM_1_PTR:]] = cir.ptr_stride(%[[#ELEM_0_PTR]] : !cir.ptr<!s32i>, %[[#OFFSET]] : !s32i), !cir.ptr<!s32i>
+// CHECK:    %[[#CONST_TWO:]] = cir.const #cir.int<2> : !s32i
+// CHECK:    cir.store %[[#CONST_TWO]], %[[#ELEM_1_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[#OFFSET1:]] = cir.const #cir.int<1> : !s32i
+// CHECK:    %[[#ELEM_2_PTR:]] = cir.ptr_stride(%[[#ELEM_1_PTR]] : !cir.ptr<!s32i>, %[[#OFFSET1]] : !s32i), !cir.ptr<!s32i>
+// CHECK:    %[[#CONST_THREE:]] = cir.const #cir.int<3> : !s32i
+// CHECK:    cir.store %[[#CONST_THREE]], %[[#ELEM_2_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[#OFFSET2:]] = cir.const #cir.int<1> : !s32i
+// CHECK:    %[[#ELEM_3_PTR:]] = cir.ptr_stride(%[[#ELEM_2_PTR]] : !cir.ptr<!s32i>, %[[#OFFSET2]] : !s32i), !cir.ptr<!s32i>
+// CHECK:    %[[#INIT_SIZE:]] = cir.const #cir.int<12> : !u64i
+// CHECK:    %[[#REMAINING_SIZE:]] = cir.binop(sub, %[[#ALLOCATION_SIZE]], %[[#INIT_SIZE]]) : !u64i
+// CHECK:    %[[#VOID_PTR:]] = cir.cast(bitcast, %[[#ELEM_3_PTR]] : !cir.ptr<!s32i>), !cir.ptr<!void>
+// CHECK:    %[[#ZERO:]] = cir.const #cir.int<0> : !u8i
+// CHECK:    %[[#ZERO_I32:]] = cir.cast(integral, %[[#ZERO]] : !u8i), !s32i
+// CHECK:    cir.libc.memset %[[#REMAINING_SIZE]] bytes from %[[#VOID_PTR]] set to %[[#ZERO_I32]] : !cir.ptr<!void>, !s32i, !u64i

--- a/clang/test/CIR/Lowering/new.cpp
+++ b/clang/test/CIR/Lowering/new.cpp
@@ -67,3 +67,19 @@ void t_constant_size_memset_init() {
 // LLVM:   %[[ADDR:.*]] = call ptr @_Znam(i64 64)
 // LLVM:   call void @llvm.memset.p0.i64(ptr %[[ADDR]], i8 0, i64 64, i1 false)
 // LLVM:   store ptr %[[ADDR]], ptr %[[ALLOCA]], align 8
+
+void t_constant_size_partial_init() {
+  auto p = new int[16] { 1, 2, 3 };
+}
+
+// LLVM: @_Z28t_constant_size_partial_initv()
+// LLVM:   %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
+// LLVM:   %[[ADDR:.*]] = call ptr @_Znam(i64 64)
+// LLVM:   store i32 1, ptr %[[ADDR]], align 4
+// LLVM:   %[[ELEM_1_PTR:.*]] = getelementptr i32, ptr %[[ADDR]], i64 1
+// LLVM:   store i32 2, ptr %[[ELEM_1_PTR]], align 4
+// LLVM:   %[[ELEM_2_PTR:.*]] = getelementptr i32, ptr %[[ELEM_1_PTR]], i64 1
+// LLVM:   store i32 3, ptr %[[ELEM_2_PTR]], align 4
+// LLVM:   %[[ELEM_3_PTR:.*]] = getelementptr i32, ptr %[[ELEM_2_PTR]], i64 1
+// LLVM:   call void @llvm.memset.p0.i64(ptr %[[ELEM_3_PTR]], i8 0, i64 52, i1 false)
+// LLVM:   store ptr %[[ADDR]], ptr %[[ALLOCA]], align 8


### PR DESCRIPTION
This implements CIR generation for the case where an array is allocated with array new and a partial initialization list is provided.