### PR TITLE
[CIR] Disable -Woverloaded-virtual when compiling with gcc

### DIFF
--- a/clang/lib/CIR/CMakeLists.txt
+++ b/clang/lib/CIR/CMakeLists.txt
@@ -1,6 +1,17 @@
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
+# GCC, unlike clang, issues a warning when one virtual function is overridden
+# in a derived class but one or more other virtual functions with the same
+# name and different signature from a base class are not overridden. This
+# leads to many warnings in the MLIR and ClangIR code when using the
+# OpenConversionPattern<>::matchAndRewrite() function in the ordinary way.
+# The "hiding" behavior is what we want, so we're just disabling the warning
+# here.
+if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual")
+endif()
+
 # Report use of deprecated APIs as errors.
 # TODO: Consider adding `/we4996` for MSVC when upstream MLIR resolves
 #       https://github.com/llvm/llvm-project/issues/65255.

--- a/clang/tools/cir-opt/CMakeLists.txt
+++ b/clang/tools/cir-opt/CMakeLists.txt
@@ -4,6 +4,17 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 include_directories(${LLVM_MAIN_SRC_DIR}/../mlir/include)
 include_directories(${CMAKE_BINARY_DIR}/tools/mlir/include)
 
+# GCC, unlike clang, issues a warning when one virtual function is overridden
+# in a derived class but one or more other virtual functions with the same
+# name and different signature from a base class are not overridden. This
+# leads to many warnings in the MLIR and ClangIR code when using the
+# OpenConversionPattern<>::matchAndRewrite() function in the ordinary way.
+# The "hiding" behavior is what we want, so we're just disabling the warning
+# here.
+if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual")
+endif()
+
 add_clang_tool(cir-opt
   cir-opt.cpp
 )


### PR DESCRIPTION
GCC, unlike clang, issues a warning when one virtual function is overridden in a derived class but one or more other virtual functions with the same name and different signature from a base class are not overridden. This leads to many warnings in the MLIR and ClangIR code when using the OpenConversionPattern<>::matchAndRewrite() function in the ordinary way. The "hiding" behavior is what we want.