### PR TITLE
[CIR][ThroughMLIR] remove nested memref wrapper for array types

### DIFF
--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -173,7 +173,14 @@ public:
     if (!mlirType)
       return mlir::LogicalResult::failure();
 
-    auto memreftype = mlir::MemRefType::get({}, mlirType);
+    auto memreftype = mlir::dyn_cast<mlir::MemRefType>(mlirType);
+    if (memreftype && mlir::isa<cir::ArrayType>(adaptor.getAllocaType())) {
+      // if the type is an array,
+      // we don't need to wrap with memref.
+    } else {
+      memreftype = mlir::MemRefType::get({}, mlirType);
+    }
+
     rewriter.replaceOpWithNewOp<mlir::memref::AllocaOp>(op, memreftype,
                                                         op.getAlignmentAttr());
     return mlir::LogicalResult::success();

--- a/clang/test/CIR/Lowering/ThroughMLIR/array.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/array.c
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir %s -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s --check-prefix=MLIR
+
+int test_array1() {
+    // CIR-LABEL: cir.func {{.*}} @test_array1
+    // CIR: %[[ARRAY:.*]] = cir.alloca !cir.array<!s32i x 3>, !cir.ptr<!cir.array<!s32i x 3>>, ["a"] {alignment = 4 : i64}
+    // CIR: %{{.*}} = cir.cast(array_to_ptrdecay, %[[ARRAY]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+
+    // MLIR-LABEL: func @test_array1
+    // MLIR: %{{.*}} = memref.alloca() {alignment = 4 : i64} : memref<i32>
+    // MLIR: %[[ARRAY:.*]] = memref.alloca() {alignment = 4 : i64} : memref<3xi32>
+    // MLIR: %{{.*}} = memref.load %[[ARRAY]][%{{.*}}] : memref<3xi32>
+    int a[3];
+    return a[1]; 
+}
+
+int test_array2() {
+    // CIR-LABEL: cir.func {{.*}} @test_array2
+    // CIR: %[[ARRAY:.*]] = cir.alloca !cir.array<!cir.array<!s32i x 4> x 3>, !cir.ptr<!cir.array<!cir.array<!s32i x 4> x 3>>, ["a"] {alignment = 16 : i64}
+    // CIR: %{{.*}} = cir.cast(array_to_ptrdecay, %[[ARRAY]] : !cir.ptr<!cir.array<!cir.array<!s32i x 4> x 3>>), !cir.ptr<!cir.array<!s32i x 4>>
+    // CIR: %{{.*}} = cir.cast(array_to_ptrdecay, %{{.*}} : !cir.ptr<!cir.array<!s32i x 4>>), !cir.ptr<!s32i>
+
+    // MLIR-LABEL: func @test_array2
+    // MLIR: %{{.*}} = memref.alloca() {alignment = 4 : i64} : memref<i32>
+    // MLIR: %[[ARRAY:.*]] = memref.alloca() {alignment = 16 : i64} : memref<3x4xi32>
+    // MLIR: %{{.*}} = memref.load %[[ARRAY]][%{{.*}}, %{{.*}}] : memref<3x4xi32>
+    int a[3][4];
+    return a[1][2]; 
+}

--- a/clang/test/CIR/Lowering/ThroughMLIR/array.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/array.cir
@@ -11,7 +11,7 @@ module {
 
 // CHECK: module {
 // CHECK: func @foo() {
-// CHECK:    = memref.alloca() {alignment = 16 : i64} : memref<memref<10xi32>>
+// CHECK:    = memref.alloca() {alignment = 16 : i64} : memref<10xi32>
 // CHECK:    return
 // CHECK:  }
 // CHECK: }


### PR DESCRIPTION
for example, lower 
`cir.alloca !cir.array<!s32i x N>, !cir.ptr<!cir.array<!s32i x N>>` 
to `memref.alloca() : memref<Nxi32>`

see https://github.com/llvm/clangir/issues/1405