### PR TITLE
[CIR] Clean up and complete CIRGlobalValueInterface methods

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2482,15 +2482,6 @@ def GlobalOp : CIR_Op<"global",
       return !getInitialValue() && getCtorRegion().empty() && getDtorRegion().empty();
     }
     bool hasInitializer() { return !isDeclaration(); }
-    bool hasAvailableExternallyLinkage() {
-      return cir::isAvailableExternallyLinkage(getLinkage());
-    }
-    bool hasInternalLinkage() {
-      return cir::isInternalLinkage(getLinkage());
-    }
-    /// Whether the definition of this global may be replaced at link time.
-    bool isWeakForLinker() { return cir::isWeakForLinker(getLinkage()); }
-    bool isDSOLocal() { return getDsolocal(); }
   }];
 
   let skipDefaultBuilders = 1;
@@ -3602,10 +3593,6 @@ def FuncOp : CIR_Op<"func", [
     //===------------------------------------------------------------------===//
 
     bool isDeclaration();
-
-    bool hasAvailableExternallyLinkage() {
-      return cir::isAvailableExternallyLinkage(getLinkage());
-    }
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
@@ -48,8 +48,64 @@ let cppNamespace = "::cir" in {
 
     let methods = [
       InterfaceMethod<"",
+      "bool", "hasExternalLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isExternalLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
       "bool", "hasAvailableExternallyLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{ return false; }]
+      /*defaultImplementation=*/[{
+        return cir::isAvailableExternallyLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "hasLinkOnceLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isLinkOnceLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "hasLinkOnceAnyLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isLinkOnceAnyLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "hasLinkOnceODRLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isLinkOnceODRLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "hasWeakLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isWeakLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "hasWeakAnyLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isWeakAnyLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "hasWeakODRLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isWeakODRLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "hasInternalLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isInternalLinkage($_op.getLinkage());
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "hasPrivateLinkage", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isPrivateLinkage($_op.getLinkage());
+      }]
       >,
       InterfaceMethod<"",
       "bool", "hasLocalLinkage", (ins), [{}],
@@ -64,9 +120,9 @@ let cppNamespace = "::cir" in {
       }]
       >,
       InterfaceMethod<"",
-      "bool", "isExternalLinkage", (ins), [{}],
+      "bool", "hasCommonLinkage", (ins), [{}],
       /*defaultImplementation=*/[{
-        return cir::isExternalLinkage($_op.getLinkage());
+        return cir::isCommonLinkage($_op.getLinkage());
       }]
       >,
       InterfaceMethod<"",
@@ -89,11 +145,23 @@ let cppNamespace = "::cir" in {
         $_op.setDsolocal(val);
       }]
       >,
+      InterfaceMethod<"",
+      "bool", "isDSOLocal", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return $_op.getDsolocal();
+      }]
+      >,
+      InterfaceMethod<"",
+      "bool", "isWeakForLinker", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return cir::isWeakForLinker($_op.getLinkage());
+      }]
+      >
     ];
     let extraClassDeclaration = [{
-    bool hasDefaultVisibility();
-    bool canBenefitFromLocalAlias();
-  }];
+      bool hasDefaultVisibility();
+      bool canBenefitFromLocalAlias();
+    }];
   }
 
 } // namespace cir

--- a/clang/lib/CIR/Interfaces/CIROpInterfaces.cpp
+++ b/clang/lib/CIR/Interfaces/CIROpInterfaces.cpp
@@ -31,7 +31,7 @@ bool CIRGlobalValueInterface::canBenefitFromLocalAlias() {
   // wouldn't even generate Comdat::Largest comdat as it tries to leave ABI
   // specifics to LLVM lowering stage, thus here we don't need test Comdat
   // selectionKind.
-  return hasDefaultVisibility() && isExternalLinkage() && !isDeclaration() &&
+  return hasDefaultVisibility() && hasExternalLinkage() && !isDeclaration() &&
          !hasComdat();
   return false;
 }


### PR DESCRIPTION
Cleans up default linkage query implementations. Removes duplicities from `extraClassDeclaration` that are now introduced through `CIRGlobalValueInterface`. This makes it more consistent with the `llvm::GlobalValue` methods.