### PR TITLE
[CIR][MLIR] Fix overloaded virtual warnings

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -54,6 +54,8 @@ struct RemoveRedundantBranches : public OpRewritePattern<BrOp> {
 
     return failure();
   }
+
+  using mlir::OpRewritePattern<BrOp>::matchAndRewrite;
 };
 
 struct RemoveEmptyScope : public OpRewritePattern<ScopeOp> {
@@ -77,6 +79,9 @@ struct RemoveEmptyScope : public OpRewritePattern<ScopeOp> {
   void rewrite(ScopeOp op, PatternRewriter &rewriter) const final {
     rewriter.eraseOp(op);
   }
+
+  using mlir::OpRewritePattern<ScopeOp>::match;
+  using mlir::OpRewritePattern<ScopeOp>::rewrite;
 };
 
 struct RemoveEmptySwitch : public OpRewritePattern<SwitchOp> {
@@ -90,6 +95,9 @@ struct RemoveEmptySwitch : public OpRewritePattern<SwitchOp> {
   void rewrite(SwitchOp op, PatternRewriter &rewriter) const final {
     rewriter.eraseOp(op);
   }
+
+  using mlir::OpRewritePattern<SwitchOp>::match;
+  using mlir::OpRewritePattern<SwitchOp>::rewrite;
 };
 
 struct RemoveTrivialTry : public OpRewritePattern<TryOp> {
@@ -114,6 +122,9 @@ struct RemoveTrivialTry : public OpRewritePattern<TryOp> {
     rewriter.inlineBlockBefore(tryBody, parentBlock, Block::iterator(op));
     rewriter.eraseOp(op);
   }
+
+  using mlir::OpRewritePattern<TryOp>::match;
+  using mlir::OpRewritePattern<TryOp>::rewrite;
 };
 
 // Remove call exception with empty cleanups
@@ -138,6 +149,9 @@ struct SimplifyCallOp : public OpRewritePattern<CallOp> {
     rewriter.eraseOp(&b->back());
     rewriter.eraseBlock(b);
   }
+
+  using mlir::OpRewritePattern<CallOp>::match;
+  using mlir::OpRewritePattern<CallOp>::rewrite;
 };
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/CIRSimplify.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRSimplify.cpp
@@ -77,6 +77,8 @@ struct SimplifyTernary final : public OpRewritePattern<TernaryOp> {
     return mlir::success();
   }
 
+  using mlir::OpRewritePattern<TernaryOp>::matchAndRewrite;
+
 private:
   bool isSimpleTernaryBranch(mlir::Region &region) const {
     if (!region.hasOneBlock())
@@ -139,6 +141,8 @@ struct SimplifySelect : public OpRewritePattern<SelectOp> {
 
     return mlir::failure();
   }
+
+  using mlir::OpRewritePattern<SelectOp>::matchAndRewrite;
 };
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -112,6 +112,8 @@ struct CIRIfFlattening : public OpRewritePattern<IfOp> {
     rewriter.replaceOp(ifOp, continueBlock->getArguments());
     return mlir::success();
   }
+
+  using mlir::OpRewritePattern<IfOp>::matchAndRewrite;
 };
 
 class CIRScopeOpFlattening : public mlir::OpRewritePattern<cir::ScopeOp> {
@@ -168,6 +170,8 @@ public:
 
     return mlir::success();
   }
+
+  using mlir::OpRewritePattern<cir::ScopeOp>::matchAndRewrite;
 };
 
 class CIRTryOpFlattening : public mlir::OpRewritePattern<cir::TryOp> {
@@ -548,6 +552,8 @@ public:
     }
     return mlir::success();
   }
+
+  using mlir::OpRewritePattern<TryOp>::matchAndRewrite;
 };
 
 class CIRLoopOpInterfaceFlattening
@@ -628,6 +634,8 @@ public:
     rewriter.eraseOp(op);
     return mlir::success();
   }
+
+  using mlir::OpInterfaceRewritePattern<cir::LoopOpInterface>::matchAndRewrite;
 };
 
 class CIRSwitchOpFlattening : public mlir::OpRewritePattern<cir::SwitchOp> {
@@ -854,6 +862,8 @@ public:
 
     return mlir::success();
   }
+
+  using mlir::OpRewritePattern<cir::SwitchOp>::matchAndRewrite;
 };
 class CIRTernaryOpFlattening : public mlir::OpRewritePattern<cir::TernaryOp> {
 public:
@@ -904,6 +914,8 @@ public:
     // Ok, we're done!
     return mlir::success();
   }
+
+  using mlir::OpRewritePattern<cir::TernaryOp>::matchAndRewrite;
 };
 
 void populateFlattenCFGPatterns(RewritePatternSet &patterns) {

--- a/clang/lib/CIR/Dialect/Transforms/SCFPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/SCFPrepare.cpp
@@ -108,6 +108,8 @@ struct canonicalizeIVtoCmpLHS : public OpRewritePattern<ForOp> {
 
     return failure();
   }
+
+  using mlir::OpRewritePattern<ForOp>::matchAndRewrite;
 };
 
 // Hoist loop invariant operations in condition block out of loop
