### PR TITLE
[CIR] Simplify FuncType printer/parser

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -387,11 +387,11 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
   }];
 
   let parameters = (ins ArrayRefParameter<"mlir::Type">:$inputs,
-                        "mlir::Type":$optionalReturnType,
+                        OptionalParameter<"mlir::Type">:$optionalReturnType,
                         "bool":$varArg);
-  // Use a custom parser to handle the optional return and argument types
+  // Use a custom parser to handle argument types with variadic elipsis.
   let assemblyFormat = [{
-    `<` custom<FuncType>($optionalReturnType, $inputs, $varArg) `>`
+    `<` custom<FuncTypeParams>($inputs, $varArg)  (`->` $optionalReturnType^)? `>`
   }];
 
   let builders = [

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -42,13 +42,13 @@ using cir::MissingFeatures;
 // CIR Custom Parser/Printer Signatures
 //===----------------------------------------------------------------------===//
 
-static mlir::ParseResult parseFuncType(mlir::AsmParser &p,
-                                       mlir::Type &optionalReturnTypes,
-                                       llvm::SmallVector<mlir::Type> &params,
-                                       bool &isVarArg);
+static mlir::ParseResult
+parseFuncTypeParams(mlir::AsmParser &p, llvm::SmallVector<mlir::Type> &params,
+                    bool &isVarArg);
 
-static void printFuncType(mlir::AsmPrinter &p, mlir::Type optionalReturnTypes,
-                          mlir::ArrayRef<mlir::Type> params, bool isVarArg);
+static void printFuncTypeParams(mlir::AsmPrinter &p,
+                                mlir::ArrayRef<mlir::Type> params,
+                                bool isVarArg);
 static mlir::ParseResult parsePointerAddrSpace(mlir::AsmParser &p,
                                                mlir::Attribute &addrSpaceAttr);
 static void printPointerAddrSpace(mlir::AsmPrinter &p,
@@ -933,54 +933,31 @@ FuncType FuncType::clone(TypeRange inputs, TypeRange results) const {
   return get(llvm::to_vector(inputs), results[0], isVarArg());
 }
 
-// A special parser is needed for function returning void to handle the missing
-// type.
-static mlir::ParseResult parseFuncTypeReturn(mlir::AsmParser &p,
-                                             mlir::Type &optionalReturnType) {
-  if (succeeded(p.parseOptionalArrow())) {
-    // `->` found. It must be followed by the return type.
-    return p.parseType(optionalReturnType);
-  }
-  // Function has `void` return in C++, no return in MLIR.
-  optionalReturnType = {};
-  return success();
-}
-
-// A special pretty-printer for function returning or not a result.
-static void printFuncTypeReturn(mlir::AsmPrinter &p,
-                                mlir::Type optionalReturnType) {
-  if (optionalReturnType)
-    p << " -> " << optionalReturnType;
-}
-
+// Custom parser that parses function parameters of form `(<type>*, ...)`.
 static mlir::ParseResult
-parseFuncTypeArgs(mlir::AsmParser &p, llvm::SmallVector<mlir::Type> &params,
-                  bool &isVarArg) {
+parseFuncTypeParams(mlir::AsmParser &p, llvm::SmallVector<mlir::Type> &params,
+                    bool &isVarArg) {
   isVarArg = false;
-  if (failed(p.parseLParen()))
-    return failure();
-  if (succeeded(p.parseOptionalRParen())) {
-    // `()` empty argument list
-    return mlir::success();
-  }
-  do {
-    if (succeeded(p.parseOptionalEllipsis())) {
-      // `...`, which must be the last thing in the list.
-      isVarArg = true;
-      break;
-    } else {
-      mlir::Type argType;
-      if (failed(p.parseType(argType)))
-        return failure();
-      params.push_back(argType);
-    }
-  } while (succeeded(p.parseOptionalComma()));
-  return p.parseRParen();
+  return p.parseCommaSeparatedList(
+      AsmParser::Delimiter::Paren, [&]() -> mlir::ParseResult {
+        if (isVarArg)
+          return p.emitError(p.getCurrentLocation(),
+                             "variadic `...` must be the last parameter");
+        if (succeeded(p.parseOptionalEllipsis())) {
+          isVarArg = true;
+          return success();
+        }
+        mlir::Type type;
+        if (failed(p.parseType(type)))
+          return failure();
+        params.push_back(type);
+        return success();
+      });
 }
 
-static void printFuncTypeArgs(mlir::AsmPrinter &p,
-                              mlir::ArrayRef<mlir::Type> params,
-                              bool isVarArg) {
+static void printFuncTypeParams(mlir::AsmPrinter &p,
+                                mlir::ArrayRef<mlir::Type> params,
+                                bool isVarArg) {
   p << '(';
   llvm::interleaveComma(params, p,
                         [&p](mlir::Type type) { p.printType(type); });
@@ -990,23 +967,6 @@ static void printFuncTypeArgs(mlir::AsmPrinter &p,
     p << "...";
   }
   p << ')';
-}
-
-// Use a custom parser to handle the optional return and argument types without
-// an optional anchor.
-static mlir::ParseResult parseFuncType(mlir::AsmParser &p,
-                                       mlir::Type &optionalReturnType,
-                                       llvm::SmallVector<mlir::Type> &params,
-                                       bool &isVarArg) {
-  if (failed(parseFuncTypeArgs(p, params, isVarArg)))
-    return failure();
-  return parseFuncTypeReturn(p, optionalReturnType);
-}
-
-static void printFuncType(mlir::AsmPrinter &p, mlir::Type optionalReturnType,
-                          mlir::ArrayRef<mlir::Type> params, bool isVarArg) {
-  printFuncTypeArgs(p, params, isVarArg);
-  printFuncTypeReturn(p, optionalReturnType);
 }
 
 /// Get the C-style return type of the function, which is !cir.void if the

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1500,3 +1500,11 @@ cir.func @cast0(%arg0: !s32i, %arg1: !s32i) {
 // expected-error @below {{!cir.func cannot have an explicit 'void' return type}}
 // expected-error @below {{failed to parse CIR_PointerType parameter}}
 cir.global external dsolocal @vfp = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i) -> !cir.void>>
+
+// -----
+
+// Verify that variadic functions do not allow an ellipsis anywhere except at
+// the end of the parameter list.
+
+// expected-error @below {{variadic `...` must be the last parameter}}
+!fty = !cir.func<(..., !s32i)>


### PR DESCRIPTION
This uses the assembly format for the optional return type and keeps a custom printer/parser only for function parameters, which still require a custom form for ellipses.