### PR TITLE
[CIR][ABI][Lowering] Fixes calling convention 

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -1277,10 +1277,10 @@ mlir::Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
       mlir::Value RetVal = callOp.getResult();
       mlir::Value dstPtr;
       for (auto *user : Caller->getUsers()) {
-          if (auto storeOp = mlir::dyn_cast<StoreOp>(user)) {
-            assert(!dstPtr && "multiple destinations for the return value");
-            dstPtr = storeOp.getAddr();
-          }
+        if (auto storeOp = mlir::dyn_cast<StoreOp>(user)) {
+          assert(!dstPtr && "multiple destinations for the return value");
+          dstPtr = storeOp.getAddr();
+        }
       }
 
       // TODO(cir): Check for volatile return values.

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -304,16 +304,16 @@ void pass_nested_u(NESTED_U a) {}
 // CHECK: %[[#V0:]] = cir.alloca !ty_NESTED_U, !cir.ptr<!ty_NESTED_U>
 // CHECK: %[[#V1:]] = cir.alloca !u64i, !cir.ptr<!u64i>, ["tmp"]
 // CHECK: %[[#V2:]] = cir.load %[[#V0]] : !cir.ptr<!ty_NESTED_U>, !ty_NESTED_U
-// CHECK: %[[#V3:]] = cir.cast(bitcast, %0 : !cir.ptr<!ty_NESTED_U>), !cir.ptr<!ty_anon2E0_>
-// CHECK: %[[#V4:]] = cir.load %3 : !cir.ptr<!ty_anon2E0_>, !ty_anon2E0_
-// CHECK: %[[#V5:]] = cir.cast(bitcast, %3 : !cir.ptr<!ty_anon2E0_>), !cir.ptr<!ty_anon2E1_>
-// CHECK: %[[#V6:]] = cir.load %5 : !cir.ptr<!ty_anon2E1_>, !ty_anon2E1_
-// CHECK: %[[#V7:]] = cir.cast(bitcast, %5 : !cir.ptr<!ty_anon2E1_>), !cir.ptr<!void>
-// CHECK: %[[#V8:]] = cir.cast(bitcast, %1 : !cir.ptr<!u64i>), !cir.ptr<!void>
+// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_NESTED_U>), !cir.ptr<!ty_anon2E0_>
+// CHECK: %[[#V4:]] = cir.load %[[#V3]] : !cir.ptr<!ty_anon2E0_>, !ty_anon2E0_
+// CHECK: %[[#V5:]] = cir.cast(bitcast, %[[#V3]] : !cir.ptr<!ty_anon2E0_>), !cir.ptr<!ty_anon2E1_>
+// CHECK: %[[#V6:]] = cir.load %[[#V5]] : !cir.ptr<!ty_anon2E1_>, !ty_anon2E1_
+// CHECK: %[[#V7:]] = cir.cast(bitcast, %[[#V5]] : !cir.ptr<!ty_anon2E1_>), !cir.ptr<!void>
+// CHECK: %[[#V8:]] = cir.cast(bitcast, %[[#V1]] : !cir.ptr<!u64i>), !cir.ptr<!void>
 // CHECK: %[[#V9:]] = cir.const #cir.int<2> : !u64i
-// CHECK: cir.libc.memcpy %9 bytes from %7 to %8 : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
-// CHECK: %[[#V10:]] = cir.load %1 : !cir.ptr<!u64i>, !u64i
-// CHECK: cir.call @pass_nested_u(%10) : (!u64i) -> ()
+// CHECK: cir.libc.memcpy %[[#V9]] bytes from %[[#V7]] to %[[#V8]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+// CHECK: %[[#V10:]] = cir.load %[[#V1]] : !cir.ptr<!u64i>, !u64i
+// CHECK: cir.call @pass_nested_u(%[[#V10]]) : (!u64i) -> ()
 
 // LLVM: void @call_nested_u()
 // LLVM: %[[#V1:]] = alloca %struct.NESTED_U, i64 1, align 1

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -302,19 +302,18 @@ void pass_nested_u(NESTED_U a) {}
 
 // CHECK: cir.func no_proto @call_nested_u()
 // CHECK: %[[#V0:]] = cir.alloca !ty_NESTED_U, !cir.ptr<!ty_NESTED_U>