@@ -199,6 +201,8 @@ struct hoistLoopInvariantInCondBlock : public OpRewritePattern<ForOp> {
 
     return failure();
   }
+
+  using mlir::OpRewritePattern<ForOp>::matchAndRewrite;
 };
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -85,6 +85,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::CopyOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::CopyOp>::matchAndRewrite;
 };
 
 class CIRToLLVMMemCpyOpLowering
@@ -95,6 +97,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::MemCpyOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::MemCpyOp>::matchAndRewrite;
 };
 
 class CIRToLLVMMemChrOpLowering
@@ -105,6 +109,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::MemChrOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::MemChrOp>::matchAndRewrite;
 };
 
 class CIRToLLVMMemMoveOpLowering
@@ -115,6 +121,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::MemMoveOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::MemMoveOp>::matchAndRewrite;
 };
 
 class CIRToLLVMMemCpyInlineOpLowering
@@ -125,6 +133,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::MemCpyInlineOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override;
+
+  using mlir::OpConversionPattern<cir::MemCpyInlineOp>::matchAndRewrite;
 };
 
 class CIRToLLVMMemSetOpLowering
@@ -135,6 +145,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::MemSetOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::MemSetOp>::matchAndRewrite;
 };
 
 class CIRToLLVMMemSetInlineOpLowering
@@ -145,6 +157,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::MemSetInlineOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override;
+
+  using mlir::OpConversionPattern<cir::MemSetInlineOp>::matchAndRewrite;
 };
 
 class CIRToLLVMPtrStrideOpLowering
@@ -161,6 +175,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::PtrStrideOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::PtrStrideOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBaseClassAddrOpLowering
@@ -171,6 +187,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BaseClassAddrOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BaseClassAddrOp>::matchAndRewrite;
 };
 
 class CIRToLLVMDerivedClassAddrOpLowering
@@ -181,6 +199,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::DerivedClassAddrOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::DerivedClassAddrOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBaseDataMemberOpLowering
@@ -196,6 +216,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BaseDataMemberOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BaseDataMemberOp>::matchAndRewrite;
 };
 
 class CIRToLLVMDerivedDataMemberOpLowering
@@ -211,6 +233,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::DerivedDataMemberOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::DerivedDataMemberOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBaseMethodOpLowering
@@ -226,6 +250,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BaseMethodOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BaseMethodOp>::matchAndRewrite;
 };
 
 class CIRToLLVMDerivedMethodOpLowering
@@ -241,6 +267,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::DerivedMethodOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::DerivedMethodOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVTTAddrPointOpLowering
@@ -251,6 +279,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VTTAddrPointOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VTTAddrPointOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBrCondOpLowering
@@ -261,6 +291,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BrCondOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BrCondOp>::matchAndRewrite;
 };
 
 class CIRToLLVMCastOpLowering : public mlir::OpConversionPattern<cir::CastOp> {
@@ -280,6 +312,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::CastOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::CastOp>::matchAndRewrite;
 };
 
 class CIRToLLVMReturnOpLowering
@@ -290,6 +324,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ReturnOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ReturnOp>::matchAndRewrite;
 };
 
 class CIRToLLVMCallOpLowering : public mlir::OpConversionPattern<cir::CallOp> {
@@ -299,6 +335,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::CallOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::CallOp>::matchAndRewrite;
 };
 
 class CIRToLLVMTryCallOpLowering
@@ -309,6 +347,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::TryCallOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::TryCallOp>::matchAndRewrite;
 };
 
 class CIRToLLVMEhInflightOpLowering
@@ -319,6 +359,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::EhInflightOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::EhInflightOp>::matchAndRewrite;
 };
 
 class CIRToLLVMAllocaOpLowering
@@ -354,6 +396,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AllocaOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AllocaOp>::matchAndRewrite;
 };
 
 class CIRToLLVMLoadOpLowering : public mlir::OpConversionPattern<cir::LoadOp> {
@@ -371,6 +415,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::LoadOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::LoadOp>::matchAndRewrite;
 };
 
 class CIRToLLVMStoreOpLowering
@@ -389,6 +435,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::StoreOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::StoreOp>::matchAndRewrite;
 };
 
 class CIRToLLVMConstantOpLowering
@@ -409,6 +457,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ConstantOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ConstantOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVecCreateOpLowering
@@ -419,6 +469,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VecCreateOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VecCreateOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVecCmpOpLowering
@@ -429,6 +481,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VecCmpOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VecCmpOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVecSplatOpLowering
@@ -439,6 +493,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VecSplatOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VecSplatOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVecTernaryOpLowering
@@ -449,6 +505,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VecTernaryOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VecTernaryOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVecShuffleOpLowering
@@ -459,6 +517,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VecShuffleOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VecShuffleOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVecShuffleDynamicOpLowering
@@ -470,6 +530,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VecShuffleDynamicOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VecShuffleDynamicOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVAStartOpLowering
@@ -480,6 +542,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VAStartOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VAStartOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVAEndOpLowering
@@ -490,6 +554,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VAEndOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VAEndOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVACopyOpLowering
@@ -500,6 +566,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VACopyOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VACopyOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVAArgOpLowering
@@ -510,6 +578,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VAArgOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VAArgOp>::matchAndRewrite;
 };
 
 class CIRToLLVMFuncOpLowering : public mlir::OpConversionPattern<cir::FuncOp> {
@@ -528,6 +598,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::FuncOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::FuncOp>::matchAndRewrite;
 };
 
 class CIRToLLVMGetGlobalOpLowering
