### PR TITLE
[CIR][NFC] Refactor GlobalOpLowering to align with upstream

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -589,8 +589,9 @@ public:
                   mlir::ConversionPatternRewriter &) const override;
 
 private:
-  void setupRegionInitializedLLVMGlobalOp(
-      cir::GlobalOp op, mlir::ConversionPatternRewriter &rewriter) const;
+  void createRegionInitializedLLVMGlobalOp(
+      cir::GlobalOp op, mlir::Attribute attr,
+      mlir::ConversionPatternRewriter &rewriter) const;
 
   mutable mlir::LLVM::ComdatOp comdatOp = nullptr;
   static void addComdat(mlir::LLVM::GlobalOp &op,


### PR DESCRIPTION
This change refactors the CIRToLLVMGlobalOpLowering handling to align with changes that were requested upstream. The upstream changes didn't entirely fit with the full incubator implementation but these changes fit the goals of the upstream refactoring into the current implementation.

No observable changes are intended for this change.