### PR TITLE
[CIR][ABI][AArch64][Lowering] Fix calls for struct types > 128 bits

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp
@@ -1166,7 +1166,13 @@ mlir::Value LowerFunction::rewriteCallOp(const LowerFunctionInfo &CallInfo,
       if (::cir::MissingFeatures::undef())
         cir_cconv_unreachable("NYI");
 
-      IRCallArgs[FirstIRArg] = alloca;
+      // TODO(cir): add check for cases where we don't need the memcpy
+      auto tmpAlloca = createTmpAlloca(
+          *this, alloca.getLoc(),
+          mlir::cast<PointerType>(alloca.getType()).getPointee());
+      auto tySize = LM.getDataLayout().getTypeAllocSize(I->getType());
+      createMemCpy(*this, tmpAlloca, alloca, tySize.getFixedValue());
+      IRCallArgs[FirstIRArg] = tmpAlloca;
 
       // NOTE(cir): Skipping Emissions, lifetime markers.
 

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -171,20 +171,24 @@ GT_128 get_gt_128(GT_128 s) {
 }
 
 // CHECK: cir.func no_proto @call_and_get_gt_128(%arg0: !cir.ptr<!ty_GT_128_>
-// CHECK: %[[#V0:]] = cir.alloca !ty_GT_128_, !cir.ptr<!ty_GT_128_>, {{.*}} {alignment = 8 : i64}
-// CHECK: %[[#V1:]] = cir.alloca !ty_GT_128_, !cir.ptr<!ty_GT_128_>, {{.*}} {alignment = 8 : i64}
-// CHECK: cir.call @get_gt_128(%[[#V1]], %arg0) : (!cir.ptr<!ty_GT_128_>, !cir.ptr<!ty_GT_128_>) -> ()
-// CHECK: %[[#V2:]] = cir.load %[[#V1]] : !cir.ptr<!ty_GT_128_>, !ty_GT_128_
-// CHECK: cir.store %[[#V2]], %[[#V0]] : !ty_GT_128_, !cir.ptr<!ty_GT_128_>
+// CHECK: %[[#V0:]] = cir.alloca !ty_GT_128_, !cir.ptr<!ty_GT_128_>, ["tmp"] {alignment = 8 : i64}
+// CHECK: %[[#V1:]] = cir.load %arg0 : !cir.ptr<!ty_GT_128_>, !ty_GT_128_
+// CHECK: %[[#V2:]] = cir.alloca !ty_GT_128_, !cir.ptr<!ty_GT_128_>, [""] {alignment = 8 : i64}
+// CHECK: %[[#V3:]] = cir.alloca !ty_GT_128_, !cir.ptr<!ty_GT_128_>, ["tmp"] {alignment = 8 : i64}
+// CHECK: %[[#V4:]] = cir.cast(bitcast, %arg0 : !cir.ptr<!ty_GT_128_>), !cir.ptr<!void>
+// CHECK: %[[#V5:]] = cir.cast(bitcast, %[[#V3]] : !cir.ptr<!ty_GT_128_>), !cir.ptr<!void>
+// CHECK: %[[#V6:]] = cir.const #cir.int<24> : !u64i
+// CHECK: cir.libc.memcpy %[[#V6]] bytes from %[[#V4]] to %[[#V5]] : !u64i, !cir.ptr<!void> -> !cir.ptr<!void>
+// CHECK: cir.call @get_gt_128(%[[#V2]], %[[#V3]]) : (!cir.ptr<!ty_GT_128_>, !cir.ptr<!ty_GT_128_>) -> ()
 // CHECK: cir.return
 
 // LLVM: void @call_and_get_gt_128(ptr %[[#V0:]])
 // LLVM: %[[#V2:]] = alloca %struct.GT_128, i64 1, align 8
-// LLVM: %[[#V3:]] = alloca %struct.GT_128, i64 1, align 8
-// LLVM: call void @get_gt_128(ptr %[[#V3]], ptr %[[#V0]])
-// LLVM: %[[#V4:]] = load %struct.GT_128, ptr %[[#V3]], align 8
-// LLVM: store %struct.GT_128 %[[#V4]], ptr %[[#V2]], align 8
-// LLVM: ret void
+// LLVM: %[[#V3:]] = load %struct.GT_128, ptr %[[#V0]], align 8
+// LLVM: %[[#V4:]] = alloca %struct.GT_128, i64 1, align 8
+// LLVM: %[[#V5:]] = alloca %struct.GT_128, i64 1, align 8
+// LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V5]], ptr %[[#V0]], i64 24, i1 false)
+// LLVM: call void @get_gt_128(ptr %[[#V4]], ptr %[[#V5]])
 GT_128 call_and_get_gt_128() {
   GT_128 s;
   s = get_gt_128(s);


### PR DESCRIPTION
In [PR#1074](https://github.com/llvm/clangir/pull/1074) we introduced calls for struct types > 128 bits, but there's is an issue here. 

[This](https://github.com/llvm/clangir/blob/3e17e7b9404e1a28bf33bdd5943f4a208134d479/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunction.cpp#L1169) is meant to be a `memcpy` of the alloca instead of directly passing the alloca, just like in the [OG](https://github.com/llvm/clangir/blob/3e17e7b9404e1a28bf33bdd5943f4a208134d479/clang/lib/CodeGen/CGCall.cpp#L5323). The PR was meant to use a `memcpy` and later handle cases where we don't need the `memcpy`.

For example, running the following code snippet `tmp.c` using `bin/clang tmp.c -o tmp -Xclang -fclangir -Xclang -fclangir-call-conv-lowering --target=aarch64-none-linux-gnu`: 
```
#include <stdio.h>

typedef struct {
  int a, b, c, d, e;
} S;

void change(S s) { s.a = 10; }

void foo(void) {
  S s;
  s.a = 9;
  change(s);
  printf("%d\n", s.a);
}

int main(void) {
  foo();
  return 0;
}
```
gives 10 instead of 9, because we pass the pointer instead of a copy. 

Relevant part of the OG LLVM output: 
```
@foo()
  %s = alloca %struct.S, align 4
  %byval-temp = alloca %struct.S, align 4
  %a = getelementptr inbounds nuw %struct.S, ptr %s, i32 0, i32 0
  store i32 9, ptr %a, align 4
  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %byval-temp, ptr align 4 %s, i64 20, i1 false)
  call void @change(ptr noundef %byval-temp)
```
Current LLVM output through CIR: 
```
@foo()
  %1 = alloca %struct.S, i64 1, align 4
  %2 = getelementptr %struct.S, ptr %1, i32 0, i32 0
  store i32 9, ptr %2, align 4
  %3 = load %struct.S, ptr %1, align 4
  call void @change(ptr %1)
```
So, there should be a memcpy.

This PR fixes this, and adds a comment/note for the future cases where we need to check if the copy is not needed. I have also updated the old test with structs having size > 128.