### PR TITLE
[CIR][CIRGen] Add alignment attribute to AtomicCmpXchg

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5390,6 +5390,7 @@ def AtomicCmpXchg : CIR_Op<"atomic.cmp_xchg",
                        CIR_AnyType:$desired,
                        Arg<MemOrder, "success memory order">:$succ_order,
                        Arg<MemOrder, "failure memory order">:$fail_order,
+                       DefaultValuedAttr<I64Attr, "0">:$alignment,
                        UnitAttr:$weak,
                        UnitAttr:$is_volatile);
 

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -424,6 +424,7 @@ static void emitAtomicCmpXchg(CIRGenFunction &CGF, AtomicExpr *E, bool IsWeak,
   auto cmpxchg = builder.create<cir::AtomicCmpXchg>(
       loc, Expected.getType(), boolTy, Ptr.getPointer(), Expected, Desired,
       SuccessOrder, FailureOrder);
+  cmpxchg.setAlignment(Ptr.getAlignment().getAsAlign().value());
   cmpxchg.setIsVolatile(E->isVolatile());
   cmpxchg.setWeak(IsWeak);
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -326,6 +326,7 @@ static mlir::Value MakeAtomicCmpXchgValue(CIRGenFunction &cgf,
       destAddr.getPointer(), cmpVal, newVal,
       cir::MemOrder::SequentiallyConsistent,
       cir::MemOrder::SequentiallyConsistent);
+  op.setAlignment(destAddr.getAlignment().getAsAlign().value());
 
   return returnBool ? op.getResult(1) : op.getResult(0);
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3197,6 +3197,7 @@ mlir::LogicalResult CIRToLLVMAtomicCmpXchgLowering::matchAndRewrite(
       op.getLoc(), adaptor.getPtr(), expected, desired,
       getLLVMAtomicOrder(adaptor.getSuccOrder()),
       getLLVMAtomicOrder(adaptor.getFailOrder()));
+  cmpxchg.setAlignment(adaptor.getAlignment());
   cmpxchg.setWeak(adaptor.getWeak());
   cmpxchg.setVolatile_(adaptor.getIsVolatile());
 

--- a/clang/test/CIR/CodeGen/atomic-xchg-field.c
+++ b/clang/test/CIR/CodeGen/atomic-xchg-field.c
@@ -55,7 +55,7 @@ void structAtomicExchange(unsigned referenceCount, wPtr item) {
 // LLVM:   store i32
 // LLVM:   %[[EXP:.*]] = load i32
 // LLVM:   %[[DES:.*]] = load i32
-// LLVM:   %[[RES:.*]] = cmpxchg weak ptr %9, i32 %[[EXP]], i32 %[[DES]] seq_cst seq_cst
+// LLVM:   %[[RES:.*]] = cmpxchg weak ptr %9, i32 %[[EXP]], i32 %[[DES]] seq_cst seq_cst, align 8
 // LLVM:   %[[OLD:.*]] = extractvalue { i32, i1 } %[[RES]], 0
 // LLVM:   %[[CMP:.*]] = extractvalue { i32, i1 } %[[RES]], 1
 // LLVM:   %[[FAIL:.*]] = xor i1 %[[CMP]], true


### PR DESCRIPTION
There is an `alignment` attribute in MLIR's LLVMIR Dialect https://github.com/llvm/clangir/blob/a7383c9d05165d16edba857ddc86e5d29d94d2cc/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td#L1880

When Clang builds IR, it adds an alignment automatically
https://github.com/llvm/clangir/blob/a7383c9d05165d16edba857ddc86e5d29d94d2cc/clang/lib/CodeGen/CGBuilder.h#L168-L177

This PR does the same thing for ClangIR.

Closes: https://github.com/llvm/clangir/issues/1275