### PR TITLE
[CIR] clang-tidy CIRGenFunction.cpp

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -849,8 +849,8 @@ public:
   /// in non-variably-sized elements, of a variable length array type,
   /// plus that largest non-variably-sized element type.  Assumes that
   /// the type has already been emitted with emitVariablyModifiedType.
-  VlaSizePair getVLASize(const VariableArrayType *vla);
-  VlaSizePair getVLASize(QualType vla);
+  VlaSizePair getVLASize(const VariableArrayType *type);
+  VlaSizePair getVLASize(QualType type);
 
   mlir::Value emitBuiltinObjectSize(const Expr *E, unsigned Type,
                                     cir::IntType ResType, mlir::Value EmittedE,


### PR DESCRIPTION
Run clang-tidy on `CIRGenFunction.cpp` and fix all the issues that were identified.  The vast majority of issues were the case of parameter and variable names.  Some of the issues that didn't have to do with names had to be resolved manually.

There should be no behavior changes.