### PR TITLE
[CIR][CUDA][NFC] Skeleton of  `setCUDAKernelCallingConvention`

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3350,11 +3350,12 @@ def DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
 def CC_C : I32EnumAttrCase<"C", 1, "c">;
 def CC_SpirKernel : I32EnumAttrCase<"SpirKernel", 2, "spir_kernel">;
 def CC_SpirFunction : I32EnumAttrCase<"SpirFunction", 3, "spir_function">;
+def CC_OpenCLKernel : I32EnumAttrCase<"OpenCLKernel", 4, "opencl_kernel">;
 
 def CallingConv : I32EnumAttr<
     "CallingConv",
     "calling convention",
-    [CC_C, CC_SpirKernel, CC_SpirFunction]> {
+    [CC_C, CC_SpirKernel, CC_SpirFunction, CC_OpenCLKernel]> {
   let cppNamespace = "::cir";
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -1531,7 +1531,9 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeFreeFunctionCall(
 static void setCUDAKernelCallingConvention(CanQualType &FTy, CIRGenModule &CGM,
                                            const FunctionDecl *FD) {
   if (FD->hasAttr<CUDAGlobalAttr>()) {
-    llvm_unreachable("NYI");
+    const FunctionType *FT = FTy->getAs<FunctionType>();
+    CGM.getTargetCIRGenInfo().setCUDAKernelCallingConvention(FT);
+    FTy = FT->getCanonicalTypeUnqualified();
   }
 }
 

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -301,6 +301,10 @@ class SPIRVTargetCIRGenInfo : public CommonSPIRTargetCIRGenInfo {
 public:
   SPIRVTargetCIRGenInfo(CIRGenTypes &CGT)
       : CommonSPIRTargetCIRGenInfo(std::make_unique<SPIRVABIInfo>(CGT)) {}
+
+  void setCUDAKernelCallingConvention(const FunctionType *&ft) const override {
+    llvm_unreachable("NYI");
+  }
 };
 
 } // namespace
@@ -349,6 +353,10 @@ class AMDGPUTargetCIRGenInfo : public TargetCIRGenInfo {
 public:
   AMDGPUTargetCIRGenInfo(CIRGenTypes &cgt)
       : TargetCIRGenInfo(std::make_unique<AMDGPUABIInfo>(cgt)) {}
+
+  void setCUDAKernelCallingConvention(const FunctionType *&ft) const override {
+    llvm_unreachable("NYI");
+  }
 };
 
 } // namespace

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -113,6 +113,12 @@ public:
     return cir::CallingConv::SpirKernel;
   }
 
+  // Set calling convention for CUDA Kernels.
+  // Some targets, such as AMD GPU or SPIRV, treat CUDA kernels as OpenCL
+  // kernels. They should reset the calling convention to OpenCLKernel,
+  // which will be further resolved by getOpenCLKernelCallingConv().
+  virtual void setCUDAKernelCallingConvention(const FunctionType *&ft) const {}
+
   virtual ~TargetCIRGenInfo() {}
 };
 


### PR DESCRIPTION
This is only a skeleton following OG, and shouldn't have changed any visible behaviour.
