### PR TITLE
[CIR] Add option to emit MLIR in LLVM dialect.

### DIFF
--- a/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
@@ -32,11 +32,9 @@ class CIRGenAction : public clang::ASTFrontendAction {
 public:
   enum class OutputType {
     EmitAssembly,
-    EmitCIR,
-    EmitCIRFlat,
+    EmitMLIR,
     EmitLLVM,
     EmitBC,
-    EmitMLIR,
     EmitObj,
     None
   };
@@ -71,20 +69,6 @@ public:
 
   CIRGenConsumer *cgConsumer;
   OutputType action;
-};
-
-class EmitCIRAction : public CIRGenAction {
-  virtual void anchor();
-
-public:
-  EmitCIRAction(mlir::MLIRContext *mlirCtx = nullptr);
-};
-
-class EmitCIRFlatAction : public CIRGenAction {
-  virtual void anchor();
-
-public:
-  EmitCIRFlatAction(mlir::MLIRContext *mlirCtx = nullptr);
 };
 
 class EmitCIROnlyAction : public CIRGenAction {

--- a/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
@@ -37,6 +37,7 @@ public:
     EmitLLVM,
     EmitBC,
     EmitMLIR,
+    EmitMLIRLLVM,
     EmitObj,
     None
   };
@@ -99,6 +100,13 @@ class EmitMLIRAction : public CIRGenAction {
 
 public:
   EmitMLIRAction(mlir::MLIRContext *mlirCtx = nullptr);
+};
+
+class EmitMLIRLLVMAction : public CIRGenAction {
+  virtual void anchor();
+
+public:
+  EmitMLIRLLVMAction(mlir::MLIRContext *mlirCtx = nullptr);
 };
 
 class EmitLLVMAction : public CIRGenAction {

--- a/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
@@ -37,7 +37,6 @@ public:
     EmitLLVM,
     EmitBC,
     EmitMLIR,
-    EmitMLIRLLVM,
     EmitObj,
     None
   };
