### PR TITLE
[CIR] Implement ::verify for cir.atomic.xchg and cir.atomic.cmp_xchg

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5481,7 +5481,7 @@ def AtomicXchg : CIR_Op<"atomic.xchg", [AllTypesMatch<["result", "val"]>]> {
     `:` type($result) attr-dict
   }];
 
-  let hasVerifier = 0;
+  let hasVerifier = 1;
 }
 
 def AtomicCmpXchg : CIR_Op<"atomic.cmp_xchg",
@@ -5524,7 +5524,7 @@ def AtomicCmpXchg : CIR_Op<"atomic.cmp_xchg",
     `:` `(` type($old) `,` type($cmp) `)` attr-dict
   }];
 
-  let hasVerifier = 0;
+  let hasVerifier = 1;
 }
 
 def MemScope_SingleThread : I32EnumAttrCase<"MemScope_SingleThread",

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -472,13 +472,8 @@ LogicalResult cir::ContinueOp::verify() {
 // AtomicXchg
 //===----------------------------------------------------------------------===//
 LogicalResult cir::AtomicXchg::verify() {
-    const auto& tps = this->getOperation()->getOperandTypes();
-
-    const auto& tp0 = mlir::dyn_cast<cir::PointerType>(tps[0]);
-    const auto& tp1 = tps[1];
-
-    if(tp0.getPointee() != tp1)
-        return emitOpError("atomic ptr type and xchg val must match");
+    if(getPtr().getType().getPointee() != getVal().getType())
+        return emitOpError("atomic_xchg ptr type and val type must match");
 
     return success();
 }
@@ -488,14 +483,10 @@ LogicalResult cir::AtomicXchg::verify() {
 // AtomicCmpXchg
 //===----------------------------------------------------------------------===//
 LogicalResult cir::AtomicCmpXchg::verify() {
-    const auto& tps = this->getOperation()->getOperandTypes();
+    auto pointeeType = getPtr().getType().getPointee();
 
-    const auto& tp0 = mlir::dyn_cast<cir::PointerType>(tps[0]);
-    const auto& tp1 = tps[1];
-    const auto& tp2 = tps[2];
-
-    if(tp0.getPointee() != tp1 or tp0.getPointee() != tp2)
-        return emitOpError("atomic ptr type and cmp_xchg expected and desired types must match");
+    if(pointeeType != getExpected().getType() or pointeeType != getDesired().getType())
+        return emitOpError("atomic_cmp_xchg ptr, expected and desired types must match");
 
     return success();
 }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -472,23 +472,23 @@ LogicalResult cir::ContinueOp::verify() {
 // AtomicXchg
 //===----------------------------------------------------------------------===//
 LogicalResult cir::AtomicXchg::verify() {
-    if(getPtr().getType().getPointee() != getVal().getType())
-        return emitOpError("ptr type and val type must match");
+  if (getPtr().getType().getPointee() != getVal().getType())
+    return emitOpError("ptr type and val type must match");
 
-    return success();
+  return success();
 }
-
 
 //===----------------------------------------------------------------------===//
 // AtomicCmpXchg
 //===----------------------------------------------------------------------===//
 LogicalResult cir::AtomicCmpXchg::verify() {
-    auto pointeeType = getPtr().getType().getPointee();
+  auto pointeeType = getPtr().getType().getPointee();
 
-    if(pointeeType != getExpected().getType() or pointeeType != getDesired().getType())
-        return emitOpError("ptr, expected and desired types must match");
+  if (pointeeType != getExpected().getType() or
+      pointeeType != getDesired().getType())
+    return emitOpError("ptr, expected and desired types must match");
 
-    return success();
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -469,6 +469,38 @@ LogicalResult cir::ContinueOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// AtomicXchg
+//===----------------------------------------------------------------------===//
+LogicalResult cir::AtomicXchg::verify() {
+    const auto& tps = this->getOperation()->getOperandTypes();
+
+    const auto& tp0 = mlir::dyn_cast<cir::PointerType>(tps[0]);
+    const auto& tp1 = tps[1];
+
+    if(tp0.getPointee() != tp1)
+        return emitOpError("atomic ptr type and xchg val must match");
+
+    return success();
+}
+
+
+//===----------------------------------------------------------------------===//
+// AtomicCmpXchg
+//===----------------------------------------------------------------------===//
+LogicalResult cir::AtomicCmpXchg::verify() {
+    const auto& tps = this->getOperation()->getOperandTypes();
+
+    const auto& tp0 = mlir::dyn_cast<cir::PointerType>(tps[0]);
+    const auto& tp1 = tps[1];
+    const auto& tp2 = tps[2];
+
+    if(tp0.getPointee() != tp1 or tp0.getPointee() != tp2)
+        return emitOpError("atomic ptr type and cmp_xchg expected and desired types must match");
+
+    return success();
+}
+
+//===----------------------------------------------------------------------===//
 // CastOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -473,7 +473,7 @@ LogicalResult cir::ContinueOp::verify() {
 //===----------------------------------------------------------------------===//
 LogicalResult cir::AtomicXchg::verify() {
     if(getPtr().getType().getPointee() != getVal().getType())
-        return emitOpError("atomic_xchg ptr type and val type must match");
+        return emitOpError("ptr type and val type must match");
 
     return success();
 }
@@ -486,7 +486,7 @@ LogicalResult cir::AtomicCmpXchg::verify() {
     auto pointeeType = getPtr().getType().getPointee();
 
     if(pointeeType != getExpected().getType() or pointeeType != getDesired().getType())
-        return emitOpError("atomic_cmp_xchg ptr, expected and desired types must match");
+        return emitOpError("ptr, expected and desired types must match");
 
     return success();
 }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1081,6 +1081,26 @@ cir.func @bad_fetch(%x: !cir.ptr<!cir.float>, %y: !cir.float) -> () {
 
 // -----
 
+!u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
+cir.func @bad_xchg(%x: !cir.ptr<!u32i>, %y: !u64i) -> () {
+  // expected-error@+1 {{ptr type and val type must match}}
+  %13 = cir.atomic.xchg(%x: !cir.ptr<!u32i>, %y: !u64i, seq_cst) : !u64i
+  cir.return
+}
+
+// -----
+
+!u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
+cir.func @bad_cmp_xchg(%x: !cir.ptr<!u32i>, %y: !u64i, %z: !u64i) -> () {
+  // expected-error@+1 {{ptr, expected and desired types must match}}
+  %14, %15 = cir.atomic.cmp_xchg(%x : !cir.ptr<!u32i>, %y : !u64i, %z : !u64i, success = seq_cst, failure = seq_cst) align(8) weak : (!u64i, !cir.bool)
+  cir.return
+}
+
+// -----
+
 cir.func @bad_operands_for_nowrap(%x: !cir.float, %y: !cir.float) {
   // expected-error@+1 {{only operations on integer values may have nsw/nuw flags}}
   %0 = cir.binop(add, %x, %y) nsw : !cir.float


### PR DESCRIPTION
Implements `::verify` for operations cir.atomic.xchg and cir.atomic.cmp_xchg

I believe the existing regression tests don't get to the CIR level type check failure and I was not able to implement a case that does.

Most attempts of reproducing cir.atomic.xchg type check failure were along the lines of:
```
int a;
long long b,c;
__atomic_exchange(&a, &b, &c, memory_order_seq_cst);
```

And they seem to never trigger the failure on `::verify` because they fail earlier in function parameter checking:
```
exmp.cpp:7:27: error: cannot initialize a parameter of type 'int *' with an rvalue of type 'long long *'
    7 |     __atomic_exchange(&a, &b, &c, memory_order_seq_cst);
      |                           ^~
```

Closes #1378 .