### PR TITLE
[CIR] Base-to-derived and derived-to-base casts on pointers to member functions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2940,6 +2940,67 @@ def ExtractMemberOp : CIR_Op<"extract_member", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// InsertMemberOp
+//===----------------------------------------------------------------------===//
+
+def InsertMemberOp : CIR_Op<"insert_member",
+                            [Pure, AllTypesMatch<["record", "result"]>]> {
+  let summary = "Overwrite the value of a member of a struct value";
+  let description = [{
+    The `cir.insert_member` operation overwrites the value of a particular
+    member in the input struct value, and returns the modified struct value. The
+    result of this operation is equal to the input struct value, except for the
+    member specified by `index_attr` whose value is equal to the given value.
+
+    This operation is named after the LLVM instruction `insertvalue`.
+
+    Currently `cir.insert_member` does not work on unions.
+
+    Example:
+
+    ```mlir
+    // Suppose we have a struct with multiple members.
+    !s32i = !cir.int<s, 32>
+    !s8i = !cir.int<s, 32>
+    !struct_ty = !cir.struct<"struct.Bar" {!s32i, !s8i}>
+
+    // And suppose we have a value of the struct type.
+    %0 = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s8i}> : !struct_ty
+    // %0 is {1, 2}
+
+    // Overwrite the second member of the struct value.
+    %1 = cir.const #cir.int<3> : !s8i
+    %2 = cir.insert_member %0[1], %1 : !struct_ty, !s8i
+    // %2 is {1, 3}
+    ```
+  }];
+
+  let arguments = (ins CIR_StructType:$record, IndexAttr:$index_attr,
+                       CIR_AnyType:$value);
+  let results = (outs CIR_StructType:$result);
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$record, "uint64_t":$index,
+                   "mlir::Value":$value), [{
+      mlir::APInt fieldIdx(64, index);
+      build($_builder, $_state, record, fieldIdx, value);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Get the index of the struct member being accessed.
+    uint64_t getIndex() { return getIndexAttr().getZExtValue(); }
+  }];
+
+  let assemblyFormat = [{
+    $record `[` $index_attr `]` `,` $value attr-dict
+    `:` qualified(type($record)) `,` qualified(type($value))
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // GetRuntimeMemberOp
 //===----------------------------------------------------------------------===//
 
@@ -3421,6 +3482,74 @@ def DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
 
   let arguments = (ins CIR_DataMemberType:$src, IndexAttr:$offset);
   let results = (outs CIR_DataMemberType:$result);
+
+  let assemblyFormat = [{
+    `(` $src `:` qualified(type($src)) `)`
+    `[` $offset `]` `->` qualified(type($result)) attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// BaseMethodOp & DerivedMethodOp
+//===----------------------------------------------------------------------===//
+
+def BaseMethodOp : CIR_Op<"base_method", [Pure]> {
+  let summary = [{
+    Cast a derived class pointer-to-member-function to a base class
+    pointer-to-member-function
+  }];
+  let description = [{
+    The `cir.base_method` operation casts a pointer-to-member-function of type
+    `Ret (Derived::*)(Args)` to a pointer-to-member-function of type
+    `Ret (Base::*)(Args)`, where `Base` is a non-virtual base class of
+    `Derived`.
+
+    The `offset` parameter gives the offset in bytes of the `Base` base class
+    subobject within a `Derived` object.
+
+    Example:
+
+    ```mlir
+    %1 = cir.base_method(%0 : !cir.method<!cir.func<(!s32i)> in !ty_Derived>) [16] -> !cir.method<!cir.func<(!s32i)> in !ty_Base>
+    ```
+  }];
+
+  let arguments = (ins CIR_MethodType:$src, IndexAttr:$offset);
+  let results = (outs CIR_MethodType:$result);
+
+  let assemblyFormat = [{
+    `(` $src `:` qualified(type($src)) `)`
+    `[` $offset `]` `->` qualified(type($result)) attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+def DerivedMethodOp : CIR_Op<"derived_method", [Pure]> {
+  let summary = [{
+    Cast a base class pointer-to-member-function to a derived class
+    pointer-to-member-function
+  }];
+  let description = [{
+    The `cir.derived_method` operation casts a pointer-to-member-function of
+    type `Ret (Base::*)(Args)` to a pointer-to-member-function of type
+    `Ret (Derived::*)(Args)`, where `Base` is a non-virtual base class of
+    `Derived`.
+
+    The `offset` parameter gives the offset in bytes of the `Base` base class
+    subobject within a `Derived` object.
+
+    Example:
+
+    ```mlir
+    %1 = cir.derived_method(%0 : !cir.method<!cir.func<(!s32i)> in !ty_Base>) [16] -> !cir.method<!cir.func<(!s32i)> in !ty_Derived>
+    ```
+  }];
+
+  let arguments = (ins CIR_MethodType:$src, IndexAttr:$offset);
+  let results = (outs CIR_MethodType:$result);
 
   let assemblyFormat = [{
     `(` $src `:` qualified(type($src)) `)`

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -70,6 +70,7 @@ struct MissingFeatures {
   static bool tbaaPointer() { return false; }
   static bool emitNullabilityCheck() { return false; }
   static bool ptrAuth() { return false; }
+  static bool memberFuncPtrAuthInfo() { return false; }
   static bool emitCFICheck() { return false; }
   static bool emitVFEInfo() { return false; }
   static bool emitWPDInfo() { return false; }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -841,13 +841,21 @@ LogicalResult cir::DynamicCastOp::verify() {
 // BaseDataMemberOp & DerivedDataMemberOp
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyDataMemberCast(Operation *op, mlir::Value src,
-                                          mlir::Type resultTy) {
+static LogicalResult verifyMemberPtrCast(Operation *op, mlir::Value src,
+                                         mlir::Type resultTy) {
   // Let the operand type be T1 C1::*, let the result type be T2 C2::*.
   // Verify that T1 and T2 are the same type.
-  auto inputMemberTy =
-      mlir::cast<cir::DataMemberType>(src.getType()).getMemberTy();
-  auto resultMemberTy = mlir::cast<cir::DataMemberType>(resultTy).getMemberTy();
+  mlir::Type inputMemberTy;
+  mlir::Type resultMemberTy;
+  if (mlir::isa<cir::DataMemberType>(src.getType())) {
+    inputMemberTy =
+        mlir::cast<cir::DataMemberType>(src.getType()).getMemberTy();
+    resultMemberTy = mlir::cast<cir::DataMemberType>(resultTy).getMemberTy();
+  } else {
+    inputMemberTy =
+        mlir::cast<cir::MethodType>(src.getType()).getMemberFuncTy();
+    resultMemberTy = mlir::cast<cir::MethodType>(resultTy).getMemberFuncTy();
+  }
   if (inputMemberTy != resultMemberTy)
     return op->emitOpError()
            << "member types of the operand and the result do not match";
@@ -856,11 +864,23 @@ static LogicalResult verifyDataMemberCast(Operation *op, mlir::Value src,
 }
 
 LogicalResult cir::BaseDataMemberOp::verify() {
-  return verifyDataMemberCast(getOperation(), getSrc(), getType());
+  return verifyMemberPtrCast(getOperation(), getSrc(), getType());
 }
 
 LogicalResult cir::DerivedDataMemberOp::verify() {
-  return verifyDataMemberCast(getOperation(), getSrc(), getType());
+  return verifyMemberPtrCast(getOperation(), getSrc(), getType());
+}
+
+//===----------------------------------------------------------------------===//
+// BaseMethodOp & DerivedMethodOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult cir::BaseMethodOp::verify() {
+  return verifyMemberPtrCast(getOperation(), getSrc(), getType());
+}
+
+LogicalResult cir::DerivedMethodOp::verify() {
+  return verifyMemberPtrCast(getOperation(), getSrc(), getType());
 }
 
 //===----------------------------------------------------------------------===//
@@ -3596,6 +3616,22 @@ LogicalResult cir::ExtractMemberOp::verify() {
     return emitError() << "member index out of bounds";
   if (recordTy.getMembers()[getIndex()] != getType())
     return emitError() << "member type mismatch";
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
+// InsertMemberOp Definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult cir::InsertMemberOp::verify() {
+  auto recordTy = mlir::cast<cir::StructType>(getRecord().getType());
+  if (recordTy.getKind() == cir::StructType::Union)
+    return emitError() << "cir.update_member currently does not work on unions";
+  if (recordTy.getMembers().size() <= getIndex())
+    return emitError() << "member index out of range";
+  if (recordTy.getMembers()[getIndex()] != getValue().getType())
+    return emitError() << "member type mismatch";
+  // The op trait already checks that the types of $result and $record match.
   return mlir::success();
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -118,6 +118,18 @@ public:
   lowerDerivedDataMember(cir::DerivedDataMemberOp op, mlir::Value loweredSrc,
                          mlir::OpBuilder &builder) const = 0;
 
+  /// Lower the given cir.base_method op to a sequence of more "primitive" CIR
+  /// operations that act on the ABI types.
+  virtual mlir::Value lowerBaseMethod(cir::BaseMethodOp op,
+                                      mlir::Value loweredSrc,
+                                      mlir::OpBuilder &builder) const = 0;
+
+  /// Lower the given cir.derived_method op to a sequence of more "primitive"
+  /// CIR operations that act on the ABI types.
+  virtual mlir::Value lowerDerivedMethod(cir::DerivedMethodOp op,
+                                         mlir::Value loweredSrc,
+                                         mlir::OpBuilder &builder) const = 0;
+
   virtual mlir::Value lowerDataMemberCmp(cir::CmpOp op, mlir::Value loweredLhs,
                                          mlir::Value loweredRhs,
                                          mlir::OpBuilder &builder) const = 0;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1038,6 +1038,24 @@ mlir::LogicalResult CIRToLLVMDerivedDataMemberOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
+mlir::LogicalResult CIRToLLVMBaseMethodOpLowering::matchAndRewrite(
+    cir::BaseMethodOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult =
+      lowerMod->getCXXABI().lowerBaseMethod(op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRToLLVMDerivedMethodOpLowering::matchAndRewrite(
+    cir::DerivedMethodOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult =
+      lowerMod->getCXXABI().lowerDerivedMethod(op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
 static mlir::Value
 getValueForVTableSymbol(mlir::Operation *op,
                         mlir::ConversionPatternRewriter &rewriter,
@@ -3526,6 +3544,24 @@ mlir::LogicalResult CIRToLLVMExtractMemberOpLowering::matchAndRewrite(
   }
 }
 
+mlir::LogicalResult CIRToLLVMInsertMemberOpLowering::matchAndRewrite(
+    cir::InsertMemberOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  std::int64_t indecies[1] = {static_cast<std::int64_t>(op.getIndex())};
+  mlir::Type recordTy = op.getRecord().getType();
+
+  if (auto cirStructTy = mlir::dyn_cast<cir::StructType>(recordTy)) {
+    if (cirStructTy.getKind() == cir::StructType::Union) {
+      op.emitError("cir.update_member cannot update member of a union");
+      return mlir::failure();
+    }
+  }
+
+  rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(
+      op, adaptor.getRecord(), adaptor.getValue(), indecies);
+  return mlir::success();
+}
+
 mlir::LogicalResult CIRToLLVMGetMethodOpLowering::matchAndRewrite(
     cir::GetMethodOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -4178,8 +4214,10 @@ void populateCIRToLLVMConversionPatterns(
   patterns.add<
       // clang-format off
       CIRToLLVMBaseDataMemberOpLowering,
+      CIRToLLVMBaseMethodOpLowering,
       CIRToLLVMCmpOpLowering,
       CIRToLLVMDerivedDataMemberOpLowering,
+      CIRToLLVMDerivedMethodOpLowering,
       CIRToLLVMGetMethodOpLowering,
       CIRToLLVMGetRuntimeMemberOpLowering,
       CIRToLLVMInvariantGroupOpLowering
@@ -4235,6 +4273,7 @@ void populateCIRToLLVMConversionPatterns(
       CIRToLLVMGetBitfieldOpLowering,
       CIRToLLVMGetGlobalOpLowering,
       CIRToLLVMGetMemberOpLowering,
+      CIRToLLVMInsertMemberOpLowering,
       CIRToLLVMIsConstantOpLowering,
       CIRToLLVMIsFPClassOpLowering,
       CIRToLLVMLLVMIntrinsicCallOpLowering,

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -213,6 +213,36 @@ public:
                   mlir::ConversionPatternRewriter &) const override;
 };
 
+class CIRToLLVMBaseMethodOpLowering
+    : public mlir::OpConversionPattern<cir::BaseMethodOp> {
+  cir::LowerModule *lowerMod;
+
+public:
+  CIRToLLVMBaseMethodOpLowering(const mlir::TypeConverter &typeConverter,
+                                mlir::MLIRContext *context,
+                                cir::LowerModule *lowerModule)
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::BaseMethodOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
+class CIRToLLVMDerivedMethodOpLowering
+    : public mlir::OpConversionPattern<cir::DerivedMethodOp> {
+  cir::LowerModule *lowerMod;
+
+public:
+  CIRToLLVMDerivedMethodOpLowering(const mlir::TypeConverter &typeConverter,
+                                   mlir::MLIRContext *context,
+                                   cir::LowerModule *lowerModule)
+      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::DerivedMethodOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
 class CIRToLLVMVTTAddrPointOpLowering
     : public mlir::OpConversionPattern<cir::VTTAddrPointOp> {
 public:
@@ -889,6 +919,16 @@ public:
 
   mlir::LogicalResult
   matchAndRewrite(cir::ExtractMemberOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
+class CIRToLLVMInsertMemberOpLowering
+    : public mlir::OpConversionPattern<cir::InsertMemberOp> {
+public:
+  using mlir::OpConversionPattern<cir::InsertMemberOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::InsertMemberOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
 };
 


### PR DESCRIPTION
This PR adds CIRGen and LLVM lowering support for base-to-derived and derived-to-base cast operations on pointers to member functions.

This PR includes a new operation `cir.update_member` to help the LLVM lowering procedure of such cast operations.

Resolve #973 .