@@ -538,6 +610,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::GetGlobalOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::GetGlobalOp>::matchAndRewrite;
 };
 
 class CIRToLLVMComplexCreateOpLowering
@@ -548,6 +622,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ComplexCreateOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ComplexCreateOp>::matchAndRewrite;
 };
 
 class CIRToLLVMComplexRealOpLowering
@@ -558,6 +634,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ComplexRealOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ComplexRealOp>::matchAndRewrite;
 };
 
 class CIRToLLVMComplexImagOpLowering
@@ -568,6 +646,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ComplexImagOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ComplexImagOp>::matchAndRewrite;
 };
 
 class CIRToLLVMComplexRealPtrOpLowering
@@ -578,6 +658,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ComplexRealPtrOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ComplexRealPtrOp>::matchAndRewrite;
 };
 
 class CIRToLLVMComplexImagPtrOpLowering
@@ -588,6 +670,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ComplexImagPtrOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ComplexImagPtrOp>::matchAndRewrite;
 };
 
 class CIRToLLVMSwitchFlatOpLowering
@@ -598,6 +682,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::SwitchFlatOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::SwitchFlatOp>::matchAndRewrite;
 };
 
 class CIRToLLVMGlobalOpLowering
@@ -619,6 +705,8 @@ public:
   matchAndRewrite(cir::GlobalOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
 
+  using mlir::OpConversionPattern<cir::GlobalOp>::matchAndRewrite;
+
 private:
   void createRegionInitializedLLVMGlobalOp(
       cir::GlobalOp op, mlir::Attribute attr,
@@ -638,6 +726,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::UnaryOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::UnaryOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBinOpLowering : public mlir::OpConversionPattern<cir::BinOp> {
@@ -649,6 +739,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BinOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BinOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBinOpOverflowOpLowering
@@ -659,6 +751,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BinOpOverflowOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BinOpOverflowOp>::matchAndRewrite;
 
 private:
   static std::string getLLVMIntrinName(cir::BinOpOverflowKind opKind,
@@ -681,6 +775,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ShiftOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ShiftOp>::matchAndRewrite;
 };
 
 class CIRToLLVMCmpOpLowering : public mlir::OpConversionPattern<cir::CmpOp> {
@@ -697,6 +793,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::CmpOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::CmpOp>::matchAndRewrite;
 };
 
 class CIRToLLVMLLVMIntrinsicCallOpLowering
@@ -708,6 +806,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::LLVMIntrinsicCallOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::LLVMIntrinsicCallOp>::matchAndRewrite;
 };
 
 class CIRToLLVMAssumeOpLowering
@@ -718,6 +818,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AssumeOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AssumeOp>::matchAndRewrite;
 };
 
 class CIRToLLVMAssumeAlignedOpLowering
@@ -728,6 +830,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AssumeAlignedOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AssumeAlignedOp>::matchAndRewrite;
 };
 
 class CIRToLLVMAssumeSepStorageOpLowering
@@ -738,6 +842,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AssumeSepStorageOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AssumeSepStorageOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBitClrsbOpLowering
@@ -748,6 +854,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BitClrsbOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BitClrsbOp>::matchAndRewrite;
 };
 
 class CIRToLLVMObjSizeOpLowering
@@ -758,6 +866,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ObjSizeOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ObjSizeOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBitClzOpLowering
@@ -768,6 +878,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BitClzOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BitClzOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBitCtzOpLowering
@@ -778,6 +890,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BitCtzOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BitCtzOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBitFfsOpLowering
@@ -788,6 +902,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BitFfsOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BitFfsOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBitParityOpLowering
@@ -798,6 +914,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BitParityOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BitParityOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBitPopcountOpLowering
@@ -808,6 +926,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BitPopcountOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BitPopcountOp>::matchAndRewrite;
 };
 
 class CIRToLLVMAtomicCmpXchgLowering
@@ -818,6 +938,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AtomicCmpXchg op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AtomicCmpXchg>::matchAndRewrite;
 };
 
 class CIRToLLVMAtomicXchgLowering
@@ -828,6 +950,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AtomicXchg op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AtomicXchg>::matchAndRewrite;
 };
 
 class CIRToLLVMAtomicFetchLowering
@@ -851,6 +975,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AtomicFetch op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AtomicFetch>::matchAndRewrite;
 };
 
 class CIRToLLVMAtomicFenceLowering
@@ -861,6 +987,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AtomicFence op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AtomicFence>::matchAndRewrite;
 };
 
 class CIRToLLVMByteswapOpLowering
@@ -871,6 +999,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ByteswapOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ByteswapOp>::matchAndRewrite;
 };
 
 class CIRToLLVMRotateOpLowering
