### PR TITLE
[CIR] Simple casts on pointers to member functions

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -548,6 +548,11 @@ LogicalResult cir::CastOp::verify() {
         mlir::isa<cir::DataMemberType>(resType))
       return success();
 
+    // Handle the pointer to member function types.
+    if (mlir::isa<cir::MethodType>(srcType) &&
+        mlir::isa<cir::MethodType>(resType))
+      return success();
+
     // This is the only cast kind where we don't want vector types to decay
     // into the element type.
     if ((!mlir::isa<cir::VectorType>(getSrc().getType()) ||
@@ -724,8 +729,9 @@ LogicalResult cir::CastOp::verify() {
     return success();
   }
   case cir::CastKind::member_ptr_to_bool: {
-    if (!mlir::isa<cir::DataMemberType>(srcType))
-      return emitOpError() << "requires !cir.data_member type for source";
+    if (!mlir::isa<cir::DataMemberType, cir::MethodType>(srcType))
+      return emitOpError()
+             << "requires !cir.data_member or !cir.method type for source";
     if (!mlir::isa<cir::BoolType>(resType))
       return emitOpError() << "requires !cir.bool type for result";
     return success();

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -134,6 +134,15 @@ public:
   virtual mlir::Value
   lowerDataMemberToBoolCast(cir::CastOp op, mlir::Value loweredSrc,
                             mlir::OpBuilder &builder) const = 0;
+
+  virtual mlir::Value lowerMethodBitcast(cir::CastOp op,
+                                         mlir::Type loweredDstTy,
+                                         mlir::Value loweredSrc,
+                                         mlir::OpBuilder &builder) const = 0;
+
+  virtual mlir::Value lowerMethodToBoolCast(cir::CastOp op,
+                                            mlir::Value loweredSrc,
+                                            mlir::OpBuilder &builder) const = 0;
 };
 
 /// Creates an Itanium-family ABI.


### PR DESCRIPTION
This patch adds support for simple cast operations on pointers to member functions, including: 1) casting pointers to member function values to boolean values; 2) reinterpret casts between pointers to member functions.