### PR TITLE
[CIR] CallConvLowering for X86 aggregate

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -347,6 +347,7 @@ struct MissingFeatures {
   static bool undef() { return false; }
   static bool noFPClass() { return false; }
   static bool llvmIntrinsicElementTypeSupport() { return false; }
+  static bool argHasMaybeUndefAttr() { return false; }
 
   //-- Missing parts of the CIRGenModule::Release skeleton.
   static bool emitModuleInitializers() { return false; }


### PR DESCRIPTION
This deals with some x86 aggregate types for CallConvLowering pass.

Suppose we have a simple struct like this.
```cpp
struct dim3 { int x, y, z; };
```
It can be coerced into
```cpp
struct dim3_ { uint64_t xy; int z; };
```
And for a function that receives it as an argument, OG does the following transformation for x86:
```cpp
void f(dim3 arg) { /* Before */ }
void f(uint64_t xy, int z) { /* After */ }
```
Now this transformation is implemented in the CallConvLowering pass of CIR.