### PR TITLE
[CIR][CUDA] Support builtin CUDA variables

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -2497,7 +2497,12 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   }
 
   if (IntrinsicID != Intrinsic::not_intrinsic) {
-    llvm_unreachable("NYI");
+    unsigned ICEArguments = 0;
+    ASTContext::GetBuiltinTypeError Error;
+    getContext().GetBuiltinType(BuiltinID, Error, &ICEArguments);
+    assert(Error == ASTContext::GE_None && "Should not codegen an error");
+    if (ICEArguments > 0)
+      llvm_unreachable("NYI");
   }
 
   // Some target-specific builtins can have aggregate return values, e.g.
@@ -2595,7 +2600,7 @@ static mlir::Value emitTargetArchBuiltinExpr(CIRGenFunction *CGF,
     llvm_unreachable("NYI");
   case llvm::Triple::nvptx:
   case llvm::Triple::nvptx64:
-    llvm_unreachable("NYI");
+    return CGF->emitNVPTXBuiltinExpr(BuiltinID, E);
   case llvm::Triple::wasm32:
   case llvm::Triple::wasm64:
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
@@ -31,53 +31,52 @@ using namespace clang::CIRGen;
 using namespace cir;
 
 mlir::Value CIRGenFunction::emitNVPTXBuiltinExpr(unsigned BuiltinID,
-                                             const CallExpr *E) {
-  auto GetIntrinsic = [&](const char *name){
-        mlir::Type intTy = cir::IntType::get(&getMLIRContext(), 32, false);
-        return builder
-          .create<cir::LLVMIntrinsicCallOp>(
-              getLoc(E->getExprLoc()), builder.getStringAttr(name),
-              intTy)
-          .getResult();
+                                                 const CallExpr *E) {
+  auto GetIntrinsic = [&](const char *name) {
+    mlir::Type intTy = cir::IntType::get(&getMLIRContext(), 32, false);
+    return builder
+        .create<cir::LLVMIntrinsicCallOp>(getLoc(E->getExprLoc()),
+                                          builder.getStringAttr(name), intTy)
+        .getResult();
   };
   switch (BuiltinID) {
-    case NVPTX::BI__nvvm_read_ptx_sreg_tid_x:
-      return GetIntrinsic("nvvm.read.ptx.sreg.tid.x");
-    case NVPTX::BI__nvvm_read_ptx_sreg_tid_y:
-      return GetIntrinsic("nvvm.read.ptx.sreg.tid.y");
-    case NVPTX::BI__nvvm_read_ptx_sreg_tid_z:
-      return GetIntrinsic("nvvm.read.ptx.sreg.tid.z");
-    case NVPTX::BI__nvvm_read_ptx_sreg_tid_w:
-      return GetIntrinsic("nvvm.read.ptx.sreg.tid.w");
+  case NVPTX::BI__nvvm_read_ptx_sreg_tid_x:
+    return GetIntrinsic("nvvm.read.ptx.sreg.tid.x");
+  case NVPTX::BI__nvvm_read_ptx_sreg_tid_y:
+    return GetIntrinsic("nvvm.read.ptx.sreg.tid.y");
+  case NVPTX::BI__nvvm_read_ptx_sreg_tid_z:
+    return GetIntrinsic("nvvm.read.ptx.sreg.tid.z");
+  case NVPTX::BI__nvvm_read_ptx_sreg_tid_w:
+    return GetIntrinsic("nvvm.read.ptx.sreg.tid.w");
 
-    case NVPTX::BI__nvvm_read_ptx_sreg_ntid_x:
-      return GetIntrinsic("nvvm.read.ptx.sreg.ntid.x");
-    case NVPTX::BI__nvvm_read_ptx_sreg_ntid_y:
-      return GetIntrinsic("nvvm.read.ptx.sreg.ntid.y");
-    case NVPTX::BI__nvvm_read_ptx_sreg_ntid_z:
-      return GetIntrinsic("nvvm.read.ptx.sreg.ntid.z");
-    case NVPTX::BI__nvvm_read_ptx_sreg_ntid_w:
-      return GetIntrinsic("nvvm.read.ptx.sreg.ntid.w");
+  case NVPTX::BI__nvvm_read_ptx_sreg_ntid_x:
+    return GetIntrinsic("nvvm.read.ptx.sreg.ntid.x");
+  case NVPTX::BI__nvvm_read_ptx_sreg_ntid_y:
+    return GetIntrinsic("nvvm.read.ptx.sreg.ntid.y");
+  case NVPTX::BI__nvvm_read_ptx_sreg_ntid_z:
+    return GetIntrinsic("nvvm.read.ptx.sreg.ntid.z");
+  case NVPTX::BI__nvvm_read_ptx_sreg_ntid_w:
+    return GetIntrinsic("nvvm.read.ptx.sreg.ntid.w");
 
-    case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_x:
-      return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.x");
-    case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_y:
-      return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.y");
-    case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_z:
-      return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.z");
-    case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_w:
-      return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.w");
+  case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_x:
+    return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.x");
+  case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_y:
+    return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.y");
+  case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_z:
+    return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.z");
+  case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_w:
+    return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.w");
 
-    case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_x:
-      return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.x");
-    case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_y:
-      return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.y");
-    case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_z:
-      return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.z");
-    case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_w:
-      return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.w");
+  case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_x:
+    return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.x");
+  case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_y:
+    return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.y");
+  case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_z:
+    return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.z");
+  case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_w:
+    return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.w");
 
-    default:
-      llvm_unreachable("NYI");
+  default:
+    llvm_unreachable("NYI");
   }
 }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
@@ -1,0 +1,83 @@
+//===---- CIRGenBuiltinX86.cpp - Emit CIR for X86 builtins ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains code to emit NVPTX Builtin calls.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenCXXABI.h"
+#include "CIRGenCall.h"
+#include "CIRGenFunction.h"
+#include "CIRGenModule.h"
+#include "TargetInfo.h"
+#include "clang/CIR/MissingFeatures.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Value.h"
+#include "clang/AST/GlobalDecl.h"
+#include "clang/Basic/Builtins.h"
+#include "clang/Basic/TargetBuiltins.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using namespace clang;
+using namespace clang::CIRGen;
+using namespace cir;
+
+mlir::Value CIRGenFunction::emitNVPTXBuiltinExpr(unsigned BuiltinID,
+                                             const CallExpr *E) {
+  auto GetIntrinsic = [&](const char *name){
+        mlir::Type intTy = cir::IntType::get(&getMLIRContext(), 32, false);
+        return builder
+          .create<cir::LLVMIntrinsicCallOp>(
+              getLoc(E->getExprLoc()), builder.getStringAttr(name),
+              intTy)
+          .getResult();
+  };
+  switch (BuiltinID) {
+    case NVPTX::BI__nvvm_read_ptx_sreg_tid_x:
+      return GetIntrinsic("nvvm.read.ptx.sreg.tid.x");
+    case NVPTX::BI__nvvm_read_ptx_sreg_tid_y:
+      return GetIntrinsic("nvvm.read.ptx.sreg.tid.y");
+    case NVPTX::BI__nvvm_read_ptx_sreg_tid_z:
+      return GetIntrinsic("nvvm.read.ptx.sreg.tid.z");
+    case NVPTX::BI__nvvm_read_ptx_sreg_tid_w:
+      return GetIntrinsic("nvvm.read.ptx.sreg.tid.w");
+
+    case NVPTX::BI__nvvm_read_ptx_sreg_ntid_x:
+      return GetIntrinsic("nvvm.read.ptx.sreg.ntid.x");
+    case NVPTX::BI__nvvm_read_ptx_sreg_ntid_y:
+      return GetIntrinsic("nvvm.read.ptx.sreg.ntid.y");
+    case NVPTX::BI__nvvm_read_ptx_sreg_ntid_z:
+      return GetIntrinsic("nvvm.read.ptx.sreg.ntid.z");
+    case NVPTX::BI__nvvm_read_ptx_sreg_ntid_w:
+      return GetIntrinsic("nvvm.read.ptx.sreg.ntid.w");
+
+    case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_x:
+      return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.x");
+    case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_y:
+      return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.y");
+    case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_z:
+      return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.z");
+    case NVPTX::BI__nvvm_read_ptx_sreg_ctaid_w:
+      return GetIntrinsic("nvvm.read.ptx.sreg.ctaid.w");
+
+    case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_x:
+      return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.x");
+    case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_y:
+      return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.y");
+    case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_z:
+      return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.z");
+    case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_w:
+      return GetIntrinsic("nvvm.read.ptx.sreg.nctaid.w");
+
+    default:
+      llvm_unreachable("NYI");
+  }
+}

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -3315,24 +3315,23 @@ LValue CIRGenFunction::emitPredefinedLValue(const PredefinedExpr *E) {
 }
 
 namespace {
-  struct LValueOrRValue {
-    LValue LV;
-    RValue RV;
-  };
-}
+struct LValueOrRValue {
+  LValue LV;
+  RValue RV;
+};
 
-static LValueOrRValue emitPseudoObjectExpr(CIRGenFunction &CGF,
-                                           const PseudoObjectExpr *E,
-                                           bool forLValue,
-                                           AggValueSlot slot) {
+LValueOrRValue emitPseudoObjectExpr(CIRGenFunction &CGF,
+                                    const PseudoObjectExpr *E, bool forLValue,
+                                    AggValueSlot slot) {
   SmallVector<CIRGenFunction::OpaqueValueMappingData, 4> opaques;
 
   // Find the result expression, if any.
   const Expr *resultExpr = E->getResultExpr();
   LValueOrRValue result;
 
-  for (PseudoObjectExpr::const_semantics_iterator
-         i = E->semantics_begin(), e = E->semantics_end(); i != e; ++i) {
+  for (PseudoObjectExpr::const_semantics_iterator i = E->semantics_begin(),
+                                                  e = E->semantics_end();
+       i != e; ++i) {
     const Expr *semantic = *i;
 
     // If this semantic expression is an opaque value, bind it
@@ -3357,7 +3356,7 @@ static LValueOrRValue emitPseudoObjectExpr(CIRGenFunction &CGF,
         opaqueData = OVMA::bind(CGF, ov, LV);
         result.RV = slot.asRValue();
 
-      // Otherwise, emit as normal.
+        // Otherwise, emit as normal.
       } else {
         opaqueData = OVMA::bind(CGF, ov, ov->getSourceExpr());
 
@@ -3372,15 +3371,15 @@ static LValueOrRValue emitPseudoObjectExpr(CIRGenFunction &CGF,
 
       opaques.push_back(opaqueData);
 
-    // Otherwise, if the expression is the result, evaluate it
-    // and remember the result.
+      // Otherwise, if the expression is the result, evaluate it
+      // and remember the result.
     } else if (semantic == resultExpr) {
       if (forLValue)
         result.LV = CGF.emitLValue(semantic);
       else
         result.RV = CGF.emitAnyExpr(semantic, slot);
 
-    // Otherwise, evaluate the expression in an ignored context.
+      // Otherwise, evaluate the expression in an ignored context.
     } else {
       CGF.emitIgnoredExpr(semantic);
     }
@@ -3393,8 +3392,10 @@ static LValueOrRValue emitPseudoObjectExpr(CIRGenFunction &CGF,
   return result;
 }
 
+} // namespace
+
 RValue CIRGenFunction::emitPseudoObjectRValue(const PseudoObjectExpr *E,
-                                               AggValueSlot slot) {
+                                              AggValueSlot slot) {
   return emitPseudoObjectExpr(*this, E, false, slot).RV;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -232,7 +232,7 @@ public:
     llvm_unreachable("NYI");
   }
   mlir::Value VisitPseudoObjectExpr(PseudoObjectExpr *E) {
-    llvm_unreachable("NYI");
+    return CGF.emitPseudoObjectRValue(E).getScalarVal();
   }
   mlir::Value VisitSYCLUniqueStableNameExpr(SYCLUniqueStableNameExpr *E) {
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1282,6 +1282,12 @@ public:
   ConstantEmission tryEmitAsConstant(DeclRefExpr *refExpr);
   ConstantEmission tryEmitAsConstant(const MemberExpr *ME);
 
+  RValue emitPseudoObjectRValue(const PseudoObjectExpr *E,
+                                AggValueSlot slot = AggValueSlot::ignored());
+
+  LValue emitPseudoObjectLValue(const PseudoObjectExpr *E);
+
+
   /// Emit the computation of the specified expression of scalar type,
   /// ignoring the result.
   mlir::Value emitScalarExpr(const clang::Expr *E);
@@ -1471,6 +1477,7 @@ public:
   mlir::Value emitAArch64SVEBuiltinExpr(unsigned BuiltinID, const CallExpr *E);
   mlir::Value emitAArch64SMEBuiltinExpr(unsigned BuiltinID, const CallExpr *E);
   mlir::Value emitX86BuiltinExpr(unsigned BuiltinID, const CallExpr *E);
+  mlir::Value emitNVPTXBuiltinExpr(unsigned BuiltinID, const CallExpr *E);
 
   /// Given an expression with a pointer type, emit the value and compute our
   /// best estimate of the alignment of the pointee.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1287,7 +1287,6 @@ public:
 
   LValue emitPseudoObjectLValue(const PseudoObjectExpr *E);
 
-
   /// Emit the computation of the specified expression of scalar type,
   /// ignoring the result.
   mlir::Value emitScalarExpr(const clang::Expr *E);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1122,10 +1122,8 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef mangledName, mlir::Type ty,
       }
     }
 
-    // TODO(cir): LLVM codegen makes sure the result is of the correct type
-    // by issuing a address space cast.
-    if (entryCIRAS != cirAS)
-      llvm_unreachable("NYI");
+    // Address space check removed because it is unnecessary because CIR records
+    // address space info in types.
 
     // (If global is requested for a definition, we always need to create a new
     // global, not just return a bitcast.)

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -13,6 +13,7 @@ add_clang_library(clangCIR
   CIRGenBuiltin.cpp
   CIRGenBuiltinAArch64.cpp
   CIRGenBuiltinX86.cpp
+  CIRGenBuiltinNVPTX.cpp
   CIRGenCXX.cpp
   CIRGenCXXABI.cpp
   CIRGenCall.cpp

--- a/clang/test/CIR/CodeGen/CUDA/cuda-builtin-vars.cu
+++ b/clang/test/CIR/CodeGen/CUDA/cuda-builtin-vars.cu
@@ -1,0 +1,87 @@
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -fclangir \
+// RUN:            -fcuda-is-device -emit-llvm -o - %s   \
+// RUN: | FileCheck --check-prefix=LLVM %s
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -fclangir \
+// RUN:            -fcuda-is-device -emit-cir -o - %s   \
+// RUN: | FileCheck --check-prefix=CIR %s
+
+#include "__clang_cuda_builtin_vars.h"
+
+// LLVM: define{{.*}} void @_Z6kernelPi(ptr %0)
+__attribute__((global))
+void kernel(int *out) {
+  int i = 0;
+
+  out[i++] = threadIdx.x;
+  // CIR:  cir.func linkonce_odr @_ZN26__cuda_builtin_threadIdx_t17__fetch_builtin_xEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.tid.x"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+
+  out[i++] = threadIdx.y;
+  // CIR:  cir.func linkonce_odr @_ZN26__cuda_builtin_threadIdx_t17__fetch_builtin_yEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.tid.y"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.tid.y()
+
+  out[i++] = threadIdx.z;
+  // CIR:  cir.func linkonce_odr @_ZN26__cuda_builtin_threadIdx_t17__fetch_builtin_zEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.tid.z"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.tid.z()
+
+
+  out[i++] = blockIdx.x;
+  // CIR:  cir.func linkonce_odr @_ZN25__cuda_builtin_blockIdx_t17__fetch_builtin_xEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.ctaid.x"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
+
+  out[i++] = blockIdx.y;
+  // CIR:  cir.func linkonce_odr @_ZN25__cuda_builtin_blockIdx_t17__fetch_builtin_yEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.ctaid.y"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.ctaid.y()
+
+  out[i++] = blockIdx.z;
+  // CIR:  cir.func linkonce_odr @_ZN25__cuda_builtin_blockIdx_t17__fetch_builtin_zEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.ctaid.z"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.ctaid.z()
+
+
+  out[i++] = blockDim.x;
+  // CIR:  cir.func linkonce_odr @_ZN25__cuda_builtin_blockDim_t17__fetch_builtin_xEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.ntid.x"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
+
+  out[i++] = blockDim.y;
+  // CIR:  cir.func linkonce_odr @_ZN25__cuda_builtin_blockDim_t17__fetch_builtin_yEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.ntid.y"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.ntid.y()
+
+  out[i++] = blockDim.z;
+  // CIR:  cir.func linkonce_odr @_ZN25__cuda_builtin_blockDim_t17__fetch_builtin_zEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.ntid.z"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.ntid.z()
+
+
+  out[i++] = gridDim.x;
+  // CIR:  cir.func linkonce_odr @_ZN24__cuda_builtin_gridDim_t17__fetch_builtin_xEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.nctaid.x"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.nctaid.x()
+
+  out[i++] = gridDim.y;
+  // CIR:  cir.func linkonce_odr @_ZN24__cuda_builtin_gridDim_t17__fetch_builtin_yEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.nctaid.y"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.nctaid.y()
+
+  out[i++] = gridDim.z;
+  // CIR:  cir.func linkonce_odr @_ZN24__cuda_builtin_gridDim_t17__fetch_builtin_zEv()
+  // CIR:  cir.llvm.intrinsic "nvvm.read.ptx.sreg.nctaid.z"
+  // LLVM: call {{.*}} i32 @llvm.nvvm.read.ptx.sreg.nctaid.z()
+
+
+  out[i++] = warpSize;
+  // CIR: cir.get_global @warpSize
+  // LLVM: load {{.*}} @warpSize,
+
+
+  // CIR: cir.return loc
+  // LLVM: ret void
+}


### PR DESCRIPTION
This PR adds support for compiling builtin variables like `threadIdx` down to the appropriate intrinsic.