### PR TITLE
[CIR] Add support for __builtin_bitreverse

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1783,6 +1783,36 @@ def RotateOp : CIR_Op<"rotate", [Pure, SameOperandsAndResultType]> {
 }
 
 //===----------------------------------------------------------------------===//
+// BitReverseOp
+//===----------------------------------------------------------------------===//
+
+def BitReverseOp : CIR_Op<"bit_reverse", [Pure, SameOperandsAndResultType]> {
+  let summary = "Reverse the bit pattern of the operand integer";
+  let description = [{
+    The `cir.bit_reverse` operation reverses the bit pattern of the operand
+    integer. Its only argument must be of unsigned integer types of width 8, 16,
+    32, or 64.
+
+    This operation covers the C/C++ builtin function `__builtin_bitreverse`.
+
+    Example:
+
+    ```mlir
+    %1 = cir.bit_reverse %0 : !u32i
+    ```
+  }];
+
+  let arguments = (ins AnyTypeOf<[UInt8, UInt16, UInt32, UInt64]>:$src);
+  let results = (outs AnyTypeOf<[UInt8, UInt16, UInt32, UInt64]>:$result);
+
+  let assemblyFormat = [{
+    $src `:` type($result) attr-dict
+  }];
+
+  let llvmOp = "BitReverseOp";
+}
+
+//===----------------------------------------------------------------------===//
 // CmpThreeWayOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1187,8 +1187,11 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_bitreverse8:
   case Builtin::BI__builtin_bitreverse16:
   case Builtin::BI__builtin_bitreverse32:
-  case Builtin::BI__builtin_bitreverse64:
-    llvm_unreachable("BI__builtin_bitreverse8 like NYI");
+  case Builtin::BI__builtin_bitreverse64: {
+    mlir::Value arg = emitScalarExpr(E->getArg(0));
+    return RValue::get(
+        builder.create<cir::BitReverseOp>(getLoc(E->getSourceRange()), arg));
+  }
 
   case Builtin::BI__builtin_rotateleft8:
   case Builtin::BI__builtin_rotateleft16:

--- a/clang/test/CIR/CodeGen/builtin-bitreverse.c
+++ b/clang/test/CIR/CodeGen/builtin-bitreverse.c
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+unsigned char bitreverse8(unsigned char value) {
+  return __builtin_bitreverse8(value);
+}
+
+// CIR-LABEL: @bitreverse8
+// CIR: %{{.+}} = cir.bit_reverse %{{.+}} : !u8i
+
+// LLVM-LABEL: @bitreverse8
+// LLVM: %{{.+}} = call i8 @llvm.bitreverse.i8(i8 %{{.+}})
+
+unsigned short bitreverse16(unsigned short value) {
+  return __builtin_bitreverse16(value);
+}
+
+// CIR-LABEL: @bitreverse16
+// CIR: %{{.+}} = cir.bit_reverse %{{.+}} : !u16i
+
+// LLVM-LABEL: @bitreverse16
+// LLVM: %{{.+}} = call i16 @llvm.bitreverse.i16(i16 %{{.+}})
+
+unsigned bitreverse32(unsigned value) {
+  return __builtin_bitreverse32(value);
+}
+
+// CIR-LABEL: @bitreverse32
+// CIR: %{{.+}} = cir.bit_reverse %{{.+}} : !u32i
+
+// LLVM-LABEL: @bitreverse32
+// LLVM: %{{.+}} = call i32 @llvm.bitreverse.i32(i32 %{{.+}})
+
+unsigned long long bitreverse64(unsigned long long value) {
+  return __builtin_bitreverse64(value);
+}
+
+// CIR-LABEL: @bitreverse64
+// CIR: %{{.+}} = cir.bit_reverse %{{.+}} : !u64i
+
+// LLVM-LABEL: @bitreverse64
+// LLVM: %{{.+}} = call i64 @llvm.bitreverse.i64(i64 %{{.+}})


### PR DESCRIPTION
This PR adds CIRGen and LLVM lowering support for the `__builtin_bitreverse` family of builtin functions.