### PR TITLE
[CIR][CUDA|HIP] Removes special handling for CUDA|HIP global function

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2354,15 +2354,6 @@ cir::FuncOp CIRGenModule::GetAddrOfFunction(clang::GlobalDecl GD, mlir::Type Ty,
   auto F = GetOrCreateCIRFunction(MangledName, Ty, GD, ForVTable, DontDefer,
                                   /*IsThunk=*/false, IsForDefinition);
 
-  // As __global__ functions (kernels) always reside on device,
-  // when we access them from host, we must refer to the kernel handle.
-  // For CUDA, it's just the device stub. For HIP, it's something different.
-  if ((langOpts.CUDA || langOpts.HIP) && !langOpts.CUDAIsDevice &&
-      cast<FunctionDecl>(GD.getDecl())->hasAttr<CUDAGlobalAttr>() &&
-      cast<FunctionDecl>(GD.getDecl())->isThisDeclarationADefinition()) {
-    llvm_unreachable("NYI");
-  }
-
   return F;
 }
 


### PR DESCRIPTION
The `GetAddrOfFunction` returns now the host address.