### PR TITLE
[CIR] Add support for comparisons between pointers to member functions

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -122,6 +122,10 @@ public:
                                          mlir::Value loweredRhs,
                                          mlir::OpBuilder &builder) const = 0;
 
+  virtual mlir::Value lowerMethodCmp(cir::CmpOp op, mlir::Value loweredLhs,
+                                     mlir::Value loweredRhs,
+                                     mlir::OpBuilder &builder) const = 0;
+
   virtual mlir::Value
   lowerDataMemberBitcast(cir::CastOp op, mlir::Type loweredDstTy,
                          mlir::Value loweredSrc,

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2893,10 +2893,17 @@ mlir::LogicalResult CIRToLLVMCmpOpLowering::matchAndRewrite(
     mlir::ConversionPatternRewriter &rewriter) const {
   auto type = cmpOp.getLhs().getType();
 
-  if (mlir::isa<cir::DataMemberType>(type)) {
+  if (mlir::isa<cir::DataMemberType, cir::MethodType>(type)) {
     assert(lowerMod && "lowering module is not available");
-    mlir::Value loweredResult = lowerMod->getCXXABI().lowerDataMemberCmp(
-        cmpOp, adaptor.getLhs(), adaptor.getRhs(), rewriter);
+
+    mlir::Value loweredResult;
+    if (mlir::isa<cir::DataMemberType>(type))
+      loweredResult = lowerMod->getCXXABI().lowerDataMemberCmp(
+          cmpOp, adaptor.getLhs(), adaptor.getRhs(), rewriter);
+    else
+      loweredResult = lowerMod->getCXXABI().lowerMethodCmp(
+          cmpOp, adaptor.getLhs(), adaptor.getRhs(), rewriter);
+
     rewriter.replaceOp(cmpOp, loweredResult);
     return mlir::success();
   }

--- a/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
@@ -78,3 +78,43 @@ void call(Foo *obj, void (Foo::*func)(int), int arg) {
 // LLVM-NEXT:    %[[#arg:]] = load i32, ptr %{{.+}}
 // LLVM-NEXT:    call void %[[#callee_ptr]](ptr %[[#adjusted_this]], i32 %[[#arg]])
 //      LLVM: }
+
+bool cmp_eq(void (Foo::*lhs)(int), void (Foo::*rhs)(int)) {
+  return lhs == rhs;
+}
+
+// CHECK-LABEL: @_Z6cmp_eqM3FooFviES1_
+// CHECK: %{{.+}} = cir.cmp(eq, %{{.+}}, %{{.+}}) : !cir.method<!cir.func<(!s32i)> in !ty_Foo>, !cir.bool
+
+// LLVM-LABEL: @_Z6cmp_eqM3FooFviES1_
+//      LLVM: %[[#lhs:]] = load { i64, i64 }, ptr %{{.+}}
+// LLVM-NEXT: %[[#rhs:]] = load { i64, i64 }, ptr %{{.+}}
+// LLVM-NEXT: %[[#lhs_ptr:]] = extractvalue { i64, i64 } %[[#lhs]], 0
+// LLVM-NEXT: %[[#rhs_ptr:]] = extractvalue { i64, i64 } %[[#rhs]], 0
+// LLVM-NEXT: %[[#ptr_cmp:]] = icmp eq i64 %[[#lhs_ptr]], %[[#rhs_ptr]]
+// LLVM-NEXT: %[[#ptr_null:]] = icmp eq i64 %[[#lhs_ptr]], 0
+// LLVM-NEXT: %[[#lhs_adj:]] = extractvalue { i64, i64 } %[[#lhs]], 1
+// LLVM-NEXT: %[[#rhs_adj:]] = extractvalue { i64, i64 } %[[#rhs]], 1
+// LLVM-NEXT: %[[#adj_cmp:]] = icmp eq i64 %[[#lhs_adj]], %[[#rhs_adj]]
+// LLVM-NEXT: %[[#tmp:]] = or i1 %[[#ptr_null]], %[[#adj_cmp]]
+// LLVM-NEXT: %{{.+}} = and i1 %[[#tmp]], %[[#ptr_cmp]]
+
+bool cmp_ne(void (Foo::*lhs)(int), void (Foo::*rhs)(int)) {
+  return lhs != rhs;
+}
+
+// CHECK-LABEL: @_Z6cmp_neM3FooFviES1_
+// CHECK: %{{.+}} = cir.cmp(ne, %{{.+}}, %{{.+}}) : !cir.method<!cir.func<(!s32i)> in !ty_Foo>, !cir.bool
+
+// LLVM-LABEL: @_Z6cmp_neM3FooFviES1_
+//      LLVM: %[[#lhs:]] = load { i64, i64 }, ptr %{{.+}}
+// LLVM-NEXT: %[[#rhs:]] = load { i64, i64 }, ptr %{{.+}}
+// LLVM-NEXT: %[[#lhs_ptr:]] = extractvalue { i64, i64 } %[[#lhs]], 0
+// LLVM-NEXT: %[[#rhs_ptr:]] = extractvalue { i64, i64 } %[[#rhs]], 0
+// LLVM-NEXT: %[[#ptr_cmp:]] = icmp ne i64 %[[#lhs_ptr]], %[[#rhs_ptr]]
+// LLVM-NEXT: %[[#ptr_null:]] = icmp ne i64 %[[#lhs_ptr]], 0
+// LLVM-NEXT: %[[#lhs_adj:]] = extractvalue { i64, i64 } %[[#lhs]], 1
+// LLVM-NEXT: %[[#rhs_adj:]] = extractvalue { i64, i64 } %[[#rhs]], 1
+// LLVM-NEXT: %[[#adj_cmp:]] = icmp ne i64 %[[#lhs_adj]], %[[#rhs_adj]]
+// LLVM-NEXT: %[[#tmp:]] = and i1 %[[#ptr_null]], %[[#adj_cmp]]
+// LLVM-NEXT: %{{.+}} = or i1 %[[#tmp]], %[[#ptr_cmp]]


### PR DESCRIPTION
The CIRGen support is already there. This PR adds LLVM lowering support for comparisons between pointers to member functions. Note that pointers to member functions could only be compared for equality.