### PR TITLE
[CIR] Add handling for initializing multi-dimension arrays

### DIFF
--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -292,3 +292,38 @@ void t_new_var_size_nontrivial(size_t n) {
 // CHECK:    %[[ALL_ONES:.*]] = cir.const #cir.int<18446744073709551615> : !u64i
 // CHECK:    %[[ALLOC_SIZE:.*]] = cir.select if %[[ANY_OVERFLOW]] then %[[ALL_ONES]] else %[[SIZE]] : (!cir.bool, !u64i, !u64i)
 // CHECK:    %[[PTR:.*]] = cir.call @_Znam(%[[ALLOC_SIZE]]) : (!u64i)
+
+void t_multidim_init() {
+  auto *p = new int[2][3] { {1, 2, 3}, {4, 5, 6}};
+}
+
+// CHECK:  cir.func @_Z15t_multidim_initv()
+// CHECK:    %[[NUM_ELEMENTS:.*]] = cir.const #cir.int<6> : !u64i
+// CHECK:    %[[ALLOCATION_SIZE:.*]] = cir.const #cir.int<24> : !u64i
+// CHECK:    %[[NEW_PTR:.*]] = cir.call @_Znam(%2) : (!u64i) -> !cir.ptr<!void>
+// CHECK:    %[[ELEMENT_PTR:.*]] = cir.cast(bitcast, %[[NEW_PTR]] : !cir.ptr<!void>), !cir.ptr<!s32i>
+// CHECK:    %[[ARRAY_ELEM0_PTR:.*]] = cir.cast(bitcast, %[[ELEMENT_PTR]] : !cir.ptr<!s32i>), !cir.ptr<!cir.array<!s32i x 3>>
+// CHECK:    %[[ELEM_00_PTR:.*]] = cir.cast(array_to_ptrdecay, %[[ARRAY_ELEM0_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+// CHECK:    %[[ELEM_00_VAL:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:    cir.store %[[ELEM_00_VAL]], %[[ELEM_00_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET:.*]] = cir.const #cir.int<1> : !s64i
+// CHECK:    %[[ELEM_01_PTR:.*]] = cir.ptr_stride(%[[ELEM_00_PTR]] : !cir.ptr<!s32i>, %[[OFFSET]] : !s64i), !cir.ptr<!s32i>
+// CHECK:    %[[ELEM_01_VAL:.*]] = cir.const #cir.int<2> : !s32i
+// CHECK:    cir.store %[[ELEM_01_VAL]], %[[ELEM_01_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET1:.*]] = cir.const #cir.int<2> : !s64i
+// CHECK:    %[[ELEM_02_PTR:.*]] = cir.ptr_stride(%[[ELEM_00_PTR]] : !cir.ptr<!s32i>, %[[OFFSET1]] : !s64i), !cir.ptr<!s32i>
+// CHECK:    %[[ELEM_02_VAL:.*]] = cir.const #cir.int<3> : !s32i
+// CHECK:    cir.store %[[ELEM_02_VAL]], %[[ELEM_02_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET3:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:    %[[ARRAY_ELEM1_PTR:.*]] = cir.ptr_stride(%[[ARRAY_ELEM0_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, %[[OFFSET3]] : !s32i), !cir.ptr<!cir.array<!s32i x 3>>
+// CHECK:    %[[ELEM_10_PTR:.*]] = cir.cast(array_to_ptrdecay, %[[ARRAY_ELEM1_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+// CHECK:    %[[ELEM_10_VAL:.*]] = cir.const #cir.int<4> : !s32i
+// CHECK:    cir.store %[[ELEM_10_VAL]], %[[ELEM_10_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET4:.*]] = cir.const #cir.int<1> : !s64i
+// CHECK:    %[[ELEM_11_PTR:.*]] = cir.ptr_stride(%[[ELEM_10_PTR]] : !cir.ptr<!s32i>, %[[OFFSET4]] : !s64i), !cir.ptr<!s32i>
+// CHECK:    %[[ELEM_11_VAL:.*]] = cir.const #cir.int<5> : !s32i
+// CHECK:    cir.store %[[ELEM_11_VAL]], %[[ELEM_11_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET5:.*]] = cir.const #cir.int<2> : !s64i
+// CHECK:    %[[ELEM_12_PTR:.*]] = cir.ptr_stride(%[[ELEM_10_PTR]] : !cir.ptr<!s32i>, %21 : !s64i), !cir.ptr<!s32i>
+// CHECK:    %[[ELEM_12_VAL:.*]] = cir.const #cir.int<6> : !s32i
+// CHECK:    cir.store %[[ELEM_12_VAL]], %[[ELEM_12_PTR]] : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/Lowering/new.cpp
+++ b/clang/test/CIR/Lowering/new.cpp
@@ -215,3 +215,23 @@ void t_new_constant_size_constructor() {
 // LLVM:    %[[NEXT_PTR:.*]] = getelementptr %class.E, ptr %[[CUR_ELEM_PTR]], i64 1
 // LLVM:    store ptr %[[NEXT_PTR]]
 // LLVM:    br label %[[LOOP_INC_BB]]
+
+void t_multidim_init() {
+  auto *p = new int[2][3] { {1, 2, 3}, {4, 5, 6}};
+}
+
+// LLVM:  @_Z15t_multidim_initv()
+// LLVM:    %[[ALLOC_PTR:.*]] = call ptr @_Znam(i64 24)
+// LLVM:    %[[ELEM_00_PTR:.*]] = getelementptr i32, ptr %[[ALLOC_PTR]], i32 0
+// LLVM:    store i32 1, ptr %[[ELEM_00_PTR]], align 4
+// LLVM:    %[[ELEM_01_PTR:.*]] = getelementptr i32, ptr %[[ELEM_00_PTR]], i64 1
+// LLVM:    store i32 2, ptr %[[ELEM_01_PTR]], align 4
+// LLVM:    %[[ELEM_02_PTR:.*]] = getelementptr i32, ptr %[[ELEM_00_PTR]], i64 2
+// LLVM:    store i32 3, ptr %[[ELEM_02_PTR]], align 4
+// LLVM:    %[[ELEM_1_PTR:.*]] = getelementptr [3 x i32], ptr %[[ALLOC_PTR]], i64 1
+// LLVM:    %[[ELEM_10_PTR:.*]] = getelementptr i32, ptr %[[ELEM_1_PTR]], i32 0
+// LLVM:    store i32 4, ptr %[[ELEM_10_PTR]], align 4
+// LLVM:    %[[ELEM_11_PTR:.*]] = getelementptr i32, ptr %[[ELEM_10_PTR]], i64 1
+// LLVM:    store i32 5, ptr %[[ELEM_11_PTR]], align 4
+// LLVM:    %[[ELEM_12_PTR:.*]] = getelementptr i32, ptr %[[ELEM_10_PTR]], i64 2
+// LLVM:    store i32 6, ptr %[[ELEM_12_PTR]], align 4


### PR DESCRIPTION
Add an implementation for array new initialization of multidimension arrays. This is able to leverage existing array element initialization with just a few changes to update the pointer types.