### PR TITLE
[CIR] New assembly format for function type return

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3857,7 +3857,7 @@ def CallOp : CIR_CallOp<"call", [NoRegionArguments]> {
                CArg<"mlir::UnitAttr", "{}">:$exception), [{
       $_state.addOperands(ValueRange{ind_target});
       $_state.addOperands(operands);
-      if (!fn_type.isVoid())
+      if (!fn_type.hasVoidReturn())
         $_state.addTypes(fn_type.getReturnType());
       $_state.addAttribute("calling_conv",
         CallingConvAttr::get($_builder.getContext(), callingConv));
@@ -3943,7 +3943,7 @@ def TryCallOp : CIR_CallOp<"try_call",
       finalCallOperands.append(operands.begin(), operands.end());
       $_state.addOperands(finalCallOperands);
 
-      if (!fn_type.isVoid())
+      if (!fn_type.hasVoidReturn())
         $_state.addTypes(fn_type.getReturnType());
 
       $_state.addAttribute("calling_conv",

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -154,6 +154,7 @@ public:
     case RecordKind::Struct:
       return "struct";
     }
+    llvm_unreachable("Invalid value for StructType::getKind()");
   }
   std::string getPrefixedName() {
     return getKindAsStr() + "." + getName().getValue().str();

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -379,10 +379,10 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
 
     ```mlir
     !cir.func<()>
-    !cir.func<!bool ()>
+    !cir.func<() -> !bool>
     !cir.func<(!s8i, !s8i)>
-    !cir.func<!s32i (!s8i, !s8i)>
-    !cir.func<!s32i (!s32i, ...)>
+    !cir.func<(!s8i, !s8i) -> !s32i>
+    !cir.func<(!s32i, ...) -> !s32i>
     ```
   }];
 
@@ -390,22 +390,26 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
                         "mlir::Type":$optionalReturnType,
                         "bool":$varArg);
   // Use a custom parser to handle the optional return and argument types
-  // without an optional anchor.
   let assemblyFormat = [{
     `<` custom<FuncType>($optionalReturnType, $inputs, $varArg) `>`
   }];
 
   let builders = [
-    // Construct with an actual return type or explicit !cir.void
+    // Create a FuncType, converting the return type from C-style to
+    // MLIR-style.  If the given return type is `cir::VoidType`, ignore it
+    // and create the FuncType with no return type, which is how MLIR
+    // represents function types.
     TypeBuilderWithInferredContext<(ins
       "llvm::ArrayRef<mlir::Type>":$inputs, "mlir::Type":$returnType,
       CArg<"bool", "false">:$isVarArg), [{
-      return $_get(returnType.getContext(), inputs,
-                       mlir::isa<cir::VoidType>(returnType) ? nullptr
-                                                            : returnType,
-                       isVarArg);
+        return $_get(returnType.getContext(), inputs,
+                     mlir::isa<cir::VoidType>(returnType) ? nullptr
+                                                          : returnType,
+                     isVarArg);
     }]>
   ];
