### PR TITLE
[CIR][HIP] Compile host code

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -515,7 +515,8 @@ void CIRGenModule::emitGlobal(GlobalDecl GD) {
   assert(!Global->hasAttr<IFuncAttr>() && "NYI");
   assert(!Global->hasAttr<CPUDispatchAttr>() && "NYI");
 
-  if (langOpts.CUDA) {
+  if (langOpts.CUDA || langOpts.HIP) {
+    // clang uses the same flag when building HIP code
     if (langOpts.CUDAIsDevice) {
       // This will implicitly mark templates and their
       // specializations as __host__ __device__.
@@ -3217,8 +3218,7 @@ void CIRGenModule::Release() {
   if (astContext.getTargetInfo().getTriple().isWasm())
     llvm_unreachable("NYI");
 
-  if (getTriple().isAMDGPU() ||
-      (getTriple().isSPIRV() && getTriple().getVendor() == llvm::Triple::AMD)) {
+  if (getTriple().isSPIRV() && getTriple().getVendor() == llvm::Triple::AMD) {
     llvm_unreachable("NYI");
   }
 
@@ -3229,9 +3229,7 @@ void CIRGenModule::Release() {
   if (!astContext.CUDAExternalDeviceDeclODRUsedByHost.empty()) {
     llvm_unreachable("NYI");
   }
-  if (langOpts.HIP && !getLangOpts().OffloadingNewDriver) {
-    llvm_unreachable("NYI");
-  }
+
   assert(!MissingFeatures::emitLLVMUsed());
   assert(!MissingFeatures::sanStats());
 

--- a/clang/test/CIR/CodeGen/HIP/simple.cpp
+++ b/clang/test/CIR/CodeGen/HIP/simple.cpp
@@ -1,0 +1,16 @@
+#include "../Inputs/cuda.h"
+
+// RUN: %clang_cc1 -triple=amdgcn-amd-amdhsa -x hip -fclangir \
+// RUN:            -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+
+
+// This should emit as a normal C++ function.
+__host__ void host_fn(int *a, int *b, int *c) {}
+
+// CIR: cir.func @_Z7host_fnPiS_S_
+
+// This shouldn't emit.
+__device__ void device_fn(int* a, double b, float c) {}
+
+// CHECK-NOT: cir.func @_Z9device_fnPidf


### PR DESCRIPTION
Adds support for `__host__` and `__device__` functions when compiling for CUDA host.

The PR follows the structure of #1309 