### PR TITLE
[CIR][CodeGen] Support return in TryOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -684,7 +684,8 @@ def StoreOp : CIR_Op<"store", [
 
 def ReturnOp : CIR_Op<"return", [ParentOneOf<["FuncOp", "ScopeOp", "IfOp",
                                               "SwitchOp", "DoWhileOp",
-                                              "WhileOp", "ForOp", "CaseOp"]>,
+                                              "WhileOp", "ForOp", "CaseOp",
+                                              "TryOp"]>,
                                  Terminator]> {
   let summary = "Return from function";
   let description = [{

--- a/clang/test/CIR/CodeGen/try-catch.cpp
+++ b/clang/test/CIR/CodeGen/try-catch.cpp
@@ -128,3 +128,24 @@ void tc5() {
 // CHECK:  cir.call exception @_Z3tc5v() : () -> ()
 // CHECK:  cir.yield
 // CHECK: }]
+
+// CHECK: cir.func @_Z3tc6v()
+void tc6() {
+  int r = 1;
+  try {
+    return;
+    ++r;
+  } catch (...) {
+  }
+}
+
+// CHECK: cir.scope {
+// CHECK:   cir.try {
+// CHECK:     cir.return
+// CHECK:   ^bb1:  // no predecessors
+// CHECK:     %[[V2:.*]] = cir.load {{.*}} : !cir.ptr<!s32i>, !s32i
+// CHECK:     %[[V3:.*]] = cir.unary(inc, %[[V2]]) : !s32i, !s32i
+// CHECK:     cir.store %[[V3]], {{.*}} : !s32i, !cir.ptr<!s32i>
+// CHECK:     cir.yield
+// CHECK:   }
+// CHECK: }


### PR DESCRIPTION
This PR adds support for returns inside of a TryOp, for example: 

```
void foo() {
  int r = 1;
  try {
    return;
    ++r;
  } catch (...) {
  }
}
```
Currently, it fails during the CodeGen with: 
```
error: 'cir.return' op expects parent op to be one of 'cir.func, cir.scope, cir.if, cir.switch, cir.do, cir.while, cir.for, cir.case'
```
were TryOp's omitted on purpose? 