+
+  let genVerifyDecl = 1;
 
   let extraClassDeclaration = [{
     /// Returns whether the function is variadic.
@@ -417,16 +421,17 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
     /// Returns the number of arguments to the function.
     unsigned getNumInputs() const { return getInputs().size(); }
 
-    /// Returns the result type of the function as an actual return type or
-    /// explicit !cir.void
+    /// Get the C-style return type of the function, which is !cir.void if the
+    /// function returns nothing and the actual return type otherwise.
     mlir::Type getReturnType() const;
 
-    /// Returns the result type of the function as an ArrayRef, enabling better
-    /// integration with generic MLIR utilities.
+    /// Get the MLIR-style return type of the function, which is an empty
+    /// ArrayRef if the function returns nothing and a single-element ArrayRef
+    /// with the actual return type otherwise.
     llvm::ArrayRef<mlir::Type> getReturnTypes() const;
 
-    /// Returns whether the function returns void.
-    bool isVoid() const;
+    /// Does the fuction type return nothing?
+    bool hasVoidReturn() const;
 
     /// Returns a clone of this function type with the given argument
     /// and result types.

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2739,15 +2739,15 @@ verifyCallCommInSymbolUses(Operation *op, SymbolTableCollection &symbolTable) {
            << stringifyCallingConv(callIf.getCallingConv());
 
   // Void function must not return any results.
-  if (fnType.isVoid() && op->getNumResults() != 0)
+  if (fnType.hasVoidReturn() && op->getNumResults() != 0)
     return op->emitOpError("callee returns void but call has results");
 
   // Non-void function calls must return exactly one result.
-  if (!fnType.isVoid() && op->getNumResults() != 1)
+  if (!fnType.hasVoidReturn() && op->getNumResults() != 1)
     return op->emitOpError("incorrect number of results for callee");
 
   // Parent function and return value types must match.
-  if (!fnType.isVoid() &&
+  if (!fnType.hasVoidReturn() &&
       op->getResultTypes().front() != fnType.getReturnType()) {
     return op->emitOpError("result type mismatch: expected ")
            << fnType.getReturnType() << ", but provided "

--- a/clang/test/CIR/CallConvLowering/AArch64/ptr-fields.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/ptr-fields.c
@@ -15,9 +15,9 @@ int foo(int x) { return x; }
 // CIR: %[[#V0:]] = cir.alloca !ty_A, !cir.ptr<!ty_A>, [""] {alignment = 4 : i64}
 // CIR: %[[#V1:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_A>), !cir.ptr<!u64i>
 // CIR: cir.store %arg0, %[[#V1]] : !u64i, !cir.ptr<!u64i>
-// CIR: %[[#V2:]] = cir.get_global @foo : !cir.ptr<!cir.func<!s32i (!s32i)>>
-// CIR: %[[#V3:]] = cir.get_member %[[#V0]][0] {name = "f"} : !cir.ptr<!ty_A> -> !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i)>>>
-// CIR: cir.store %[[#V2]], %[[#V3]] : !cir.ptr<!cir.func<!s32i (!s32i)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i)>>>
+// CIR: %[[#V2:]] = cir.get_global @foo : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+// CIR: %[[#V3:]] = cir.get_member %[[#V0]][0] {name = "f"} : !cir.ptr<!ty_A> -> !cir.ptr<!cir.ptr<!cir.func<(!s32i) -> !s32i>>>
+// CIR: cir.store %[[#V2]], %[[#V3]] : !cir.ptr<!cir.func<(!s32i) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!s32i) -> !s32i>>>
 // CIR: cir.return
 
 // LLVM: void @passA(i64 %[[#V0:]])

--- a/clang/test/CIR/CallConvLowering/x86_64/fptrs.c
+++ b/clang/test/CIR/CallConvLowering/x86_64/fptrs.c
@@ -10,10 +10,10 @@ typedef int (*myfptr)(S);
 int foo(S s) { return 42 + s.a; }
 
 // CHECK: cir.func {{.*@bar}}
-// CHECK:   %[[#V0:]] = cir.alloca !cir.ptr<!cir.func<!s32i (!ty_S)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!ty_S)>>>, ["a", init]
-// CHECK:   %[[#V1:]] = cir.get_global @foo : !cir.ptr<!cir.func<!s32i (!s32i)>> 
-// CHECK:   %[[#V2:]] = cir.cast(bitcast, %[[#V1]] : !cir.ptr<!cir.func<!s32i (!s32i)>>), !cir.ptr<!cir.func<!s32i (!ty_S)>>
-// CHECK:   cir.store %[[#V2]], %[[#V0]] : !cir.ptr<!cir.func<!s32i (!ty_S)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!ty_S)>>>
+// CHECK:   %[[#V0:]] = cir.alloca !cir.ptr<!cir.func<(!ty_S) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!ty_S) -> !s32i>>>, ["a", init]
+// CHECK:   %[[#V1:]] = cir.get_global @foo : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+// CHECK:   %[[#V2:]] = cir.cast(bitcast, %[[#V1]] : !cir.ptr<!cir.func<(!s32i) -> !s32i>>), !cir.ptr<!cir.func<(!ty_S) -> !s32i>>
+// CHECK:   cir.store %[[#V2]], %[[#V0]] : !cir.ptr<!cir.func<(!ty_S) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!ty_S) -> !s32i>>>
 void bar() {
   myfptr a = foo;
 }
@@ -22,15 +22,15 @@ void bar() {
 // CHECK:   %[[#V0:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, [""] {alignment = 4 : i64}
 // CHECK:   %[[#V1:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S>), !cir.ptr<!s32i>
 // CHECK:   cir.store %arg0, %[[#V1]] : !s32i, !cir.ptr<!s32i>
-// CHECK:   %[[#V2:]] = cir.alloca !cir.ptr<!cir.func<!s32i (!ty_S)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!ty_S)>>>, ["a", init]
-// CHECK:   %[[#V3:]] = cir.get_global @foo : !cir.ptr<!cir.func<!s32i (!s32i)>>
-// CHECK:   %[[#V4:]] = cir.cast(bitcast, %[[#V3]] : !cir.ptr<!cir.func<!s32i (!s32i)>>), !cir.ptr<!cir.func<!s32i (!ty_S)>>
-// CHECK:   cir.store %[[#V4]], %[[#V2]] : !cir.ptr<!cir.func<!s32i (!ty_S)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!ty_S)>>>
-// CHECK:   %[[#V5:]] = cir.load %[[#V2]] : !cir.ptr<!cir.ptr<!cir.func<!s32i (!ty_S)>>>, !cir.ptr<!cir.func<!s32i (!ty_S)>>
+// CHECK:   %[[#V2:]] = cir.alloca !cir.ptr<!cir.func<(!ty_S) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!ty_S) -> !s32i>>>, ["a", init]
+// CHECK:   %[[#V3:]] = cir.get_global @foo : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+// CHECK:   %[[#V4:]] = cir.cast(bitcast, %[[#V3]] : !cir.ptr<!cir.func<(!s32i) -> !s32i>>), !cir.ptr<!cir.func<(!ty_S) -> !s32i>>
+// CHECK:   cir.store %[[#V4]], %[[#V2]] : !cir.ptr<!cir.func<(!ty_S) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!ty_S) -> !s32i>>>
+// CHECK:   %[[#V5:]] = cir.load %[[#V2]] : !cir.ptr<!cir.ptr<!cir.func<(!ty_S) -> !s32i>>>, !cir.ptr<!cir.func<(!ty_S) -> !s32i>>
 // CHECK:   %[[#V6:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S>), !cir.ptr<!s32i>
 // CHECK:   %[[#V7:]] = cir.load %[[#V6]] : !cir.ptr<!s32i>, !s32i
-// CHECK:   %[[#V8:]] = cir.cast(bitcast, %[[#V5]] : !cir.ptr<!cir.func<!s32i (!ty_S)>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
-// CHECK:   %[[#V9:]] = cir.call %[[#V8]](%[[#V7]]) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
+// CHECK:   %[[#V8:]] = cir.cast(bitcast, %[[#V5]] : !cir.ptr<!cir.func<(!ty_S) -> !s32i>>), !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+// CHECK:   %[[#V9:]] = cir.call %[[#V8]](%[[#V7]]) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i
 
 // LLVM: define dso_local void @baz(i32 %0)
 // LLVM:   %[[#V1:]] = alloca %struct.S, i64 1

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -359,19 +359,19 @@ folly::coro::Task<int> go4() {
 // CHECK:   %17 = cir.alloca !ty_anon2E2_, !cir.ptr<!ty_anon2E2_>, ["ref.tmp1"] {alignment = 1 : i64}
 
 // Get the lambda invoker ptr via `lambda operator folly::coro::Task<int> (*)(int const&)()`
-// CHECK:   %18 = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%17) : (!cir.ptr<!ty_anon2E2_>) -> !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>
-// CHECK:   %19 = cir.unary(plus, %18) : !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>
-// CHECK:   cir.yield %19 : !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>
+// CHECK:   %18 = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%17) : (!cir.ptr<!ty_anon2E2_>) -> !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
+// CHECK:   %19 = cir.unary(plus, %18) : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
+// CHECK:   cir.yield %19 : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
 // CHECK: }
-// CHECK: cir.store %12, %3 : !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>>
+// CHECK: cir.store %12, %3 : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>
 // CHECK: cir.scope {
 // CHECK:   %17 = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp2", init] {alignment = 4 : i64}
-// CHECK:   %18 = cir.load %3 : !cir.ptr<!cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>>, !cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>
+// CHECK:   %18 = cir.load %3 : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
 // CHECK:   %19 = cir.const #cir.int<3> : !s32i
 // CHECK:   cir.store %19, %17 : !s32i, !cir.ptr<!s32i>
 
 // Call invoker, which calls operator() indirectly.
-// CHECK:   %20 = cir.call %18(%17) : (!cir.ptr<!cir.func<![[IntTask]] (!cir.ptr<!s32i>)>>, !cir.ptr<!s32i>) -> ![[IntTask]]
+// CHECK:   %20 = cir.call %18(%17) : (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!s32i>) -> ![[IntTask]]
 // CHECK:   cir.store %20, %4 : ![[IntTask]], !cir.ptr<![[IntTask]]>
 // CHECK: }
 

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -118,11 +118,11 @@ void vcall(C1 &c1) {
 // CHECK:   %5 = cir.load %2 : !cir.ptr<!s32i>, !s32i
 // CHECK:   cir.call @_ZN5buffyC2ERKS_(%3, %1) : (!cir.ptr<!ty_buffy>, !cir.ptr<!ty_buffy>) -> ()
 // CHECK:   %6 = cir.load %3 : !cir.ptr<!ty_buffy>, !ty_buffy
-// CHECK:   %7 = cir.cast(bitcast, %4 : !cir.ptr<!ty_C1_>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_C1_>, !s32i, !ty_buffy)>>>>
-// CHECK:   %8 = cir.load %7 : !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_C1_>, !s32i, !ty_buffy)>>>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_C1_>, !s32i, !ty_buffy)>>>
-// CHECK:   %9 = cir.vtable.address_point( %8 : !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_C1_>, !s32i, !ty_buffy)>>>, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_C1_>, !s32i, !ty_buffy)>>>
-// CHECK:   %10 = cir.load align(8) %9 : !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_C1_>, !s32i, !ty_buffy)>>>, !cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_C1_>, !s32i, !ty_buffy)>>
-// CHECK:   %11 = cir.call %10(%4, %5, %6) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_C1_>, !s32i, !ty_buffy)>>, !cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i
+// CHECK:   %7 = cir.cast(bitcast, %4 : !cir.ptr<!ty_C1_>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i>>>>
+// CHECK:   %8 = cir.load %7 : !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i>>>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i>>>
+// CHECK:   %9 = cir.vtable.address_point( %8 : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i>>>, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i>>>
+// CHECK:   %10 = cir.load align(8) %9 : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i>>>, !cir.ptr<!cir.func<(!cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i>>
+// CHECK:   %11 = cir.call %10(%4, %5, %6) : (!cir.ptr<!cir.func<(!cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i>>, !cir.ptr<!ty_C1_>, !s32i, !ty_buffy) -> !s32i
 // CHECK:   cir.return
 // CHECK: }
 

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -36,7 +36,7 @@ public:
 };
 
 // Class A
-// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.record.decl.ast>
+// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
 
 // Class B
 // CHECK: ![[ClassB:ty_.*]] = !cir.struct<class "B" {![[ClassA]]}>

--- a/clang/test/CIR/CodeGen/dynamic-cast-exact.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast-exact.cpp
@@ -16,10 +16,10 @@ struct Derived final : Base1 {};
 Derived *ptr_cast(Base1 *ptr) {
   return dynamic_cast<Derived *>(ptr);
   //      CHECK: %[[#SRC:]] = cir.load %{{.+}} : !cir.ptr<!cir.ptr<!ty_Base1_>>, !cir.ptr<!ty_Base1_>
-  // CHECK-NEXT: %[[#EXPECTED_VPTR:]] = cir.vtable.address_point(@_ZTV7Derived, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-  // CHECK-NEXT: %[[#SRC_VPTR_PTR:]] = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_Base1_>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-  // CHECK-NEXT: %[[#SRC_VPTR:]] = cir.load %[[#SRC_VPTR_PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>, !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-  // CHECK-NEXT: %[[#SUCCESS:]] = cir.cmp(eq, %[[#SRC_VPTR]], %[[#EXPECTED_VPTR]]) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.bool
+  // CHECK-NEXT: %[[#EXPECTED_VPTR:]] = cir.vtable.address_point(@_ZTV7Derived, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+  // CHECK-NEXT: %[[#SRC_VPTR_PTR:]] = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_Base1_>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+  // CHECK-NEXT: %[[#SRC_VPTR:]] = cir.load %[[#SRC_VPTR_PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>, !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+  // CHECK-NEXT: %[[#SUCCESS:]] = cir.cmp(eq, %[[#SRC_VPTR]], %[[#EXPECTED_VPTR]]) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.bool
   // CHECK-NEXT: %{{.+}} = cir.ternary(%[[#SUCCESS]], true {
   // CHECK-NEXT:   %[[#RES:]] = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_Base1_>), !cir.ptr<!ty_Derived>
   // CHECK-NEXT:   cir.yield %[[#RES]] : !cir.ptr<!ty_Derived>
@@ -39,10 +39,10 @@ Derived *ptr_cast(Base1 *ptr) {
 Derived &ref_cast(Base1 &ref) {
   return dynamic_cast<Derived &>(ref);
   //      CHECK: %[[#SRC:]] = cir.load %{{.+}} : !cir.ptr<!cir.ptr<!ty_Base1_>>, !cir.ptr<!ty_Base1_>
-  // CHECK-NEXT: %[[#EXPECTED_VPTR:]] = cir.vtable.address_point(@_ZTV7Derived, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-  // CHECK-NEXT: %[[#SRC_VPTR_PTR:]] = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_Base1_>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-  // CHECK-NEXT: %[[#SRC_VPTR:]] = cir.load %[[#SRC_VPTR_PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>, !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-  // CHECK-NEXT: %[[#SUCCESS:]] = cir.cmp(eq, %[[#SRC_VPTR]], %[[#EXPECTED_VPTR]]) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.bool
+  // CHECK-NEXT: %[[#EXPECTED_VPTR:]] = cir.vtable.address_point(@_ZTV7Derived, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+  // CHECK-NEXT: %[[#SRC_VPTR_PTR:]] = cir.cast(bitcast, %[[#SRC]] : !cir.ptr<!ty_Base1_>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+  // CHECK-NEXT: %[[#SRC_VPTR:]] = cir.load %[[#SRC_VPTR_PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>, !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+  // CHECK-NEXT: %[[#SUCCESS:]] = cir.cmp(eq, %[[#SRC_VPTR]], %[[#EXPECTED_VPTR]]) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.bool
   // CHECK-NEXT: %[[#FAILED:]] = cir.unary(not, %[[#SUCCESS]]) : !cir.bool, !cir.bool
   // CHECK-NEXT: cir.if %[[#FAILED]] {
   // CHECK-NEXT:   cir.call @__cxa_bad_cast() : () -> ()

--- a/clang/test/CIR/CodeGen/fun-ptr.c
+++ b/clang/test/CIR/CodeGen/fun-ptr.c
@@ -17,7 +17,7 @@ typedef struct A {
   fun_typ fun;
 } A;
 
-// CIR: !ty_A = !cir.struct<struct "A" {!cir.ptr<!cir.func<!s32i (!cir.ptr<!cir.struct<struct "A">>)>>} #cir.record.decl.ast>
+// CIR: !ty_A = !cir.struct<struct "A" {!cir.ptr<!cir.func<(!cir.ptr<!cir.struct<struct "A">>) -> !s32i>>} #cir.record.decl.ast>
 A a = {(fun_typ)0};
 
 int extract_a(Data* d) {
@@ -27,15 +27,15 @@ int extract_a(Data* d) {
 // CIR: cir.func {{@.*foo.*}}(%arg0: !cir.ptr<!ty_Data>
 // CIR:   [[TMP0:%.*]] = cir.alloca !cir.ptr<!ty_Data>, !cir.ptr<!cir.ptr<!ty_Data>>, ["d", init]
 // CIR:   [[TMP1:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
-// CIR:   [[TMP2:%.*]] = cir.alloca !cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>>, ["f", init]
+// CIR:   [[TMP2:%.*]] = cir.alloca !cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>>, ["f", init]
 // CIR:   cir.store %arg0, [[TMP0]] : !cir.ptr<!ty_Data>, !cir.ptr<!cir.ptr<!ty_Data>>
-// CIR:   [[TMP3:%.*]] = cir.const #cir.ptr<null> : !cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>
-// CIR:   cir.store [[TMP3]], [[TMP2]] : !cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>>
-// CIR:   [[TMP4:%.*]] = cir.get_global {{@.*extract_a.*}} : !cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>
-// CIR:   cir.store [[TMP4]], [[TMP2]] : !cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>>
-// CIR:   [[TMP5:%.*]] = cir.load [[TMP2]] : !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>>, !cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>
+// CIR:   [[TMP3:%.*]] = cir.const #cir.ptr<null> : !cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>
+// CIR:   cir.store [[TMP3]], [[TMP2]] : !cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>>
+// CIR:   [[TMP4:%.*]] = cir.get_global {{@.*extract_a.*}} : !cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>
+// CIR:   cir.store [[TMP4]], [[TMP2]] : !cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>>
+// CIR:   [[TMP5:%.*]] = cir.load [[TMP2]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>>, !cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>
 // CIR:   [[TMP6:%.*]] = cir.load [[TMP0]] : !cir.ptr<!cir.ptr<!ty_Data>>, !cir.ptr<!ty_Data>
-// CIR:   [[TMP7:%.*]] = cir.call [[TMP5]]([[TMP6]]) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!ty_Data>)>>, !cir.ptr<!ty_Data>) -> !s32i
+// CIR:   [[TMP7:%.*]] = cir.call [[TMP5]]([[TMP6]]) : (!cir.ptr<!cir.func<(!cir.ptr<!ty_Data>) -> !s32i>>, !cir.ptr<!ty_Data>) -> !s32i
 // CIR:   cir.store [[TMP7]], [[TMP1]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM: define dso_local i32 {{@.*foo.*}}(ptr %0)

--- a/clang/test/CIR/CodeGen/hello.c
+++ b/clang/test/CIR/CodeGen/hello.c
@@ -11,7 +11,7 @@ int main (void) {
 // CHECK: cir.global "private" constant cir_private dsolocal @".str" = #cir.const_array<"Hello, world!\0A\00" : !cir.array<!s8i x 15>> : !cir.array<!s8i x 15> {alignment = 1 : i64}
 // CHECK: cir.func @main() -> !s32i
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
-// CHECK:   %1 = cir.get_global @printf : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s8i>, ...)>>
+// CHECK:   %1 = cir.get_global @printf : !cir.ptr<!cir.func<(!cir.ptr<!s8i>, ...) -> !s32i>>
 // CHECK:   %2 = cir.get_global @".str" : !cir.ptr<!cir.array<!s8i x 15>>
 // CHECK:   %3 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!s8i x 15>>), !cir.ptr<!s8i>
 // CHECK:   %4 = cir.call @printf(%3) : (!cir.ptr<!s8i>) -> !s32i

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -207,27 +207,27 @@ int g3() {
 
 // CHECK-LABEL: @_Z2g3v()
 // CHECK:     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
-// CHECK:     %1 = cir.alloca !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>>, ["fn", init] {alignment = 8 : i64}
+// CHECK:     %1 = cir.alloca !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>>, ["fn", init] {alignment = 8 : i64}
 // CHECK:     %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["task", init] {alignment = 4 : i64}
 
 // 1. Use `operator int (*)(int const&)()` to retrieve the fnptr to `__invoke()`.
 // CHECK:     %3 = cir.scope {
 // CHECK:       %7 = cir.alloca !ty_anon2E5_, !cir.ptr<!ty_anon2E5_>, ["ref.tmp0"] {alignment = 1 : i64}
-// CHECK:       %8 = cir.call @_ZZ2g3vENK3$_0cvPFiRKiEEv(%7) : (!cir.ptr<!ty_anon2E5_>) -> !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
-// CHECK:       %9 = cir.unary(plus, %8) : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
-// CHECK:       cir.yield %9 : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
+// CHECK:       %8 = cir.call @_ZZ2g3vENK3$_0cvPFiRKiEEv(%7) : (!cir.ptr<!ty_anon2E5_>) -> !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>
+// CHECK:       %9 = cir.unary(plus, %8) : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>
+// CHECK:       cir.yield %9 : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>
 // CHECK:     }
 
 // 2. Load ptr to `__invoke()`.
-// CHECK:     cir.store %3, %1 : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>>
+// CHECK:     cir.store %3, %1 : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>>
 // CHECK:     %4 = cir.scope {
 // CHECK:       %7 = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp1", init] {alignment = 4 : i64}
-// CHECK:       %8 = cir.load %1 : !cir.ptr<!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>>, !cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>
+// CHECK:       %8 = cir.load %1 : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>
 // CHECK:       %9 = cir.const #cir.int<3> : !s32i
 // CHECK:       cir.store %9, %7 : !s32i, !cir.ptr<!s32i>
 
 // 3. Call `__invoke()`, which effectively executes `operator()`.
-// CHECK:       %10 = cir.call %8(%7) : (!cir.ptr<!cir.func<!s32i (!cir.ptr<!s32i>)>>, !cir.ptr<!s32i>) -> !s32i
+// CHECK:       %10 = cir.call %8(%7) : (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>, !cir.ptr<!s32i>) -> !s32i
 // CHECK:       cir.yield %10 : !s32i
 // CHECK:     }
 

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -34,14 +34,14 @@ int main() {
 // CIR: ![[VTableTypeMother:ty_.*]] = !cir.struct<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
 // CIR: ![[VTableTypeFather:ty_.*]] = !cir.struct<struct  {!cir.array<!cir.ptr<!u8i> x 3>}>
 // CIR: ![[VTableTypeChild:ty_.*]] = !cir.struct<struct  {!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 3>}>
-// CIR: !ty_Father = !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.record.decl.ast>
-// CIR: !ty_Mother = !cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.record.decl.ast>
+// CIR: !ty_Father = !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
+// CIR: !ty_Mother = !cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
 // CIR: !ty_Child = !cir.struct<class "Child" {!ty_Mother, !ty_Father} #cir.record.decl.ast>
 
 // CIR: cir.func linkonce_odr @_ZN6MotherC2Ev(%arg0: !cir.ptr<!ty_Mother>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV6Mother, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_Mother>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   cir.store %2, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV6Mother, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_Mother>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   cir.store %2, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.return
 // CIR: }
 
@@ -51,13 +51,13 @@ int main() {
 // LLVM-DAG: }
 
 // CIR: cir.func linkonce_odr @_ZN5ChildC2Ev(%arg0: !cir.ptr<!ty_Child>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_Child>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, vtable_index = 1, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_Child>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, vtable_index = 1, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 // CIR:   %7 = cir.base_class_addr(%1 : !cir.ptr<!ty_Child> nonnull) [8] -> !cir.ptr<!ty_Father>
-// CIR:   %8 = cir.cast(bitcast, %7 : !cir.ptr<!ty_Father>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>> loc(#loc8)
-// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+// CIR:   %8 = cir.cast(bitcast, %7 : !cir.ptr<!ty_Father>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>> loc(#loc8)
+// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.return
 // CIR: }
 

--- a/clang/test/CIR/CodeGen/no-prototype.c
+++ b/clang/test/CIR/CodeGen/no-prototype.c
@@ -35,8 +35,8 @@ int test1(int x) {
 int noProto2();
 int test2(int x) {
   return noProto2(x);
-  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto2 : !cir.ptr<!cir.func<!s32i (!s32i)>>
-  // CHECK:  {{.*}} = cir.call [[GGO]](%{{[0-9]+}}) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
+  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto2 : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+  // CHECK:  {{.*}} = cir.call [[GGO]](%{{[0-9]+}}) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i
 }
 int noProto2(int x) { return x; }
 // CHECK: cir.func no_proto @noProto2(%arg0: !s32i {{.+}}) -> !s32i
@@ -50,9 +50,9 @@ int noProto3();
 int test3(int x) {
 // CHECK: cir.func @test3
   return noProto3(x);
-  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto3 : !cir.ptr<!cir.func<!s32i (...)>>
-  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<!s32i (...)>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
-  // CHECK:  {{%.*}} = cir.call [[CAST]](%{{[0-9]+}}) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
+  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto3 : !cir.ptr<!cir.func<(...) -> !s32i>>
+  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<(...) -> !s32i>>), !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+  // CHECK:  {{%.*}} = cir.call [[CAST]](%{{[0-9]+}}) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i
 }
 
 
@@ -67,18 +67,18 @@ int noProto4() { return 0; }
 // cir.func private no_proto @noProto4() -> !s32i
 int test4(int x) {
   return noProto4(x); // Even if we know the definition, this should compile.
-  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto4 : !cir.ptr<!cir.func<!s32i ()>>
-  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<!s32i ()>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
-  // CHECK:  {{%.*}} = cir.call [[CAST]]({{%.*}}) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
+  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto4 : !cir.ptr<!cir.func<() -> !s32i>>
+  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<() -> !s32i>>), !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+  // CHECK:  {{%.*}} = cir.call [[CAST]]({{%.*}}) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i
 }
 
 // No-proto definition followed by an incorrect call due to lack of args.
 int noProto5();
 int test5(int x) {
   return noProto5();
-  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto5 : !cir.ptr<!cir.func<!s32i (!s32i)>>
-  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<!s32i (!s32i)>>), !cir.ptr<!cir.func<!s32i ()>>
-  // CHECK:  {{%.*}} = cir.call [[CAST]]() : (!cir.ptr<!cir.func<!s32i ()>>) -> !s32i
+  // CHECK:  [[GGO:%.*]] = cir.get_global @noProto5 : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+  // CHECK:  [[CAST:%.*]] = cir.cast(bitcast, [[GGO]] : !cir.ptr<!cir.func<(!s32i) -> !s32i>>), !cir.ptr<!cir.func<() -> !s32i>>
+  // CHECK:  {{%.*}} = cir.call [[CAST]]() : (!cir.ptr<!cir.func<() -> !s32i>>) -> !s32i
 }
 int noProto5(int x) { return x; }
 // CHECK: cir.func no_proto @noProto5(%arg0: !s32i {{.+}}) -> !s32i

--- a/clang/test/CIR/CodeGen/store.c
+++ b/clang/test/CIR/CodeGen/store.c
@@ -24,7 +24,7 @@ void storeNoArgsFn() {
 
 // CHECK:  cir.func {{.*@storeNoArgsFn}}
 // CHECK:    %0 = cir.alloca
-// CHECK:    %1 = cir.get_global @get42 : !cir.ptr<!cir.func<!s32i ()>>
-// CHECK:    %2 = cir.cast(bitcast, %1 : !cir.ptr<!cir.func<!s32i ()>>), !cir.ptr<!cir.func<!s32i (...)>>
-// CHECK:    cir.store %2, %0 : !cir.ptr<!cir.func<!s32i (...)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (...)>>>
+// CHECK:    %1 = cir.get_global @get42 : !cir.ptr<!cir.func<() -> !s32i>>
+// CHECK:    %2 = cir.cast(bitcast, %1 : !cir.ptr<!cir.func<() -> !s32i>>), !cir.ptr<!cir.func<(...) -> !s32i>>
+// CHECK:    cir.store %2, %0 : !cir.ptr<!cir.func<(...) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(...) -> !s32i>>>
 

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -32,7 +32,7 @@ void yoyo(incomplete *i) {}
 //  CHECK-DAG: !ty_Foo = !cir.struct<struct "Foo" {!s32i, !s8i, !ty_Bar}>
 //  CHECK-DAG: !ty_Mandalore = !cir.struct<struct "Mandalore" {!u32i, !cir.ptr<!void>, !s32i} #cir.record.decl.ast>
 //  CHECK-DAG: !ty_Adv = !cir.struct<class "Adv" {!ty_Mandalore}>
-//  CHECK-DAG: !ty_Entry = !cir.struct<struct "Entry" {!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>}>
+//  CHECK-DAG: !ty_Entry = !cir.struct<struct "Entry" {!cir.ptr<!cir.func<(!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>) -> !u32i>>}>
 
 //      CHECK: cir.func linkonce_odr @_ZN3Bar6methodEv(%arg0: !cir.ptr<!ty_Bar>
 // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_Bar>, !cir.ptr<!cir.ptr<!ty_Bar>>, ["this", init] {alignment = 8 : i64}
@@ -172,4 +172,4 @@ void ppp() { Entry x; }
 
 // CHECK: cir.func linkonce_odr @_ZN5EntryC2Ev(%arg0: !cir.ptr<!ty_Entry>
 
-// CHECK: cir.get_member %1[0] {name = "procAddr"} : !cir.ptr<!ty_Entry> -> !cir.ptr<!cir.ptr<!cir.func<!u32i (!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>)>>>
+// CHECK: cir.get_member %1[0] {name = "procAddr"} : !cir.ptr<!ty_Entry> -> !cir.ptr<!cir.ptr<!cir.func<(!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>) -> !u32i>>>

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -27,8 +27,8 @@ public:
 // RTTI_DISABLED: ![[VTableTypeA:ty_.*]] = !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
 
 // Class A
-// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.record.decl.ast>
-// RTTI_DISABLED: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>} #cir.record.decl.ast>
+// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
+// RTTI_DISABLED: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
 
 // Class B
 // CHECK: ![[ClassB:ty_.*]] = !cir.struct<class "B" {![[ClassA]]}>
@@ -45,9 +45,9 @@ public:
 // CHECK:   %1 = cir.load %0 : !cir.ptr<!cir.ptr<![[ClassB]]>>, !cir.ptr<![[ClassB]]>
 // CHECK:   %2 = cir.base_class_addr(%1 : !cir.ptr<![[ClassB]]> nonnull) [0] -> !cir.ptr<![[ClassA]]>
 // CHECK:   cir.call @_ZN1AC2Ev(%2) : (!cir.ptr<![[ClassA]]>) -> ()
-// CHECK:   %3 = cir.vtable.address_point(@_ZTV1B, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-// CHECK:   %4 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassB]]>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CHECK:   cir.store %3, %4 : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+// CHECK:   %3 = cir.vtable.address_point(@_ZTV1B, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CHECK:   %4 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassB]]>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CHECK:   cir.store %3, %4 : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CHECK:   cir.return
 // CHECK: }
 
@@ -73,9 +73,9 @@ public:
 // CHECK:    %0 = cir.alloca !cir.ptr<![[ClassA]]>, !cir.ptr<!cir.ptr<![[ClassA]]>>, ["this", init] {alignment = 8 : i64}
 // CHECK:    cir.store %arg0, %0 : !cir.ptr<![[ClassA]]>, !cir.ptr<!cir.ptr<![[ClassA]]>>
 // CHECK:    %1 = cir.load %0 : !cir.ptr<!cir.ptr<![[ClassA]]>>, !cir.ptr<![[ClassA]]>
-// CHECK:    %2 = cir.vtable.address_point(@_ZTV1A, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-// CHECK:    %3 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassA]]>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CHECK:    cir.store %2, %3 : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+// CHECK:    %2 = cir.vtable.address_point(@_ZTV1A, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CHECK:    %3 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassA]]>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CHECK:    cir.store %2, %3 : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CHECK:    cir.return
 // CHECK:  }
 

--- a/clang/test/CIR/CodeGen/vtt.cpp
+++ b/clang/test/CIR/CodeGen/vtt.cpp
@@ -38,9 +38,9 @@ int f() {
 
 // Class A constructor
 // CIR: cir.func linkonce_odr @_ZN1AC2Ev(%arg0: !cir.ptr<!ty_A>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1A, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_A>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1A, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_A>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR: }
 
 // Vtable of Class D
@@ -115,19 +115,19 @@ int f() {
 // CIR:   %[[VTT_D_TO_C:.*]] = cir.vtt.address_point @_ZTT1D, offset = 3 -> !cir.ptr<!cir.ptr<!void>>
 // CIR:   cir.call @_ZN1CC2Ev(%[[C_PTR]], %[[VTT_D_TO_C]]) : (!cir.ptr<!ty_C>, !cir.ptr<!cir.ptr<!void>>) -> ()
 
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 0, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
-// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_D>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 2, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 0, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_D>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 2, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 
 // CIR:   %{{[0-9]+}} = cir.base_class_addr(%{{[0-9]+}} : !cir.ptr<!ty_D> nonnull) [40] -> !cir.ptr<!ty_A>
-// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_A>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 1, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>
+// CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_A>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 1, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 
 // CIR:   cir.base_class_addr(%{{[0-9]+}} : !cir.ptr<!ty_D> nonnull) [16] -> !cir.ptr<!ty_C>
-// CIR:   cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_C>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
-// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<!u32i ()>>>>
+// CIR:   cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!ty_C>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
+// CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.return
 // CIR: }
 

--- a/clang/test/CIR/IR/being_and_nothingness.cir
+++ b/clang/test/CIR/IR/being_and_nothingness.cir
@@ -1,12 +1,12 @@
 // RUN: cir-opt %s | FileCheck %s
 // Exercise different ways to encode a function returning void
+// This test is less useful that it used to be, because a redundant `!cir.void`
+// as a function return type is no longer supported.
 !s32i = !cir.int<s, 32>
 !f = !cir.func<()>
-!f2 = !cir.func<!s32i()>
+!f2 = !cir.func<() -> !s32i>
 !void = !cir.void
 !fnptr2 = !cir.ptr<!cir.func<(!s32i)>>
-// Try some useless !void
-!fnptr3 = !cir.ptr<!cir.func<!void (!s32i)>>
 module {
   cir.func @ind2(%fnptr: !fnptr2, %a : !s32i) {
     // CHECK:  cir.func @ind2(%arg0: !cir.ptr<!cir.func<(!s32i)>>, %arg1: !s32i) {
@@ -14,15 +14,6 @@ module {
   }
   cir.func @f2() {
     // CHECK:  cir.func @f2() {
-    cir.return
-  }
-  // Try with a lot of useless !void
-  cir.func @ind3(%fnptr: !fnptr3, %a : !s32i) -> !void {
-    // CHECK:  cir.func @ind3(%arg0: !cir.ptr<!cir.func<(!s32i)>>, %arg1: !s32i) {
-    cir.return
-  }
-  cir.func @f3() -> !cir.void {
-    // CHECK:  cir.func @f3() {
     cir.return
   }
 }

--- a/clang/test/CIR/IR/call-op-call-conv.cir
+++ b/clang/test/CIR/IR/call-op-call-conv.cir
@@ -2,7 +2,7 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 !s32i = !cir.int<s, 32>
-!fnptr = !cir.ptr<!cir.func<!s32i (!s32i)>>
+!fnptr = !cir.ptr<!cir.func<(!s32i) -> !s32i>>
 
 module {
   cir.func @my_add(%a: !s32i, %b: !s32i) -> !s32i cc(spir_function) {
@@ -22,6 +22,6 @@ module {
   }
 }
 
-// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i cc(spir_kernel)
-// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i cc(spir_function)
+// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i cc(spir_kernel)
+// CHECK: %{{[0-9]+}} = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i cc(spir_function)
 // CHECK: %{{[0-9]+}} = cir.try_call @my_add(%{{[0-9]+}}, %{{[0-9]+}}) ^{{.+}}, ^{{.+}} : (!s32i, !s32i) -> !s32i cc(spir_function)

--- a/clang/test/CIR/IR/call.cir
+++ b/clang/test/CIR/IR/call.cir
@@ -1,7 +1,7 @@
 // RUN: cir-opt %s | FileCheck %s
 
 !s32i = !cir.int<s, 32>
-!fnptr = !cir.ptr<!cir.func<!s32i (!s32i)>>
+!fnptr = !cir.ptr<!cir.func<(!s32i) -> !s32i>>
 
 #fn_attr = #cir<extra({inline = #cir.inline<no>, optnone = #cir.optnone})>
 #fn_attr1 = #cir<extra({nothrow = #cir.nothrow})>
@@ -16,7 +16,7 @@ module {
 
   cir.func @ind(%fnptr: !fnptr, %a : !s32i) {
     %r = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i
-// CHECK: %0 = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
+// CHECK: %0 = cir.call %arg0(%arg1) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i
     // Check parse->pretty-print round-trip on extra() attribute
     %7 = cir.call @_ZNSt5arrayIiLm8192EEixEm(%a) : (!s32i) -> !s32i extra(#fn_attr1)
 // CHECK: %1 = cir.call @_ZNSt5arrayIiLm8192EEixEm(%arg1) : (!s32i) -> !s32i extra(#fn_attr1)

--- a/clang/test/CIR/IR/func.cir
+++ b/clang/test/CIR/IR/func.cir
@@ -28,7 +28,7 @@ module {
 
   // Should parse custom assembly format.
   cir.func @parse_func_type() -> () {
-    %1 = cir.alloca !cir.ptr<!cir.func<!s32i (!s32i, ...)>>, !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i, ...)>>>, ["fn", init] {alignment = 8 : i64}
+    %1 = cir.alloca !cir.ptr<!cir.func<(!s32i, ...) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!s32i, ...) -> !s32i>>>, ["fn", init] {alignment = 8 : i64}
     cir.return
   }
 

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1490,3 +1490,13 @@ cir.func @cast0(%arg0: !s32i, %arg1: !s32i) {
   %1 = cir.cmp(eq, %arg0, %arg1): !s32i, !s32i
   cir.return
 }
+
+// -----
+
+// Verify that void-returning functions have no return type listed in
+// MLIR assembly.
+
+!s32i = !cir.int<s, 32>
+// expected-error @below {{!cir.func cannot have an explicit 'void' return type}}
+// expected-error @below {{failed to parse CIR_PointerType parameter}}
+cir.global external dsolocal @vfp = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i) -> !cir.void>>

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1159,8 +1159,8 @@ cir.func @bad_long_double(%arg0 : !cir.long_double<!cir.float>) -> () {
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!Base = !cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>}>
-!Derived = !cir.struct<struct "Derived" {!cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>}>}>
+!Base = !cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
+!Derived = !cir.struct<struct "Derived" {!cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
 
 module {
   cir.global "private" constant external @_ZTI4Base : !cir.ptr<!u32i>
@@ -1181,8 +1181,8 @@ module {
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!Base = !cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>}>
-!Derived = !cir.struct<struct "Derived" {!cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>}>}>
+!Base = !cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
+!Derived = !cir.struct<struct "Derived" {!cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
 
 module {
   cir.global "private" constant external @_ZTI4Base : !cir.ptr<!u8i>

--- a/clang/test/CIR/Lowering/ThroughMLIR/vtable.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/vtable.cir
@@ -13,9 +13,9 @@
 !ty_anon_struct2 = !cir.struct<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 4>}>
 !ty_anon_struct3 = !cir.struct<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 3>}>
 !ty_anon_struct4 = !cir.struct<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 4>, !cir.array<!cir.ptr<!cir.int<u, 8>> x 3>}>
-!ty_Father = !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>
-!ty_Mother = !cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>
-!ty_Child = !cir.struct<class "Child" {!cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>, !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<!cir.int<u, 32> ()>>>} #cir.record.decl.ast>} #cir.record.decl.ast>
+!ty_Father = !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>
+!ty_Mother = !cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>
+!ty_Child = !cir.struct<class "Child" {!cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>, !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>} #cir.record.decl.ast>
 
 module {
   cir.func linkonce_odr @_ZN6Mother6simpleEv(%arg0: !cir.ptr<!ty_Mother>) { 

--- a/clang/test/CIR/Lowering/call-op-call-conv.cir
+++ b/clang/test/CIR/Lowering/call-op-call-conv.cir
@@ -2,7 +2,7 @@
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
-!fnptr = !cir.ptr<!cir.func<!s32i (!s32i)>>
+!fnptr = !cir.ptr<!cir.func<(!s32i) -> !s32i>>
 
 module {
   cir.func private @my_add(%a: !s32i, %b: !s32i) -> !s32i cc(spir_function)

--- a/clang/test/CIR/Lowering/call.cir
+++ b/clang/test/CIR/Lowering/call.cir
@@ -38,11 +38,11 @@ module {
   }
 
   // check indirect call lowering
-  cir.global "private" external @fp : !cir.ptr<!cir.func<!s32i (!s32i)>>
+  cir.global "private" external @fp : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
   cir.func @callIndirect(%arg: !s32i) -> !s32i {
-    %fpp = cir.get_global @fp : !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i)>>>
-    %fp = cir.load %fpp : !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i)>>>, !cir.ptr<!cir.func<!s32i (!s32i)>>
-    %retval = cir.call %fp(%arg) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
+    %fpp = cir.get_global @fp : !cir.ptr<!cir.ptr<!cir.func<(!s32i) -> !s32i>>>
+    %fp = cir.load %fpp : !cir.ptr<!cir.ptr<!cir.func<(!s32i) -> !s32i>>>, !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+    %retval = cir.call %fp(%arg) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i
     cir.return %retval : !s32i
   }
 
@@ -77,12 +77,12 @@ module {
   // LLVM-NEXT:   ret i32 %1
 
   // check indirect vararg call lowering
-  cir.global "private" external @varargfp : !cir.ptr<!cir.func<!s32i (!s32i, ...)>>
+  cir.global "private" external @varargfp : !cir.ptr<!cir.func<(!s32i, ...) -> !s32i>>
   cir.func @varargCallIndirect() -> !s32i {
-    %fpp = cir.get_global @varargfp : !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i, ...)>>>
-    %fp = cir.load %fpp : !cir.ptr<!cir.ptr<!cir.func<!s32i (!s32i, ...)>>>, !cir.ptr<!cir.func<!s32i (!s32i, ...)>>
+    %fpp = cir.get_global @varargfp : !cir.ptr<!cir.ptr<!cir.func<(!s32i, ...) -> !s32i>>>
+    %fp = cir.load %fpp : !cir.ptr<!cir.ptr<!cir.func<(!s32i, ...) -> !s32i>>>, !cir.ptr<!cir.func<(!s32i, ...) -> !s32i>>
     %zero = cir.const #cir.int<0> : !s32i
-    %retval = cir.call %fp(%zero, %zero) : (!cir.ptr<!cir.func<!s32i (!s32i, ...)>>, !s32i, !s32i) -> !s32i
+    %retval = cir.call %fp(%zero, %zero) : (!cir.ptr<!cir.func<(!s32i, ...) -> !s32i>>, !s32i, !s32i) -> !s32i
     cir.return %retval : !s32i
   }
 

--- a/clang/test/CIR/Lowering/func.cir
+++ b/clang/test/CIR/Lowering/func.cir
@@ -6,11 +6,11 @@ module {
   cir.func no_proto private @noProto3(...) -> !s32i
   // MLIR: llvm.func @noProto3(...) -> i32
   cir.func @test3(%arg0: !s32i) {
-    %3 = cir.get_global @noProto3 : !cir.ptr<!cir.func<!s32i (...)>>
+    %3 = cir.get_global @noProto3 : !cir.ptr<!cir.func<(...) -> !s32i>>
     // MLIR: %[[#FN_PTR:]] = llvm.mlir.addressof @noProto3 : !llvm.ptr
-    %4 = cir.cast(bitcast, %3 : !cir.ptr<!cir.func<!s32i (...)>>), !cir.ptr<!cir.func<!s32i (!s32i)>>
+    %4 = cir.cast(bitcast, %3 : !cir.ptr<!cir.func<(...) -> !s32i>>), !cir.ptr<!cir.func<(!s32i) -> !s32i>>
     // MLIR: %[[#FUNC:]] = llvm.bitcast %[[#FN_PTR]] : !llvm.ptr to !llvm.ptr
-    %5 = cir.call %4(%arg0) : (!cir.ptr<!cir.func<!s32i (!s32i)>>, !s32i) -> !s32i
+    %5 = cir.call %4(%arg0) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i
     // MLIR: %{{.+}} = llvm.call %[[#FUNC]](%{{.+}}) : !llvm.ptr, (i32) -> i32
     cir.return
   }

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -15,7 +15,7 @@
 !ty_Bar = !cir.struct<struct "Bar" {!s32i, !s8i} #cir.record.decl.ast>
 !ty_StringStruct = !cir.struct<struct "StringStruct" {!cir.array<!s8i x 3>, !cir.array<!s8i x 3>, !cir.array<!s8i x 3>} #cir.record.decl.ast>
 !ty_StringStructPtr = !cir.struct<struct "StringStructPtr" {!cir.ptr<!s8i>} #cir.record.decl.ast>
-!ty_anon2E1_ = !cir.struct<struct "anon.1" {!cir.ptr<!cir.func<!cir.void (!cir.int<s, 32>)>>} #cir.record.decl.ast>
+!ty_anon2E1_ = !cir.struct<struct "anon.1" {!cir.ptr<!cir.func<(!cir.int<s, 32>)>>} #cir.record.decl.ast>
 
 module {
   cir.global external @a = #cir.int<3> : !s32i
@@ -164,7 +164,7 @@ module {
   // MLIR: }
   // LLVM: @undefStruct = global %struct.Bar undef
 
-  cir.global "private" internal @Handlers = #cir.const_array<[#cir.const_struct<{#cir.global_view<@myfun> : !cir.ptr<!cir.func<!void (!s32i)>>}> : !ty_anon2E1_]> : !cir.array<!ty_anon2E1_ x 1>
+  cir.global "private" internal @Handlers = #cir.const_array<[#cir.const_struct<{#cir.global_view<@myfun> : !cir.ptr<!cir.func<(!s32i)>>}> : !ty_anon2E1_]> : !cir.array<!ty_anon2E1_ x 1>
   cir.func internal private @myfun(%arg0: !s32i) {
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
@@ -179,10 +179,10 @@ module {
     %3 = cir.load %0 : !cir.ptr<!s32i>, !s32i
     %4 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!ty_anon2E1_ x 1>>), !cir.ptr<!ty_anon2E1_>
     %5 = cir.ptr_stride(%4 : !cir.ptr<!ty_anon2E1_>, %3 : !s32i), !cir.ptr<!ty_anon2E1_>
-    %6 = cir.get_member %5[0] {name = "func"} : !cir.ptr<!ty_anon2E1_> -> !cir.ptr<!cir.ptr<!cir.func<!void (!s32i)>>>
-    %7 = cir.load %6 : !cir.ptr<!cir.ptr<!cir.func<!void (!s32i)>>>, !cir.ptr<!cir.func<!void (!s32i)>>
+    %6 = cir.get_member %5[0] {name = "func"} : !cir.ptr<!ty_anon2E1_> -> !cir.ptr<!cir.ptr<!cir.func<(!s32i)>>>
+    %7 = cir.load %6 : !cir.ptr<!cir.ptr<!cir.func<(!s32i)>>>, !cir.ptr<!cir.func<(!s32i)>>
     %8 = cir.load %1 : !cir.ptr<!s32i>, !s32i
-    cir.call %7(%8) : (!cir.ptr<!cir.func<!void (!s32i)>>, !s32i) -> ()
+    cir.call %7(%8) : (!cir.ptr<!cir.func<(!s32i)>>, !s32i) -> ()
     cir.return
   }
   //MLIR-LABEL: @foo

--- a/clang/test/CIR/Lowering/hello.cir
+++ b/clang/test/CIR/Lowering/hello.cir
@@ -8,7 +8,7 @@ module @"/tmp/test.raw" attributes {cir.lang = #cir.lang<c>, cir.sob = #cir.sign
   cir.global "private" constant internal @".str" = #cir.const_array<"Hello, world!\0A\00" : !cir.array<!s8i x 15>> : !cir.array<!s8i x 15> {alignment = 1 : i64}
   cir.func @main() -> !s32i {
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
-    %1 = cir.get_global @printf : !cir.ptr<!cir.func<!s32i (!cir.ptr<!s8i>, ...)>>
+    %1 = cir.get_global @printf : !cir.ptr<!cir.func<(!cir.ptr<!s8i>, ...) -> !s32i>>
     %2 = cir.get_global @".str" : !cir.ptr<!cir.array<!s8i x 15>>
     %3 = cir.cast(array_to_ptrdecay, %2 : !cir.ptr<!cir.array<!s8i x 15>>), !cir.ptr<!s8i>
     %4 = cir.call @printf(%3) : (!cir.ptr<!s8i>) -> !s32i


### PR DESCRIPTION
Change the assembly format for `cir::FuncType` from
```
!cir.func<!returnType (!argType)>
```
to
```
!cir.func<(!argType) -> !returnType>
```

This change (1) is easier to parse because it doesn't require lookahead, (2) is consistent with the format of ClangIR `FuncOp` assembly, and (3) is consistent with function types in other MLIR dialects.

Change all the tests to use or to expect the new format for function types.

The contents and the semantics of `cir::FuncType` are unchanged.  Only the assembly format is being changed.  Functions that return `void` in C or C++ are still represented in MLIR as having no return type.

Most of the changes are in `parseFuncType` and `printFuncType` and the functions they call in `CIRTypes.cpp`.

A `FuncType::verify` function was added to check that an explicit return type is not `cir::VoidType`.

`FuncType::isVoid()` was renamed to `FuncType::hasVoidReturn()`

Some comments for `FuncType` were improved.

An `llvm_unreachable` was added to `StructType::getKindAsStr` to suppress a compiler warning and to catch a memory error that corrupts the `RecordKind` field.  (This was a drive-by fix and has nothing to do with the rest of this change.)