@@ -100,13 +99,6 @@ class EmitMLIRAction : public CIRGenAction {
 
 public:
   EmitMLIRAction(mlir::MLIRContext *mlirCtx = nullptr);
-};
-
-class EmitMLIRLLVMAction : public CIRGenAction {
-  virtual void anchor();
-
-public:
-  EmitMLIRLLVMAction(mlir::MLIRContext *mlirCtx = nullptr);
 };
 
 class EmitLLVMAction : public CIRGenAction {

--- a/clang/include/clang/CIR/LowerToLLVM.h
+++ b/clang/include/clang/CIR/LowerToLLVM.h
@@ -29,13 +29,19 @@ class ModuleOp;
 namespace cir {
 
 namespace direct {
+mlir::ModuleOp lowerDirectlyFromCIRToLLVMDialect(mlir::ModuleOp theModule,
+                                                 bool disableVerifier = false,
+                                                 bool disableCCLowering = false,
+                                                 bool disableDebugInfo = false);
+
+// Lower directly from pristine CIR to LLVMIR.
 std::unique_ptr<llvm::Module> lowerDirectlyFromCIRToLLVMIR(
     mlir::ModuleOp theModule, llvm::LLVMContext &llvmCtx,
     bool disableVerifier = false, bool disableCCLowering = false,
     bool disableDebugInfo = false);
-}
 
-// Lower directly from pristine CIR to LLVMIR.
+} // namespace direct
+
 std::unique_ptr<llvm::Module>
 lowerFromCIRToMLIRToLLVMIR(mlir::ModuleOp theModule,
                            std::unique_ptr<mlir::MLIRContext> mlirCtx,

--- a/clang/include/clang/CIR/LowerToMLIR.h
+++ b/clang/include/clang/CIR/LowerToMLIR.h
@@ -12,10 +12,16 @@
 #ifndef CLANG_CIR_LOWERTOMLIR_H
 #define CLANG_CIR_LOWERTOMLIR_H
 
+#include "mlir/Transforms/DialectConversion.h"
+
 namespace cir {
 
 void populateCIRLoopToSCFConversionPatterns(mlir::RewritePatternSet &patterns,
                                             mlir::TypeConverter &converter);
+
+mlir::ModuleOp
+lowerFromCIRToMLIRToLLVMDialect(mlir::ModuleOp theModule,
+                                mlir::MLIRContext *mlirCtx = nullptr);
 } // namespace cir
 
 #endif // CLANG_CIR_LOWERTOMLIR_H_

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3121,14 +3121,14 @@ def emit_cir_flat : Flag<["-"], "emit-cir-flat">, Visibility<[ClangOption, CC1Op
   Group<Action_Group>, HelpText<"Similar to -emit-cir but also lowers structured CFG into basic blocks.">;
 def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to MLIR (standard dialects "
-  "or the LLVM dialect), emit the .mlir file.">;
+  "when `-fno-clangir-direct-lowering` is used or the LLVM dialect when "
+  "`-fclangir-direct-lowering` is used), emit the .mlir file.">;
 def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[CC1Option]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to the selected MLIR dialect, emit the .mlir file. "
-  "Allowed values are `std` for MLIR standard dialects "
-  "`llvm` for the LLVM dialect and `cir` for the ClangIR dialect.">,
-  Values<"std,llvm,cir">,
+  "Allowed values are `std` for MLIR standard dialects and `llvm` for the LLVM dialect.">,
+  Values<"std,llvm">,
   NormalizedValuesScope<"FrontendOptions">,
-  NormalizedValues<["MLIR_STD", "MLIR_LLVM", "MLIR_CIR"]>,
+  NormalizedValues<["MLIR_STD", "MLIR_LLVM"]>,
   MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_Default">;
 /// ClangIR-specific options - END
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3119,17 +3119,17 @@ def emit_cir_only : Flag<["-"], "emit-cir-only">,
   HelpText<"Build ASTs and convert to CIR, discarding output">;
 def emit_cir_flat : Flag<["-"], "emit-cir-flat">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, HelpText<"Similar to -emit-cir but also lowers structured CFG into basic blocks.">;
-def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
+def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[ClangOption]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to MLIR (standard dialects "
   "when `-fno-clangir-direct-lowering` is used or the LLVM dialect when "
   "`-fclangir-direct-lowering` is used), emit the .mlir file.">;
-def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[CC1Option]>, Group<Action_Group>,
+def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[ClangOption, CC1Option]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to the selected MLIR dialect, emit the .mlir file. "
-  "Allowed values are `std` for MLIR standard dialects and `llvm` for the LLVM dialect.">,
-  Values<"std,llvm">,
-  NormalizedValuesScope<"FrontendOptions">,
-  NormalizedValues<["MLIR_STD", "MLIR_LLVM"]>,
-  MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_Default">;
+  "Allowed values are `core` for MLIR standard dialects and `llvm` for the LLVM dialect.">,
+  Values<"core,llvm,cir,cir-flat">,
+  NormalizedValuesScope<"frontend">,
+  NormalizedValues<["MLIR_CORE", "MLIR_LLVM", "MLIR_CIR", "MLIR_CIR_FLAT"]>,
+  MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_CORE">;
 /// ClangIR-specific options - END
 
 def flto : Flag<["-"], "flto">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3121,6 +3121,8 @@ def emit_cir_flat : Flag<["-"], "emit-cir-flat">, Visibility<[ClangOption, CC1Op
   Group<Action_Group>, HelpText<"Similar to -emit-cir but also lowers structured CFG into basic blocks.">;
 def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to MLIR, emit the .milr file">;
+def emit_mlir_llvm : Flag<["-"], "emit-mlir-llvm">, Visibility<[CC1Option]>, Group<Action_Group>,
+  HelpText<"Build ASTs and then lower through ClangIR to MLIR LLVM Dialect, emit the .mlir file">;
 /// ClangIR-specific options - END
 
 def flto : Flag<["-"], "flto">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3120,9 +3120,16 @@ def emit_cir_only : Flag<["-"], "emit-cir-only">,
 def emit_cir_flat : Flag<["-"], "emit-cir-flat">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, HelpText<"Similar to -emit-cir but also lowers structured CFG into basic blocks.">;
 def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
-  HelpText<"Build ASTs and then lower through ClangIR to MLIR, emit the .milr file">;
-def emit_mlir_llvm : Flag<["-"], "emit-mlir-llvm">, Visibility<[CC1Option]>, Group<Action_Group>,
-  HelpText<"Build ASTs and then lower through ClangIR to MLIR LLVM Dialect, emit the .mlir file">;
+  HelpText<"Build ASTs and then lower through ClangIR to MLIR (standard dialects "
+  "or the LLVM dialect), emit the .mlir file.">;
+def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[CC1Option]>, Group<Action_Group>,
+  HelpText<"Build ASTs and then lower through ClangIR to the selected MLIR dialect, emit the .mlir file. "
+  "Allowed values are `std` for MLIR standard dialects "
+  "`llvm` for the LLVM dialect and `cir` for the ClangIR dialect.">,
+  Values<"std,llvm,cir">,
+  NormalizedValuesScope<"FrontendOptions">,
+  NormalizedValues<["MLIR_STD", "MLIR_LLVM", "MLIR_CIR"]>,
+  MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_Default">;
 /// ClangIR-specific options - END
 
 def flto : Flag<["-"], "flto">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3113,12 +3113,6 @@ defm clangir_call_conv_lowering : BoolFOption<"clangir-call-conv-lowering",
   NegFlag<SetFalse, [], [ClangOption, CC1Option], "Ignore calling convetion during lowering">,
   BothFlags<[], [ClangOption, CC1Option], "">>;
 
-def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
-  Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR, emit the .cir file">;
-def emit_cir_only : Flag<["-"], "emit-cir-only">,
-  HelpText<"Build ASTs and convert to CIR, discarding output">;
-def emit_cir_flat : Flag<["-"], "emit-cir-flat">, Visibility<[ClangOption, CC1Option]>,
-  Group<Action_Group>, HelpText<"Similar to -emit-cir but also lowers structured CFG into basic blocks.">;
 def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[ClangOption]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to MLIR (standard dialects "
   "when `-fno-clangir-direct-lowering` is used or the LLVM dialect when "
@@ -3130,6 +3124,14 @@ def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[ClangOption, CC1Opti
   NormalizedValuesScope<"frontend">,
   NormalizedValues<["MLIR_CORE", "MLIR_LLVM", "MLIR_CIR", "MLIR_CIR_FLAT"]>,
   MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_CORE">;
+def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
+  Group<Action_Group>, Alias<emit_mlir_EQ>, AliasArgs<["cir"]>,
+  HelpText<"Build ASTs and then lower to ClangIR, emit the .cir file">;
+def emit_cir_only : Flag<["-"], "emit-cir-only">,
+  HelpText<"Build ASTs and convert to CIR, discarding output">;
+def emit_cir_flat : Flag<["-"], "emit-cir-flat">, Visibility<[ClangOption, CC1Option]>,
+  Group<Action_Group>, Alias<emit_mlir_EQ>, AliasArgs<["cir-flat"]>,
+  HelpText<"Similar to -emit-cir but also lowers structured CFG into basic blocks.">;
 /// ClangIR-specific options - END
 
 def flto : Flag<["-"], "flto">,

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -99,8 +99,6 @@ TYPE("ir",                       LLVM_BC,      INVALID,         "bc",     phases
 TYPE("lto-ir",                   LTO_IR,       INVALID,         "s",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("lto-bc",                   LTO_BC,       INVALID,         "o",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
-TYPE("cir",                      CIR,          INVALID,         "cir",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
-TYPE("cir-flat",                 CIR_FLAT,     INVALID,         "cir",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("mlir",                     MLIR,         INVALID,         "mlir",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
 // Misc.

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -77,9 +77,6 @@ enum ActionKind {
   /// Emit a .mlir file
   EmitMLIR,
 
-  /// Emit an .mlir file with LLVM dialect
-  EmitMLIRLLVM,
-
   /// Emit a .ll file.
   EmitLLVM,
 
@@ -532,6 +529,13 @@ public:
   std::string ClangIRLifetimeCheckOpts;
   std::string ClangIRIdiomRecognizerOpts;
   std::string ClangIRLibOptOpts;
+
+  enum {
+    MLIR_Default,
+    MLIR_STD,
+    MLIR_LLVM,
+    MLIR_CIR
+  } MLIRTargetDialect = MLIR_Default;
 
   /// The input kind, either specified via -x argument or deduced from the input
   /// file name.

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -65,12 +65,6 @@ enum ActionKind {
   /// Translate input source into HTML.
   EmitHTML,
 
-  /// Emit a .cir file
-  EmitCIR,
-
-  /// Emit a .cir file with flat ClangIR
-  EmitCIRFlat,
-
   /// Generate CIR, bud don't emit anything.
   EmitCIROnly,
 

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -160,6 +160,8 @@ enum ActionKind {
   PrintDependencyDirectivesSourceMinimizerOutput
 };
 
+enum MLIRDialectKind { MLIR_CORE, MLIR_LLVM, MLIR_CIR, MLIR_CIR_FLAT };
+
 } // namespace frontend
 
 /// The kind of a file that we've been handed as an input.
@@ -530,7 +532,7 @@ public:
   std::string ClangIRIdiomRecognizerOpts;
   std::string ClangIRLibOptOpts;
 
-  enum { MLIR_Default, MLIR_STD, MLIR_LLVM } MLIRTargetDialect = MLIR_Default;
+  frontend::MLIRDialectKind MLIRTargetDialect;
 
   /// The input kind, either specified via -x argument or deduced from the input
   /// file name.

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -77,6 +77,9 @@ enum ActionKind {
   /// Emit a .mlir file
   EmitMLIR,
 
+  /// Emit an .mlir file with LLVM dialect
+  EmitMLIRLLVM,
+
   /// Emit a .ll file.
   EmitLLVM,
 

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -530,12 +530,7 @@ public:
   std::string ClangIRIdiomRecognizerOpts;
   std::string ClangIRLibOptOpts;
 
-  enum {
-    MLIR_Default,
-    MLIR_STD,
-    MLIR_LLVM,
-    MLIR_CIR
-  } MLIRTargetDialect = MLIR_Default;
+  enum { MLIR_Default, MLIR_STD, MLIR_LLVM } MLIRTargetDialect = MLIR_Default;
 
   /// The input kind, either specified via -x argument or deduced from the input
   /// file name.

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -28,7 +28,7 @@ mlir::LogicalResult runCIRToCIRPasses(
     llvm::StringRef lifetimeOpts, bool enableIdiomRecognizer,
     llvm::StringRef idiomRecognizerOpts, bool enableLibOpt,
     llvm::StringRef libOptOpts, std::string &passOptParsingFailure,
-    bool enableCIRSimplify, bool flattenCIR, bool emitMLIR,
+    bool enableCIRSimplify, bool flattenCIR, bool emitCore,
     bool enableCallConvLowering, bool enableMem2Reg) {
 
   llvm::TimeTraceScope scope("CIR To CIR Passes");
@@ -81,7 +81,7 @@ mlir::LogicalResult runCIRToCIRPasses(
   if (enableMem2Reg)
     pm.addPass(mlir::createMem2Reg());
 
-  if (emitMLIR)
+  if (emitCore)
     pm.addPass(mlir::createSCFPreparePass());
 
   // FIXME: once CIRCodenAction fixes emission other than CIR we

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4689,11 +4689,11 @@ void populateCIRToLLVMPasses(mlir::OpPassManager &pm, bool useCCLowering) {
 
 extern void registerCIRDialectTranslation(mlir::MLIRContext &context);
 
-std::unique_ptr<llvm::Module>
-lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx,
-                             bool disableVerifier, bool disableCCLowering,
-                             bool disableDebugInfo) {
-  llvm::TimeTraceScope scope("lower from CIR to LLVM directly");
+mlir::ModuleOp lowerDirectlyFromCIRToLLVMDialect(mlir::ModuleOp theModule,
+                                                 bool disableVerifier,
+                                                 bool disableCCLowering,
+                                                 bool disableDebugInfo) {
+  llvm::TimeTraceScope scope("lower from CIR to LLVM Dialect");
 
   mlir::MLIRContext *mlirCtx = theModule.getContext();
   mlir::PassManager pm(mlirCtx);
@@ -4721,6 +4721,20 @@ lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx,
   // Now that we ran all the lowering passes, verify the final output.
   if (theModule.verify().failed())
     report_fatal_error("Verification of the final LLVMIR dialect failed!");
+
+  return theModule;
+}
+
+std::unique_ptr<llvm::Module>
+lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp theModule, LLVMContext &llvmCtx,
+                             bool disableVerifier, bool disableCCLowering,
+                             bool disableDebugInfo) {
+  llvm::TimeTraceScope scope("lower from CIR to LLVM directly");
+
+  lowerDirectlyFromCIRToLLVMDialect(theModule, disableVerifier,
+                                    disableCCLowering, disableDebugInfo);
+
+  mlir::MLIRContext *mlirCtx = theModule.getContext();
 
   mlir::registerBuiltinDialectTranslation(*mlirCtx);
   mlir::registerLLVMDialectTranslation(*mlirCtx);

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -47,6 +47,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "clang/CIR/LowerToLLVM.h"
 #include "clang/CIR/LowerToMLIR.h"
 #include "clang/CIR/LoweringHelpers.h"
 #include "clang/CIR/Passes.h"
@@ -1458,13 +1459,14 @@ void ConvertCIRToMLIRPass::runOnOperation() {
     signalPassFailure();
 }
 
-std::unique_ptr<llvm::Module>
-lowerFromCIRToMLIRToLLVMIR(mlir::ModuleOp theModule,
-                           std::unique_ptr<mlir::MLIRContext> mlirCtx,
-                           LLVMContext &llvmCtx) {
-  llvm::TimeTraceScope scope("Lower from CIR to MLIR To LLVM");
+mlir::ModuleOp lowerFromCIRToMLIRToLLVMDialect(mlir::ModuleOp theModule,
+                                               mlir::MLIRContext *mlirCtx) {
+  llvm::TimeTraceScope scope("Lower from CIR to MLIR To LLVM Dialect");
+  if (!mlirCtx) {
+    mlirCtx = theModule.getContext();
+  }
 
-  mlir::PassManager pm(mlirCtx.get());
+  mlir::PassManager pm(mlirCtx);
 
   pm.addPass(createConvertCIRToMLIRPass());
   pm.addPass(createConvertMLIRToLLVMPass());
@@ -1477,6 +1479,17 @@ lowerFromCIRToMLIRToLLVMIR(mlir::ModuleOp theModule,
   // Now that we ran all the lowering passes, verify the final output.
   if (theModule.verify().failed())
     report_fatal_error("Verification of the final LLVMIR dialect failed!");
+
+  return theModule;
+}
+
+std::unique_ptr<llvm::Module>
+lowerFromCIRToMLIRToLLVMIR(mlir::ModuleOp theModule,
+                           std::unique_ptr<mlir::MLIRContext> mlirCtx,
+                           LLVMContext &llvmCtx) {
+  llvm::TimeTraceScope scope("Lower from CIR to MLIR To LLVM");
+
+  lowerFromCIRToMLIRToLLVMDialect(theModule, mlirCtx.get());
 
   mlir::registerBuiltinDialectTranslation(*mlirCtx);
   mlir::registerLLVMDialectTranslation(*mlirCtx);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -413,15 +413,14 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
     // -{fsyntax-only,-analyze,emit-ast} only run up to the compiler.
   } else if ((PhaseArg = DAL.getLastArg(options::OPT_fsyntax_only)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_print_supported_cpus)) ||
-             (PhaseArg = DAL.getLastArg(options::OPT_print_enabled_extensions)) ||
+             (PhaseArg =
+                  DAL.getLastArg(options::OPT_print_enabled_extensions)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_module_file_info)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_verify_pch)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_rewrite_objc)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_rewrite_legacy_objc)) ||
              (PhaseArg = DAL.getLastArg(options::OPT__migrate)) ||
              (PhaseArg = DAL.getLastArg(options::OPT__analyze)) ||
-             (PhaseArg = DAL.getLastArg(options::OPT_emit_cir)) ||
-             (PhaseArg = DAL.getLastArg(options::OPT_emit_cir_flat)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_mlir)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_mlir_EQ)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_ast))) {
@@ -5085,10 +5084,6 @@ Action *Driver::ConstructPhaseAction(
       return C.MakeAction<MigrateJobAction>(Input, types::TY_Remap);
     if (Args.hasArg(options::OPT_emit_ast))
       return C.MakeAction<CompileJobAction>(Input, types::TY_AST);
-    if (Args.hasArg(options::OPT_emit_cir))
-      return C.MakeAction<CompileJobAction>(Input, types::TY_CIR);
-    if (Args.hasArg(options::OPT_emit_cir_flat))
-      return C.MakeAction<CompileJobAction>(Input, types::TY_CIR_FLAT);
     if (Args.hasArg(options::OPT_emit_mlir))
       return C.MakeAction<CompileJobAction>(Input, types::TY_MLIR);
     if (Args.hasArg(options::OPT_emit_mlir_EQ))

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -422,6 +422,8 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
              (PhaseArg = DAL.getLastArg(options::OPT__analyze)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_cir)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_cir_flat)) ||
+             (PhaseArg = DAL.getLastArg(options::OPT_emit_mlir)) ||
+             (PhaseArg = DAL.getLastArg(options::OPT_emit_mlir_EQ)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_emit_ast))) {
     FinalPhase = phases::Compile;
 
@@ -5087,6 +5089,10 @@ Action *Driver::ConstructPhaseAction(
       return C.MakeAction<CompileJobAction>(Input, types::TY_CIR);
     if (Args.hasArg(options::OPT_emit_cir_flat))
       return C.MakeAction<CompileJobAction>(Input, types::TY_CIR_FLAT);
+    if (Args.hasArg(options::OPT_emit_mlir))
+      return C.MakeAction<CompileJobAction>(Input, types::TY_MLIR);
+    if (Args.hasArg(options::OPT_emit_mlir_EQ))
+      return C.MakeAction<CompileJobAction>(Input, types::TY_MLIR);
     if (Args.hasArg(options::OPT_module_file_info))
       return C.MakeAction<CompileJobAction>(Input, types::TY_ModuleFile);
     if (Args.hasArg(options::OPT_verify_pch))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5418,6 +5418,18 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-emit-cir");
     } else if (JA.getType() == types::TY_CIR_FLAT) {
       CmdArgs.push_back("-emit-cir-flat");
+    } else if (JA.getType() == types::TY_MLIR) {
+      if (Args.hasArg(options::OPT_emit_mlir)) {
+        if (Args.hasArg(options::OPT_fno_clangir_direct_lowering)) {
+          CmdArgs.push_back("-emit-mlir=core");
+        } else {
+          CmdArgs.push_back("-emit-mlir=llvm");
+        }
+      } else {
+        CmdArgs.push_back(Args.MakeArgString(
+            Twine("-emit-mlir=") +
+            Args.getLastArgValue(options::OPT_emit_mlir_EQ)));
+      }
     } else if (JA.getType() == types::TY_LLVM_BC ||
                JA.getType() == types::TY_LTO_BC) {
       // Emit textual llvm IR for AMDGPU offloading for -emit-llvm -S

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5242,8 +5242,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   if (Args.hasArg(options::OPT_fclangir) ||
-      Args.hasArg(options::OPT_emit_cir) ||
-      Args.hasArg(options::OPT_emit_cir_flat))
+      Args.hasArg(options::OPT_emit_mlir) ||
+      Args.hasArg(options::OPT_emit_mlir_EQ))
     CmdArgs.push_back("-fclangir");
 
   Args.addOptOutFlag(CmdArgs, options::OPT_fclangir_direct_lowering,
@@ -5414,10 +5414,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     } else if (JA.getType() == types::TY_LLVM_IR ||
                JA.getType() == types::TY_LTO_IR) {
       CmdArgs.push_back("-emit-llvm");
-    } else if (JA.getType() == types::TY_CIR) {
-      CmdArgs.push_back("-emit-cir");
-    } else if (JA.getType() == types::TY_CIR_FLAT) {
-      CmdArgs.push_back("-emit-cir-flat");
     } else if (JA.getType() == types::TY_MLIR) {
       if (Args.hasArg(options::OPT_emit_mlir)) {
         if (Args.hasArg(options::OPT_fno_clangir_direct_lowering)) {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2738,7 +2738,7 @@ static const auto &getFrontendActionTable() {
       {frontend::EmitCIRFlat, OPT_emit_cir_flat},
       {frontend::EmitCIROnly, OPT_emit_cir_only},
       {frontend::EmitMLIR, OPT_emit_mlir},
-      {frontend::EmitMLIRLLVM, OPT_emit_mlir_llvm},
+      {frontend::EmitMLIR, OPT_emit_mlir_EQ},
       {frontend::EmitHTML, OPT_emit_html},
       {frontend::EmitLLVM, OPT_emit_llvm},
       {frontend::EmitLLVMOnly, OPT_emit_llvm_only},
@@ -2847,6 +2847,13 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
         if (Opts.ASTDumpDecls)
           GenerateArg(Consumer, OPT_ast_dump);
       }
+    };
+  }
+
+  if (Opts.ProgramAction == frontend::EmitMLIR) {
+    GenerateProgramAction = [&]() {
+      if (Opts.MLIRTargetDialect == FrontendOptions::MLIR_Default)
+        GenerateArg(Consumer, OPT_emit_mlir);
     };
   }
 
@@ -4670,7 +4677,6 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::EmitCIRFlat:
   case frontend::EmitCIROnly:
   case frontend::EmitMLIR:
-  case frontend::EmitMLIRLLVM:
   case frontend::EmitHTML:
   case frontend::EmitLLVM:
   case frontend::EmitLLVMOnly:

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2852,8 +2852,8 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
 
   if (Opts.ProgramAction == frontend::EmitMLIR) {
     GenerateProgramAction = [&]() {
-      if (Opts.MLIRTargetDialect == FrontendOptions::MLIR_Default)
-        GenerateArg(Consumer, OPT_emit_mlir);
+      if (Opts.MLIRTargetDialect == clang::frontend::MLIR_CORE)
+        GenerateArg(Consumer, OPT_emit_mlir_EQ, "core");
     };
   }
 
@@ -3118,7 +3118,8 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     Diags.Report(diag::err_drv_argument_only_allowed_with) << "-fsystem-module"
                                                            << "-emit-module";
   if (Args.hasArg(OPT_fclangir) || Args.hasArg(OPT_emit_cir) ||
-      Args.hasArg(OPT_emit_cir_flat))
+      Args.hasArg(OPT_emit_cir_flat) || Args.hasArg(OPT_emit_mlir) ||
+      Args.hasArg(OPT_emit_mlir_EQ))
     Opts.UseClangIRPipeline = true;
 
   if (Args.hasArg(OPT_fclangir_direct_lowering))

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2738,6 +2738,7 @@ static const auto &getFrontendActionTable() {
       {frontend::EmitCIRFlat, OPT_emit_cir_flat},
       {frontend::EmitCIROnly, OPT_emit_cir_only},
       {frontend::EmitMLIR, OPT_emit_mlir},
+      {frontend::EmitMLIRLLVM, OPT_emit_mlir_llvm},
       {frontend::EmitHTML, OPT_emit_html},
       {frontend::EmitLLVM, OPT_emit_llvm},
       {frontend::EmitLLVMOnly, OPT_emit_llvm_only},
@@ -4669,6 +4670,7 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::EmitCIRFlat:
   case frontend::EmitCIROnly:
   case frontend::EmitMLIR:
+  case frontend::EmitMLIRLLVM:
   case frontend::EmitHTML:
   case frontend::EmitLLVM:
   case frontend::EmitLLVMOnly:

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2734,8 +2734,6 @@ static const auto &getFrontendActionTable() {
       {frontend::DumpTokens, OPT_dump_tokens},
       {frontend::EmitAssembly, OPT_S},
       {frontend::EmitBC, OPT_emit_llvm_bc},
-      {frontend::EmitCIR, OPT_emit_cir},
-      {frontend::EmitCIRFlat, OPT_emit_cir_flat},
       {frontend::EmitCIROnly, OPT_emit_cir_only},
       {frontend::EmitMLIR, OPT_emit_mlir},
       {frontend::EmitMLIR, OPT_emit_mlir_EQ},
@@ -3117,8 +3115,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)
     Diags.Report(diag::err_drv_argument_only_allowed_with) << "-fsystem-module"
                                                            << "-emit-module";
-  if (Args.hasArg(OPT_fclangir) || Args.hasArg(OPT_emit_cir) ||
-      Args.hasArg(OPT_emit_cir_flat) || Args.hasArg(OPT_emit_mlir) ||
+  if (Args.hasArg(OPT_fclangir) || Args.hasArg(OPT_emit_mlir) ||
       Args.hasArg(OPT_emit_mlir_EQ))
     Opts.UseClangIRPipeline = true;
 
@@ -4674,8 +4671,6 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::ASTView:
   case frontend::EmitAssembly:
   case frontend::EmitBC:
-  case frontend::EmitCIR:
-  case frontend::EmitCIRFlat:
   case frontend::EmitCIROnly:
   case frontend::EmitMLIR:
   case frontend::EmitHTML:

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -60,9 +60,10 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
     llvm::report_fatal_error(
         "-emit-cir and -emit-cir-only only valid when using -fclangir");
 
-  if (CI.getFrontendOpts().ClangIRDirectLowering && Act == EmitMLIR)
-    llvm::report_fatal_error(
-        "ClangIR direct lowering is incompatible with -emit-mlir");
+  if (Act == EmitMLIR && CI.getFrontendOpts().ClangIRDirectLowering &&
+      CI.getFrontendOpts().MLIRTargetDialect == FrontendOptions::MLIR_STD)
+    llvm::report_fatal_error("ClangIR direct lowering is incompatible with "
+                             "emitting of MLIR standard dialects");
 
   switch (CI.getFrontendOpts().ProgramAction) {
   case ASTDeclList:            return std::make_unique<ASTDeclListAction>();
@@ -99,8 +100,6 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
     return std::make_unique<cir::EmitCIROnlyAction>();
   case EmitMLIR:
     return std::make_unique<cir::EmitMLIRAction>();
-  case EmitMLIRLLVM:
-    return std::make_unique<cir::EmitMLIRLLVMAction>();
 #else
   case EmitCIR:
   case EmitCIRFlat:

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -61,7 +61,7 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
         "-emit-cir and -emit-cir-only only valid when using -fclangir");
 
   if (Act == EmitMLIR && CI.getFrontendOpts().ClangIRDirectLowering &&
-      CI.getFrontendOpts().MLIRTargetDialect == FrontendOptions::MLIR_STD)
+      CI.getFrontendOpts().MLIRTargetDialect == frontend::MLIR_CORE)
     llvm::report_fatal_error("ClangIR direct lowering is incompatible with "
                              "emitting of MLIR standard dialects");
 

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -99,6 +99,8 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
     return std::make_unique<cir::EmitCIROnlyAction>();
   case EmitMLIR:
     return std::make_unique<cir::EmitMLIRAction>();
+  case EmitMLIRLLVM:
+    return std::make_unique<cir::EmitMLIRLLVMAction>();
 #else
   case EmitCIR:
   case EmitCIRFlat:

--- a/clang/test/CIR/Lowering/ThroughMLIR/binop.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/binop.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 void testSignedIntBinOps(int a, int b) {

--- a/clang/test/CIR/Lowering/ThroughMLIR/bit.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/bit.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 int clz_u16(unsigned short x) {

--- a/clang/test/CIR/Lowering/ThroughMLIR/call.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/call.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 void foo(int i) {}

--- a/clang/test/CIR/Lowering/ThroughMLIR/cmp.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/cmp.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 bool testSignedIntCmpOps(int a, int b) {

--- a/clang/test/CIR/Lowering/ThroughMLIR/doWhile.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/doWhile.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 int sum() {

--- a/clang/test/CIR/Lowering/ThroughMLIR/for.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/for.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 int a[101], b[101];

--- a/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 float f[32000];

--- a/clang/test/CIR/Lowering/ThroughMLIR/if.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/if.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 void foo() {

--- a/clang/test/CIR/Lowering/ThroughMLIR/vectype.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/vectype.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 typedef int vi4 __attribute__((vector_size(16)));

--- a/clang/test/CIR/Lowering/ThroughMLIR/while.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/while.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 void singleWhile() {

--- a/clang/test/CIR/cc1.c
+++ b/clang/test/CIR/cc1.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM

--- a/clang/test/CIR/emit-mlir.c
+++ b/clang/test/CIR/emit-mlir.c
@@ -1,5 +1,5 @@
-// RUN: %clang -fclangir -emit-mlir %s -o - | FileCheck %s -check-prefix=LLVM
-// RUN: %clang -fno-clangir-direct-lowering -emit-mlir %s -o - | FileCheck %s -check-prefix=CORE
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -emit-mlir %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir %s -o - | FileCheck %s -check-prefix=CORE
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=llvm %s -o - | FileCheck %s -check-prefix=LLVM
 // RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=core %s -o - 2>&1 | FileCheck %s -check-prefix=CORE_ERR
@@ -10,16 +10,16 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir %s -o - | FileCheck %s -check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir-flat %s -o - | FileCheck %s -check-prefix=CIR_FLAT
 
-// RUN: %clang -fclangir -emit-mlir %s -o - | FileCheck %s -check-prefix=LLVM
-// RUN: %clang -fno-clangir-direct-lowering -emit-mlir %s -o - | FileCheck %s -check-prefix=CORE
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -emit-mlir %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir %s -o - | FileCheck %s -check-prefix=CORE
 
-// RUN: %clang -fclangir -emit-mlir %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_LLVM
-// RUN: %clang -fno-clangir-direct-lowering -emit-mlir %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_CORE
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -emit-mlir %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_CORE
 
-// RUN: %clang -fclangir -emit-mlir=llvm %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_LLVM
-// RUN: %clang -fno-clangir-direct-lowering -emit-mlir=core %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_CORE
-// RUN: %clang -fclangir -emit-mlir=cir %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_CIR
-// RUN: %clang -fclangir -emit-mlir=cir-flat %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_CIR_FLAT
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -emit-mlir=llvm %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_LLVM
+// RUN: %clang -target x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir=core %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_CORE
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_CIR
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir-flat %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_CIR_FLAT
 
 int foo(int a, int b) {
     int c;

--- a/clang/test/CIR/emit-mlir.c
+++ b/clang/test/CIR/emit-mlir.c
@@ -1,23 +1,44 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir %s -o - | FileCheck %s -check-prefix=LLVM
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir %s -o - | FileCheck %s -check-prefix=STD
+// RUN: %clang -fclangir -emit-mlir %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang -fno-clangir-direct-lowering -emit-mlir %s -o - | FileCheck %s -check-prefix=CORE
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=llvm %s -o - | FileCheck %s -check-prefix=LLVM
-// RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=std %s -o - 2>&1 | FileCheck %s -check-prefix=STD_ERR
+// RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=core %s -o - 2>&1 | FileCheck %s -check-prefix=CORE_ERR
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir=llvm %s -o - | FileCheck %s -check-prefix=LLVM
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir=std %s -o - | FileCheck %s -check-prefix=STD
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir=core %s -o - | FileCheck %s -check-prefix=CORE
 
-// RUN: %clang -fclangir -Xclang -emit-mlir %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_NO_VALUE
-// RUN: %clang -fclangir -Xclang -emit-mlir=llvm %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_LLVM
-// RUN: %clang -fno-clangir-direct-lowering -Xclang -emit-mlir=std %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_STD
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir %s -o - | FileCheck %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir-flat %s -o - | FileCheck %s -check-prefix=CIR_FLAT
+
+// RUN: %clang -fclangir -emit-mlir %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang -fno-clangir-direct-lowering -emit-mlir %s -o - | FileCheck %s -check-prefix=CORE
+
+// RUN: %clang -fclangir -emit-mlir %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_LLVM
+// RUN: %clang -fno-clangir-direct-lowering -emit-mlir %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_CORE
+
+// RUN: %clang -fclangir -emit-mlir=llvm %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_LLVM
+// RUN: %clang -fno-clangir-direct-lowering -emit-mlir=core %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_CORE
+// RUN: %clang -fclangir -emit-mlir=cir %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_CIR
+// RUN: %clang -fclangir -emit-mlir=cir-flat %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_CIR_FLAT
 
 int foo(int a, int b) {
-    return a + b;
+    int c;
+    if (a) {
+      c = a;
+    }
+    c = b;
+    return c;
 }
 
 // LLVM: llvm.func @foo
-// STD: func.func @foo
-// STD_ERR: ClangIR direct lowering is incompatible with emitting of MLIR standard dialects
-// OPTS_NO_VALUE: "-emit-mlir"
+// CORE: func.func @foo
+// CIR: cir.func @foo
+// CIR: cir.scope
+// CIR_FLAT: cir.func @foo
+// CIR_FLAT: ^bb1
+// CIR_FLAT-NOT: cir.scope
+// CORE_ERR: ClangIR direct lowering is incompatible with emitting of MLIR standard dialects
 // OPTS_LLVM: "-emit-mlir=llvm"
-// OPTS_STD: "-emit-mlir=std"
+// OPTS_CORE: "-emit-mlir=core"
+// OPTS_CIR: "-emit-mlir=cir"
+// OPTS_CIR_FLAT: "-emit-mlir=cir-flat"

--- a/clang/test/CIR/emit-mlir.c
+++ b/clang/test/CIR/emit-mlir.c
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir %s -o - | FileCheck %s -check-prefix=STD
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=llvm %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=std %s -o - 2>&1 | FileCheck %s -check-prefix=STD_ERR
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir=llvm %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir=std %s -o - | FileCheck %s -check-prefix=STD
+
+// RUN: %clang -fclangir -Xclang -emit-mlir %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_NO_VALUE
+// RUN: %clang -fclangir -Xclang -emit-mlir=llvm %s -o - -###  2>&1 | FileCheck %s -check-prefix=OPTS_LLVM
+// RUN: %clang -fno-clangir-direct-lowering -Xclang -emit-mlir=std %s -o - -### 2>&1 | FileCheck %s -check-prefix=OPTS_STD
+
+int foo(int a, int b) {
+    return a + b;
+}
+
+// LLVM: llvm.func @foo
+// STD: func.func @foo
+// STD_ERR: ClangIR direct lowering is incompatible with emitting of MLIR standard dialects
+// OPTS_NO_VALUE: "-emit-mlir"
+// OPTS_LLVM: "-emit-mlir=llvm"
+// OPTS_STD: "-emit-mlir=std"

--- a/clang/test/CIR/mlirprint.c
+++ b/clang/test/CIR/mlirprint.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-flat -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRFLAT
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRMLIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-clangir-direct-lowering -emit-mlir=core -mmlir --mlir-print-ir-after-all %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRMLIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -mmlir --mlir-print-ir-after-all -mllvm -print-after-all  %s -o %t.ll 2>&1 | FileCheck %s -check-prefix=CIR -check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-drop-ast %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CIRPASS
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-flat -mmlir --mlir-print-ir-before=cir-flatten-cfg %s -o %t.cir 2>&1 | FileCheck %s -check-prefix=CFGPASS


### PR DESCRIPTION
This PR adds the flag `-emit-mlir-llvm` to allow emitting of MLIR in the LLVM dialect (cc @xlauko who asked me to do this).
I'm not sure if the naming of the flag is the best and maybe someone will have a better idea.
Another solution would be to make the `-emit-mlir` flag have a value, that specifies the target dialect (CIR/MLIR std dialects/LLVM Dialect).