### PR TITLE
[CIR][CIRGen][TBAA] Add support for pointer tbaa

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTBAAAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTBAAAttrs.td
@@ -22,21 +22,37 @@ def CIR_TBAAOmnipotentChar
 def CIR_TBAAScalarAttr : CIR_Attr<"TBAAScalar", "tbaa_scalar", [], "TBAAAttr"> {
   let summary = "Describes a scalar type in TBAA with an identifier.";
 
-  let parameters = (ins StringRefParameter<> : $id, CIR_AnyType : $type);
+  let parameters = (ins StringRefParameter<>:$id, 
+                        CIR_AnyType:$type, 
+                        OptionalParameter<"cir::TBAAScalarAttr">:$parent);
 
   let description = [{
     Define a TBAA scalar attribute.
+    The optional `parent` attribute is used to describe the parent type of the 
+    scalar type. If the `parent` is null or omitted, the parent type is the 
+    `omnipotent char` type.
 
     Example:
     ```mlir
     // CIR_TBAAScalarAttr
     #tbaa_scalar = #cir.tbaa_scalar<id = "int", type = !s32i>
     #tbaa_scalar1 = #cir.tbaa_scalar<id = "long long", type = !s64i>
+
+    #tbaa_scalar2 = #cir.tbaa_scalar<id = "any pointer", type = !cir.ptr<!s32i>>
+    #tbaa_scalar3 = #cir.tbaa_scalar<id = "p1 int", type = !cir.ptr<!s32i>, 
+                                     parent = #tbaa_scalar2>
     ```
     
     See the following link for more details:
     https://llvm.org/docs/LangRef.html#tbaa-metadata
   }];
+
+  let builders = [
+    AttrBuilder<(ins "llvm::StringRef":$id, 
+                     "mlir::Type":$type), [{
+      return $_get($_ctxt, id, type, /*parent =*/ nullptr);
+    }]>
+  ];
 
   let assemblyFormat = "`<` struct(params) `>`";
 }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -65,7 +65,6 @@ struct MissingFeatures {
   static bool tbaaMergeTBAAInfo() { return false; }
   static bool tbaaMayAlias() { return false; }
   static bool tbaaNewStructPath() { return false; }
-  static bool tbaaPointer() { return false; }
   static bool emitNullabilityCheck() { return false; }
   static bool ptrAuth() { return false; }
   static bool memberFuncPtrAuthInfo() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenTBAA.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTBAA.h
@@ -112,7 +112,7 @@ class CIRGenTBAA {
   // An internal helper function to generate metadata used
   // to describe accesses to objects of the given type.
   cir::TBAAAttr getTypeInfoHelper(clang::QualType qty);
-  cir::TBAAAttr getScalarTypeInfo(clang::QualType qty);
+  cir::TBAAScalarAttr getScalarTypeInfo(clang::QualType qty);
 
   cir::TBAAAttr getValidBaseTypeInfo(clang::QualType qty);
   cir::TBAAAttr getBaseTypeInfoHelper(const clang::Type *ty);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerTBAAToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerTBAAToLLVM.cpp
@@ -25,7 +25,11 @@ public:
     if (auto scalarAttr = mlir::dyn_cast<cir::TBAAScalarAttr>(tbaa)) {
       mlir::DataLayout layout;
       auto size = layout.getTypeSize(scalarAttr.getType());
-      return createScalarTypeNode(scalarAttr.getId(), getChar(), size);
+      mlir::LLVM::TBAANodeAttr parent =
+          scalarAttr.getParent()
+              ? lowerCIRTBAAAttrToLLVMTBAAAttr(scalarAttr.getParent())
+              : getChar();
+      return createScalarTypeNode(scalarAttr.getId(), parent, size);
     }
     if (auto structAttr = mlir::dyn_cast<cir::TBAAStructAttr>(tbaa)) {
       llvm::SmallVector<mlir::LLVM::TBAAMemberAttr, 4> members;

--- a/clang/test/CIR/CodeGen/tbaa-enum.c
+++ b/clang/test/CIR/CodeGen/tbaa-enum.c
@@ -1,16 +1,15 @@
 // This is inspired from clang/test/CodeGen/tbaa.c, with both CIR and LLVM checks.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1 -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -relaxed-aliasing
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -relaxed-aliasing -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=NO-TBAA --input-file=%t.ll %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O0 -disable-llvm-passes
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O0 -disable-llvm-passes -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=NO-TBAA --input-file=%t.ll %s
 
 // NO-TBAA-NOT: !tbaa
 
-// CIR: #tbaa[[NYI:.*]] = #cir.tbaa
 // CIR: #tbaa[[CHAR:.*]] = #cir.tbaa_omnipotent_char
 // CIR: #tbaa[[INT:.*]] = #cir.tbaa_scalar<id = "int", type = !s32i>
 // CIR: #tbaa[[LONG_LONG:.*]] = #cir.tbaa_scalar<id = "long long", type = !s64i>
@@ -136,10 +135,10 @@ uint8_t g3(Enum8 *E, uint8_t *val) {
   return *val;
 }
 
-// LLVM: [[TAG_i32]] = !{[[TYPE_i32:!.*]], [[TYPE_i32]], i64 0}
-// LLVM: [[TYPE_i32]] = !{!"int", [[TYPE_char:!.*]],
-// LLVM: [[TYPE_char]] = !{!"omnipotent char", [[TAG_c_tbaa:!.*]],
+// LLVM: [[TYPE_char:!.*]] = !{!"omnipotent char", [[TAG_c_tbaa:!.*]],
 // LLVM: [[TAG_c_tbaa]] = !{!"Simple C/C++ TBAA"}
+// LLVM: [[TAG_i32]] = !{[[TYPE_i32:!.*]], [[TYPE_i32]], i64 0}
+// LLVM: [[TYPE_i32]] = !{!"int", [[TYPE_char]],
 // LLVM: [[TAG_i64]] = !{[[TYPE_i64:!.*]], [[TYPE_i64]], i64 0}
 // LLVM: [[TYPE_i64]] = !{!"long long", [[TYPE_char]],
 // LLVM: [[TAG_long]] = !{[[TYPE_long:!.*]], [[TYPE_long]], i64 0}

--- a/clang/test/CIR/CodeGen/tbaa-enum.cpp
+++ b/clang/test/CIR/CodeGen/tbaa-enum.cpp
@@ -1,16 +1,15 @@
 // This is inspired from clang/test/CodeGen/tbaa.c, with both CIR and LLVM checks.
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1 -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -relaxed-aliasing
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -relaxed-aliasing -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=NO-TBAA --input-file=%t.ll %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O0 -disable-llvm-passes
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O0 -disable-llvm-passes -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=NO-TBAA --input-file=%t.ll %s
 
 // NO-TBAA-NOT: !tbaa
 
-// CIR: #tbaa[[NYI:.*]] = #cir.tbaa
 // CIR: #tbaa[[CHAR:.*]] = #cir.tbaa_omnipotent_char
 // CIR: #tbaa[[INT:.*]] = #cir.tbaa_scalar<id = "int", type = !s32i>
 // CIR: #tbaa[[EnumAuto32:.*]] = #cir.tbaa_scalar<id = "_ZTS10EnumAuto32", type = !u32i>
@@ -139,10 +138,10 @@ uint8_t g3(Enum8 *E, uint8_t *val) {
   return *val;
 }
 
-// LLVM: [[TAG_i32]] = !{[[TYPE_i32:!.*]], [[TYPE_i32]], i64 0}
-// LLVM: [[TYPE_i32]] = !{!"int", [[TYPE_char:!.*]],
-// LLVM: [[TYPE_char]] = !{!"omnipotent char", [[TAG_c_tbaa:!.*]],
+// LLVM: [[TYPE_char:!.*]] = !{!"omnipotent char", [[TAG_c_tbaa:!.*]],
 // LLVM: [[TAG_c_tbaa]] = !{!"Simple C++ TBAA"}
+// LLVM: [[TAG_i32]] = !{[[TYPE_i32:!.*]], [[TYPE_i32]], i64 0}
+// LLVM: [[TYPE_i32]] = !{!"int", [[TYPE_char]],
 // LLVM: [[TAG_EnumAuto32]] = !{[[TYPE_EnumAuto32:!.*]], [[TYPE_EnumAuto32]], i64 0}
 // LLVM: [[TYPE_EnumAuto32]] = !{!"_ZTS10EnumAuto32", [[TYPE_char]],
 // LLVM: [[TAG_i64]] = !{[[TYPE_i64:!.*]], [[TYPE_i64]], i64 0}

--- a/clang/test/CIR/CodeGen/tbaa-pointer.cpp
+++ b/clang/test/CIR/CodeGen/tbaa-pointer.cpp
@@ -1,0 +1,126 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1 -no-pointer-tbaa
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -no-pointer-tbaa
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1 -pointer-tbaa
+// RUN: FileCheck --check-prefix=CIR-POINTER-TBAA --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -pointer-tbaa
+// RUN: FileCheck --check-prefix=LLVM-POINTER-TBAA --input-file=%t.ll %s
+
+// CIR: #tbaa[[CHAR:.*]] = #cir.tbaa_omnipotent_char
+// CIR: #tbaa[[INT:.*]] = #cir.tbaa_scalar<id = "int", type = !s32i>
+// CIR: #tbaa[[PTR_TO_A:.*]] = #cir.tbaa_scalar<id = "any pointer", type = !cir.ptr<!ty_A>>
+// CIR: #tbaa[[STRUCT_A:.*]] = #cir.tbaa_struct<id = "_ZTS1A", members = {<#tbaa[[INT]], 0>, <#tbaa[[INT]], 4>}>
+// CIR: #tbaa[[TAG_STRUCT_A_a:.*]] = #cir.tbaa_tag<base = #tbaa[[STRUCT_A]], access = #tbaa[[INT]], offset = 0>
+
+// CIR-POINTER-TBAA: #tbaa[[CHAR:.*]] = #cir.tbaa_omnipotent_char
+// CIR-POINTER-TBAA: #tbaa[[INT:.*]] = #cir.tbaa_scalar<id = "int", type = !s32i>
+// CIR-POINTER-TBAA-DAG: #tbaa[[p1_INT:.*]] = #cir.tbaa_scalar<id = "p1 int", type = !cir.ptr<!s32i>
+// CIR-POINTER-TBAA-DAG: #tbaa[[p2_INT:.*]] = #cir.tbaa_scalar<id = "p2 int", type = !cir.ptr<!cir.ptr<!s32i>>
+// CIR-POINTER-TBAA-DAG: #tbaa[[p3_INT:.*]] = #cir.tbaa_scalar<id = "p3 int", type = !cir.ptr<!cir.ptr<!cir.ptr<!s32i>>>
+// CIR-POINTER-TBAA-DAG: #tbaa[[STRUCT_A:.*]] = #cir.tbaa_struct<id = "_ZTS1A", members = {<#tbaa[[INT]], 0>, <#tbaa[[INT]], 4>}>
+// CIR-POINTER-TBAA-DAG: #tbaa[[p1_STRUCT_A:.*]] = #cir.tbaa_scalar<id = "p1 _ZTS1A", type = !cir.ptr<!ty_A>
+// CIR-POINTER-TBAA-DAG: #tbaa[[p2_STRUCT_A:.*]] = #cir.tbaa_scalar<id = "p2 _ZTS1A", type = !cir.ptr<!cir.ptr<!ty_A>>
+// CIR-POINTER-TBAA-DAG: #tbaa[[p3_STRUCT_A:.*]] = #cir.tbaa_scalar<id = "p3 _ZTS1A", type = !cir.ptr<!cir.ptr<!cir.ptr<!ty_A>>>
+
+int test_scalar_pointer(int*** p3) {
+    int* p1;
+    int** p2;
+    p2 = *p3;
+    p1 = *p2;
+    int t = *p1;
+
+    // CIR-POINTER-TBAA-LABEL: _Z19test_scalar_pointerPPPi
+    // CIR-POINTER-TBAA: %{{.*}} = cir.load deref %{{.*}} : !cir.ptr<!cir.ptr<!cir.ptr<!cir.ptr<!s32i>>>>, !cir.ptr<!cir.ptr<!cir.ptr<!s32i>>> tbaa(#tbaa[[p3_INT]])
+    // CIR-POINTER-TBAA: %{{.*}} = cir.load deref %{{.*}} : !cir.ptr<!cir.ptr<!cir.ptr<!s32i>>>, !cir.ptr<!cir.ptr<!s32i>> tbaa(#tbaa[[p2_INT]])
+    // CIR-POINTER-TBAA: %{{.*}} = cir.load deref %{{.*}} : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i> tbaa(#tbaa[[p1_INT]])
+
+    // LLVM-LABEL: _Z19test_scalar_pointerPPPi
+    // LLVM: %[[p2:.*]] = load ptr, ptr %{{.*}}, align 8, !tbaa ![[TBAA_ANY_PTR:.*]]
+    // LLVM: %[[p1:.*]] = load ptr, ptr %[[p2]], align 8, !tbaa ![[TBAA_ANY_PTR]]
+    // LLVM: %[[t:.*]] = load i32, ptr %[[p1]], align 4, !tbaa ![[TBAA_INT:.*]]
+
+    // LLVM-POINTER-TBAA-LABEL: _Z19test_scalar_pointerPPPi
+    // LLVM-POINTER-TBAA: %[[p2:.*]] = load ptr, ptr %{{.*}}, align 8, !tbaa ![[TBAA_p2_INT:.*]]
+    // LLVM-POINTER-TBAA: %[[p1:.*]] = load ptr, ptr %[[p2]], align 8, !tbaa ![[TBAA_p1_INT:.*]]
+    // LLVM-POINTER-TBAA: %[[t:.*]] = load i32, ptr %[[p1]], align 4, !tbaa ![[TBAA_INT:.*]]
+    return t;
+}
+
+struct A {
+    int a;
+    int b;
+};
+
+int test_struct_pointer(A*** p3, int A::***m3) {
+    A* p1;
+    A** p2;
+    p2 = *p3;
+    p1 = *p2;
+
+    // CIR-POINTER-TBAA-LABEL: _Z19test_struct_pointerPPP1APPMS_i
+    // CIR-POINTER-TBAA: %{{.*}} = cir.load deref %{{.*}} : !cir.ptr<!cir.ptr<!cir.ptr<!cir.ptr<!ty_A>>>>, !cir.ptr<!cir.ptr<!cir.ptr<!ty_A>>> tbaa(#tbaa[[p3_STRUCT_A]])
+    // CIR-POINTER-TBAA: %{{.*}} = cir.load deref %{{.*}} : !cir.ptr<!cir.ptr<!cir.ptr<!ty_A>>>, !cir.ptr<!cir.ptr<!ty_A>> tbaa(#tbaa[[p2_STRUCT_A]])
+    // CIR-POINTER-TBAA: %{{.*}} = cir.load %{{.*}} : !cir.ptr<!cir.ptr<!ty_A>>, !cir.ptr<!ty_A> tbaa(#tbaa[[p1_STRUCT_A]])
+
+    // LLVM-LABEL: _Z19test_struct_pointerPPP1APPMS_i
+    // LLVM: %[[p2:.*]] = load ptr, ptr %{{.*}}, align 8, !tbaa ![[TBAA_ANY_PTR]]
+    // LLVM: %[[p1:.*]] = load ptr, ptr %[[p2]], align 8, !tbaa ![[TBAA_ANY_PTR]]
+    // LLVM: %[[t:.*]] = load i32, ptr %[[p1]], align 4, !tbaa ![[TBAA_STRUCT_A_a:.*]]
+
+    // LLVM-POINTER-TBAA-LABEL: _Z19test_struct_pointerPPP1APPMS_i
+    // LLVM-POINTER-TBAA: %[[p2:.*]] = load ptr, ptr %{{.*}}, align 8, !tbaa ![[TBAA_p2_STRUCT_A:.*]]
+    // LLVM-POINTER-TBAA: %[[p1:.*]] = load ptr, ptr %[[p2]], align 8, !tbaa ![[TBAA_p1_STRUCT_A:.*]]
+    // LLVM-POINTER-TBAA: %[[t:.*]] = load i32, ptr %[[p1]], align 4, !tbaa ![[TBAA_STRUCT_A_a:.*]]
+    return p1->a;
+}
+
+void test_member_pointer(A& a, int A::***m3, int val) {
+
+    // CIR-LABEL: _Z19test_member_pointerR1APPMS_ii
+    // CIR: %{{.*}} = cir.load %{{.*}} : !cir.ptr<!cir.data_member<!s32i in !ty_A>>, !cir.data_member<!s32i in !ty_A> tbaa(#tbaa[[CHAR]])
+
+    // CIR-POINTER-TBAA-LABEL: _Z19test_member_pointerR1APPMS_ii
+    // CIR-POINTER-TBAA: %{{.*}} = cir.load %{{.*}} : !cir.ptr<!cir.data_member<!s32i in !ty_A>>, !cir.data_member<!s32i in !ty_A> tbaa(#tbaa[[CHAR]])
+
+    // LLVM-LABEL: _Z19test_member_pointerR1APPMS_ii
+    // LLVM: %[[m2:.*]] = load ptr, ptr %{{.*}}, align 8, !tbaa ![[TBAA_ANY_PTR:.*]]
+    // LLVM: %[[m1:.*]] = load i64, ptr %[[m2]], align 8, !tbaa ![[TBAA_member_ptr:.*]]
+    // LLVM: %[[A_a:.*]] = getelementptr i8, ptr %{{.*}}, i64 %[[m1]]
+    // LLVM: store i32 %{{.*}}, ptr %[[A_a]], align 4, !tbaa ![[TBAA_INT]]
+
+    // LLVM-POINTER-TBAA-LABEL: _Z19test_member_pointerR1APPMS_ii
+    // LLVM-POINTER-TBAA: %[[m2:.*]] = load ptr, ptr %{{.*}}, align 8, !tbaa ![[TBAA_ANY_PTR:.*]]
+    // LLVM-POINTER-TBAA: %[[m1:.*]] = load i64, ptr %[[m2]], align 8, !tbaa ![[TBAA_member_ptr:.*]]
+    // LLVM-POINTER-TBAA: %[[A_a:.*]] = getelementptr i8, ptr %{{.*}}, i64 %[[m1]]
+    // LLVM-POINTER-TBAA: store i32 %{{.*}}, ptr %[[A_a]], align 4, !tbaa ![[TBAA_INT]]
+    a.***m3 = val; 
+}
+
+// LLVM: ![[TBAA_ANY_PTR]] = !{![[TBAA_ANY_PTR_PARENT:.*]], ![[TBAA_ANY_PTR_PARENT]], i64 0}
+// LLVM: ![[TBAA_ANY_PTR_PARENT]] = !{!"any pointer", ![[CHAR:.*]], i64 0}
+// LLVM: ![[CHAR]] = !{!"omnipotent char", ![[ROOT:.*]], i64 0}
+// LLVM: ![[ROOT]] = !{!"Simple C++ TBAA"}
+// LLVM: ![[TBAA_INT]] = !{![[TBAA_INT_PARENT:.*]], ![[TBAA_INT_PARENT]], i64 0}
+// LLVM: ![[TBAA_INT_PARENT]] = !{!"int", ![[CHAR]], i64 0}
+// LLVM: ![[TBAA_STRUCT_A_a]] = !{![[TBAA_STRUCT_A:.*]], ![[TBAA_INT_PARENT]], i64 0}
+// LLVM: ![[TBAA_STRUCT_A]] = !{!"_ZTS1A", ![[TBAA_INT_PARENT]], i64 0, ![[TBAA_INT_PARENT]], i64 4}
+// LLVM: ![[TBAA_member_ptr]] = !{![[CHAR]], ![[CHAR]], i64 0}
+
+// LLVM-POINTER-TBAA: ![[TBAA_p2_INT]] = !{![[TBAA_p2_INT_PARENT:.*]], ![[TBAA_p2_INT_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_p2_INT_PARENT]] = !{!"p2 int", ![[TBAA_ANY_PTR_PARENT:.*]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_ANY_PTR_PARENT]] = !{!"any pointer", ![[CHAR:.*]], i64 0}
+// LLVM-POINTER-TBAA: ![[CHAR]] = !{!"omnipotent char", ![[ROOT:.*]], i64 0}
+// LLVM-POINTER-TBAA: ![[ROOT]] = !{!"Simple C++ TBAA"}
+// LLVM-POINTER-TBAA: ![[TBAA_p1_INT]] = !{![[TBAA_p1_INT_PARENT:.*]], ![[TBAA_p1_INT_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_p1_INT_PARENT]] = !{!"p1 int", ![[TBAA_ANY_PTR_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_INT]] = !{![[TBAA_INT_PARENT:.*]], ![[TBAA_INT_PARENT]], i64 
+// LLVM-POINTER-TBAA: ![[TBAA_INT_PARENT]] = !{!"int", ![[CHAR]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_p2_STRUCT_A]] = !{![[TBAA_p2_STRUCT_A_PARENT:.*]], ![[TBAA_p2_STRUCT_A_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_p2_STRUCT_A_PARENT]] = !{!"p2 _ZTS1A", ![[TBAA_ANY_PTR_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_p1_STRUCT_A]] = !{![[TBAA_p1_STRUCT_A_PARENT:.*]], ![[TBAA_p1_STRUCT_A_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_p1_STRUCT_A_PARENT]] = !{!"p1 _ZTS1A", ![[TBAA_ANY_PTR_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_STRUCT_A_a]] = !{![[TBAA_STRUCT_A:.*]], ![[TBAA_INT_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_STRUCT_A]] = !{!"_ZTS1A", ![[TBAA_INT_PARENT]], i64 0, ![[TBAA_INT_PARENT]], i64 4}
+// LLVM-POINTER-TBAA: ![[TBAA_ANY_PTR]] = !{![[TBAA_ANY_PTR_PARENT]], ![[TBAA_ANY_PTR_PARENT]], i64 0}
+// LLVM-POINTER-TBAA: ![[TBAA_member_ptr]] = !{![[CHAR]], ![[CHAR]], i64 0}

--- a/clang/test/CIR/CodeGen/tbaa-struct.cpp
+++ b/clang/test/CIR/CodeGen/tbaa-struct.cpp
@@ -2,19 +2,18 @@
 // g13 is not supported due to DiscreteBitFieldABI is NYI.
 // see clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp CIRRecordLowering::accumulateBitFields
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir -O1 -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -no-struct-path-tbaa
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -no-struct-path-tbaa -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=CHECK --input-file=%t.ll %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -no-pointer-tbaa
 // RUN: FileCheck --check-prefixes=PATH,OLD-PATH --input-file=%t.ll %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -relaxed-aliasing
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O1 -disable-llvm-passes -relaxed-aliasing -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=NO-TBAA --input-file=%t.ll %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O0 -disable-llvm-passes
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll -O0 -disable-llvm-passes -no-pointer-tbaa
 // RUN: FileCheck --check-prefix=NO-TBAA --input-file=%t.ll %s
 
 // NO-TBAA-NOT: !tbaa
-// CIR: #tbaa[[NYI:.*]] = #cir.tbaa
 // CIR: #tbaa[[CHAR:.*]] = #cir.tbaa_omnipotent_char
 // CIR: #tbaa[[INT:.*]] = #cir.tbaa_scalar<id = "int", type = !s32i>
 // CIR: #tbaa[[SHORT:.*]] = #cir.tbaa_scalar<id = "short", type = !s16i>
@@ -377,10 +376,10 @@ uint32_t g15(StructS *S, StructS3 *S3, uint64_t count) {
 // LLVM: [[TYPE_i16]] = !{!"short", [[TYPE_char]],
 // LLVM: [[TAG_char]] = !{[[TYPE_char]], [[TYPE_char]], i64 0}
 
-// OLD-PATH: [[TAG_i32]] = !{[[TYPE_INT:!.*]], [[TYPE_INT]], i64 0}
-// OLD-PATH: [[TYPE_INT]] = !{!"int", [[TYPE_CHAR:!.*]], i64 0}
-// OLD-PATH: [[TYPE_CHAR]] = !{!"omnipotent char", [[TAG_cxx_tbaa:!.*]],
+// OLD-PATH: [[TYPE_CHAR:!.*]] = !{!"omnipotent char", [[TAG_cxx_tbaa:!.*]],
 // OLD-PATH: [[TAG_cxx_tbaa]] = !{!"Simple C++ TBAA"}
+// OLD-PATH: [[TAG_i32]] = !{[[TYPE_INT:!.*]], [[TYPE_INT]], i64 0}
+// OLD-PATH: [[TYPE_INT]] = !{!"int", [[TYPE_CHAR]], i64 0}
 // OLD-PATH: [[TAG_A_f32]] = !{[[TYPE_A:!.*]], [[TYPE_INT]], i64 4}
 // OLD-PATH: [[TYPE_A]] = !{!"_ZTS7StructA", [[TYPE_SHORT:!.*]], i64 0, [[TYPE_INT]], i64 4, [[TYPE_SHORT]], i64 8, [[TYPE_INT]], i64 12}
 // OLD-PATH: [[TYPE_SHORT:!.*]] = !{!"short", [[TYPE_CHAR]]


### PR DESCRIPTION
This patch introduces support for pointer TBAA, which can be enabled using the `-fpointer-tbaa` flag. By default, this feature is now enabled.

To ensure test compatibility, the tests (`tbaa-enum.cpp`, `tbaa-enum.c`, and `tbaa-struct.cpp`) have been updated to include the `-fno-pointer-tbaa` flag.

Related Pull Requests of OG:
- https://github.com/llvm/llvm-project/pull/76612
- https://github.com/llvm/llvm-project/pull/116991