@@ -881,6 +1011,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::RotateOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::RotateOp>::matchAndRewrite;
 };
 
 class CIRToLLVMSelectOpLowering
@@ -891,6 +1023,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::SelectOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::SelectOp>::matchAndRewrite;
 };
 
 class CIRToLLVMBrOpLowering : public mlir::OpConversionPattern<cir::BrOp> {
@@ -900,6 +1034,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::BrOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::BrOp>::matchAndRewrite;
 };
 
 class CIRToLLVMGetMemberOpLowering
@@ -910,6 +1046,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::GetMemberOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::GetMemberOp>::matchAndRewrite;
 };
 
 class CIRToLLVMExtractMemberOpLowering
@@ -920,6 +1058,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ExtractMemberOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ExtractMemberOp>::matchAndRewrite;
 };
 
 class CIRToLLVMInsertMemberOpLowering
@@ -930,6 +1070,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::InsertMemberOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::InsertMemberOp>::matchAndRewrite;
 };
 
 class CIRToLLVMGetMethodOpLowering
@@ -945,6 +1087,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::GetMethodOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::GetMethodOp>::matchAndRewrite;
 };
 
 class CIRToLLVMGetRuntimeMemberOpLowering
@@ -960,6 +1104,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::GetRuntimeMemberOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::GetRuntimeMemberOp>::matchAndRewrite;
 };
 
 class CIRToLLVMPtrDiffOpLowering
@@ -972,6 +1118,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::PtrDiffOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::PtrDiffOp>::matchAndRewrite;
 };
 
 class CIRToLLVMExpectOpLowering
@@ -982,6 +1130,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ExpectOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ExpectOp>::matchAndRewrite;
 };
 
 class CIRToLLVMVTableAddrPointOpLowering
@@ -992,6 +1142,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::VTableAddrPointOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::VTableAddrPointOp>::matchAndRewrite;
 };
 
 class CIRToLLVMStackSaveOpLowering
@@ -1002,6 +1154,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::StackSaveOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::StackSaveOp>::matchAndRewrite;
 };
 
 class CIRToLLVMUnreachableOpLowering
@@ -1012,6 +1166,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::UnreachableOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::UnreachableOp>::matchAndRewrite;
 };
 
 class CIRToLLVMTrapOpLowering : public mlir::OpConversionPattern<cir::TrapOp> {
@@ -1021,6 +1177,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::TrapOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::TrapOp>::matchAndRewrite;
 };
 
 class CIRToLLVMInlineAsmOpLowering
@@ -1038,6 +1196,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::InlineAsmOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::InlineAsmOp>::matchAndRewrite;
 };
 
 class CIRToLLVMInvariantGroupOpLowering
@@ -1053,6 +1213,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::InvariantGroupOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::InvariantGroupOp>::matchAndRewrite;
 };
 
 class CIRToLLVMPrefetchOpLowering
@@ -1063,6 +1225,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::PrefetchOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::PrefetchOp>::matchAndRewrite;
 };
 
 class CIRToLLVMSetBitfieldOpLowering
@@ -1073,6 +1237,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::SetBitfieldOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::SetBitfieldOp>::matchAndRewrite;
 };
 
 class CIRToLLVMGetBitfieldOpLowering
@@ -1083,6 +1249,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::GetBitfieldOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::GetBitfieldOp>::matchAndRewrite;
 };
 
 class CIRToLLVMIsConstantOpLowering
@@ -1093,6 +1261,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::IsConstantOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::IsConstantOp>::matchAndRewrite;
 };
 
 class CIRToLLVMCmpThreeWayOpLowering
@@ -1103,6 +1273,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::CmpThreeWayOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::CmpThreeWayOp>::matchAndRewrite;
 
 private:
   static std::string getLLVMIntrinsicName(bool signedCmp, unsigned operandWidth,
@@ -1117,6 +1289,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ReturnAddrOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ReturnAddrOp>::matchAndRewrite;
 };
 
 class CIRToLLVMFrameAddrOpLowering
@@ -1127,6 +1301,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::FrameAddrOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::FrameAddrOp>::matchAndRewrite;
 };
 
 class CIRToLLVMClearCacheOpLowering
@@ -1137,6 +1313,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ClearCacheOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ClearCacheOp>::matchAndRewrite;
 };
 
 class CIRToLLVMEhTypeIdOpLowering
@@ -1147,6 +1325,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::EhTypeIdOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::EhTypeIdOp>::matchAndRewrite;
 };
 
 class CIRToLLVMCatchParamOpLowering
@@ -1157,6 +1337,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::CatchParamOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::CatchParamOp>::matchAndRewrite;
 };
 
 class CIRToLLVMResumeOpLowering
@@ -1167,6 +1349,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ResumeOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ResumeOp>::matchAndRewrite;
 };
 
 class CIRToLLVMAllocExceptionOpLowering
@@ -1177,6 +1361,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AllocExceptionOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AllocExceptionOp>::matchAndRewrite;
 };
 
 class CIRToLLVMFreeExceptionOpLowering
@@ -1187,6 +1373,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::FreeExceptionOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::FreeExceptionOp>::matchAndRewrite;
 };
 
 class CIRToLLVMThrowOpLowering
