### PR TITLE
[CIR] Track size_t and int size with module attributes

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -123,6 +123,79 @@ def CIR_OptInfoAttr : CIR_Attr<"OptInfo", "opt_info"> {
 }
 
 //===----------------------------------------------------------------------===//
+// TypeSizeInfoAttr
+//===----------------------------------------------------------------------===//
+
+def CIR_TypeSizeInfoAttr : CIR_Attr<"TypeSizeInfo", "type_size_info"> {
+  let summary = "the size of types in bits";
+  let description = [{
+    The `cir.type_size` attribute is attached to a module, recording lengths
+    of various types if their names don't include it.
+
+    It is worth noticing that size_t and pointers are considered to have the
+    same length in Clang IR.
+
+    Float and double types are represented by cir::SingleType and cir::
+    DoubleType respectively, whose constructos don't need the type size as an
+    argument. So their lengths are not stored here.
+
+    Examples:
+
+    ```mlir
+    // sizeof(int) == 4, sizeof(size_t) == 8
+    module attributes {
+      cir.type_size = #cir.type_size<
+        char = 8,
+        int = 32,
+        size_t = 64
+      >
+    } {}
+    ```
+  }];
+
+  let parameters = (ins "unsigned":$char_size,
+                        "unsigned":$int_size,
+                        "unsigned":$size_t_size);
+
+  let assemblyFormat = [{
+    `<`
+      `char` `=` $char_size `,`
+      `int` `=` $int_size `,`
+      `size_t` `=` $size_t_size
+    `>`
+  }];
+
+  let extraClassDeclaration = [{
+    unsigned getPointerSize() const { return getSizeTSize(); }
+
+    mlir::Type getCharType(mlir::MLIRContext *ctx) const {
+      return cir::IntType::get(ctx, getCharSize(), /*signed=*/true);
+    }
+
+    mlir::Type getUCharType(mlir::MLIRContext *ctx) const {
+      return cir::IntType::get(ctx, getCharSize(), /*signed=*/false);
+    }
+
+    mlir::Type getIntType(mlir::MLIRContext *ctx) const {
+      return cir::IntType::get(ctx, getIntSize(), /*signed=*/true);
+    }
+
+    mlir::Type getUIntType(mlir::MLIRContext *ctx) const {
+      return cir::IntType::get(ctx, getIntSize(), /*signed=*/false);
+    }
+
+    mlir::Type getSizeType(mlir::MLIRContext *ctx) const {
+      return cir::IntType::get(ctx, getSizeTSize(), /*signed=*/false);
+    }
+
+    mlir::Type getPtrDiffType(mlir::MLIRContext *ctx) const {
+      return cir::IntType::get(ctx, getSizeTSize(), /*signed=*/true);
+    }
+  }];
+}
+
+
+//===----------------------------------------------------------------------===//
 // BoolAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -34,6 +34,7 @@ def CIR_Dialect : Dialect {
     // Names of CIR parameter attributes.
     static llvm::StringRef getSExtAttrName() { return "cir.signext"; }
     static llvm::StringRef getZExtAttrName() { return "cir.zeroext"; }
+    static llvm::StringRef getTypeSizeInfoAttrName() { return "cir.type_size_info"; }
     static llvm::StringRef getSOBAttrName() { return "cir.sob"; }
     static llvm::StringRef getLangAttrName() { return "cir.lang"; }
     static llvm::StringRef getTripleAttrName() { return "cir.triple"; }

--- a/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
+++ b/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
@@ -16,7 +16,7 @@ void foo(int i) __attribute__((annotate("withargfunc", "os", 23 )));
 void bar() __attribute__((annotate("withargfunc", "os", 22))) {
 }
 
-// BEFORE: module @{{.*}}attribute-annotate-multiple.cpp" attributes {cir.lang =
+// BEFORE: module @{{.*}}attribute-annotate-multiple.cpp" attributes {{{.*}}cir.lang =
 
 // BEFORE: cir.global external @a = #cir.ptr<null> : !cir.ptr<!cir.double>
 // BEFORE-SAME: [#cir.annotation<name = "withargs", args = ["21", 12 : i32]>]

--- a/clang/test/CIR/CodeGen/dlti.c
+++ b/clang/test/CIR/CodeGen/dlti.c
@@ -5,6 +5,12 @@ void foo() {}
 
 //      CHECK: module @"{{.*}}dlti.c" attributes {
 //  CHECK-DAG: cir.sob = #cir.signed_overflow_behavior<undefined>,
+//  CHECK-DAG: cir.type_size_info =
+//  CHECK-DAG:   #cir.type_size_info<
+//  CHECK-DAG:     char = 8,
+//  CHECK-DAG:     int = {{16|32}},
+//  CHECK-DAG:     size_t = {{32|64}}
+//  CHECK-DAG: >
 //  CHECK-DAG: dlti.dl_spec =
 //  CHECK-DAG:   #dlti.dl_spec<
 //  CHECK-DAG:     i16 = dense<16> : vector<2xi64>,

--- a/clang/test/CIR/CodeGen/sourcelocation.cpp
+++ b/clang/test/CIR/CodeGen/sourcelocation.cpp
@@ -18,7 +18,7 @@ int s0(int a, int b) {
 // CIR: #loc6 = loc("{{.*}}sourcelocation.cpp":6:19)
 // CIR: #loc21 = loc(fused[#loc3, #loc4])
 // CIR: #loc22 = loc(fused[#loc5, #loc6])
-// CIR: module @"{{.*}}sourcelocation.cpp" attributes {cir.lang = #cir.lang<cxx>, cir.sob = #cir.signed_overflow_behavior<undefined>
+// CIR: module @"{{.*}}sourcelocation.cpp" attributes {{{.*}}cir.lang = #cir.lang<cxx>, {{.*}}cir.sob = #cir.signed_overflow_behavior<undefined>
 // CIR:   cir.func @_Z2s0ii(%arg0: !s32i loc(fused[#loc3, #loc4]), %arg1: !s32i loc(fused[#loc5, #loc6])) -> !s32i
 // CIR:     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64} loc(#loc21)
 // CIR:     %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init] {alignment = 4 : i64} loc(#loc22)


### PR DESCRIPTION
To give LoweringPrepare type information from `CIRGenTypeCache`, this PR adds two attributes to ModuleOp:
```mlir
module attributes {
  cir.int_size = #cir.int_size<32>,
  cir.size_type_size = #cir.size_type_size<64>,
  ...
} {}
```
The `CIRDataLayout` class is also extended to have `getPtrDiffTy` and so on.

Some tests that only expects `cir.lang` and `cir.sob` are also changed to take this into account.