### PR TITLE
[CIR][CIRGen] Atomics: handle atomic_compare_exchange_weak

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -565,7 +565,8 @@ static void emitAtomicOp(CIRGenFunction &CGF, AtomicExpr *E, Address Dest,
   case AtomicExpr::AO__c11_atomic_compare_exchange_weak:
   case AtomicExpr::AO__opencl_atomic_compare_exchange_weak:
   case AtomicExpr::AO__hip_atomic_compare_exchange_weak:
-    llvm_unreachable("NYI");
+    emitAtomicCmpXchgFailureSet(CGF, E, true, Dest, Ptr, Val1, Val2,
+                                FailureOrder, Size, Order, Scope);
     return;
   case AtomicExpr::AO__atomic_compare_exchange:
   case AtomicExpr::AO__atomic_compare_exchange_n:

--- a/clang/test/CIR/CodeGen/atomic.cpp
+++ b/clang/test/CIR/CodeGen/atomic.cpp
@@ -308,6 +308,21 @@ bool fi4c(atomic_int *i) {
 // LLVM-LABEL: @_Z4fi4cPU7_Atomici
 // LLVM: cmpxchg ptr {{.*}}, i32 {{.*}}, i32 {{.*}} seq_cst seq_cst, align 4
 
+bool fi4d(atomic_int *i) {
+  int cmp = 0;
+  return atomic_compare_exchange_weak(i, &cmp, 1);
+}
+
+// CHECK-LABEL: @_Z4fi4dPU7_Atomici
+// CHECK: %old, %cmp = cir.atomic.cmp_xchg({{.*}} : !cir.ptr<!s32i>, {{.*}} : !s32i, {{.*}} : !s32i, success = seq_cst, failure = seq_cst) align(4) weak : (!s32i, !cir.bool)
+// CHECK: %[[CMP:.*]] = cir.unary(not, %cmp) : !cir.bool, !cir.bool
+// CHECK: cir.if %[[CMP:.*]] {
+// CHECK:   cir.store %old, {{.*}} : !s32i, !cir.ptr<!s32i>
+// CHECK: }
+
+// LLVM-LABEL: @_Z4fi4dPU7_Atomici
+// LLVM: cmpxchg weak ptr {{.*}}, i32 {{.*}}, i32 {{.*}} seq_cst seq_cst, align 4
+
 bool fsb(bool *c) {
   return __atomic_exchange_n(c, 1, memory_order_seq_cst);
 }


### PR DESCRIPTION
Traditional Clang implementation: https://github.com/llvm/clangir/blob/a0091e38f1027e35d17819e02ee1ae257a12d296/clang/lib/CodeGen/CGAtomic.cpp#L545-L550