@@ -1197,6 +1385,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::ThrowOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::ThrowOp>::matchAndRewrite;
 };
 
 class CIRToLLVMIsFPClassOpLowering
@@ -1207,6 +1397,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::IsFPClassOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::IsFPClassOp>::matchAndRewrite;
 };
 
 class CIRToLLVMPtrMaskOpLowering
@@ -1217,6 +1409,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::PtrMaskOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::PtrMaskOp>::matchAndRewrite;
 };
 
 class CIRToLLVMAbsOpLowering : public mlir::OpConversionPattern<cir::AbsOp> {
@@ -1226,6 +1420,8 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::AbsOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
+
+  using mlir::OpConversionPattern<cir::AbsOp>::matchAndRewrite;
 };
 
 class CIRToLLVMSignBitOpLowering
@@ -1236,7 +1432,10 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::SignBitOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override;
+
+  using mlir::OpConversionPattern<cir::SignBitOp>::matchAndRewrite;
 };
+
 mlir::ArrayAttr lowerCIRTBAAAttr(mlir::Attribute tbaa,
                                  mlir::ConversionPatternRewriter &rewriter,
                                  cir::LowerModule *lowerMod);

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRLoopToSCF.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRLoopToSCF.cpp
@@ -297,6 +297,8 @@ public:
     rewriter.eraseOp(op);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::ForOp>::matchAndRewrite;
 };
 
 class CIRWhileOpLowering : public mlir::OpConversionPattern<cir::WhileOp> {
@@ -311,6 +313,8 @@ public:
     rewriter.eraseOp(op);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::WhileOp>::matchAndRewrite;
 };
 
 class CIRDoOpLowering : public mlir::OpConversionPattern<cir::DoWhileOp> {
@@ -325,6 +329,8 @@ public:
     rewriter.eraseOp(op);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::DoWhileOp>::matchAndRewrite;
 };
 
 class CIRConditionOpLowering
@@ -343,6 +349,8 @@ public:
         })
         .Default([](auto) { return mlir::failure(); });
   }
+
+  using mlir::OpConversionPattern<cir::ConditionOp>::matchAndRewrite;
 };
 
 void populateCIRLoopToSCFConversionPatterns(mlir::RewritePatternSet &patterns,

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -72,6 +72,8 @@ public:
                                                       adaptor.getOperands());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::ReturnOp>::matchAndRewrite;
 };
 
 struct ConvertCIRToMLIRPass
@@ -108,6 +110,8 @@ public:
         op, op.getCalleeAttr(), types, adaptor.getOperands());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::CallOp>::matchAndRewrite;
 };
 
 /// Given a type convertor and a data layout, convert the given type to a type
@@ -185,6 +189,8 @@ public:
                                                         op.getAlignmentAttr());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::AllocaOp>::matchAndRewrite;
 };
 
 // Find base and indices from memref.reinterpret_cast
@@ -251,6 +257,8 @@ public:
     rewriter.replaceOp(op, result);
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::LoadOp>::matchAndRewrite;
 };
 
 class CIRStoreOpLowering : public mlir::OpConversionPattern<cir::StoreOp> {
@@ -276,6 +284,8 @@ public:
                                                          adaptor.getAddr());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::StoreOp>::matchAndRewrite;
 };
 
 class CIRCosOpLowering : public mlir::OpConversionPattern<cir::CosOp> {
@@ -288,6 +298,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::CosOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::CosOp>::matchAndRewrite;
 };
 
 class CIRSqrtOpLowering : public mlir::OpConversionPattern<cir::SqrtOp> {
@@ -300,6 +312,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::SqrtOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::SqrtOp>::matchAndRewrite;
 };
 
 class CIRFAbsOpLowering : public mlir::OpConversionPattern<cir::FAbsOp> {
@@ -312,7 +326,10 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::AbsFOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::FAbsOp>::matchAndRewrite;
 };
+
 class CIRAbsOpLowering : public mlir::OpConversionPattern<cir::AbsOp> {
 public:
   using mlir::OpConversionPattern<cir::AbsOp>::OpConversionPattern;
@@ -323,6 +340,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::AbsIOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::AbsOp>::matchAndRewrite;
 };
 
 class CIRFloorOpLowering : public mlir::OpConversionPattern<cir::FloorOp> {
@@ -335,6 +354,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::FloorOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::FloorOp>::matchAndRewrite;
 };
 
 class CIRCeilOpLowering : public mlir::OpConversionPattern<cir::CeilOp> {
@@ -347,6 +368,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::CeilOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::CeilOp>::matchAndRewrite;
 };
 
 class CIRLog10OpLowering : public mlir::OpConversionPattern<cir::Log10Op> {
@@ -359,6 +382,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::Log10Op>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::Log10Op>::matchAndRewrite;
 };
 
 class CIRLogOpLowering : public mlir::OpConversionPattern<cir::LogOp> {
@@ -371,6 +396,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::LogOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::LogOp>::matchAndRewrite;
 };
 
 class CIRLog2OpLowering : public mlir::OpConversionPattern<cir::Log2Op> {
@@ -383,6 +410,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::Log2Op>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::Log2Op>::matchAndRewrite;
 };
 
 class CIRRoundOpLowering : public mlir::OpConversionPattern<cir::RoundOp> {
@@ -395,6 +424,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::RoundOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::RoundOp>::matchAndRewrite;
 };
 
 class CIRExpOpLowering : public mlir::OpConversionPattern<cir::ExpOp> {
@@ -407,6 +438,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::ExpOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::ExpOp>::matchAndRewrite;
 };
 
 class CIRShiftOpLowering : public mlir::OpConversionPattern<cir::ShiftOp> {
@@ -440,6 +473,8 @@ public:
 
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::ShiftOp>::matchAndRewrite;
 };
 
 class CIRExp2OpLowering : public mlir::OpConversionPattern<cir::Exp2Op> {
@@ -452,6 +487,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::Exp2Op>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::Exp2Op>::matchAndRewrite;
 };
 
 class CIRSinOpLowering : public mlir::OpConversionPattern<cir::SinOp> {
@@ -464,6 +501,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::math::SinOp>(op, adaptor.getSrc());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::SinOp>::matchAndRewrite;
 };
 
 template <typename CIROp, typename MLIROp>
