### PR TITLE
[CIR][CIRGen][TBAA] Add support for struct types

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTBAAAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTBAAAttrs.td
@@ -50,9 +50,35 @@ def CIR_TBAATagAttr : CIR_Attr<"TBAATag", "tbaa_tag", [], "TBAAAttr"> {
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
+def CIR_TBAAStructAttr : CIR_Attr<"TBAAStruct", 
+                                  "tbaa_struct", [], "TBAAAttr"> {
+  let summary = "Describes a struct type in TBAA";
+
+  let parameters = (ins CIR_StructType : $type);
+
+  let description = [{
+    Define a TBAA struct attribute.
+
+    Example:
+    ```mlir
+    // CIR_TBAAStructAttr
+    !ty_StructA = !cir.struct<struct "StructA" {!u16i, !u32i, !u16i, !u32i} #cir.record.decl.ast>
+    !ty_StructS = !cir.struct<struct "StructS" {!u16i, !u32i} #cir.record.decl.ast>
+    #tbaa_struct = #cir.tbaa_struct<type = !ty_StructA>
+    #tbaa_struct1 = #cir.tbaa_struct<type = !ty_StructS>
+    ```
+    
+    See the following link for more details:
+    https://llvm.org/docs/LangRef.html#tbaa-metadata
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
 def CIR_AnyTBAAAttr : AnyAttrOf<[
   CIR_TBAAAttr, 
   CIR_TBAAOmnipotentChar, 
-  CIR_TBAAScalarAttr, 
+  CIR_TBAAScalarAttr,
+  CIR_TBAAStructAttr,
   CIR_TBAATagAttr
 ]>;

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -59,7 +59,7 @@ struct MissingFeatures {
   static bool emitTypeCheck() { return false; }
   static bool tbaa() { return false; }
   static bool tbaaStruct() { return false; }
-  static bool tbaaTagForStruct() { return false; }
+  static bool tbaaTagForStruct() { return true; }
   static bool tbaaTagForEnum() { return false; }
   static bool tbaaTagForBitInt() { return false; }
   static bool tbaaVTablePtr() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenTBAA.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTBAA.cpp
@@ -203,8 +203,8 @@ cir::TBAAAttr CIRGenTBAA::getTypeInfo(clang::QualType qty) {
   // be considered may-alias too.
   // function.
   if (isValidBaseType(qty)) {
-    assert(!cir::MissingFeatures::tbaaTagForStruct());
-    return tbaa_NYI(mlirContext);
+    assert(cir::MissingFeatures::tbaaTagForStruct());
+    return cir::TBAAStructAttr::get(mlirContext, types.convertType(qty));
   }
 
   const clang::Type *ty = astContext.getCanonicalType(qty).getTypePtr();
@@ -248,7 +248,7 @@ mlir::ArrayAttr CIRGenTBAA::getTBAAStructInfo(clang::QualType qty) {
 }
 
 cir::TBAAAttr CIRGenTBAA::getBaseTypeInfo(clang::QualType qty) {
-  return tbaa_NYI(mlirContext);
+  return cir::TBAAStructAttr::get(mlirContext, types.convertType(qty));
 }
 
 cir::TBAAAttr CIRGenTBAA::getAccessTagInfo(TBAAAccessInfo tbaaInfo) {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -109,7 +109,7 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
     }
     return TypeSwitch<Attribute, AliasResult>(attr)
         .Case<cir::TBAAAttr, cir::TBAAOmnipotentCharAttr, cir::TBAAScalarAttr,
-              cir::TBAATagAttr>([&](auto attr) {
+              cir::TBAAStructAttr, cir::TBAATagAttr>([&](auto attr) {
           os << decltype(attr)::getMnemonic();
           return AliasResult::OverridableAlias;
         })

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "clang/CIR/Target/AArch64.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -240,6 +241,12 @@ createLowerModule(mlir::ModuleOp module, mlir::PatternRewriter &rewriter) {
   // Create context.
   cir_cconv_assert(!cir::MissingFeatures::langOpts());
   clang::LangOptions langOpts;
+  if (auto langAttr = mlir::cast_if_present<cir::LangAttr>(
+          module->getAttr(cir::CIRDialect::getLangAttrName()))) {
+    if (langAttr.isCXX()) {
+      langOpts.CPlusPlus = true;
+    }
+  }
 
   // FIXME(cir): This just uses the default code generation options. We need to
   // account for custom options.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerTBAAToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerTBAAToLLVM.cpp
@@ -4,6 +4,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -14,11 +15,15 @@ namespace direct {
 
 class CIRToLLVMTBAAAttrLowering {
 public:
-  CIRToLLVMTBAAAttrLowering(mlir::MLIRContext *mlirContext)
-      : mlirContext(mlirContext) {}
+  CIRToLLVMTBAAAttrLowering(mlir::MLIRContext *mlirContext,
+                            const clang::LangOptions &features)
+      : mlirContext(mlirContext), features(features) {}
   mlir::LLVM::TBAARootAttr getRoot() {
-    return mlir::LLVM::TBAARootAttr::get(
-        mlirContext, mlir::StringAttr::get(mlirContext, "Simple C/C++ TBAA"));
+    if (features.CPlusPlus) {
+      return createTBAARoot("Simple C++ TBAA");
+    } else {
+      return createTBAARoot("Simple C/C++ TBAA");
+    }
   }
 
   mlir::LLVM::TBAATypeDescriptorAttr getChar() {
@@ -35,14 +40,22 @@ public:
         llvm::ArrayRef<mlir::LLVM::TBAAMemberAttr>(members));
   }
 
+private:
+  mlir::LLVM::TBAARootAttr createTBAARoot(llvm::StringRef name) {
+    return mlir::LLVM::TBAARootAttr::get(
+        mlirContext, mlir::StringAttr::get(mlirContext, name));
+  }
+
 protected:
   mlir::MLIRContext *mlirContext;
+  const clang::LangOptions &features;
 };
 
 class CIRToLLVMTBAAScalarAttrLowering : public CIRToLLVMTBAAAttrLowering {
 public:
-  CIRToLLVMTBAAScalarAttrLowering(mlir::MLIRContext *mlirContext)
-      : CIRToLLVMTBAAAttrLowering(mlirContext) {}
+  CIRToLLVMTBAAScalarAttrLowering(mlir::MLIRContext *mlirContext,
+                                  const clang::LangOptions &features)
+      : CIRToLLVMTBAAAttrLowering(mlirContext, features) {}
   mlir::LLVM::TBAATypeDescriptorAttr
   lowerScalarType(cir::TBAAScalarAttr scalarAttr) {
     mlir::DataLayout layout;
@@ -51,11 +64,341 @@ public:
   }
 };
 
+class CIRToLLVMTBAAStructAttrLowering : public CIRToLLVMTBAAAttrLowering {
+public:
+  CIRToLLVMTBAAStructAttrLowering(mlir::MLIRContext *mlirContext,
+                                  clang::ASTContext &astContext,
+                                  const clang::CodeGenOptions &codeGenOpts,
+                                  const clang::LangOptions &features)
+      : CIRToLLVMTBAAAttrLowering(mlirContext, features),
+        astContext(astContext), codeGenOpts(codeGenOpts) {}
+
+  mlir::LLVM::TBAATypeDescriptorAttr lowerStructType(const clang::Type *ty) {
+    return getBaseTypeInfoHelper(ty);
+  }
+
+  mlir::LLVM::TBAATypeDescriptorAttr getTypeInfoHelper(const clang::Type *ty) {
+    using namespace clang;
+    uint64_t size = astContext.getTypeSizeInChars(ty).getQuantity();
+    // Handle builtin types.
+    if (const BuiltinType *bty = dyn_cast<BuiltinType>(ty)) {
+      switch (bty->getKind()) {
+      // Character types are special and can alias anything.
+      // In C++, this technically only includes "char" and "unsigned char",
+      // and not "signed char". In C, it includes all three. For now,
+      // the risk of exploiting this detail in C++ seems likely to outweigh
+      // the benefit.
+      case BuiltinType::Char_U:
+      case BuiltinType::Char_S:
+      case BuiltinType::UChar:
+      case BuiltinType::SChar:
+        return getChar();
+
+      // Unsigned types can alias their corresponding signed types.
+      case BuiltinType::UShort:
+        return getTypeInfo(astContext.ShortTy);
+      case BuiltinType::UInt:
+        return getTypeInfo(astContext.IntTy);
+      case BuiltinType::ULong:
+        return getTypeInfo(astContext.LongTy);
+      case BuiltinType::ULongLong:
+        return getTypeInfo(astContext.LongLongTy);
+      case BuiltinType::UInt128:
+        return getTypeInfo(astContext.Int128Ty);
+
+      case BuiltinType::UShortFract:
+        return getTypeInfo(astContext.ShortFractTy);
+      case BuiltinType::UFract:
+        return getTypeInfo(astContext.FractTy);
+      case BuiltinType::ULongFract:
+        return getTypeInfo(astContext.LongFractTy);
+
+      case BuiltinType::SatUShortFract:
+        return getTypeInfo(astContext.SatShortFractTy);
+      case BuiltinType::SatUFract:
+        return getTypeInfo(astContext.SatFractTy);
+      case BuiltinType::SatULongFract:
+        return getTypeInfo(astContext.SatLongFractTy);
+
+      case BuiltinType::UShortAccum:
+        return getTypeInfo(astContext.ShortAccumTy);
+      case BuiltinType::UAccum:
+        return getTypeInfo(astContext.AccumTy);
+      case BuiltinType::ULongAccum:
+        return getTypeInfo(astContext.LongAccumTy);
+
+      case BuiltinType::SatUShortAccum:
+        return getTypeInfo(astContext.SatShortAccumTy);
+      case BuiltinType::SatUAccum:
+        return getTypeInfo(astContext.SatAccumTy);
+      case BuiltinType::SatULongAccum:
+        return getTypeInfo(astContext.SatLongAccumTy);
+
+      // Treat all other builtin types as distinct types. This includes
+      // treating wchar_t, char16_t, and char32_t as distinct from their
+      // "underlying types".
+      default:
+        return createScalarTypeNode(bty->getName(features), getChar(), size);
+      }
+    }
+
+    // C++1z [basic.lval]p10: "If a program attempts to access the stored value
+    // of an object through a glvalue of other than one of the following types
+    // the behavior is undefined: [...] a char, unsigned char, or std::byte
+    // type."
+    if (ty->isStdByteType())
+      return getChar();
+
+    // Handle pointers and references.
+    //
+    // C has a very strict rule for pointer aliasing. C23 6.7.6.1p2:
+    //     For two pointer types to be compatible, both shall be identically
+    //     qualified and both shall be pointers to compatible types.
+    //
+    // This rule is impractically strict; we want to at least ignore CVR
+    // qualifiers. Distinguishing by CVR qualifiers would make it UB to
+    // e.g. cast a `char **` to `const char * const *` and dereference it,
+    // which is too common and useful to invalidate. C++'s similar types
+    // rule permits qualifier differences in these nested positions; in fact,
+    // C++ even allows that cast as an implicit conversion.
+    //
+    // Other qualifiers could theoretically be distinguished, especially if
+    // they involve a significant representation difference.  We don't
+    // currently do so, however.
+    //
+    // Computing the pointee type string recursively is implicitly more
+    // forgiving than the standards require.  Effectively, we are turning
+    // the question "are these types compatible/similar" into "are
+    // accesses to these types allowed to alias".  In both C and C++,
+    // the latter question has special carve-outs for signedness
+    // mismatches that only apply at the top level.  As a result, we are
+    // allowing e.g. `int *` l-values to access `unsigned *` objects.
+    if (ty->isPointerType() || ty->isReferenceType()) {
+      auto anyPtr = createScalarTypeNode("any pointer", getChar(), size);
+      if (!codeGenOpts.PointerTBAA)
+        return anyPtr;
+      assert(!cir::MissingFeatures::tbaaPointer());
+      return nullptr;
+    }
+
+    // Accesses to arrays are accesses to objects of their element types.
+    if (codeGenOpts.NewStructPathTBAA && ty->isArrayType())
+      return getTypeInfo(cast<clang::ArrayType>(ty)->getElementType());
+
+    // Enum types are distinct types. In C++ they have "underlying types",
+    // however they aren't related for TBAA.
+    if (const clang::EnumType *ety = dyn_cast<clang::EnumType>(ty)) {
+      if (!features.CPlusPlus)
+        return getTypeInfo(ety->getDecl()->getIntegerType());
+
+      // In C++ mode, types have linkage, so we can rely on the ODR and
+      // on their mangled names, if they're external.
+      // TODO: Is there a way to get a program-wide unique name for a
+      // decl with local linkage or no linkage?
+      if (!ety->getDecl()->isExternallyVisible())
+        return getChar();
+
+      SmallString<256> outName;
+      llvm::raw_svector_ostream out(outName);
+      mangleCanonicalTypeName(ety, out);
+      return createScalarTypeNode(outName, getChar(), size);
+    }
+
+    if (const auto *eit = dyn_cast<BitIntType>(ty)) {
+      SmallString<256> outName;
+      llvm::raw_svector_ostream out(outName);
+      // Don't specify signed/unsigned since integer types can alias despite
+      // sign differences.
+      out << "_BitInt(" << eit->getNumBits() << ')';
+      return createScalarTypeNode(outName, getChar(), size);
+    }
+
+    // For now, handle any other kind of type conservatively.
+    return getChar();
+  }
+  mlir::LLVM::TBAATypeDescriptorAttr getTypeInfo(const clang::Type *ty) {
+    return getTypeInfo(clang::QualType(ty, 0));
+  }
+  mlir::LLVM::TBAATypeDescriptorAttr getTypeInfo(clang::QualType qty) {
+    // If the type has the may_alias attribute (even on a typedef), it is
+    // effectively in the general char alias class.
+    if (typeHasMayAlias(qty)) {
+      return getChar();
+    }
+    // We need this function to not fall back to returning the "omnipotent char"
+    // type node for aggregate and union types. Otherwise, any dereference of an
+    // aggregate will result into the may-alias access descriptor, meaning all
+    // subsequent accesses to direct and indirect members of that aggregate will
+    // be considered may-alias too.
+    // TODO: Combine getTypeInfo() and getValidBaseTypeInfo() into a single
+    // function.
+    if (isValidBaseType(qty)) {
+      return getValidBaseTypeInfo(qty);
+    }
+
+    const clang::Type *ty = astContext.getCanonicalType(qty).getTypePtr();
+    if (auto attr = metadataCache[ty]) {
+      return attr;
+    }
+
+    // Note that the following helper call is allowed to add new nodes to the
+    // cache, which invalidates all its previously obtained iterators. So we
+    // first generate the node for the type and then add that node to the cache.
+    auto typeNode = getTypeInfoHelper(ty);
+    return metadataCache[ty] = typeNode;
+  }
+
+private:
+  mlir::LLVM::TBAATypeDescriptorAttr
+  getBaseTypeInfoHelper(const clang::Type *ty) {
+    using namespace clang;
+    if (auto *tty = mlir::dyn_cast<clang::RecordType>(ty)) {
+      const clang::RecordDecl *rd = tty->getDecl()->getDefinition();
+      const ASTRecordLayout &layout = astContext.getASTRecordLayout(rd);
+      SmallVector<mlir::LLVM::TBAAMemberAttr, 4> fields;
+      if (const CXXRecordDecl *cxxrd = dyn_cast<CXXRecordDecl>(rd)) {
+        // Handle C++ base classes. Non-virtual bases can treated a kind of
+        // field. Virtual bases are more complex and omitted, but avoid an
+        // incomplete view for NewStructPathTBAA.
+        if (codeGenOpts.NewStructPathTBAA && cxxrd->getNumVBases() != 0)
+          return nullptr;
+        for (const CXXBaseSpecifier &cxxBaseSpecifier : cxxrd->bases()) {
+          if (cxxBaseSpecifier.isVirtual())
+            continue;
+          QualType baseQTy = cxxBaseSpecifier.getType();
+          const CXXRecordDecl *baseRD = baseQTy->getAsCXXRecordDecl();
+          if (baseRD->isEmpty())
+            continue;
+          auto typeNode = isValidBaseType(baseQTy)
+                              ? getValidBaseTypeInfo(baseQTy)
+                              : getTypeInfo(baseQTy);
+          if (!typeNode)
+            return nullptr;
+          uint64_t offset = layout.getBaseClassOffset(baseRD).getQuantity();
+          [[maybe_unused]] uint64_t size =
+              astContext.getASTRecordLayout(baseRD).getDataSize().getQuantity();
+          fields.push_back(mlir::LLVM::TBAAMemberAttr::get(typeNode, offset));
+        }
+        // The order in which base class subobjects are allocated is
+        // unspecified, so may differ from declaration order. In particular,
+        // Itanium ABI will allocate a primary base first. Since we exclude
+        // empty subobjects, the objects are not overlapping and their offsets
+        // are unique.
+        llvm::sort(fields, [](const mlir::LLVM::TBAAMemberAttr &lhs,
+                              const mlir::LLVM::TBAAMemberAttr &rhs) {
+          return lhs.getOffset() < rhs.getOffset();
+        });
+      }
+      for (FieldDecl *field : rd->fields()) {
+        if (field->isZeroSize(astContext) || field->isUnnamedBitField())
+          continue;
+        QualType fieldQTy = field->getType();
+        auto typeNode = isValidBaseType(fieldQTy)
+                            ? getValidBaseTypeInfo(fieldQTy)
+                            : getTypeInfo(fieldQTy);
+        if (!typeNode)
+          return nullptr;
+
+        uint64_t bitOffset = layout.getFieldOffset(field->getFieldIndex());
+        uint64_t offset =
+            astContext.toCharUnitsFromBits(bitOffset).getQuantity();
+        [[maybe_unused]] uint64_t size =
+            astContext.getTypeSizeInChars(fieldQTy).getQuantity();
+        fields.push_back(mlir::LLVM::TBAAMemberAttr::get(typeNode, offset));
+      }
+
+      SmallString<256> outName;
+      if (features.CPlusPlus) {
+        // Don't use the mangler for C code.
+        llvm::raw_svector_ostream out(outName);
+        mangleCanonicalTypeName(ty, out);
+      } else {
+        outName = rd->getName();
+      }
+
+      if (codeGenOpts.NewStructPathTBAA) {
+        assert(!cir::MissingFeatures::tbaaNewStructPath());
+        return nullptr;
+      }
+      return mlir::LLVM::TBAATypeDescriptorAttr::get(mlirContext, outName,
+                                                     fields);
+    }
+    return nullptr;
+  }
+
+  mlir::LLVM::TBAATypeDescriptorAttr getValidBaseTypeInfo(clang::QualType qty) {
+    assert(isValidBaseType(qty) && "Must be a valid base type");
+
+    const clang::Type *ty = astContext.getCanonicalType(qty).getTypePtr();
+
+    // nullptr is a valid value in the cache, so use find rather than []
+    auto iter = baseTypeMetadataCache.find(ty);
+    if (iter != baseTypeMetadataCache.end())
+      return iter->second;
+
+    // First calculate the metadata, before recomputing the insertion point, as
+    // the helper can recursively call us.
+    auto typeNode = getBaseTypeInfoHelper(ty);
+    LLVM_ATTRIBUTE_UNUSED auto inserted =
+        baseTypeMetadataCache.insert({ty, typeNode});
+    assert(inserted.second && "BaseType metadata was already inserted");
+
+    return typeNode;
+  }
+  static bool typeHasMayAlias(clang::QualType qty) {
+    // Tagged types have declarations, and therefore may have attributes.
+    if (auto *td = qty->getAsTagDecl())
+      if (td->hasAttr<clang::MayAliasAttr>())
+        return true;
+
+    // Also look for may_alias as a declaration attribute on a typedef.
+    // FIXME: We should follow GCC and model may_alias as a type attribute
+    // rather than as a declaration attribute.
+    // auto
+    while (auto *tt = qty->getAs<clang::TypedefType>()) {
+      if (tt->getDecl()->hasAttr<clang::MayAliasAttr>())
+        return true;
+      qty = tt->desugar();
+    }
+    return false;
+  }
+
+  /// Check if the given type is a valid base type to be used in access tags.
+  static bool isValidBaseType(clang::QualType qty) {
+    if (const clang::RecordType *tty = qty->getAs<clang::RecordType>()) {
+      const clang::RecordDecl *rd = tty->getDecl()->getDefinition();
+      // Incomplete types are not valid base access types.
+      if (!rd)
+        return false;
+      if (rd->hasFlexibleArrayMember())
+        return false;
+      // rd can be struct, union, class, interface or enum.
+      // For now, we only handle struct and class.
+      if (rd->isStruct() || rd->isClass())
+        return true;
+    }
+    return false;
+  }
+
+  void mangleCanonicalTypeName(const clang::Type *qty, llvm::raw_ostream &out) {
+    astContext.createMangleContext()->mangleCanonicalTypeName(
+        clang::QualType(qty, 0), out);
+  }
+
+  clang::ASTContext &astContext;
+  const clang::CodeGenOptions &codeGenOpts;
+  llvm::DenseMap<const clang::Type *, mlir::LLVM::TBAATypeDescriptorAttr>
+      metadataCache;
+  llvm::DenseMap<const clang::Type *, mlir::LLVM::TBAATypeDescriptorAttr>
+      baseTypeMetadataCache;
+};
+
 mlir::ArrayAttr lowerCIRTBAAAttr(mlir::Attribute tbaa,
                                  mlir::ConversionPatternRewriter &rewriter,
                                  cir::LowerModule *lowerMod) {
   auto *ctx = rewriter.getContext();
-  CIRToLLVMTBAAScalarAttrLowering scalarLower(ctx);
+  CIRToLLVMTBAAScalarAttrLowering scalarLower(
+      ctx, lowerMod->getContext().getLangOpts());
   if (auto charAttr = mlir::dyn_cast<cir::TBAAOmnipotentCharAttr>(tbaa)) {
     auto accessType = scalarLower.getChar();
     auto tag = mlir::LLVM::TBAATagAttr::get(accessType, accessType, 0);
@@ -65,6 +408,37 @@ mlir::ArrayAttr lowerCIRTBAAAttr(mlir::Attribute tbaa,
     auto accessType = scalarLower.lowerScalarType(scalarAttr);
     auto tag = mlir::LLVM::TBAATagAttr::get(accessType, accessType, 0);
     return mlir::ArrayAttr::get(ctx, {tag});
+  }
+  if (auto tbaaTag = mlir::dyn_cast<cir::TBAATagAttr>(tbaa)) {
+    mlir::LLVM::TBAATypeDescriptorAttr accessType;
+    if (mlir::isa<cir::TBAAOmnipotentCharAttr>(tbaaTag.getAccess())) {
+      accessType = scalarLower.getChar();
+    } else if (auto scalarAttr =
+                   mlir::dyn_cast<cir::TBAAScalarAttr>(tbaaTag.getAccess())) {
+      accessType = scalarLower.lowerScalarType(
+          mlir::dyn_cast<cir::TBAAScalarAttr>(tbaaTag.getAccess()));
+    } else {
+      return nullptr;
+    }
+    if (auto structAttr =
+            mlir::dyn_cast<cir::TBAAStructAttr>(tbaaTag.getBase())) {
+      cir::StructType structType =
+          mlir::dyn_cast<cir::StructType>(structAttr.getType());
+      auto ast = structType.getAst();
+      CIRToLLVMTBAAStructAttrLowering structLower(
+          rewriter.getContext(), ast.getRawDecl()->getASTContext(),
+          lowerMod->getContext().getCodeGenOpts(),
+          lowerMod->getContext().getLangOpts());
+      auto baseType =
+          structLower.lowerStructType(ast.getRawDecl()->getTypeForDecl());
+      if (!baseType) {
+        return nullptr;
+      }
+
+      auto tag = mlir::LLVM::TBAATagAttr::get(baseType, accessType,
+                                              tbaaTag.getOffset());
+      return mlir::ArrayAttr::get(ctx, {tag});
+    }
   }
   return mlir::ArrayAttr();
 }

--- a/clang/test/CIR/CodeGen/tbaa-struct.cpp
+++ b/clang/test/CIR/CodeGen/tbaa-struct.cpp
@@ -1,0 +1,404 @@
+// This is inspired from clang/test/CodeGen/tbaa.cpp, with both CIR and LLVM checks.
+// g13 is not supported due to DiscreteBitFieldABI is NYI.
+// see clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp CIRRecordLowering::accumulateBitFields
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -no-struct-path-tbaa
+// RUN: FileCheck --check-prefix=CHECK --input-file=%t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes
+// RUN: FileCheck --check-prefixes=PATH,OLD-PATH --input-file=%t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -relaxed-aliasing
+// RUN: FileCheck --check-prefix=NO-TBAA --input-file=%t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O0 -disable-llvm-passes
+// RUN: FileCheck --check-prefix=NO-TBAA --input-file=%t.ll %s
+
+// NO-TBAA-NOT: !tbaa
+// CIR: #tbaa[[NYI:.*]] = #cir.tbaa
+// CIR: #tbaa[[CHAR:.*]] = #cir.tbaa_omnipotent_char
+// CIR: #tbaa[[INT:.*]] = #cir.tbaa_scalar<id = "int", type = !s32i>
+// CIR: #tbaa[[SHORT:.*]] = #cir.tbaa_scalar<id = "short", type = !s16i>
+// CIR: #tbaa[[STRUCT_StructA:.*]] = #cir.tbaa_struct<type = !ty_StructA>
+// CIR: #tbaa[[STRUCT_StructS:.*]] = #cir.tbaa_struct<type = !ty_StructS>
+// CIR: #tbaa[[STRUCT_StructS2:.*]] = #cir.tbaa_struct<type = !ty_StructS2_>
+// CIR: #tbaa[[STRUCT_StructB:.*]] = #cir.tbaa_struct<type = !ty_StructB>
+// CIR: #tbaa[[STRUCT_six:.*]] = #cir.tbaa_struct<type = !ty_six>
+// CIR: #tbaa[[TAG_StructA_f32:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructA]], access = #tbaa[[INT]], offset = 4>
+// CIR: #tbaa[[TAG_StructA_f16:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructA]], access = #tbaa[[SHORT]], offset = 0>
+// CIR: #tbaa[[TAG_StructS_f32:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructS]], access = #tbaa[[INT]], offset = 4>
+// CIR: #tbaa[[TAG_StructS_f16:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructS]], access = #tbaa[[SHORT]], offset = 0>
+// CIR: #tbaa[[TAG_StructS2_f32:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructS2]], access = #tbaa[[INT]], offset = 4>
+// CIR: #tbaa[[TAG_StructS2_f16:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructS2]], access = #tbaa[[SHORT]], offset = 0>
+// CIR: #tbaa[[STRUCT_StructC:.*]] = #cir.tbaa_struct<type = !ty_StructC>
+// CIR: #tbaa[[STRUCT_StructD:.*]] = #cir.tbaa_struct<type = !ty_StructD>
+// CIR: #tbaa[[TAG_StructB_a_f32:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructB]], access = #tbaa[[INT]], offset = 8>
+// CIR: #tbaa[[TAG_StructB_a_f16:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructB]], access = #tbaa[[SHORT]], offset = 4>
+// CIR: #tbaa[[TAG_StructB_f32:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructB]], access = #tbaa[[INT]], offset = 20>
+// CIR: #tbaa[[TAG_StructB_a_f32_2:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructB]], access = #tbaa[[INT]], offset = 16>
+// CIR: #tbaa[[TAG_six_b:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_six]], access = #tbaa[[CHAR]], offset = 4>
+// CIR: #tbaa[[TAG_StructC_b_a_f32:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructC]], access = #tbaa[[INT]], offset = 12>
+// CIR: #tbaa[[TAG_StructD_b_a_f32:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_StructD]], access = #tbaa[[INT]], offset = 12>
+
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef struct
+{
+   uint16_t f16;
+   uint32_t f32;
+   uint16_t f16_2;
+   uint32_t f32_2;
+} StructA;
+typedef struct
+{
+   uint16_t f16;
+   StructA a;
+   uint32_t f32;
+} StructB;
+typedef struct
+{
+   uint16_t f16;
+   StructB b;
+   uint32_t f32;
+} StructC;
+typedef struct
+{
+   uint16_t f16;
+   StructB b;
+   uint32_t f32;
+   uint8_t f8;
+} StructD;
+
+typedef struct
+{
+   uint16_t f16;
+   uint32_t f32;
+} StructS;
+typedef struct
+{
+   uint16_t f16;
+   uint32_t f32;
+} StructS2;
+
+uint32_t g(uint32_t *s, StructA *A, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z1g
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[INT]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructA_f32]])
+
+
+  // CHECK-LABEL: define{{.*}} i32 @_Z1g
+  // CHECK: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32:!.*]]
+  // CHECK: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH-LABEL: define{{.*}} i32 @_Z1g
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32:!.*]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_A_f32:!.*]]
+  *s = 1;
+  A->f32 = 4;
+  return *s;
+}
+
+uint32_t g2(uint32_t *s, StructA *A, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z2g2
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[INT]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u16i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u16i, !cir.ptr<!u16i> tbaa(#tbaa[[TAG_StructA_f16]])
+
+  // CHECK-LABEL: define{{.*}} i32 @_Z2g2
+  // CHECK: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // CHECK: store i16 4, ptr %{{.*}}, align {{4|2}}, !tbaa [[TAG_i16:!.*]]
+  // PATH-LABEL: define{{.*}} i32 @_Z2g2
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH: store i16 4, ptr %{{.*}}, align {{4|2}}, !tbaa [[TAG_A_f16:!.*]]
+  *s = 1;
+  A->f16 = 4;
+  return *s;
+}
+
+uint32_t g3(StructA *A, StructB *B, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z2g3
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructA_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructB_a_f32]])
+
+  // CHECK-LABEL: define{{.*}} i32 @_Z2g3
+  // CHECK: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // CHECK: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH-LABEL: define{{.*}} i32 @_Z2g3
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_A_f32]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_B_a_f32:!.*]]
+  A->f32 = 1;
+  B->a.f32 = 4;
+  return A->f32;
+}
+
+uint32_t g4(StructA *A, StructB *B, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z2g4
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructA_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u16i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u16i, !cir.ptr<!u16i> tbaa(#tbaa[[TAG_StructB_a_f16]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z2g4
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i16 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i16]]
+  // PATH-LABEL: define{{.*}} i32 @_Z2g4
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_A_f32]]
+  // PATH: store i16 4, ptr %{{.*}}, align {{4|2}}, !tbaa [[TAG_B_a_f16:!.*]]
+  A->f32 = 1;
+  B->a.f16 = 4;
+  return A->f32;
+}
+
+uint32_t g5(StructA *A, StructB *B, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z2g5
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructA_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructB_f32]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z2g5
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH-LABEL: define{{.*}} i32 @_Z2g5
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_A_f32]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_B_f32:!.*]]
+  A->f32 = 1;
+  B->f32 = 4;
+  return A->f32;
+}
+
+uint32_t g6(StructA *A, StructB *B, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z2g6
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructA_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructB_a_f32_2]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z2g6
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH-LABEL: define{{.*}} i32 @_Z2g6
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_A_f32]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_B_a_f32_2:!.*]]
+  A->f32 = 1;
+  B->a.f32_2 = 4;
+  return A->f32;
+}
+
+uint32_t g7(StructA *A, StructS *S, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z2g7
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructA_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructS_f32]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z2g7
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH-LABEL: define{{.*}} i32 @_Z2g7
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_A_f32]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_S_f32:!.*]]
+  A->f32 = 1;
+  S->f32 = 4;
+  return A->f32;
+}
+
+uint32_t g8(StructA *A, StructS *S, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z2g8
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructA_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u16i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u16i, !cir.ptr<!u16i> tbaa(#tbaa[[TAG_StructS_f16]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z2g8
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i16 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i16]]
+  // PATH-LABEL: define{{.*}} i32 @_Z2g8
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_A_f32]]
+  // PATH: store i16 4, ptr %{{.*}}, align {{4|2}}, !tbaa [[TAG_S_f16:!.*]]
+  A->f32 = 1;
+  S->f16 = 4;
+  return A->f32;
+}
+
+uint32_t g9(StructS *S, StructS2 *S2, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z2g9
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructS_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructS2_f32]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z2g9
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH-LABEL: define{{.*}} i32 @_Z2g9
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_S_f32]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_S2_f32:!.*]]
+  S->f32 = 1;
+  S2->f32 = 4;
+  return S->f32;
+}
+
+uint32_t g10(StructS *S, StructS2 *S2, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z3g10
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructS_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u16i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u16i, !cir.ptr<!u16i> tbaa(#tbaa[[TAG_StructS2_f16]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z3g10
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i16 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i16]]
+  // PATH-LABEL: define{{.*}} i32 @_Z3g10
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_S_f32]]
+  // PATH: store i16 4, ptr %{{.*}}, align {{4|2}}, !tbaa [[TAG_S2_f16:!.*]]
+  S->f32 = 1;
+  S2->f16 = 4;
+  return S->f32;
+}
+
+uint32_t g11(StructC *C, StructD *D, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z3g11
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructC_b_a_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructD_b_a_f32]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z3g11
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH-LABEL: define{{.*}} i32 @_Z3g11
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_C_b_a_f32:!.*]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_D_b_a_f32:!.*]]
+  C->b.a.f32 = 1;
+  D->b.a.f32 = 4;
+  return C->b.a.f32;
+}
+
+uint32_t g12(StructC *C, StructD *D, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z3g12
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructB_a_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructB_a_f32]])
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z3g12
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // TODO(cir): differentiate the two accesses.
+  // PATH-LABEL: define{{.*}} i32 @_Z3g12
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_B_a_f32]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_B_a_f32]]
+  StructB *b1 = &(C->b);
+  StructB *b2 = &(D->b);
+  // b1, b2 have different context.
+  b1->a.f32 = 1;
+  b2->a.f32 = 4;
+  return b1->a.f32;
+}
+
+struct six {
+  char a;
+  int :0;
+  char b;
+  char c;
+};
+char g14(struct six *a, struct six *b) {
+  // CIR-LABEL: cir.func @_Z3g14
+  // CIR: %[[TMP1:.*]] = cir.load %{{.*}} : !cir.ptr<!cir.ptr<!ty_six>>, !cir.ptr<!ty_six>
+  // CIR: %[[TMP2:.*]] = cir.get_member %[[TMP1]][2] {name = "b"} : !cir.ptr<!ty_six> -> !cir.ptr<!s8i>
+  // CIR: %[[TMP3:.*]] = cir.load %[[TMP2]] : !cir.ptr<!s8i>, !s8i tbaa(#tbaa[[TAG_six_b]])
+
+  // LLVM-LABEL: define{{.*}} i8 @_Z3g14
+  // LLVM: load i8, ptr %{{.*}}, align 1, !tbaa [[TAG_char]]
+  // PATH-LABEL: define{{.*}} i8 @_Z3g14
+  // PATH: load i8, ptr %{{.*}}, align 1, !tbaa [[TAG_six_b:!.*]]
+  return a->b;
+}
+
+// Types that differ only by name may alias.
+typedef StructS StructS3;
+uint32_t g15(StructS *S, StructS3 *S3, uint64_t count) {
+  // CIR-LABEL: cir.func @_Z3g15
+  // CIR: %[[INT_1:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR: %[[UINT_1:.*]] = cir.cast(integral, %[[INT_1]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_1]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructS_f32]])
+  // CIR: %[[INT_4:.*]] = cir.const #cir.int<4> : !s32i
+  // CIR: %[[UINT_4:.*]] = cir.cast(integral, %[[INT_4]] : !s32i), !u32i
+  // CIR: cir.store %[[UINT_4]], %{{.*}} : !u32i, !cir.ptr<!u32i> tbaa(#tbaa[[TAG_StructS_f32]])
+
+
+  // LLVM-LABEL: define{{.*}} i32 @_Z3g15
+  // LLVM: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // LLVM: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_i32]]
+  // PATH-LABEL: define{{.*}} i32 @_Z3g15
+  // PATH: store i32 1, ptr %{{.*}}, align 4, !tbaa [[TAG_S_f32]]
+  // PATH: store i32 4, ptr %{{.*}}, align 4, !tbaa [[TAG_S_f32]]
+  S->f32 = 1;
+  S3->f32 = 4;
+  return S->f32;
+}
+
+// LLVM: [[TYPE_char:!.*]] = !{!"omnipotent char", [[TAG_cxx_tbaa:!.*]],
+// LLVM: [[TAG_cxx_tbaa]] = !{!"Simple C++ TBAA"}
+// LLVM: [[TAG_i32]] = !{[[TYPE_i32:!.*]], [[TYPE_i32]], i64 0}
+// LLVM: [[TYPE_i32]] = !{!"int", [[TYPE_char]],
+// LLVM: [[TAG_i16]] = !{[[TYPE_i16:!.*]], [[TYPE_i16]], i64 0}
+// LLVM: [[TYPE_i16]] = !{!"short", [[TYPE_char]],
+// LLVM: [[TAG_char]] = !{[[TYPE_char]], [[TYPE_char]], i64 0}
+
+// OLD-PATH: [[TAG_i32]] = !{[[TYPE_INT:!.*]], [[TYPE_INT]], i64 0}
+// OLD-PATH: [[TYPE_INT]] = !{!"int", [[TYPE_CHAR:!.*]], i64 0}
+// OLD-PATH: [[TYPE_CHAR]] = !{!"omnipotent char", [[TAG_cxx_tbaa:!.*]],
+// OLD-PATH: [[TAG_cxx_tbaa]] = !{!"Simple C++ TBAA"}
+// OLD-PATH: [[TAG_A_f32]] = !{[[TYPE_A:!.*]], [[TYPE_INT]], i64 4}
+// OLD-PATH: [[TYPE_A]] = !{!"_ZTS7StructA", [[TYPE_SHORT:!.*]], i64 0, [[TYPE_INT]], i64 4, [[TYPE_SHORT]], i64 8, [[TYPE_INT]], i64 12}
+// OLD-PATH: [[TYPE_SHORT:!.*]] = !{!"short", [[TYPE_CHAR]]
+// OLD-PATH: [[TAG_A_f16]] = !{[[TYPE_A]], [[TYPE_SHORT]], i64 0}
+// OLD-PATH: [[TAG_B_a_f32]] = !{[[TYPE_B:!.*]], [[TYPE_INT]], i64 8}
+// OLD-PATH: [[TYPE_B]] = !{!"_ZTS7StructB", [[TYPE_SHORT]], i64 0, [[TYPE_A]], i64 4, [[TYPE_INT]], i64 20}
+// OLD-PATH: [[TAG_B_a_f16]] = !{[[TYPE_B]], [[TYPE_SHORT]], i64 4}
+// OLD-PATH: [[TAG_B_f32]] = !{[[TYPE_B]], [[TYPE_INT]], i64 20}
+// OLD-PATH: [[TAG_B_a_f32_2]] = !{[[TYPE_B]], [[TYPE_INT]], i64 16}
+// OLD-PATH: [[TAG_S_f32]] = !{[[TYPE_S:!.*]], [[TYPE_INT]], i64 4}
+// OLD-PATH: [[TYPE_S]] = !{!"_ZTS7StructS", [[TYPE_SHORT]], i64 0, [[TYPE_INT]], i64 4}
+// OLD-PATH: [[TAG_S_f16]] = !{[[TYPE_S]], [[TYPE_SHORT]], i64 0}
+// OLD-PATH: [[TAG_S2_f32]] = !{[[TYPE_S2:!.*]], [[TYPE_INT]], i64 4}
+// OLD-PATH: [[TYPE_S2]] = !{!"_ZTS8StructS2", [[TYPE_SHORT]], i64 0, [[TYPE_INT]], i64 4}
+// OLD-PATH: [[TAG_S2_f16]] = !{[[TYPE_S2]], [[TYPE_SHORT]], i64 0}
+// OLD-PATH: [[TAG_C_b_a_f32]] = !{[[TYPE_C:!.*]], [[TYPE_INT]], i64 12}
+// OLD-PATH: [[TYPE_C]] = !{!"_ZTS7StructC", [[TYPE_SHORT]], i64 0, [[TYPE_B]], i64 4, [[TYPE_INT]], i64 28}
+// OLD-PATH: [[TAG_D_b_a_f32]] = !{[[TYPE_D:!.*]], [[TYPE_INT]], i64 12}
+// OLD-PATH: [[TYPE_D]] = !{!"_ZTS7StructD", [[TYPE_SHORT]], i64 0, [[TYPE_B]], i64 4, [[TYPE_INT]], i64 28, [[TYPE_CHAR]], i64 32}
+// OLD-PATH: [[TAG_six_b]] = !{[[TYPE_six:!.*]], [[TYPE_CHAR]], i64 4}
+// OLD-PATH: [[TYPE_six]] = !{!"_ZTS3six", [[TYPE_CHAR]], i64 0, [[TYPE_CHAR]], i64 4, [[TYPE_CHAR]], i64 5}


### PR DESCRIPTION
This patch introduces support for TBAA with struct types. The converted `CIR_StructType` is stored in `TBAAStructAttr`, which is then lowered using `CIRToLLVMTBAAStructAttrLowering`.