### PR TITLE
[CIR][CIRGen] Move CIRGenModule::getTargetCIRGenInfo() to CIRGenModule.cpp

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -508,57 +508,51 @@ void CIRGenModule::setDSOLocal(CIRGlobalValueInterface gv) const {
 }
 
 const TargetCIRGenInfo &CIRGenModule::getTargetCIRGenInfo() {
-  if (TheTargetCIRGenInfo)
-    return *TheTargetCIRGenInfo;
+  if (theTargetCIRGenInfo)
+    return *theTargetCIRGenInfo;
 
-  // Helper to set the unique_ptr while still keeping the return value.
-  auto SetCIRGenInfo = [&](TargetCIRGenInfo *P) -> const TargetCIRGenInfo & {
-    this->TheTargetCIRGenInfo.reset(P);
-    return *P;
-  };
+  const llvm::Triple &triple = getTarget().getTriple();
 
-  const llvm::Triple &Triple = getTarget().getTriple();
-
-  switch (Triple.getArch()) {
+  switch (triple.getArch()) {
   default:
     assert(false && "Target not yet supported!");
 
   case llvm::Triple::aarch64_be:
   case llvm::Triple::aarch64: {
-    AArch64ABIKind Kind = AArch64ABIKind::AAPCS;
+    AArch64ABIKind kind = AArch64ABIKind::AAPCS;
     assert(getTarget().getABI() == "aapcs" ||
            getTarget().getABI() == "darwinpcs" &&
                "Only Darwin supported for aarch64");
-    Kind = AArch64ABIKind::DarwinPCS;
-    return *(TheTargetCIRGenInfo =
-                 createAArch64TargetCIRGenInfo(genTypes, Kind));
+    kind = AArch64ABIKind::DarwinPCS;
+    return *(theTargetCIRGenInfo =
+                 createAArch64TargetCIRGenInfo(genTypes, kind));
   }
 
   case llvm::Triple::x86_64: {
-    StringRef ABI = getTarget().getABI();
-    X86AVXABILevel AVXLevel = (ABI == "avx512" ? X86AVXABILevel::AVX512
-                               : ABI == "avx"  ? X86AVXABILevel::AVX
+    StringRef abi = getTarget().getABI();
+    X86AVXABILevel avxLevel = (abi == "avx512" ? X86AVXABILevel::AVX512
+                               : abi == "avx"  ? X86AVXABILevel::AVX
                                                : X86AVXABILevel::None);
 
-    switch (Triple.getOS()) {
+    switch (triple.getOS()) {
     default:
       assert(false && "OSType NYI");
     case llvm::Triple::Linux:
-      return *(TheTargetCIRGenInfo =
-                   createX86_64TargetCIRGenInfo(genTypes, AVXLevel));
+      return *(theTargetCIRGenInfo =
+                   createX86_64TargetCIRGenInfo(genTypes, avxLevel));
     }
   }
 
   case llvm::Triple::spirv64: {
-    return *(TheTargetCIRGenInfo = createSPIRVTargetCIRGenInfo(genTypes));
+    return *(theTargetCIRGenInfo = createSPIRVTargetCIRGenInfo(genTypes));
   }
 
   case llvm::Triple::nvptx64: {
-    return *(TheTargetCIRGenInfo = createNVPTXTargetCIRGenInfo(genTypes));
+    return *(theTargetCIRGenInfo = createNVPTXTargetCIRGenInfo(genTypes));
   }
 
   case llvm::Triple::amdgcn: {
-    return *(TheTargetCIRGenInfo = createAMDGPUTargetCIRGenInfo(genTypes));
+    return *(theTargetCIRGenInfo = createAMDGPUTargetCIRGenInfo(genTypes));
   }
   }
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -507,6 +507,62 @@ void CIRGenModule::setDSOLocal(CIRGlobalValueInterface gv) const {
   gv.setDSOLocal(shouldAssumeDSOLocal(*this, gv));
 }
 
+const TargetCIRGenInfo &CIRGenModule::getTargetCIRGenInfo() {
+  if (TheTargetCIRGenInfo)
+    return *TheTargetCIRGenInfo;
+
+  // Helper to set the unique_ptr while still keeping the return value.
+  auto SetCIRGenInfo = [&](TargetCIRGenInfo *P) -> const TargetCIRGenInfo & {
+    this->TheTargetCIRGenInfo.reset(P);
+    return *P;
+  };
+
+  const llvm::Triple &Triple = getTarget().getTriple();
+
+  switch (Triple.getArch()) {
+  default:
+    assert(false && "Target not yet supported!");
+
+  case llvm::Triple::aarch64_be:
+  case llvm::Triple::aarch64: {
+    AArch64ABIKind Kind = AArch64ABIKind::AAPCS;
+    assert(getTarget().getABI() == "aapcs" ||
+           getTarget().getABI() == "darwinpcs" &&
+               "Only Darwin supported for aarch64");
+    Kind = AArch64ABIKind::DarwinPCS;
+    return *(TheTargetCIRGenInfo =
+                 createAArch64TargetCIRGenInfo(genTypes, Kind));
+  }
+
+  case llvm::Triple::x86_64: {
+    StringRef ABI = getTarget().getABI();
+    X86AVXABILevel AVXLevel = (ABI == "avx512" ? X86AVXABILevel::AVX512
+                               : ABI == "avx"  ? X86AVXABILevel::AVX
+                                               : X86AVXABILevel::None);
+
+    switch (Triple.getOS()) {
+    default:
+      assert(false && "OSType NYI");
+    case llvm::Triple::Linux:
+      return *(TheTargetCIRGenInfo =
+                   createX86_64TargetCIRGenInfo(genTypes, AVXLevel));
+    }
+  }
+
+  case llvm::Triple::spirv64: {
+    return *(TheTargetCIRGenInfo = createSPIRVTargetCIRGenInfo(genTypes));
+  }
+
+  case llvm::Triple::nvptx64: {
+    return *(TheTargetCIRGenInfo = createNVPTXTargetCIRGenInfo(genTypes));
+  }
+
+  case llvm::Triple::amdgcn: {
+    return *(TheTargetCIRGenInfo = createAMDGPUTargetCIRGenInfo(genTypes));
+  }
+  }
+}
+
 const ABIInfo &CIRGenModule::getABIInfo() {
   return getTargetCIRGenInfo().getABIInfo();
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -74,7 +74,7 @@ public:
   const std::string &getModuleNameHash() const { return ModuleNameHash; }
 
 private:
-  mutable std::unique_ptr<TargetCIRGenInfo> TheTargetCIRGenInfo;
+  mutable std::unique_ptr<TargetCIRGenInfo> theTargetCIRGenInfo;
 
   /// The builder is a helper class to create IR inside a function. The
   /// builder is stateful, in particular it keeps an "insertion point": this

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -18,6 +18,8 @@
 #include "CIRGenValue.h"
 #include "mlir/IR/Types.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
+#include "clang/CIR/Target/AArch64.h"
+#include "clang/CIR/Target/x86.h"
 
 #include <memory>
 
@@ -122,7 +124,20 @@ public:
   virtual ~TargetCIRGenInfo() {}
 };
 
+std::unique_ptr<TargetCIRGenInfo>
+createAArch64TargetCIRGenInfo(CIRGenTypes &CGT, cir::AArch64ABIKind Kind);
+
+std::unique_ptr<TargetCIRGenInfo>
+createX86_64TargetCIRGenInfo(CIRGenTypes &CGT, cir::X86AVXABILevel AVXLevel);
+
 void computeSPIRKernelABIInfo(CIRGenModule &CGM, CIRGenFunctionInfo &FI);
+
+std::unique_ptr<TargetCIRGenInfo> createSPIRVTargetCIRGenInfo(CIRGenTypes &CGT);
+
+std::unique_ptr<TargetCIRGenInfo> createNVPTXTargetCIRGenInfo(CIRGenTypes &CGT);
+
+std::unique_ptr<TargetCIRGenInfo>
+createAMDGPUTargetCIRGenInfo(CIRGenTypes &CGT);
 
 } // namespace clang::CIRGen
 


### PR DESCRIPTION
Makes it consistent with C++ conventions and [OG](https://github.com/advay168/clangir/blob/436c635af6c7ec3d184a1f7e92a624acdf856991/clang/lib/CodeGen/CodeGenModule.cpp#L108).