@@ -483,6 +522,8 @@ public:
     rewriter.replaceOp(op, newOp);
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<CIROp>::matchAndRewrite;
 };
 
 using CIRBitClzOpLowering =
@@ -527,6 +568,8 @@ public:
 
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::BitClrsbOp>::matchAndRewrite;
 };
 
 class CIRBitFfsOpLowering : public mlir::OpConversionPattern<cir::BitFfsOp> {
@@ -560,6 +603,8 @@ public:
 
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::BitFfsOp>::matchAndRewrite;
 };
 
 class CIRBitParityOpLowering
@@ -580,6 +625,8 @@ public:
     rewriter.replaceOp(op, res);
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::BitParityOp>::matchAndRewrite;
 };
 
 class CIRConstantOpLowering
@@ -632,6 +679,8 @@ public:
         this->lowerCirAttrToMlirAttr(op.getValue(), rewriter));
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::ConstantOp>::matchAndRewrite;
 };
 
 class CIRFuncOpLowering : public mlir::OpConversionPattern<cir::FuncOp> {
@@ -669,6 +718,8 @@ public:
     rewriter.eraseOp(op);
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::FuncOp>::matchAndRewrite;
 };
 
 class CIRUnaryOpLowering : public mlir::OpConversionPattern<cir::UnaryOp> {
@@ -715,6 +766,8 @@ public:
 
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::UnaryOp>::matchAndRewrite;
 };
 
 class CIRBinOpLowering : public mlir::OpConversionPattern<cir::BinOp> {
@@ -805,6 +858,8 @@ public:
 
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::BinOp>::matchAndRewrite;
 };
 
 class CIRCmpOpLowering : public mlir::OpConversionPattern<cir::CmpOp> {
@@ -832,6 +887,8 @@ public:
 
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::CmpOp>::matchAndRewrite;
 };
 
 class CIRBrOpLowering : public mlir::OpRewritePattern<cir::BrOp> {
@@ -844,6 +901,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::cf::BranchOp>(op, op.getDest());
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpRewritePattern<cir::BrOp>::matchAndRewrite;
 };
 
 class CIRScopeOpLowering : public mlir::OpConversionPattern<cir::ScopeOp> {
@@ -881,6 +940,8 @@ class CIRScopeOpLowering : public mlir::OpConversionPattern<cir::ScopeOp> {
 
     return mlir::LogicalResult::success();
   }
+
+  using mlir::OpConversionPattern<cir::ScopeOp>::matchAndRewrite;
 };
 
 struct CIRBrCondOpLowering : public mlir::OpConversionPattern<cir::BrCondOp> {
@@ -896,6 +957,8 @@ struct CIRBrCondOpLowering : public mlir::OpConversionPattern<cir::BrCondOp> {
 
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::BrCondOp>::matchAndRewrite;
 };
 
 class CIRTernaryOpLowering : public mlir::OpConversionPattern<cir::TernaryOp> {
@@ -923,6 +986,8 @@ public:
     rewriter.replaceOp(op, ifOp);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::TernaryOp>::matchAndRewrite;
 };
 
 class CIRYieldOpLowering : public mlir::OpConversionPattern<cir::YieldOp> {
@@ -940,6 +1005,8 @@ public:
         })
         .Default([](auto) { return mlir::failure(); });
   }
+
+  using mlir::OpConversionPattern<cir::YieldOp>::matchAndRewrite;
 };
 
 class CIRIfOpLowering : public mlir::OpConversionPattern<cir::IfOp> {
@@ -962,6 +1029,8 @@ public:
     rewriter.replaceOp(ifop, newIfOp);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::IfOp>::matchAndRewrite;
 };
 
 class CIRGlobalOpLowering : public mlir::OpConversionPattern<cir::GlobalOp> {
@@ -1048,6 +1117,8 @@ public:
 
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::GlobalOp>::matchAndRewrite;
 };
 
 class CIRGetGlobalOpLowering
