### PR TITLE
[CIR] Add attribute visitor for lowering globals

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrVisitor.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrVisitor.h
@@ -1,0 +1,47 @@
+//===- CIRAttrVisitor.h - Visitor for CIR attributes ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the CirAttrVisitor interface.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_CIR_DIALECT_IR_CIRATTRVISITOR_H
+#define LLVM_CLANG_CIR_DIALECT_IR_CIRATTRVISITOR_H
+
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
+
+namespace cir {
+
+#define DISPATCH(NAME) return getImpl()->visitCir##NAME(cirAttr);
+
+template <typename ImplClass, typename RetTy> class CirAttrVisitor {
+public:
+  RetTy visit(mlir::Attribute attr) {
+#define ATTRDEF(NAME)                                                          \
+  if (const auto cirAttr = mlir::dyn_cast<cir::NAME>(attr))                    \
+    DISPATCH(NAME);
+#include "clang/CIR/Dialect/IR/CIRAttrDefsList.inc"
+    llvm_unreachable("unhandled attribute type");
+  }
+
+  // If the implementation chooses not to implement a certain visit
+  // method, fall back to the parent.
+#define ATTRDEF(NAME)                                                          \
+  RetTy visitCir##NAME(NAME cirAttr) { DISPATCH(Attr); }
+#include "clang/CIR/Dialect/IR/CIRAttrDefsList.inc"
+
+  RetTy visitCirAttr(mlir::Attribute attr) { return RetTy(); }
+
+  ImplClass *getImpl() { return static_cast<ImplClass *>(this); }
+};
+
+#undef DISPATCH
+
+} // namespace cir
+
+#endif // LLVM_CLANG_CIR_DIALECT_IR_CIRATTRVISITOR_H

--- a/clang/include/clang/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/include/clang/CIR/Dialect/IR/CMakeLists.txt
@@ -26,6 +26,7 @@ mlir_tablegen(CIROpsStructs.h.inc -gen-attrdef-decls)
 mlir_tablegen(CIROpsStructs.cpp.inc -gen-attrdef-defs)
 mlir_tablegen(CIROpsAttributes.h.inc -gen-attrdef-decls)
 mlir_tablegen(CIROpsAttributes.cpp.inc -gen-attrdef-defs)
+mlir_tablegen(CIRAttrDefsList.inc -gen-attrdef-list)
 add_public_tablegen_target(MLIRCIREnumsGen)
 
 clang_tablegen(CIRBuiltinsLowering.inc -gen-cir-builtins-lowering

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -22,7 +22,8 @@ namespace direct {
 
 /// Convert a CIR attribute to an LLVM attribute. May use the datalayout for
 /// lowering attributes to-be-stored in memory.
-mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::Attribute attr,
+mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
+                                const mlir::Attribute attr,
                                 mlir::ConversionPatternRewriter &rewriter,
                                 const mlir::TypeConverter *converter,
                                 mlir::DataLayout const &dataLayout);

--- a/mlir/test/mlir-tblgen/attrdefs.td
+++ b/mlir/test/mlir-tblgen/attrdefs.td
@@ -1,5 +1,6 @@
 // RUN: mlir-tblgen -gen-attrdef-decls -I %S/../../include %s | FileCheck %s --check-prefix=DECL
 // RUN: mlir-tblgen -gen-attrdef-defs -I %S/../../include %s | FileCheck %s --check-prefix=DEF
+// RUN: mlir-tblgen -gen-attrdef-list -I %S/../../include %s | FileCheck %s --check-prefix=LIST
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
@@ -18,6 +19,13 @@ include "mlir/IR/OpBase.td"
 // DEF: ::test::SimpleAAttr,
 // DEF: ::test::CompoundAAttr,
 // DEF: ::test::SingleParameterAttr
+
+// LIST: ATTRDEF(IndexAttr)
+// LIST: ATTRDEF(SimpleAAttr)
+// LIST: ATTRDEF(CompoundAAttr)
+// LIST: ATTRDEF(SingleParameterAttr)
+
+// LIST: #undef ATTRDEF
 
 // DEF-LABEL: ::mlir::OptionalParseResult generatedAttributeParser(
 // DEF-SAME: ::mlir::AsmParser &parser,

--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -690,6 +690,7 @@ class DefGenerator {
 public:
   bool emitDecls(StringRef selectedDialect);
   bool emitDefs(StringRef selectedDialect);
+  bool emitList(StringRef selectedDialect);
 
 protected:
   DefGenerator(ArrayRef<const Record *> defs, raw_ostream &os,
@@ -1025,6 +1026,23 @@ bool DefGenerator::emitDefs(StringRef selectedDialect) {
   return false;
 }
 
+bool DefGenerator::emitList(StringRef selectedDialect) {
+  emitSourceFileHeader(("List of " + defType + "Def Definitions").str(), os);
+
+  SmallVector<AttrOrTypeDef, 16> defs;
+  collectAllDefs(selectedDialect, defRecords, defs);
+  if (defs.empty())
+    return false;
+
+  auto interleaveFn = [&](const AttrOrTypeDef &def) {
+    os << defType.upper() << "DEF(" << def.getCppClassName() << ")";
+  };
+  llvm::interleave(defs, os, interleaveFn, "\n");
+  os << "\n\n";
+  os << "#undef " << defType.upper() << "DEF" << "\n";
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // Type Constraints
 //===----------------------------------------------------------------------===//
@@ -1099,6 +1117,12 @@ static mlir::GenRegistration
                    AttrDefGenerator generator(records, os);
                    return generator.emitDecls(attrDialect);
                  });
+static mlir::GenRegistration
+    genAttrList("gen-attrdef-list", "Generate an AttrDef list",
+                [](const RecordKeeper &records, raw_ostream &os) {
+                  AttrDefGenerator generator(records, os);
+                  return generator.emitList(attrDialect);
+                });
 
 //===----------------------------------------------------------------------===//
 // TypeDef


### PR DESCRIPTION
This adds a new mlir-tablegen option to generate a .inc file with the complete set of attrdefs defined in a .td file and uses the file generated for CIR attrdefs to create an attr visitor. This visitor is used in the lowering of global variables directly to LLVM IR.

The purpose of this change is to align the incubator lowering implementation with the recent upstream changes to make future upstreaming easier, while also fulfilling the upstream request to have the visitor be based on a tablegen created file.

The new mlir-tablegen feature will be upstreamed after it is established here.

No observable change is intended in the CIR code.