### PR TITLE
[CIR] Fix Address element type problems

### DIFF
--- a/clang/lib/CIR/CodeGen/Address.h
+++ b/clang/lib/CIR/CodeGen/Address.h
@@ -25,6 +25,9 @@
 
 namespace clang::CIRGen {
 
+// Forward declaration to avoid a circular dependency
+class CIRGenBuilderTy;
+
 // Indicates whether a pointer is known not to be null.
 enum KnownNonNull_t { NotKnownNonNull, KnownNonNull };
 
@@ -106,6 +109,10 @@ public:
   }
 
   bool hasOffset() const { return bool(offset); }
+
+  /// Return address with different element type, a bitcast pointer, and
+  /// the same alignment.
+  Address withElementType(CIRGenBuilderTy &builder, mlir::Type ElemTy) const;
 
   mlir::Value getPointer() const {
     assert(isValid());

--- a/clang/lib/CIR/CodeGen/Address.h
+++ b/clang/lib/CIR/CodeGen/Address.h
@@ -64,6 +64,9 @@ public:
     assert(pointer && "Pointer cannot be null");
     assert(elementType && "Element type cannot be null");
     assert(!alignment.isZero() && "Alignment cannot be zero");
+
+    assert(mlir::cast<cir::PointerType>(pointer.getType()).getPointee() ==
+           ElementType);
   }
 
   Address(mlir::Value basePtr, mlir::Type elementType,
@@ -104,16 +107,6 @@ public:
 
   bool hasOffset() const { return bool(offset); }
 
-  /// Return address with different element type, but same pointer and
-  /// alignment.
-  Address withElementType(mlir::Type ElemTy) const {
-    if (!hasOffset())
-      return Address(getBasePointer(), ElemTy, getAlignment(),
-                     getPointerAuthInfo(), /*Offset=*/nullptr,
-                     isKnownNonNull());
-    return Address(getPointer(), ElemTy, getAlignment(), isKnownNonNull());
-  }
-
   mlir::Value getPointer() const {
     assert(isValid());
     return PointerAndKnownNonNull.getPointer();
@@ -142,11 +135,17 @@ public:
 
   /// Return the type of the pointer value.
   cir::PointerType getType() const {
+    assert(mlir::cast<cir::PointerType>(
+               PointerAndKnownNonNull.getPointer().getType())
+               .getPointee() == ElementType);
     return mlir::cast<cir::PointerType>(getPointer().getType());
   }
 
   mlir::Type getElementType() const {
     assert(isValid());
+    assert(mlir::cast<cir::PointerType>(
+               PointerAndKnownNonNull.getPointer().getType())
+               .getPointee() == ElementType);
     return ElementType;
   }
 

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -214,9 +214,9 @@ std::pair<mlir::Value, mlir::Type> CIRGenFunction::emitAsmInputLValue(
         getTargetHooks().isScalarizableAsmOperand(*this, Ty)) {
       Ty = cir::IntType::get(&getMLIRContext(), Size, false);
 
-      return {builder.createLoad(getLoc(Loc),
-                                 InputValue.getAddress().withElementType(Ty)),
-              mlir::Type()};
+      auto InputAddr = builder.createElementBitCast(
+          getLoc(Loc), InputValue.getAddress(), Ty);
+      return {builder.createLoad(getLoc(Loc), InputAddr), mlir::Type()};
     }
   }
 
@@ -320,7 +320,8 @@ static void emitAsmStores(CIRGenFunction &CGF, const AsmStmt &S,
     // ResultTypeRequiresCast.size() elements of RegResults.
     if ((i < ResultTypeRequiresCast.size()) && ResultTypeRequiresCast[i]) {
       unsigned Size = CGF.getContext().getTypeSize(ResultRegQualTys[i]);
-      Address A = Dest.getAddress().withElementType(ResultRegTypes[i]);
+      Address A = Builder.createElementBitCast(
+          Dest.getPointer().getLoc(), Dest.getAddress(), ResultRegTypes[i]);
       if (CGF.getTargetHooks().isScalarizableAsmOperand(CGF, TruncTy)) {
         Builder.createStore(CGF.getLoc(S.getAsmLoc()), Tmp, A);
         continue;
@@ -478,7 +479,9 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
       // Otherwise there will be a mis-match if the matrix is also an
       // input-argument which is represented as vector.
       if (isa<MatrixType>(OutExpr->getType().getCanonicalType()))
-        DestAddr = DestAddr.withElementType(convertType(OutExpr->getType()));
+        DestAddr = builder.createElementBitCast(
+            DestAddr.getPointer().getLoc(), DestAddr,
+            convertType(OutExpr->getType()));
 
       ArgTypes.push_back(DestAddr.getType());
       ArgElemTypes.push_back(DestAddr.getElementType());

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -214,9 +214,10 @@ std::pair<mlir::Value, mlir::Type> CIRGenFunction::emitAsmInputLValue(
         getTargetHooks().isScalarizableAsmOperand(*this, Ty)) {
       Ty = cir::IntType::get(&getMLIRContext(), Size, false);
 
-      auto InputAddr = builder.createElementBitCast(
-          getLoc(Loc), InputValue.getAddress(), Ty);
-      return {builder.createLoad(getLoc(Loc), InputAddr), mlir::Type()};
+      return {builder.createLoad(
+                  getLoc(Loc),
+                  InputValue.getAddress().withElementType(builder, Ty)),
+              mlir::Type()};
     }
   }
 
@@ -320,8 +321,7 @@ static void emitAsmStores(CIRGenFunction &CGF, const AsmStmt &S,
     // ResultTypeRequiresCast.size() elements of RegResults.
     if ((i < ResultTypeRequiresCast.size()) && ResultTypeRequiresCast[i]) {
       unsigned Size = CGF.getContext().getTypeSize(ResultRegQualTys[i]);
-      Address A = Builder.createElementBitCast(
-          Dest.getPointer().getLoc(), Dest.getAddress(), ResultRegTypes[i]);
+      Address A = Dest.getAddress().withElementType(Builder, ResultRegTypes[i]);
       if (CGF.getTargetHooks().isScalarizableAsmOperand(CGF, TruncTy)) {
         Builder.createStore(CGF.getLoc(S.getAsmLoc()), Tmp, A);
         continue;
@@ -479,9 +479,8 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
       // Otherwise there will be a mis-match if the matrix is also an
       // input-argument which is represented as vector.
       if (isa<MatrixType>(OutExpr->getType().getCanonicalType()))
-        DestAddr = builder.createElementBitCast(
-            DestAddr.getPointer().getLoc(), DestAddr,
-            convertType(OutExpr->getType()));
+        DestAddr =
+            DestAddr.withElementType(builder, convertType(OutExpr->getType()));
 
       ArgTypes.push_back(DestAddr.getType());
       ArgElemTypes.push_back(DestAddr.getElementType());

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -305,8 +305,7 @@ Address AtomicInfo::castToAtomicIntPointer(Address addr) const {
   if (intTy && intTy.getWidth() == AtomicSizeInBits)
     return addr;
   auto ty = CGF.getBuilder().getUIntNTy(AtomicSizeInBits);
-  return CGF.getBuilder().createElementBitCast(addr.getPointer().getLoc(), addr,
-                                               ty);
+  return addr.withElementType(CGF.getBuilder(), ty);
 }
 
 Address AtomicInfo::convertToAtomicIntPointer(Address Addr) const {
@@ -1244,9 +1243,9 @@ RValue CIRGenFunction::emitAtomicExpr(AtomicExpr *E) {
     if (RValTy->isVoidType())
       return RValue::get(nullptr);
 
-    Address A = builder.createElementBitCast(Dest.getPointer().getLoc(), Dest,
-                                             convertTypeForMem(RValTy));
-    return convertTempToRValue(A, RValTy, E->getExprLoc());
+    return convertTempToRValue(
+        Dest.withElementType(builder, convertTypeForMem(RValTy)), RValTy,
+        E->getExprLoc());
   }
 
   // The memory order is not known at compile-time.  The atomic operations
@@ -1323,9 +1322,10 @@ RValue CIRGenFunction::emitAtomicExpr(AtomicExpr *E) {
 
   if (RValTy->isVoidType())
     return RValue::get(nullptr);
-  Address A = builder.createElementBitCast(Dest.getPointer().getLoc(), Dest,
-                                           convertTypeForMem(RValTy));
-  return convertTempToRValue(A, RValTy, E->getExprLoc());
+
+  return convertTempToRValue(
+      Dest.withElementType(builder, convertTypeForMem(RValTy)), RValTy,
+      E->getExprLoc());
 }
 
 void CIRGenFunction::emitAtomicStore(RValue rvalue, LValue lvalue,

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -305,7 +305,8 @@ Address AtomicInfo::castToAtomicIntPointer(Address addr) const {
   if (intTy && intTy.getWidth() == AtomicSizeInBits)
     return addr;
   auto ty = CGF.getBuilder().getUIntNTy(AtomicSizeInBits);
-  return addr.withElementType(ty);
+  return CGF.getBuilder().createElementBitCast(addr.getPointer().getLoc(), addr,
+                                               ty);
 }
 
 Address AtomicInfo::convertToAtomicIntPointer(Address Addr) const {
@@ -1243,8 +1244,9 @@ RValue CIRGenFunction::emitAtomicExpr(AtomicExpr *E) {
     if (RValTy->isVoidType())
       return RValue::get(nullptr);
 
-    return convertTempToRValue(Dest.withElementType(convertTypeForMem(RValTy)),
-                               RValTy, E->getExprLoc());
+    Address A = builder.createElementBitCast(Dest.getPointer().getLoc(), Dest,
+                                             convertTypeForMem(RValTy));
+    return convertTempToRValue(A, RValTy, E->getExprLoc());
   }
 
   // The memory order is not known at compile-time.  The atomic operations
@@ -1321,8 +1323,9 @@ RValue CIRGenFunction::emitAtomicExpr(AtomicExpr *E) {
 
   if (RValTy->isVoidType())
     return RValue::get(nullptr);
-  return convertTempToRValue(Dest.withElementType(convertTypeForMem(RValTy)),
-                             RValTy, E->getExprLoc());
+  Address A = builder.createElementBitCast(Dest.getPointer().getLoc(), Dest,
+                                           convertTypeForMem(RValTy));
+  return convertTempToRValue(A, RValTy, E->getExprLoc());
 }
 
 void CIRGenFunction::emitAtomicStore(RValue rvalue, LValue lvalue,

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -134,3 +134,15 @@ uint64_t CIRGenBuilderTy::computeOffsetFromGlobalViewIndices(
 
   return offset;
 }
+
+// This can't be defined in Address.h because that file is included by
+// CIRGenBuilder.h
+Address Address::withElementType(CIRGenBuilderTy &builder,
+                                 mlir::Type ElemTy) const {
+  if (!hasOffset())
+    return Address(builder.createPtrBitcast(getBasePointer(), ElemTy), ElemTy,
+                   getAlignment(), getPointerAuthInfo(), /*Offset=*/nullptr,
+                   isKnownNonNull());
+  return Address(builder.createPtrBitcast(getPointer(), ElemTy), ElemTy,
+                 getAlignment(), isKnownNonNull());
+}

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -733,7 +733,7 @@ public:
     auto ptrTy = getPointerTo(destType);
     auto baseAddr = create<cir::BaseClassAddrOp>(
         loc, ptrTy, addr.getPointer(), mlir::APInt(64, offset), assumeNotNull);
-    return Address(baseAddr, ptrTy, addr.getAlignment());
+    return Address(baseAddr, destType, addr.getAlignment());
   }
 
   Address createDerivedClassAddr(mlir::Location loc, Address addr,
@@ -745,7 +745,7 @@ public:
     auto ptrTy = getPointerTo(destType);
     auto derivedAddr = create<cir::DerivedClassAddrOp>(
         loc, ptrTy, addr.getPointer(), mlir::APInt(64, offset), assumeNotNull);
-    return Address(derivedAddr, ptrTy, addr.getAlignment());
+    return Address(derivedAddr, destType, addr.getAlignment());
   }
 
   mlir::Value createVTTAddrPoint(mlir::Location loc, mlir::Type retTy,

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -4488,8 +4488,7 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
   }
   case NEON::BI__builtin_neon_vld1_dup_v:
   case NEON::BI__builtin_neon_vld1q_dup_v: {
-    Address ptrAddr = builder.createElementBitCast(getLoc(E->getExprLoc()),
-                                                   PtrOp0, vTy.getEltType());
+    Address ptrAddr = PtrOp0.withElementType(builder, vTy.getEltType());
     mlir::Value val = builder.createLoad(getLoc(E->getExprLoc()), ptrAddr);
     cir::VecSplatOp vecSplat =
         builder.create<cir::VecSplatOp>(getLoc(E->getExprLoc()), vTy, val);

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -4488,7 +4488,8 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
   }
   case NEON::BI__builtin_neon_vld1_dup_v:
   case NEON::BI__builtin_neon_vld1q_dup_v: {
-    Address ptrAddr = PtrOp0.withElementType(vTy.getEltType());
+    Address ptrAddr = builder.createElementBitCast(getLoc(E->getExprLoc()),
+                                                   PtrOp0, vTy.getEltType());
     mlir::Value val = builder.createLoad(getLoc(E->getExprLoc()), ptrAddr);
     cir::VecSplatOp vecSplat =
         builder.create<cir::VecSplatOp>(getLoc(E->getExprLoc()), vTy, val);

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -408,8 +408,7 @@ void CIRGenModule::emitCXXGlobalVarDeclInit(const VarDecl *varDecl,
   builder.setInsertionPointToStart(block);
   auto getGlobal = builder.createGetGlobal(addr);
 
-  Address declAddr(getGlobal, getGlobal.getType(),
-                   getASTContext().getDeclAlign(varDecl));
+  Address declAddr(getGlobal, getASTContext().getDeclAlign(varDecl));
   assert(performInit && "cannot have constant initializer which needs "
                         "destruction for reference");
   RValue rv = cgf.emitReferenceBindingToExpr(init);

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -1672,7 +1672,7 @@ CIRGenFunction::getAddressOfBaseClass(Address Value,
       VBase, BaseValueTy, not NullCheckValue);
 
   // Cast to the destination type.
-  Value = builder.createElementBitCast(getLoc(Loc), Value, BaseValueTy);
+  Value = Value.withElementType(builder, BaseValueTy);
 
   return Value;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -1672,7 +1672,7 @@ CIRGenFunction::getAddressOfBaseClass(Address Value,
       VBase, BaseValueTy, not NullCheckValue);
 
   // Cast to the destination type.
-  Value = Value.withElementType(BaseValueTy);
+  Value = builder.createElementBitCast(getLoc(Loc), Value, BaseValueTy);
 
   return Value;
 }
@@ -1894,7 +1894,7 @@ void CIRGenFunction::emitCXXAggrConstructorCall(
     builder.create<cir::ArrayCtor>(
         *currSrcLoc, arrayOp, [&](mlir::OpBuilder &b, mlir::Location loc) {
           auto arg = b.getInsertionBlock()->addArgument(ptrToElmType, loc);
-          Address curAddr = Address(arg, ptrToElmType, eltAlignment);
+          Address curAddr = Address(arg, elementType, eltAlignment);
           auto currAVS = AggValueSlot::forAddr(
               curAddr, type.getQualifiers(), AggValueSlot::IsDestructed,
               AggValueSlot::DoesNotNeedGCBarriers, AggValueSlot::IsNotAliased,

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -244,9 +244,8 @@ static void emitStoresForConstant(CIRGenModule &CGM, const VarDecl &D,
   // FIXME(cir): This is closer to memcpy behavior but less optimal, instead of
   // copy from a global, we just create a cir.const out of it.
 
-  if (addr.getElementType() != Ty) {
-    addr = builder.createElementBitCast(addr.getPointer().getLoc(), addr, Ty);
-  }
+  if (addr.getElementType() != Ty)
+    addr = addr.withElementType(builder, Ty);
 
   auto loc = CGM.getLoc(D.getSourceRange());
   builder.createStore(loc, builder.getConstant(loc, constant), addr);

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -245,9 +245,7 @@ static void emitStoresForConstant(CIRGenModule &CGM, const VarDecl &D,
   // copy from a global, we just create a cir.const out of it.
 
   if (addr.getElementType() != Ty) {
-    auto ptr = addr.getPointer();
-    ptr = builder.createBitcast(ptr.getLoc(), ptr, builder.getPointerTo(Ty));
-    addr = addr.withPointer(ptr, addr.isKnownNonNull());
+    addr = builder.createElementBitCast(addr.getPointer().getLoc(), addr, Ty);
   }
 
   auto loc = CGM.getLoc(D.getSourceRange());
@@ -1108,7 +1106,7 @@ void CIRGenFunction::emitArrayDestroy(mlir::Value begin, mlir::Value end,
   builder.create<cir::ArrayDtor>(
       *currSrcLoc, begin, [&](mlir::OpBuilder &b, mlir::Location loc) {
         auto arg = b.getInsertionBlock()->addArgument(ptrToElmType, loc);
-        Address curAddr = Address(arg, ptrToElmType, elementAlign);
+        Address curAddr = Address(arg, cirElementType, elementAlign);
         if (useEHCleanup) {
           pushRegularPartialArrayCleanup(arg, arg, elementType, elementAlign,
                                          destroyer);

--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -237,7 +237,8 @@ void CIRGenFunction::emitAnyExprToExn(const Expr *e, Address addr) {
   // __cxa_allocate_exception returns a void*;  we need to cast this
   // to the appropriate type for the object.
   auto ty = convertTypeForMem(e->getType());
-  Address typedAddr = addr.withElementType(ty);
+  Address typedAddr =
+      builder.createElementBitCast(getLoc(e->getExprLoc()), addr, ty);
 
   // From LLVM's codegen:
   // FIXME: this isn't quite right!  If there's a final unelided call

--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -237,8 +237,7 @@ void CIRGenFunction::emitAnyExprToExn(const Expr *e, Address addr) {
   // __cxa_allocate_exception returns a void*;  we need to cast this
   // to the appropriate type for the object.
   auto ty = convertTypeForMem(e->getType());
-  Address typedAddr =
-      builder.createElementBitCast(getLoc(e->getExprLoc()), addr, ty);
+  Address typedAddr = addr.withElementType(builder, ty);
 
   // From LLVM's codegen:
   // FIXME: this isn't quite right!  If there's a final unelided call

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2938,7 +2938,8 @@ mlir::Value CIRGenFunction::emitLoadOfScalar(Address addr, bool isVolatile,
         CGM.getABIInfo().getOptimalVectorMemoryType(vTy, getLangOpts());
 
     if (vTy != newVecTy) {
-      const Address cast = addr.withElementType(newVecTy);
+      const Address cast = builder.createElementBitCast(
+          addr.getPointer().getLoc(), addr, newVecTy);
       mlir::Value v = builder.createLoad(loc, cast, isVolatile);
       const uint64_t oldNumElements = vTy.getSize();
       SmallVector<int64_t, 16> mask(oldNumElements);

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2938,8 +2938,7 @@ mlir::Value CIRGenFunction::emitLoadOfScalar(Address addr, bool isVolatile,
         CGM.getABIInfo().getOptimalVectorMemoryType(vTy, getLangOpts());
 
     if (vTy != newVecTy) {
-      const Address cast = builder.createElementBitCast(
-          addr.getPointer().getLoc(), addr, newVecTy);
+      const Address cast = addr.withElementType(builder, newVecTy);
       mlir::Value v = builder.createLoad(loc, cast, isVolatile);
       const uint64_t oldNumElements = vTy.getSize();
       SmallVector<int64_t, 16> mask(oldNumElements);

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -999,7 +999,9 @@ void AggExprEmitter::VisitCastExpr(CastExpr *E) {
 
     // GCC union extension
     QualType Ty = E->getSubExpr()->getType();
-    Address CastPtr = Dest.getAddress().withElementType(CGF.convertType(Ty));
+    Address CastPtr = CGF.getBuilder().createElementBitCast(
+        CGF.getLoc(E->getExprLoc()), Dest.getAddress(), CGF.convertType(Ty));
+
     emitInitializationToLValue(E->getSubExpr(),
                                CGF.makeAddrLValue(CastPtr, Ty));
     break;

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -999,9 +999,8 @@ void AggExprEmitter::VisitCastExpr(CastExpr *E) {
 
     // GCC union extension
     QualType Ty = E->getSubExpr()->getType();
-    Address CastPtr = CGF.getBuilder().createElementBitCast(
-        CGF.getLoc(E->getExprLoc()), Dest.getAddress(), CGF.convertType(Ty));
-
+    Address CastPtr = Dest.getAddress().withElementType(CGF.getBuilder(),
+                                                        CGF.convertType(Ty));
     emitInitializationToLValue(E->getSubExpr(),
                                CGF.makeAddrLValue(CastPtr, Ty));
     break;

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -379,8 +379,7 @@ static void emitNullBaseClassInitialization(CIRGenFunction &CGF,
   if (Base->isEmpty())
     return;
 
-  DestPtr = CGF.getBuilder().createElementBitCast(DestPtr.getPointer().getLoc(),
-                                                  DestPtr, CGF.UInt8Ty);
+  DestPtr = DestPtr.withElementType(CGF.getBuilder(), CGF.UInt8Ty);
 
   const ASTRecordLayout &Layout = CGF.getContext().getASTRecordLayout(Base);
   CharUnits NVSize = Layout.getNonVirtualSize();
@@ -1050,8 +1049,7 @@ void CIRGenFunction::emitNewArrayInitializer(
     if (const ConstantArrayType *CAT = dyn_cast_or_null<ConstantArrayType>(
             AllocType->getAsArrayTypeUnsafe())) {
       ElementTy = convertTypeForMem(AllocType);
-      auto CastOp = builder.createPtrBitcast(CurPtr.getPointer(), ElementTy);
-      CurPtr = Address(CastOp, ElementTy, CurPtr.getAlignment());
+      CurPtr = CurPtr.withElementType(builder, ElementTy);
       InitListElements *= getContext().getConstantArrayElementCount(CAT);
     }
 
@@ -1096,8 +1094,7 @@ void CIRGenFunction::emitNewArrayInitializer(
     }
 
     // Switch back to initializing one base element at a time.
-    CurPtr = builder.createElementBitCast(getLoc(E->getExprLoc()), CurPtr,
-                                          BeginPtr.getElementType());
+    CurPtr = CurPtr.withElementType(builder, BeginPtr.getElementType());
   }
 
   // If all elements have already been initialized, skip any further
@@ -1136,8 +1133,7 @@ void CIRGenFunction::emitNewArrayInitializer(
     if (InitListElements)
       llvm_unreachable("NYI");
     auto arrayType = convertType(CCE->getType());
-    CurPtr = builder.createElementBitCast(getLoc(CCE->getLocation()), CurPtr,
-                                          arrayType);
+    CurPtr = CurPtr.withElementType(builder, arrayType);
     emitCXXAggrConstructorCall(Ctor, NumElements, CurPtr, CCE,
                                /*NewPointerIsChecked*/ true,
                                CCE->requiresZeroInitialization());

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1606,8 +1606,8 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     mlir::Value DestPtr = CGF.getBuilder().createBitcast(
         CGF.getLoc(E->getExprLoc()), SourceAddr.getPointer(), DestPtrTy);
 
-    Address DestAddr =
-        SourceAddr.withPointer(DestPtr).withElementType(DestElemTy);
+    Address DestAddr = Address(DestPtr, DestElemTy, SourceAddr.getAlignment(),
+                               SourceAddr.isKnownNonNull());
     LValue DestLVal = CGF.makeAddrLValue(DestAddr, DestTy);
     DestLVal.setTBAAInfo(TBAAAccessInfo::getMayAliasInfo());
     return emitLoadOfLValue(DestLVal, CE->getExprLoc());

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -2723,7 +2723,7 @@ Address CIRGenItaniumCXXABI::initializeArrayCookie(CIRGenFunction &CGF,
 
   // Write the number of elements into the appropriate slot.
   Address NumElementsPtr =
-      CGF.getBuilder().createElementBitCast(Loc, CookiePtr, CGF.SizeTy);
+      CookiePtr.withElementType(CGF.getBuilder(), CGF.SizeTy);
   CGF.getBuilder().createStore(Loc, NumElements, NumElementsPtr);
 
   if (CGF.SanOpts.has(SanitizerKind::Address))

--- a/clang/test/CIR/CodeGen/atomic-thread-fence.c
+++ b/clang/test/CIR/CodeGen/atomic-thread-fence.c
@@ -87,10 +87,11 @@ void loadWithThreadFence(DataPtr d) {
 // CIR:    %[[LOAD_DATA:.*]] = cir.load %[[DATA]] : !cir.ptr<!cir.ptr<!ty_Data>>, !cir.ptr<!ty_Data>
 // CIR:    %[[DATA_VALUE:.*]] = cir.get_member %[[LOAD_DATA]][1] {name = "ptr"} : !cir.ptr<!ty_Data> -> !cir.ptr<!cir.ptr<!void>>
 // CIR:    %[[CASTED_DATA_VALUE:.*]] = cir.cast(bitcast, %[[DATA_VALUE]] : !cir.ptr<!cir.ptr<!void>>), !cir.ptr<!u64i>
-// CIR:    %[[ATOMIC_LOAD:.*]] = cir.load atomic(seq_cst) %[[CASTED_DATA_VALUE]] : !cir.ptr<!u64i>, !u64i
 // CIR:    %[[CASTED_ATOMIC_TEMP:.*]] = cir.cast(bitcast, %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>), !cir.ptr<!u64i>
+// CIR:    %[[ATOMIC_LOAD:.*]] = cir.load atomic(seq_cst) %[[CASTED_DATA_VALUE]] : !cir.ptr<!u64i>, !u64i
 // CIR:    cir.store %[[ATOMIC_LOAD]], %[[CASTED_ATOMIC_TEMP]] : !u64i, !cir.ptr<!u64i>
-// CIR:    %[[ATOMIC_LOAD_PTR:.*]] = cir.load %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// CIR:    %[[DOUBLE_CASTED_ATOMIC_TEMP:.*]] = cir.cast(bitcast, %[[CASTED_ATOMIC_TEMP]] : !cir.ptr<!u64i>), !cir.ptr<!cir.ptr<!void>>
+// CIR:    %[[ATOMIC_LOAD_PTR:.*]] = cir.load %[[DOUBLE_CASTED_ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR:    cir.return
 
 // LLVM-LABEL: @loadWithThreadFence
@@ -115,10 +116,11 @@ void loadWithSignalFence(DataPtr d) {
 // CIR:    %[[LOAD_DATA:.*]] = cir.load %[[DATA]] : !cir.ptr<!cir.ptr<!ty_Data>>, !cir.ptr<!ty_Data>
 // CIR:    %[[DATA_PTR:.*]] = cir.get_member %[[LOAD_DATA]][1] {name = "ptr"} : !cir.ptr<!ty_Data> -> !cir.ptr<!cir.ptr<!void>>
 // CIR:    %[[CASTED_DATA_PTR:.*]] = cir.cast(bitcast, %[[DATA_PTR]] : !cir.ptr<!cir.ptr<!void>>), !cir.ptr<!u64i>
-// CIR:    %[[ATOMIC_LOAD:.*]] = cir.load atomic(seq_cst) %[[CASTED_DATA_PTR]] : !cir.ptr<!u64i>, !u64i
 // CIR:    %[[CASTED_ATOMIC_TEMP:.*]] = cir.cast(bitcast, %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>), !cir.ptr<!u64i>
+// CIR:    %[[ATOMIC_LOAD:.*]] = cir.load atomic(seq_cst) %[[CASTED_DATA_PTR]] : !cir.ptr<!u64i>, !u64i
 // CIR:    cir.store %[[ATOMIC_LOAD]], %[[CASTED_ATOMIC_TEMP]] : !u64i, !cir.ptr<!u64i>
-// CIR:    %[[LOAD_ATOMIC_TEMP:.*]] = cir.load %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// CIR:    %[[DOUBLE_CASTED_ATOMIC_TEMP:.*]] = cir.cast(bitcast, %[[CASTED_ATOMIC_TEMP]] : !cir.ptr<!u64i>), !cir.ptr<!cir.ptr<!void>>
+// CIR:    %[[LOAD_ATOMIC_TEMP:.*]] = cir.load %[[DOUBLE_CASTED_ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR:    cir.return
 
 // LLVM-LABEL: @loadWithSignalFence

--- a/clang/test/CIR/CodeGen/atomic-xchg-field.c
+++ b/clang/test/CIR/CodeGen/atomic-xchg-field.c
@@ -27,7 +27,8 @@ void field_access(wPtr item) {
 // CHECK-NEXT: %[[WADDR:.*]] = cir.alloca !cir.ptr<![[W]]>, {{.*}} {alignment = 8 : i64}
 // CHECK: %[[FIELD:.*]] = cir.load %[[WADDR]]
 // CHECK: %[[MEMBER:.*]] = cir.get_member %[[FIELD]][1] {name = "ref"}
-// CHECK: cir.atomic.xchg(%[[MEMBER]] : !cir.ptr<!cir.ptr<!void>>, {{.*}} : !u64i, seq_cst)
+// CHECK: %[[CASTED_MEMBER:.*]] = cir.cast(bitcast, %[[MEMBER]] : !cir.ptr<!cir.ptr<!void>>), !cir.ptr<!u64i>
+// CHECK: cir.atomic.xchg(%[[CASTED_MEMBER]] : !cir.ptr<!u64i>, {{.*}} : !u64i, seq_cst)
 
 // LLVM-LABEL: @field_access
 // LLVM: = alloca ptr, i64 1, align 8
@@ -77,8 +78,8 @@ void structLoad(unsigned referenceCount, wPtr item) {
 
 // CHECK-LABEL: @structLoad
 // CHECK:    %[[ATOMIC_TEMP:.*]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["atomic-temp"]
-// CHECK:    %[[ATOMIC_LOAD:.*]] = cir.load atomic(seq_cst) %6 : !cir.ptr<!u64i>, !u64i
 // CHECK:    %[[RES:.*]] = cir.cast(bitcast, %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!void>>), !cir.ptr<!u64i>
+// CHECK:    %[[ATOMIC_LOAD:.*]] = cir.load atomic(seq_cst) %6 : !cir.ptr<!u64i>, !u64i
 // CHECK:    cir.store %[[ATOMIC_LOAD]], %[[RES]] : !u64i, !cir.ptr<!u64i>
 
 // No LLVM tests needed for this one, already covered elsewhere.

--- a/clang/test/CIR/CodeGen/atomic.cpp
+++ b/clang/test/CIR/CodeGen/atomic.cpp
@@ -239,7 +239,7 @@ void fd3(struct S *a, struct S *b, struct S *c) {
 }
 
 // CHECK-LABEL: @_Z3fd3P1SS0_S0_
-// CHECK: cir.atomic.xchg({{.*}} : !cir.ptr<!ty_S>, {{.*}} : !u64i, seq_cst) : !u64i
+// CHECK: cir.atomic.xchg({{.*}} : !cir.ptr<!u64i>, {{.*}} : !u64i, seq_cst) : !u64i
 
 // FIXME: CIR is producing an over alignment of 8, only 4 needed.
 // LLVM-LABEL: @_Z3fd3P1SS0_S0_
@@ -261,7 +261,7 @@ bool fd4(struct S *a, struct S *b, struct S *c) {
 }
 
 // CHECK-LABEL: @_Z3fd4P1SS0_S0_
-// CHECK: %old, %cmp = cir.atomic.cmp_xchg({{.*}} : !cir.ptr<!ty_S>, {{.*}} : !u64i, {{.*}} : !u64i, success = seq_cst, failure = seq_cst) align(8) weak : (!u64i, !cir.bool)
+// CHECK: %old, %cmp = cir.atomic.cmp_xchg({{.*}} : !cir.ptr<!u64i>, {{.*}} : !u64i, {{.*}} : !u64i, success = seq_cst, failure = seq_cst) align(8) weak : (!u64i, !cir.bool)
 
 // LLVM-LABEL: @_Z3fd4P1SS0_S0_
 // LLVM: cmpxchg weak ptr {{.*}}, i64 {{.*}}, i64 {{.*}} seq_cst seq_cst, align 8
@@ -328,7 +328,7 @@ bool fsb(bool *c) {
 }
 
 // CHECK-LABEL: @_Z3fsbPb
-// CHECK: cir.atomic.xchg({{.*}} : !cir.ptr<!cir.bool>, {{.*}} : !u8i, seq_cst) : !u8i
+// CHECK: cir.atomic.xchg({{.*}} : !cir.ptr<!u8i>, {{.*}} : !u8i, seq_cst) : !u8i
 
 // LLVM-LABEL: @_Z3fsbPb
 // LLVM: atomicrmw xchg ptr {{.*}}, i8 {{.*}} seq_cst, align 1

--- a/clang/test/CIR/CodeGen/union-init.c
+++ b/clang/test/CIR/CodeGen/union-init.c
@@ -54,9 +54,9 @@ typedef union {
 // CHECK: %[[VAL_0:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
 // CHECK: %[[VAL_1:.*]] = cir.alloca !ty_U, !cir.ptr<!ty_U>, ["u", init] {alignment = 4 : i64}
 // CHECK: cir.store %arg0, %[[VAL_0]] : !s32i, !cir.ptr<!s32i>
-// CHECK: %[[VAL_2:.*]] = cir.load %[[VAL_0]] : !cir.ptr<!s32i>, !s32i
-// CHECK: %[[VAL_3:.*]] = cir.cast(bitcast, %[[VAL_1]] : !cir.ptr<!ty_U>), !cir.ptr<!s32i>
-// CHECK: cir.store %[[VAL_2]], %[[VAL_3]] : !s32i, !cir.ptr<!s32i>
+// CHECK: %[[VAL_2:.*]] = cir.cast(bitcast, %[[VAL_1]] : !cir.ptr<!ty_U>), !cir.ptr<!s32i>
+// CHECK: %[[VAL_3:.*]] = cir.load %[[VAL_0]] : !cir.ptr<!s32i>, !s32i
+// CHECK: cir.store %[[VAL_3]], %[[VAL_2]] : !s32i, !cir.ptr<!s32i>
 
 void union_cast(int x) {
   U u = (U) x;


### PR DESCRIPTION
There were problems with the pointer type and element type of the Address class getting out of sync. In the traditional codegen the pointer has no type, so it was sufficient for the Address class to simply track the type it was supposed to be pointing to. Since ClangIR pointer values are typed, the Address::withType function wasn't really doing what it was supposed to. It returned an object with the same pointer that the original object had, but with a mismatched element type.

This change updates the Address::withType function to perform a bitcast to get the expected pointer type before creating a new Address object. It also adds assertions in the Address class to verify that pointer type and element type are consistent and updates many places that were causing those assertions to fire.

These code changes cause extra bitcasts to be emitted in a few places. Regression tests have been updated as needed to reflect the CIR that is now generated.