@@ -1070,6 +1141,8 @@ public:
     rewriter.replaceOpWithNewOp<mlir::memref::GetGlobalOp>(op, type, symbol);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::GetGlobalOp>::matchAndRewrite;
 };
 
 class CIRVectorCreateLowering
@@ -1100,6 +1173,8 @@ public:
     rewriter.replaceOp(op, result);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::VecCreateOp>::matchAndRewrite;
 };
 
 class CIRVectorInsertLowering
@@ -1114,6 +1189,8 @@ public:
         op, adaptor.getValue(), adaptor.getVec(), adaptor.getIndex());
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::VecInsertOp>::matchAndRewrite;
 };
 
 class CIRVectorExtractLowering
@@ -1128,6 +1205,8 @@ public:
         op, adaptor.getVec(), adaptor.getIndex());
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::VecExtractOp>::matchAndRewrite;
 };
 
 class CIRVectorCmpOpLowering : public mlir::OpConversionPattern<cir::VecCmpOp> {
@@ -1160,6 +1239,8 @@ public:
         op, typeConverter->convertType(op.getType()), bitResult);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::VecCmpOp>::matchAndRewrite;
 };
 
 class CIRCastOpLowering : public mlir::OpConversionPattern<cir::CastOp> {
@@ -1269,6 +1350,8 @@ public:
     }
     return mlir::failure();
   }
+
+  using mlir::OpConversionPattern<cir::CastOp>::matchAndRewrite;
 };
 
 class CIRPtrStrideOpLowering
@@ -1351,6 +1434,8 @@ public:
     rewriter.eraseOp(baseOp);
     return mlir::success();
   }
+
+  using mlir::OpConversionPattern<cir::PtrStrideOp>::matchAndRewrite;
 };
 
 void populateCIRToMLIRConversionPatterns(mlir::RewritePatternSet &patterns,

--- a/clang/utils/TableGen/CIRLoweringEmitter.cpp
+++ b/clang/utils/TableGen/CIRLoweringEmitter.cpp
@@ -28,6 +28,8 @@ void GenerateLowering(const Record *Operation) {
   public:
     using OpConversionPattern<cir::)C++" +
       Name + R"C++(>::OpConversionPattern;
+    using OpConversionPattern<cir::)C++" +
+      Name + R"C++(>::matchAndRewrite;
 
   mlir::LogicalResult
   matchAndRewrite(cir::)C++" +

--- a/mlir/include/mlir/Conversion/LinalgToStandard/LinalgToStandard.h
+++ b/mlir/include/mlir/Conversion/LinalgToStandard/LinalgToStandard.h
@@ -40,6 +40,8 @@ public:
 
   LogicalResult matchAndRewrite(LinalgOp op,
                                 PatternRewriter &rewriter) const override;
+
+  using OpInterfaceRewritePattern<LinalgOp>::matchAndRewrite;
 };
 
 /// Populate the given list with patterns that convert from Linalg to Standard.

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -13,6 +13,7 @@
 
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
@@ -1415,6 +1416,7 @@ struct DownscaleSizeOneWindowed2DConvolution final
                                 PatternRewriter &rewriter) const override {
     return returningMatchAndRewrite(convOp, rewriter);
   }
+  using OpRewritePattern<Conv2DOp>::matchAndRewrite;
 };
 
 extern template struct DownscaleSizeOneWindowed2DConvolution<Conv2DNhwcHwcfOp,
@@ -1438,6 +1440,7 @@ struct DownscaleDepthwiseConv2DNhwcHwcOp final
                                 PatternRewriter &rewriter) const override {
     return returningMatchAndRewrite(convOp, rewriter);
   }
+  using OpRewritePattern<DepthwiseConv2DNhwcHwcOp>::matchAndRewrite;
 };
 
 struct DownscaleConv2DOp final : public OpRewritePattern<Conv2DOp> {
@@ -1451,6 +1454,7 @@ struct DownscaleConv2DOp final : public OpRewritePattern<Conv2DOp> {
                                 PatternRewriter &rewriter) const override {
     return returningMatchAndRewrite(convOp, rewriter);
   }
+  using OpRewritePattern<Conv2DOp>::matchAndRewrite;
 };
 
 ///
@@ -1476,6 +1480,7 @@ struct LinalgGeneralizationPattern
                                 PatternRewriter &rewriter) const override {
     return returningMatchAndRewrite(op, rewriter);
   }
+  using OpInterfaceRewritePattern<LinalgOp>::matchAndRewrite;
 };
 
 struct LinalgSpecializationPattern : public OpRewritePattern<GenericOp> {
@@ -1490,6 +1495,7 @@ struct LinalgSpecializationPattern : public OpRewritePattern<GenericOp> {
                                 PatternRewriter &rewriter) const override {
     return returningMatchAndRewrite(op, rewriter);
   }
+  using OpRewritePattern<GenericOp>::matchAndRewrite;
 };
 
 /// Vectorization pattern for memref::CopyOp.