-// CHECK: %[[#V1:]] = cir.alloca !u64i, !cir.ptr<!u64i>, ["tmp"] {alignment = 8 : i64}
+// CHECK: %[[#V1:]] = cir.alloca !u64i, !cir.ptr<!u64i>, ["tmp"]
 // CHECK: %[[#V2:]] = cir.load %[[#V0]] : !cir.ptr<!ty_NESTED_U>, !ty_NESTED_U
-// CHECK: %[[#V3:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_NESTED_U>)
-// CHECK: %[[#V4:]] = cir.load %[[#V3]]
-// CHECK: %[[#V5:]] = cir.cast(bitcast, %[[#V3]]
-// CHECK: %[[#V6:]] = cir.load %[[#V5]]
-// CHECK: %[[#V7:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_NESTED_U>), !cir.ptr<!void>
-// CHECK: %[[#V8:]] = cir.cast(bitcast, %[[#V1]] : !cir.ptr<!u64i>), !cir.ptr<!void>
+// CHECK: %[[#V3:]] = cir.cast(bitcast, %0 : !cir.ptr<!ty_NESTED_U>), !cir.ptr<!ty_anon2E0_>
+// CHECK: %[[#V4:]] = cir.load %3 : !cir.ptr<!ty_anon2E0_>, !ty_anon2E0_
+// CHECK: %[[#V5:]] = cir.cast(bitcast, %3 : !cir.ptr<!ty_anon2E0_>), !cir.ptr<!ty_anon2E1_>
+// CHECK: %[[#V6:]] = cir.load %5 : !cir.ptr<!ty_anon2E1_>, !ty_anon2E1_
+// CHECK: %[[#V7:]] = cir.cast(bitcast, %5 : !cir.ptr<!ty_anon2E1_>), !cir.ptr<!void>
+// CHECK: %[[#V8:]] = cir.cast(bitcast, %1 : !cir.ptr<!u64i>), !cir.ptr<!void>
 // CHECK: %[[#V9:]] = cir.const #cir.int<2> : !u64i
-// CHECK: cir.libc.memcpy %[[#V9]] bytes from %[[#V7]] to %[[#V8]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
-// CHECK: %[[#V10:]] = cir.load %[[#V1]] : !cir.ptr<!u64i>, !u64i
-// CHECK: cir.call @pass_nested_u(%[[#V10]]) : (!u64i) -> ()
-// CHECK: cir.return
+// CHECK: cir.libc.memcpy %9 bytes from %7 to %8 : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+// CHECK: %[[#V10:]] = cir.load %1 : !cir.ptr<!u64i>, !u64i
+// CHECK: cir.call @pass_nested_u(%10) : (!u64i) -> ()
 
 // LLVM: void @call_nested_u()
 // LLVM: %[[#V1:]] = alloca %struct.NESTED_U, i64 1, align 1
