### PR TITLE
[CIR][CIRGen] handle `__builtin_elementwise_acos`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -415,20 +415,6 @@ RValue CIRGenFunction::emitRotate(const CallExpr *E, bool IsRotateRight) {
   return RValue::get(r);
 }
 
-template <unsigned N>
-RValue CIRGenFunction::emitBuiltinWithOneOverloadedType(const CallExpr *E,
-                                                        llvm::StringRef Name) {
-  static_assert(N, "expect non-empty argument");
-  mlir::Type cirTy = convertType(E->getArg(0)->getType());
-  SmallVector<mlir::Value, N> Args;
-  for (unsigned I = 0; I < N; ++I) {
-    Args.push_back(emitScalarExpr(E->getArg(I)));
-  }
-  const auto call = builder.create<cir::LLVMIntrinsicCallOp>(
-      getLoc(E->getExprLoc()), builder.getStringAttr(Name), cirTy, Args);
-  return RValue::get(call->getResult(0));
-}
-
 static bool isMemBuiltinOutOfBoundPossible(const clang::Expr *sizeArg,
                                            const clang::Expr *dstSizeArg,
                                            clang::ASTContext &astContext,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1405,7 +1405,17 @@ public:
   RValue emitRotate(const CallExpr *E, bool IsRotateRight);
   template <unsigned N>
   RValue emitBuiltinWithOneOverloadedType(const CallExpr *E,
-                                          llvm::StringRef Name);
+                                          llvm::StringRef Name) {
+    static_assert(N, "expect non-empty argument");
+    mlir::Type cirTy = convertType(E->getArg(0)->getType());
+    SmallVector<mlir::Value, N> Args;
+    for (unsigned I = 0; I < N; ++I) {
+      Args.push_back(emitScalarExpr(E->getArg(I)));
+    }
+    const auto call = builder.create<cir::LLVMIntrinsicCallOp>(
+        getLoc(E->getExprLoc()), builder.getStringAttr(Name), cirTy, Args);
+    return RValue::get(call->getResult(0));
+  }
   mlir::Value emitTargetBuiltinExpr(unsigned BuiltinID,
                                     const clang::CallExpr *E,
                                     ReturnValueSlot ReturnValue);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1403,17 +1403,17 @@ public:
   RValue emitBuiltinExpr(const clang::GlobalDecl GD, unsigned BuiltinID,
                          const clang::CallExpr *E, ReturnValueSlot ReturnValue);
   RValue emitRotate(const CallExpr *E, bool IsRotateRight);
-  template <unsigned N>
+  template <uint32_t N>
   RValue emitBuiltinWithOneOverloadedType(const CallExpr *E,
                                           llvm::StringRef Name) {
     static_assert(N, "expect non-empty argument");
     mlir::Type cirTy = convertType(E->getArg(0)->getType());
-    SmallVector<mlir::Value, N> Args;
-    for (unsigned I = 0; I < N; ++I) {
-      Args.push_back(emitScalarExpr(E->getArg(I)));
+    SmallVector<mlir::Value, N> args;
+    for (uint32_t i = 0; i < N; ++i) {
+      args.push_back(emitScalarExpr(E->getArg(i)));
     }
     const auto call = builder.create<cir::LLVMIntrinsicCallOp>(
-        getLoc(E->getExprLoc()), builder.getStringAttr(Name), cirTy, Args);
+        getLoc(E->getExprLoc()), builder.getStringAttr(Name), cirTy, args);
     return RValue::get(call->getResult(0));
   }
   mlir::Value emitTargetBuiltinExpr(unsigned BuiltinID,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1403,6 +1403,9 @@ public:
   RValue emitBuiltinExpr(const clang::GlobalDecl GD, unsigned BuiltinID,
                          const clang::CallExpr *E, ReturnValueSlot ReturnValue);
   RValue emitRotate(const CallExpr *E, bool IsRotateRight);
+  template <unsigned N>
+  RValue emitBuiltinWithOneOverloadedType(const CallExpr *E,
+                                          llvm::StringRef Name);
   mlir::Value emitTargetBuiltinExpr(unsigned BuiltinID,
                                     const clang::CallExpr *E,
                                     ReturnValueSlot ReturnValue);

--- a/clang/test/CIR/CodeGen/builtins-elementwise.c
+++ b/clang/test/CIR/CodeGen/builtins-elementwise.c
@@ -36,3 +36,24 @@ void test_builtin_elementwise_abs(vint4 vi4, int i, float f, double d,
     // LLVM: {{%.*}} = call <4 x double> @llvm.fabs.v4f64(<4 x double> {{%.*}})
     vd4 = __builtin_elementwise_abs(vd4);
 }
+
+void test_builtin_elementwise_acos(float f, double d, vfloat4 vf4,
+                                   vdouble4  vd4) {
+  // CIR-LABEL: test_builtin_elementwise_acos
+  // LLVM-LABEL: test_builtin_elementwise_acos
+  // CIR: {{%.*}} = cir.llvm.intrinsic "acos" {{%.*}} : (!cir.float) -> !cir.float
+  // LLVM: {{%.*}} = call float @llvm.acos.f32(float {{%.*}})
+  f = __builtin_elementwise_acos(f);
+
+  // CIR: {{%.*}} = cir.llvm.intrinsic "acos" {{%.*}} : (!cir.double) -> !cir.double
+  // LLVM: {{%.*}} = call double @llvm.acos.f64(double {{%.*}})
+  d = __builtin_elementwise_acos(d);
+
+  // CIR: {{%.*}} = cir.llvm.intrinsic "acos" {{%.*}} : (!cir.vector<!cir.float x 4>) -> !cir.vector<!cir.float x 4>
+  // LLVM: {{%.*}} = call <4 x float> @llvm.acos.v4f32(<4 x float> {{%.*}})
+  vf4 = __builtin_elementwise_acos(vf4);
+
+  // CIR: {{%.*}} = cir.llvm.intrinsic "acos" {{%.*}} : (!cir.vector<!cir.double x 4>) -> !cir.vector<!cir.double x 4>
+  // LLVM: {{%.*}} = call <4 x double> @llvm.acos.v4f64(<4 x double> {{%.*}})
+  vd4 = __builtin_elementwise_acos(vd4);
+}


### PR DESCRIPTION
Traditional Clang implementation: https://github.com/llvm/clangir/blob/a0091e38f1027e35d17819e02ee1ae257a12d296/clang/lib/CodeGen/CGBuiltin.cpp#L4116-L4118

I use the first argument type as the return type. It is OK for `__builtin_elementwise_acos`, however, I'm not sure it is OK for other builtin functions.

Resolves: https://github.com/llvm/clangir/issues/1361
