### PR TITLE
[CIR][CodeGen] Always emit EHResumeBlock in place

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -284,9 +284,6 @@ void CIRGenFunction::emitEHResumeBlock(bool isCleanup,
 
 mlir::Block *CIRGenFunction::getEHResumeBlock(bool isCleanup,
                                               cir::TryOp tryOp) {
-
-  if (ehResumeBlock)
-    return ehResumeBlock;
   // Setup unwind.
   assert(tryOp && "expected available cir.try");
   ehResumeBlock = tryOp.getCatchUnwindEntryBlock();

--- a/clang/test/CIR/CodeGen/string.cpp
+++ b/clang/test/CIR/CodeGen/string.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -std=c++20 -target x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang++ -std=c++20 -target x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include <iostream>

--- a/clang/test/CIR/CodeGen/string.cpp
+++ b/clang/test/CIR/CodeGen/string.cpp
@@ -1,46 +1,34 @@
 // RUN: %clang++ -std=c++20 -target x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-#include <iostream>
 #include <string>
 
 void foo(const char *path) {
   std::string foo = path;
-  std::cout << foo;
+  for (auto ch : foo)
+    putchar(ch);
 }
 
-// CHECK:      cir.func @_Z3fooPKc(%arg0: !cir.ptr<!s8i>
-// CHECK-NEXT:   %[[V0:.*]] = cir.alloca !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>, ["path", init] {alignment = 8 : i64}
-// CHECK-NEXT:   %[[V1:.*]] = cir.alloca !ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E, !cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>, ["foo", init] {alignment = 8 : i64}
-// CHECK-NEXT:   %[[V2:.*]] = cir.alloca !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>, !cir.ptr<!cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>>, ["tmp.try.call.res"] {alignment = 8 : i64}
-// CHECK-NEXT:   cir.store %arg0, %[[V0]] : !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
-// CHECK-NEXT:   cir.scope {
-// CHECK-NEXT:     %[[V5:.*]] = cir.alloca !ty_std3A3Aallocator3Cchar3E, !cir.ptr<!ty_std3A3Aallocator3Cchar3E>, ["ref.tmp0"] {alignment = 1 : i64}
-// CHECK-NEXT:     %[[V6:.*]] = cir.load %[[V0]] : !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!s8i>
-// CHECK-NEXT:     cir.call @_ZNSaIcEC1Ev(%[[V5]]) : (!cir.ptr<!ty_std3A3Aallocator3Cchar3E>) -> ()
-// CHECK-NEXT:     cir.try synthetic cleanup {
-// CHECK-NEXT:       cir.call exception @_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEPKcRKS3_(%[[V1]], %[[V6]], %[[V5]]) : (!cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>, !cir.ptr<!s8i>, !cir.ptr<!ty_std3A3Aallocator3Cchar3E>) -> () cleanup {
-// CHECK-NEXT:         cir.call @_ZNSaIcED1Ev(%[[V5]]) : (!cir.ptr<!ty_std3A3Aallocator3Cchar3E>) -> ()
-// CHECK-NEXT:         cir.yield
-// CHECK-NEXT:       }
-// CHECK-NEXT:       cir.yield
-// CHECK-NEXT:     } catch [#cir.unwind {
-// CHECK-NEXT:       cir.resume
-// CHECK-NEXT:     }]
-// CHECK-NEXT:     cir.call @_ZNSaIcED1Ev(%[[V5]]) : (!cir.ptr<!ty_std3A3Aallocator3Cchar3E>) -> ()
-// CHECK-NEXT:   }
-// CHECK-NEXT:   %[[V3:.*]] = cir.get_global @_ZSt4cout : !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>
+// CHECK:      cir.for : cond {
+// CHECK-NEXT:   %[[V11:.*]] = cir.call @_ZN9__gnu_cxxeqIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEbRKNS_17__normal_iteratorIT_T0_EESD_QrqXeqcldtfp_4baseEcldtfp0_4baseERSt14convertible_toIbEE({{.*}}, {{.*}}) : (!cir.ptr<!ty___gnu_cxx3A3A__normal_iterator3Cchar_2A2C_std3A3A__cxx113A3Abasic_string3Cchar3E3E>, !cir.ptr<!ty___gnu_cxx3A3A__normal_iterator3Cchar_2A2C_std3A3A__cxx113A3Abasic_string3Cchar3E3E>) -> !cir.bool
+// CHECK-NEXT:   %[[V12:.*]] = cir.unary(not, {{.*}}) : !cir.bool, !cir.bool
+// CHECK-NEXT:   cir.condition(%[[V12]])
+// CHECK-NEXT: } body {
+// CHECK-NEXT:   %[[V11:.*]] = cir.call @_ZNK9__gnu_cxx17__normal_iteratorIPcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEdeEv({{.*}}) : (!cir.ptr<!ty___gnu_cxx3A3A__normal_iterator3Cchar_2A2C_std3A3A__cxx113A3Abasic_string3Cchar3E3E>) -> !cir.ptr<!s8i>
+// CHECK-NEXT:   %[[V12:.*]] = cir.load %[[V11]] : !cir.ptr<!s8i>, !s8i
+// CHECK-NEXT:   cir.store %[[V12]], {{.*}} : !s8i, !cir.ptr<!s8i>
+// CHECK-NEXT:   %[[V13:.*]] = cir.load {{.*}} : !cir.ptr<!s8i>, !s8i
+// CHECK-NEXT:   %[[V14:.*]] = cir.cast(integral, %[[V13]] : !s8i), !s32i
 // CHECK-NEXT:   cir.try synthetic cleanup {
-// CHECK-NEXT:     %[[V5:.*]] = cir.call exception @_ZStlsIcSt11char_traitsIcESaIcEERSt13basic_ostreamIT_T0_ES7_RKNSt7__cxx1112basic_stringIS4_S5_T1_EE(%[[V3]], %[[V1]]) : (!cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>, !cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>) -> !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E> cleanup {
-// CHECK-NEXT:       cir.call @_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev(%[[V1]]) : (!cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>) -> ()
+// CHECK-NEXT:     %[[V16:.*]] = cir.call exception @putchar(%[[V14]]) : (!s32i) -> !s32i cleanup {
+// CHECK-NEXT:       cir.call @_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev({{.*}}) : (!cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>) -> ()
 // CHECK-NEXT:       cir.yield
 // CHECK-NEXT:     }
-// CHECK-NEXT:     cir.store %[[V5]], %[[V2]] : !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>, !cir.ptr<!cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>>
+// CHECK-NEXT:     cir.store %[[V16]], {{.*}} : !s32i, !cir.ptr<!s32i>
 // CHECK-NEXT:     cir.yield
 // CHECK-NEXT:   } catch [#cir.unwind {
 // CHECK-NEXT:     cir.resume
 // CHECK-NEXT:   }]
-// CHECK-NEXT:   %[[V4:.*]] = cir.load %[[V2]] : !cir.ptr<!cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>>, !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>
-// CHECK-NEXT:   cir.call @_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev(%[[V1]]) : (!cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>) -> ()
-// CHECK-NEXT:   cir.return
+// CHECK-NEXT:   %[[V15:.*]] = cir.load {{.*}} : !cir.ptr<!s32i>, !s32i
+// CHECK-NEXT:   cir.yield
 // CHECK-NEXT: }

--- a/clang/test/CIR/CodeGen/string.cpp
+++ b/clang/test/CIR/CodeGen/string.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang++ -std=c++20 -target x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang -std=c++20 -target x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include <string>

--- a/clang/test/CIR/CodeGen/string.cpp
+++ b/clang/test/CIR/CodeGen/string.cpp
@@ -1,0 +1,46 @@
+// RUN: %clang -std=c++20 -target x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+#include <iostream>
+#include <string>
+
+void foo(const char *path) {
+  std::string foo = path;
+  std::cout << foo;
+}
+
+// CHECK:      cir.func @_Z3fooPKc(%arg0: !cir.ptr<!s8i>
+// CHECK-NEXT:   %[[V0:.*]] = cir.alloca !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>, ["path", init] {alignment = 8 : i64}
+// CHECK-NEXT:   %[[V1:.*]] = cir.alloca !ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E, !cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>, ["foo", init] {alignment = 8 : i64}
+// CHECK-NEXT:   %[[V2:.*]] = cir.alloca !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>, !cir.ptr<!cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>>, ["tmp.try.call.res"] {alignment = 8 : i64}
+// CHECK-NEXT:   cir.store %arg0, %[[V0]] : !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
+// CHECK-NEXT:   cir.scope {
+// CHECK-NEXT:     %[[V5:.*]] = cir.alloca !ty_std3A3Aallocator3Cchar3E, !cir.ptr<!ty_std3A3Aallocator3Cchar3E>, ["ref.tmp0"] {alignment = 1 : i64}
+// CHECK-NEXT:     %[[V6:.*]] = cir.load %[[V0]] : !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!s8i>
+// CHECK-NEXT:     cir.call @_ZNSaIcEC1Ev(%[[V5]]) : (!cir.ptr<!ty_std3A3Aallocator3Cchar3E>) -> ()
+// CHECK-NEXT:     cir.try synthetic cleanup {
+// CHECK-NEXT:       cir.call exception @_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2IS3_EEPKcRKS3_(%[[V1]], %[[V6]], %[[V5]]) : (!cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>, !cir.ptr<!s8i>, !cir.ptr<!ty_std3A3Aallocator3Cchar3E>) -> () cleanup {
+// CHECK-NEXT:         cir.call @_ZNSaIcED1Ev(%[[V5]]) : (!cir.ptr<!ty_std3A3Aallocator3Cchar3E>) -> ()
+// CHECK-NEXT:         cir.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       cir.yield
+// CHECK-NEXT:     } catch [#cir.unwind {
+// CHECK-NEXT:       cir.resume
+// CHECK-NEXT:     }]
+// CHECK-NEXT:     cir.call @_ZNSaIcED1Ev(%[[V5]]) : (!cir.ptr<!ty_std3A3Aallocator3Cchar3E>) -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   %[[V3:.*]] = cir.get_global @_ZSt4cout : !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>
+// CHECK-NEXT:   cir.try synthetic cleanup {
+// CHECK-NEXT:     %[[V5:.*]] = cir.call exception @_ZStlsIcSt11char_traitsIcESaIcEERSt13basic_ostreamIT_T0_ES7_RKNSt7__cxx1112basic_stringIS4_S5_T1_EE(%[[V3]], %[[V1]]) : (!cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>, !cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>) -> !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E> cleanup {
+// CHECK-NEXT:       cir.call @_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev(%[[V1]]) : (!cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>) -> ()
+// CHECK-NEXT:       cir.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     cir.store %[[V5]], %[[V2]] : !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>, !cir.ptr<!cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>>
+// CHECK-NEXT:     cir.yield
+// CHECK-NEXT:   } catch [#cir.unwind {
+// CHECK-NEXT:     cir.resume
+// CHECK-NEXT:   }]
+// CHECK-NEXT:   %[[V4:.*]] = cir.load %[[V2]] : !cir.ptr<!cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>>, !cir.ptr<!ty_std3A3Abasic_ostream3Cchar2C_std3A3Achar_traits3Cchar3E3E>
+// CHECK-NEXT:   cir.call @_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev(%[[V1]]) : (!cir.ptr<!ty_std3A3A__cxx113A3Abasic_string3Cchar2C_std3A3Achar_traits3Cchar3E2C_std3A3Aallocator3Cchar3E3E>) -> ()
+// CHECK-NEXT:   cir.return
+// CHECK-NEXT: }


### PR DESCRIPTION
Currently, CIR tries to [mimic](https://github.com/llvm/clangir/blob/aff6245c9ea82b5034dd8021a610d9f067a96200/clang/lib/CIR/CodeGen/CIRGenException.cpp#L288) the [original Codegen](https://github.com/llvm/clangir/blob/aff6245c9ea82b5034dd8021a610d9f067a96200/clang/lib/CodeGen/CGException.cpp#L1626):- if there is an existing resume block, we return this block. This doesn't work. 

In the original CodeGen, after we return this `ehResumeBlock`, we branch to it, but currently in CIR we do not perform branch operations for these blocks, [comment for reference](https://github.com/llvm/clangir/blob/aff6245c9ea82b5034dd8021a610d9f067a96200/clang/lib/CIR/CodeGen/CIRGenException.cpp#L739): 

So, basically we are not using the returned `ehResumeBlock`, and this causes and error. For example this case fails during CodeGen: 
```
#include <iostream>
#include <string>

void foo(const char *path) {
  std::string foo = path;
  std::cout << foo;
}
```
with 
```
error: empty block: expect at least a terminator
```
the relevant part of the module before verification with the error looks like: 
```
"cir.try"() <{catch_types = [#cir.unwind], cleanup, synthetic}> ({
  %119 = "cir.call"(%117, %115) <{ast = #cir.call.expr.ast, callee = @_ZStlsIcSt11char_traitsIcESaIcEERSt13basic_ostreamIT_T0_ES7_RKNSt7__cxx1112basic_stringIS4_S5_T1_EE, calling_conv = 1 : i32, exception, extra_attrs = #cir<extra({})>, side_effect = 1 : i32}> ({
    "cir.call"(%115) <{callee = @_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev, calling_conv = 1 : i32, extra_attrs = #cir<extra({nothrow = #cir.nothrow})>, side_effect = 1 : i32}> ({
    }) : (!cir.ptr<!cir.struct<class "std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>" {!cir.struct<struct "std::__cxx11::basic_string<char>::_Alloc_hider" {!cir.ptr<!cir.int<s, 8>>} #cir.record.decl.ast>, !cir.int<u, 64>, !cir.struct<union "anon.0" padded {!cir.array<!cir.int<s, 8> x 16>, !cir.int<u, 64>, !cir.array<!cir.int<u, 8> x 8>} #cir.record.decl.ast>} #cir.record.decl.ast>>) -> ()
    "cir.yield"() : () -> ()
  })  
  "cir.store"(%119, %116) 
  "cir.yield"() : () -> ()
}, {
^bb0:
}) : () -> ()
```
The block is empty, because we only returned `ehResumeBlock`, and did not populate the block.

My suggestion is to always emit a resume block and not try to reuse resume blocks in CIR. This PR adds this. 