### PR TITLE
[CIR][CodeGen] Fix extra Yieldop case during try-catch generation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -718,7 +718,8 @@ struct CallEndCatch final : EHScopeStack::Cleanup {
     // here. For CIR, just let it pass since the cleanup is going
     // to be emitted on a later pass when lowering the catch region.
     // CGF.EmitRuntimeCallOrTryCall(getEndCatchFn(CGF.CGM));
-    CGF.getBuilder().create<cir::YieldOp>(*CGF.currSrcLoc);
+    if (!CGF.getBuilder().getBlock()->mightHaveTerminator())
+      CGF.getBuilder().create<cir::YieldOp>(*CGF.currSrcLoc);
   }
 };
 } // namespace

--- a/clang/test/CIR/CodeGen/try-catch.cpp
+++ b/clang/test/CIR/CodeGen/try-catch.cpp
@@ -82,22 +82,22 @@ unsigned long long tc3() {
   return z;
 }
 
-// CIR: cir.func @_Z3tc4v()
+// CHECK: cir.func @_Z3tc4v()
 unsigned long long tc4() {
   int x = 50, y = 3;
   unsigned long long z;
 
-  // CIR-NOT: cir.try
+  // CHECK-NOT: cir.try
   try {
     int a = 4;
     a++;
 
-    // CIR: cir.scope {
-    // CIR: cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
-    // CIR-NOT: cir.alloca !cir.ptr<!cir.eh.info>
-    // CIR: cir.const #cir.int<4> : !s32i
-    // CIR: cir.unary(inc,
-    // CIR: cir.store %11, %8 : !s32i, !cir.ptr<!s32i>
+    // CHECK: cir.scope {
+    // CHECK: cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
+    // CHECK-NOT: cir.alloca !cir.ptr<!cir.eh.info>
+    // CHECK: cir.const #cir.int<4> : !s32i
+    // CHECK: cir.unary(inc,
+    // CHECK: cir.store %11, %8 : !s32i, !cir.ptr<!s32i>
   } catch (int idx) {
     z = 98;
     idx++;

--- a/clang/test/CIR/CodeGen/try-catch.cpp
+++ b/clang/test/CIR/CodeGen/try-catch.cpp
@@ -105,3 +105,26 @@ unsigned long long tc4() {
 
   return z;
 }
+
+struct S {
+  S() {};
+  int a;
+};
+
+// CHECK: cir.func @_Z3tc5v()
+void tc5() {
+  try {
+    S s;
+  } catch (...) {
+    tc5();
+  }
+}
+
+// CHECK: cir.try {
+// CHECK: cir.call exception @_ZN1SC2Ev({{.*}}) : (!cir.ptr<!ty_S>) -> ()
+// CHECK: cir.yield
+// CHECK: } catch [type #cir.all {
+// CHECK:  {{.*}} = cir.catch_param -> !cir.ptr<!void>
+// CHECK:  cir.call exception @_Z3tc5v() : () -> ()
+// CHECK:  cir.yield
+// CHECK: }]


### PR DESCRIPTION
Currently, trying to generate CIR for the following code snippet `yield.cpp` fails. Using `bin/clang++ yield.cpp -Xclang -fclangir -Xclang -emit-cir -S -o -`: 
``` 
struct S {
  S() {};
  int a;
};

void foo() {
  try {
    S s;
  } catch (...) {
    foo();
  }
}
```

The error: 
```
loc("yield.cpp":6:6): error: 'cir.yield' op must be the last operation in the parent block
```
There is an extra YieldOp! The CIR dump before verification looks something like:
```
"cir.scope"() ({
  %0 = "cir.alloca"() <{alignment = 4 : i64, allocaType = !cir.struct<struct "S" {!cir.int<s, 32>} #cir.record.decl.ast>, ast = #cir.var.decl.ast, init, name = "s"}> : () -> !cir.ptr<!cir.struct<struct "S" {!cir.int<s, 32>} #cir.record.decl.ast>>
  "cir.try"() <{catch_types = [#cir.all]}> ({
    "cir.call"(%0) <{callee = @_ZN1SC1Ev, calling_conv = 1 : i32, exception, extra_attrs = #cir<extra({})>, side_effect = 1 : i32}> ({
      "cir.yield"() : () -> ()
    }) : (!cir.ptr<!cir.struct<struct "S" {!cir.int<s, 32>} #cir.record.decl.ast>>) -> ()
    "cir.yield"() : () -> ()
  }, {
    %1 = "cir.catch_param"() : () -> !cir.ptr<!cir.void>
    "cir.call"() <{ast = #cir.call.expr.ast, callee = @_Z3foov, calling_conv = 1 : i32, exception, extra_attrs = #cir<extra({})>, side_effect = 1 : i32}> ({
      "cir.yield"() : () -> ()
      "cir.yield"() : () -> () <--- **DUPLICATE**
    }) : () -> ()
    "cir.yield"() : () -> ()
  }) : () -> ()
  "cir.yield"() : () -> ()
}, {
}) : () -> ()
```
This PR adds a check for an already existing terminator before creating a YieldOp during the cleanup.