### PR TITLE
[CIR][CUDA] Fix destructor behaviour

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -373,9 +373,9 @@ bool CIRGenModule::MayBeEmittedEagerly(const ValueDecl *global) {
   if (fd) {
     // Implicit template instantiations may change linkage if they are later
     // explicitly instantiated, so they should not be emitted eagerly.
-    // TODO(cir): do we care?
-    assert(fd->getTemplateSpecializationKind() != TSK_ImplicitInstantiation &&
-           "not implemented");
+    if (fd->getTemplateSpecializationKind() == TSK_ImplicitInstantiation)
+      return false;
+
     assert(!fd->isTemplated() && "Templates NYI");
   }
   const auto *vd = dyn_cast<VarDecl>(global);

--- a/clang/test/CIR/CodeGen/CUDA/destructor.cu
+++ b/clang/test/CIR/CodeGen/CUDA/destructor.cu
@@ -1,0 +1,27 @@
+#include "../Inputs/cuda.h"
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:            -x cuda -emit-cir -target-sdk-version=12.3 \
+// RUN:            %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR-HOST --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -fclangir \
+// RUN:            -fcuda-is-device -emit-cir -target-sdk-version=12.3 \
+// RUN:            %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR-DEVICE --input-file=%t.cir %s
+
+// Make sure we do emit device-side kernel even if it's only referenced
+// by the destructor of a variable not present on device.
+template<typename T> __global__ void f(T) {}
+template<typename T> struct A {
+  ~A() { f<<<1, 1>>>(T()); }
+};
+
+// CIR-DEVICE: cir.func @_Z1fIiEvT_
+
+// CIR-HOST: cir.func {{.*}} @_ZN1AIiED2Ev{{.*}} {
+// CIR-HOST:   cir.call @__cudaPushCallConfiguration
+// CIR-HOST:   cir.call @_Z16__device_stub__fIiEvT_
+// CIR-HOST: }
+
+A<int> a;


### PR DESCRIPTION
CIR didn't work on structs with destructor but without constructor. Now it is fixed.

Moreover, CUDA kernels must be emitted if it was referred to in the destructor of a non-device variable. It seems already working, so I just unblocked the code path.