@@ -1498,6 +1504,7 @@ struct CopyVectorizationPattern : public OpRewritePattern<memref::CopyOp> {
 
   LogicalResult matchAndRewrite(memref::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override;
+  using OpRewritePattern<memref::CopyOp>::matchAndRewrite;
 };
 
 using OptimizeCopyFn =
@@ -1510,6 +1517,7 @@ struct DecomposePadOpPattern : public OpRewritePattern<tensor::PadOp> {
       : OpRewritePattern<tensor::PadOp>(context, benefit) {}
   LogicalResult matchAndRewrite(tensor::PadOp padOp,
                                 PatternRewriter &rewriter) const override;
+  using OpRewritePattern<tensor::PadOp>::matchAndRewrite;
 
 protected:
   Value createFillOrGenerateOp(RewriterBase &rewriter, tensor::PadOp padOp,
@@ -1555,6 +1563,7 @@ struct DecomposeOuterUnitDimsPackOpPattern
   using OpRewritePattern<tensor::PackOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::PackOp packOp,
                                 PatternRewriter &rewriter) const override;
+  using OpRewritePattern<tensor::PackOp>::matchAndRewrite;
 };
 
 /// Rewrites a tensor::UnPackOp into a sequence of rank-reduced
@@ -1589,6 +1598,7 @@ struct DecomposeOuterUnitDimsUnPackOpPattern
   using OpRewritePattern<tensor::UnPackOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::UnPackOp unpackOp,
                                 PatternRewriter &rewriter) const override;
+  using OpRewritePattern<tensor::UnPackOp>::matchAndRewrite;
 };
 
 /// Match and rewrite for the pattern:
@@ -1620,6 +1630,7 @@ struct LinalgCopyVTRForwardingPattern
 
   LogicalResult matchAndRewrite(vector::TransferReadOp xferOp,
                                 PatternRewriter &rewriter) const override;
+  using OpRewritePattern<vector::TransferReadOp>::matchAndRewrite;
 };
 
 /// Match and rewrite for the pattern:
@@ -1648,6 +1659,7 @@ struct LinalgCopyVTWForwardingPattern
 
   LogicalResult matchAndRewrite(vector::TransferWriteOp xferOp,
                                 PatternRewriter &rewriter) const override;
+  using OpRewritePattern<vector::TransferWriteOp>::matchAndRewrite;
 };
 
 /// Rewrite extract_slice(tensor.pad(x)) into tensor.pad(extract_slice(x)).
@@ -1671,6 +1683,8 @@ struct ExtractSliceOfPadTensorSwapPattern
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override;
+
+  using OpRewritePattern<tensor::ExtractSliceOp>::matchAndRewrite;
 
 private:
   ControlFn controlFn;

--- a/mlir/include/mlir/IR/DialectRegistry.h
+++ b/mlir/include/mlir/IR/DialectRegistry.h
@@ -245,6 +245,8 @@ public:
         extensionFn(context, dialects...);
       }
       ExtensionFnT extensionFn;
+
+      using DialectExtension<Extension, DialectsT...>::apply;
     };
     return addExtension(TypeID::getFromOpaquePointer(
                             reinterpret_cast<const void *>(extensionFn)),

--- a/mlir/include/mlir/Transforms/DialectConversion.h
+++ b/mlir/include/mlir/Transforms/DialectConversion.h
@@ -607,7 +607,7 @@ protected:
   /// An optional type converter for use by this pattern.
   const TypeConverter *typeConverter = nullptr;
 
-private:
+protected:
   using RewritePattern::rewrite;
 };
 
@@ -688,8 +688,9 @@ public:
     return matchAndRewrite(op, OpAdaptor(oneToOneOperands, adaptor), rewriter);
   }
 
-private:
+protected:
   using ConversionPattern::matchAndRewrite;
+  using ConversionPattern::rewrite;
 };
 
 /// OpInterfaceConversionPattern is a wrapper around ConversionPattern that
@@ -751,7 +752,7 @@ public:
     return matchAndRewrite(op, getOneToOneAdaptorOperands(operands), rewriter);
   }
 
-private:
+protected:
   using ConversionPattern::matchAndRewrite;
 };
 


### PR DESCRIPTION
There is a difference in behavior between clang and gcc that was leading to a very large number of -Woverloaded-virtual warnings when compiling with gcc.

The difference in behavior is that gcc warns for "partial" virtual overloads. That is, when a base class contains multiple virtual functions with the same name and a derived class overrides at least one but not all of them, gcc issues a warning saying that the non-overridden variations were hidden. This diagnostic is only reported if the -Woverloaded-virtual is explicitly specified on the command line, which it is by the clang project.

The standard way to suppress this warning, indicating that the behavior was intentional (which it was in all cases I'm fixing here) is to add a "using" statement for the overloaded symbol in the derived class. However, there was a secondary problem that this couldn't be done in the ClangIR classes because of a "using" clause in the base class that was marked as "private".

This change updates a few files in the MLIR, both to allow subclasses to add their own "using" statements by making the base class "using" statement protected, and also fixes a large number of places where the derived class "using" statement was needed in MLIR dialects, in addition to adding such statements where needed in the ClangIR code.

The MLIR changes will likely be made upstream, but I am adding them here in the clangir incubator as an proof-of-concept to show what will be needed in downstream projects.