@@ -368,3 +367,46 @@ void bar(void) {
 // LLVM:  %[[#V3:]] = call [2 x i64] @foo()
 // LLVM:  store [2 x i64] %[[#V3]], ptr %[[#V2]], align 8
 // LLVM:  call void @llvm.memcpy.p0.p0.i64(ptr %[[#V1]], ptr %[[#V2]], i64 14, i1 false)
+
+
+#pragma pack(push)
+#pragma pack(1)
+typedef struct {
+   short  f0;
+   int  f1;
+} PackedS2;
+#pragma pack(pop)
+
+PackedS2 g[3] = {{1,2},{3,4},{5,6}};
+
+void baz(PackedS2 a) {
+  short *x = &g[2].f0;
+  (*x) = a.f0;
+}
+
+void qux(void) {
+  const PackedS2 *s1 = &g[1];
+  baz(*s1);
+}
+
+// check source of memcpy
+// CHECK: cir.func @qux
+// CHECK: %[[#V0:]] = cir.alloca !cir.ptr<!ty_PackedS2_>, !cir.ptr<!cir.ptr<!ty_PackedS2_>>, ["s1", init]
+// CHECK: %[[#V1:]] = cir.alloca !u64i, !cir.ptr<!u64i>, ["tmp"]
+// CHECK: %[[#V2:]] = cir.get_global @g : !cir.ptr<!cir.array<!ty_PackedS2_ x 3>>
+// CHECK: %[[#V3:]] = cir.const #cir.int<1> : !s32i
+// CHECK: %[[#V4:]] = cir.cast(array_to_ptrdecay, %[[#V2]] : !cir.ptr<!cir.array<!ty_PackedS2_ x 3>>), !cir.ptr<!ty_PackedS2_>
+// CHECK: %[[#V5:]] = cir.ptr_stride(%[[#V4]] : !cir.ptr<!ty_PackedS2_>, %[[#V3]] : !s32i), !cir.ptr<!ty_PackedS2_>
+// CHECK: cir.store %[[#V5]], %[[#V0]] : !cir.ptr<!ty_PackedS2_>, !cir.ptr<!cir.ptr<!ty_PackedS2_>>
+// CHECK: %[[#V6:]] = cir.load deref %[[#V0]] : !cir.ptr<!cir.ptr<!ty_PackedS2_>>, !cir.ptr<!ty_PackedS2_>
+// CHECK: %[[#V7:]] = cir.cast(bitcast, %[[#V6]] : !cir.ptr<!ty_PackedS2_>), !cir.ptr<!void>  
+// CHECK: %[[#V8:]] = cir.const #cir.int<6> : !u64i
+// CHECK: cir.libc.memcpy %[[#V8]] bytes from %[[#V7]] 
+
+// LLVM: void @qux
+// LLVM: %[[#V1:]] = alloca ptr, i64 1, align 8
+// LLVM: %[[#V2:]] = alloca i64, i64 1, align 8
+// LLVM: store ptr getelementptr (%struct.PackedS2, ptr @g, i64 1), ptr %[[#V1]], align 8
+// LLVM: %[[#V3:]] = load ptr, ptr %[[#V1]], align 8
+// LLVM: %[[#V4:]] = load %struct.PackedS2, ptr %[[#V3]], align 1
+// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V2]], ptr %[[#V3]], i64 6, i1 false)


### PR DESCRIPTION
This PR fixes two run time bugs in the calling convention pass. These bugs were found with `csmith`.

Case #1.  Return value from a function. 
Before this PR the returned value were stored in a bit casted memory location.
But  for the next example it's not  safe: the size of a memory slot is less than the size of return value. And the store operation cause a segfault!
```
#pragma pack(push)
#pragma pack(1)
 typedef struct {
    int f0 : 18;
    int f1 : 31;
    int f2 : 5;
    int f3 : 29;
    int f4 : 24;
 } PackedS;
#pragma pack(pop)
```
CIR type for this struct is `!ty_PackedS1_ = !cir.struct<struct "PackedS1" {!cir.array<!u8i x 14>}>`,  i.e. it occupies 14 bytes.
Before this PR the next code 
```
PackedS foo(void) {
     PackedS s;
     return s;
}

 void check(void) {     
     PackedS y = foo();    
}
```
produced the next CIR:
```
  %0 = cir.alloca !ty_PackedS1_, !cir.ptr<!ty_PackedS1_>, ["y", init] {alignment = 1 : i64}
  %1 = cir.call @foo() : () -> !cir.array<!u64i x 2> 
  %2 = cir.cast(bitcast, %0 : !cir.ptr<!ty_PackedS1_>), !cir.ptr<!cir.array<!u64i x 2>>
  cir.store %1, %2 : !cir.array<!u64i x 2>, !cir.ptr<!cir.array<!u64i x 2>>
```
As one cat see, `%1` is an array of two 64-bit integers and the memory was allocated for 14 bytes only (size of struct). Hence the segfault! This PR fixes such cases and now we have a coercion through memory, which is even with the OG.


Case #2.  Passing an argument from a pointer deref.
Previously for the struct types passed by value we tried to find alloca instruction in order to use it as a source for memcpy operation.  But if we have pointer dereference, (in other words if we have a `<!cir.ptr < !cir.ptr ...  > >` as alloca result) we don't need to search for the address of  the location where this pointer stored - instead we're interested in the pointer itself. And it's a general approach - instead of trying to find an alloca instruction we need to find a first pointer on the way - that will be an address we meed to use for the memcpy source.

I combined these two cases into a single PR since there are only few changes actually. But I can split in two if you'd prefer

