### PR TITLE
[CIR] Delete `FuncOp::verifyType`

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3597,12 +3597,6 @@ def FuncOp : CIR_Op<"func", [
        return getFunctionType().getReturnTypes();
     }
 
-    /// Hook for OpTrait::FunctionOpInterfaceTrait, called after verifying that
-    /// the 'type' attribute is present and checks if it holds a function type.
-    /// Ensures getType, getNumFuncArguments, and getNumFuncResults can be
-    /// called safely.
-    llvm::LogicalResult verifyType();
-
     //===------------------------------------------------------------------===//
     // SymbolOpInterface Methods
     //===------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2588,25 +2588,6 @@ void cir::FuncOp::print(OpAsmPrinter &p) {
   }
 }
 
-// Hook for OpTrait::FunctionLike, called after verifying that the 'type'
-// attribute is present.  This can check for preconditions of the
-// getNumArguments hook not failing.
-LogicalResult cir::FuncOp::verifyType() {
-  auto type = getFunctionType();
-  if (!isa<cir::FuncType>(type))
-    return emitOpError("requires '" + getFunctionTypeAttrName().str() +
-                       "' attribute of function type");
-  if (!getNoProto() && type.isVarArg() && type.getNumInputs() == 0)
-    return emitError()
-           << "prototyped function must have at least one non-variadic input";
-  if (auto rt = type.getReturnTypes();
-      !rt.empty() && mlir::isa<cir::VoidType>(rt.front()))
-    return emitOpError("The return type for a function returning void should "
-                       "be empty instead of an explicit !cir.void");
-
-  return success();
-}
-
 // Verifies linkage types
 // - functions don't have 'common' linkage
 // - external functions have 'external' or 'extern_weak' linkage

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -624,13 +624,6 @@ module {
 // -----
 
 module {
-  // expected-error@+1 {{prototyped function must have at least one non-variadic input}}
-  cir.func private @variadic(...) -> !cir.int<s, 32>
-}
-
-// -----
-
-module {
   // expected-error@+1 {{custom op 'cir.func' variadic arguments must be in the end of the argument list}}
   cir.func @variadic(..., !cir.int<s, 32>) -> !cir.int<s, 32>
 }


### PR DESCRIPTION
Get rid of the function `FuncOp::verifyType`.  The function performed three checks:

1. Check that `isa<cir::FuncType>(getFunctionType())`.  This is a tautology that is always true, since the return type of `getFunctionType()` is already `cir::FuncType`.

2. Report an error if `type.isVarArg() && type.getNumInputs() == 0`, i.e. when a variadic function has no named parameters.  That check is incorrect.  In C++, variadic functions don't need to have any named parameters.  `void f(...) { }` is legal in C++ and ClangIR needs to be able to compile it.

3. Report an error when the return type is `void`.  This check is correct (`void` return is represented as no return in MLIR), but it is redundant.  This is already checked in `FuncType::verify`.

Since `FuncOp::verifyType` serves no useful purpose, delete it, along with the test for `int variadic(...)` that was in
`clang/test/CIR/IR/invalid.cir`.