### PR TITLE
[CIR] Enable cir.bool binops

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2682,8 +2682,8 @@ mlir::LogicalResult CIRToLLVMBinOpLowering::matchAndRewrite(
          "inconsistent operands' types not supported yet");
 
   mlir::Type type = op.getRhs().getType();
-  assert((mlir::isa<cir::IntType, cir::CIRFPTypeInterface, cir::VectorType,
-                    mlir::IntegerType>(type)) &&
+  assert((mlir::isa<cir::IntType, cir::BoolType, cir::CIRFPTypeInterface,
+                    cir::VectorType, mlir::IntegerType>(type)) &&
          "operand type not supported yet");
 
   auto llvmTy = getTypeConverter()->convertType(op.getType());

--- a/clang/test/CIR/Lowering/binop-bool.cir
+++ b/clang/test/CIR/Lowering/binop-bool.cir
@@ -1,0 +1,18 @@
+// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+module {
+  cir.func @foo() {
+    %0 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["a", init] {alignment = 4 : i64}
+    %1 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b", init] {alignment = 4 : i64}
+    %2 = cir.load %0 : !cir.ptr<!cir.bool>, !cir.bool
+    %3 = cir.load %1 : !cir.ptr<!cir.bool>, !cir.bool
+    %4 = cir.binop(or, %2, %3) : !cir.bool
+    // CHECK: = llvm.or {{.*}}, {{.*}} : i1
+    %5 = cir.binop(xor, %2, %3) : !cir.bool
+    // CHECK: = llvm.xor {{.*}}, {{.*}} : i1
+    %6 = cir.binop(and, %2, %3) : !cir.bool
+    // CHECK: = llvm.and {{.*}}, {{.*}} : i1
+    cir.return
+  }
+}


### PR DESCRIPTION
Add !cir.bool to the list of types accepted by the binop rewriter. Although we don't generate boolean binops from logical operations on C++ boolean values, there will be cases where such operations are useful while generating conditions for other operations, such as the overflow checks needed for array new handling.