### PR TITLE
[CIR] Add 'core-flat' as an option value for '-emit-mlir='

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -37,13 +37,15 @@ std::unique_ptr<Pass> createIdiomRecognizerPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createLibOptPass();
 std::unique_ptr<Pass> createLibOptPass(clang::ASTContext *astCtx);
 std::unique_ptr<Pass> createFlattenCFGPass();
+std::unique_ptr<Pass> createFlattenCFGPass(bool throughMLIR);
 std::unique_ptr<Pass> createHoistAllocasPass();
 std::unique_ptr<Pass> createGotoSolverPass();
 
 /// Create a pass to lower ABI-independent function definitions/calls.
 std::unique_ptr<Pass> createCallConvLoweringPass();
 
-void populateCIRPreLoweringPasses(mlir::OpPassManager &pm, bool useCCLowering);
+void populateCIRPreLoweringPasses(mlir::OpPassManager &pm, bool useCCLowering,
+                                  bool emitCore);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -127,6 +127,10 @@ def FlattenCFG : Pass<"cir-flatten-cfg"> {
     In other words, this pass removes such CIR operations like IfOp, LoopOp,
     ScopeOp and etc. and produces a flat CIR.
   }];
+  let options = [
+    Option<"throughMLIR", "through-mlir", "bool", /*default=*/"false",
+        "Prepare the flat CIR for lowering through MLIR">,
+  ];
   let constructor = "mlir::createFlattenCFGPass()";
   let dependentDialects = ["cir::CIRDialect"];
 }

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3067,9 +3067,9 @@ def emit_mlir : Flag<["-"], "emit-mlir">, Visibility<[ClangOption]>, Group<Actio
 def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[ClangOption, CC1Option]>, Group<Action_Group>,
   HelpText<"Build ASTs and then lower through ClangIR to the selected MLIR dialect, emit the .mlir file. "
   "Allowed values are `core` for MLIR standard dialects and `llvm` for the LLVM dialect.">,
-  Values<"core,llvm,cir,cir-flat">,
+  Values<"core,llvm,cir,cir-flat,core-flat">,
   NormalizedValuesScope<"frontend">,
-  NormalizedValues<["MLIR_CORE", "MLIR_LLVM", "MLIR_CIR", "MLIR_CIR_FLAT"]>,
+  NormalizedValues<["MLIR_CORE", "MLIR_LLVM", "MLIR_CIR", "MLIR_CIR_FLAT", "MLIR_CORE_FLAT"]>,
   MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_CORE">;
 def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, Alias<emit_mlir_EQ>, AliasArgs<["cir"]>,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -151,7 +151,13 @@ enum ActionKind {
   PrintDependencyDirectivesSourceMinimizerOutput
 };
 
-enum MLIRDialectKind { MLIR_CORE, MLIR_LLVM, MLIR_CIR, MLIR_CIR_FLAT };
+enum MLIRDialectKind {
+  MLIR_CORE,
+  MLIR_LLVM,
+  MLIR_CIR,
+  MLIR_CIR_FLAT,
+  MLIR_CORE_FLAT
+};
 
 } // namespace frontend
 

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -76,7 +76,7 @@ mlir::LogicalResult runCIRToCIRPasses(
   pm.addPass(mlir::createLoweringPreparePass(&astContext));
 
   if (flattenCIR || enableMem2Reg)
-    mlir::populateCIRPreLoweringPasses(pm, enableCallConvLowering);
+    mlir::populateCIRPreLoweringPasses(pm, enableCallConvLowering, emitCore);
 
   if (enableMem2Reg)
     pm.addPass(mlir::createMem2Reg());
@@ -96,11 +96,12 @@ mlir::LogicalResult runCIRToCIRPasses(
 
 namespace mlir {
 
-void populateCIRPreLoweringPasses(OpPassManager &pm, bool useCCLowering) {
+void populateCIRPreLoweringPasses(OpPassManager &pm, bool useCCLowering,
+                                  bool emitCore) {
   if (useCCLowering)
     pm.addPass(createCallConvLoweringPass());
   pm.addPass(createHoistAllocasPass());
-  pm.addPass(createFlattenCFGPass());
+  pm.addPass(createFlattenCFGPass(/*throughMLIR=*/emitCore));
   pm.addPass(createGotoSolverPass());
 }
 

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -206,12 +206,16 @@ public:
           feOptions.ClangIRCallConvLowering &&
           !(action == CIRGenAction::OutputType::EmitMLIR &&
             feOptions.MLIRTargetDialect == frontend::MLIR_CIR);
+
       bool flattenCIR =
           action == CIRGenAction::OutputType::EmitMLIR &&
-          feOptions.MLIRTargetDialect == clang::frontend::MLIR_CIR_FLAT;
+          (feOptions.MLIRTargetDialect == clang::frontend::MLIR_CORE_FLAT ||
+           feOptions.MLIRTargetDialect == clang::frontend::MLIR_CIR_FLAT);
 
-      bool emitCore = action == CIRGenAction::OutputType::EmitMLIR &&
-                      feOptions.MLIRTargetDialect == clang::frontend::MLIR_CORE;
+      bool emitCore =
+          action == CIRGenAction::OutputType::EmitMLIR &&
+          (feOptions.MLIRTargetDialect == clang::frontend::MLIR_CORE ||
+           feOptions.MLIRTargetDialect == clang::frontend::MLIR_CORE_FLAT);
 
       // Setup and run CIR pipeline.
       std::string passOptParsingFailure;
@@ -283,6 +287,7 @@ public:
     case CIRGenAction::OutputType::EmitMLIR: {
       switch (feOptions.MLIRTargetDialect) {
       case clang::frontend::MLIR_CORE:
+      case clang::frontend::MLIR_CORE_FLAT:
         // case for direct lowering is already checked in compiler invocation
         // no need to check here
         emitMLIR(lowerFromCIRToMLIR(mlirMod, mlirCtx.get()), false);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4780,7 +4780,7 @@ std::unique_ptr<mlir::Pass> createConvertCIRToLLVMPass() {
 }
 
 void populateCIRToLLVMPasses(mlir::OpPassManager &pm, bool useCCLowering) {
-  populateCIRPreLoweringPasses(pm, useCCLowering);
+  populateCIRPreLoweringPasses(pm, useCCLowering, /*emitCore=*/false);
   pm.addPass(createConvertCIRToLLVMPass());
 }
 

--- a/clang/test/CIR/Lowering/ThroughMLIR/cf.ret.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/cf.ret.c
@@ -1,0 +1,92 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core-flat %s -o - | FileCheck %s
+
+void foo() {
+  int a = 0;
+  int b = 0;
+  if (a < 0)
+    return;
+  ++b;
+  return;
+}
+
+// CHECK-LABEL: func.func @foo() {
+// CHECK:    %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+// CHECK:    %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+// CHECK:    %[[c0_i32:.+]] = arith.constant 0 : i32
+// CHECK:    memref.store %[[c0_i32]], %[[alloca]][] : memref<i32>
+// CHECK:    %[[c0_i32_1:.+]] = arith.constant 0 : i32
+// CHECK:    memref.store %[[c0_i32_1]], %[[alloca_0]][] : memref<i32>
+// CHECK:    cf.br ^bb1
+// CHECK:  ^bb1:
+// CHECK:    %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+// CHECK:    %[[c0_i32_2:.+]] = arith.constant 0 : i32
+// CHECK:    %[[ONE:.+]] = arith.cmpi slt, %[[ZERO]], %[[c0_i32_2]] : i32
+// CHECK:    cf.cond_br %[[ONE]], ^bb2, ^bb3
+// CHECK:  ^bb2:
+// CHECK:    cf.br ^bb5
+// CHECK:  ^bb3:
+// CHECK:    cf.br ^bb4
+// CHECK:  ^bb4:
+// CHECK:    %[[TWO:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+// CHECK:    %[[c1_i32:.+]] = arith.constant 1 : i32
+// CHECK:    %[[THREE:.+]] = arith.addi %[[TWO]], %[[c1_i32]] : i32
+// CHECK:    memref.store %[[THREE]], %[[alloca_0]][] : memref<i32>
+// CHECK:    cf.br ^bb5
+// CHECK:  ^bb5:
+// CHECK:    return
+// CHECK:  }
+
+void foo2() {
+  int b = 0;
+  for (int i = 0; i < 8; ++i)
+    if (b > 4)
+      return;
+  ++b;
+  return;
+}
+
+// CHECK-LABEL:   func.func @foo2() {
+// CHECK:     %[[alloca:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+// CHECK:     %[[alloca_0:.+]] = memref.alloca() {alignment = 4 : i64} : memref<i32>
+// CHECK:     %[[c0_i32:.+]] = arith.constant 0 : i32
+// CHECK:     memref.store %[[c0_i32]], %[[alloca_0]][] : memref<i32>
+// CHECK:     cf.br ^bb1
+// CHECK:   ^bb1:
+// CHECK:     %[[c0_i32_1:.+]] = arith.constant 0 : i32
+// CHECK:     memref.store %[[c0_i32_1]], %[[alloca]][] : memref<i32>
+// CHECK:     cf.br ^bb2
+// CHECK:   ^bb2:
+// CHECK:     %[[ZERO:.+]] = memref.load %[[alloca]][] : memref<i32>
+// CHECK:     %[[c8_i32:.+]] = arith.constant 8 : i32
+// CHECK:     %[[ONE:.+]] = arith.cmpi slt, %[[ZERO]], %[[c8_i32]] : i32
+// CHECK:     cf.cond_br %[[ONE]], ^bb3, ^bb9
+// CHECK:   ^bb3:
+// CHECK:     cf.br ^bb4
+// CHECK:   ^bb4:
+// CHECK:     %[[TWO:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+// CHECK:     %[[c4_i32:.+]] = arith.constant 4 : i32
+// CHECK:     %[[THREE:.+]] = arith.cmpi sgt, %[[TWO]], %[[c4_i32]] : i32
+// CHECK:     cf.cond_br %[[THREE]], ^bb5, ^bb6
+// CHECK:   ^bb5:
+// CHECK:     cf.br ^bb11
+// CHECK:   ^bb6:
+// CHECK:     cf.br ^bb7
+// CHECK:   ^bb7:
+// CHECK:     cf.br ^bb8
+// CHECK:   ^bb8:
+// CHECK:     %[[FOUR:.+]] = memref.load %[[alloca]][] : memref<i32>
+// CHECK:     %[[c1_i32:.+]] = arith.constant 1 : i32
+// CHECK:     %[[FIVE:.+]] = arith.addi %[[FOUR]], %[[c1_i32]] : i32
+// CHECK:     memref.store %[[FIVE]], %[[alloca]][] : memref<i32>
+// CHECK:     cf.br ^bb2
+// CHECK:   ^bb9:
+// CHECK:     cf.br ^bb10
+// CHECK:   ^bb10:
+// CHECK:     %[[SIX:.+]] = memref.load %[[alloca_0]][] : memref<i32>
+// CHECK:     %[[c1_i32_2:.+]] = arith.constant 1 : i32
+// CHECK:     %[[SEVEN:.+]] = arith.addi %[[SIX]], %[[c1_i32_2]] : i32
+// CHECK:     memref.store %[[SEVEN]], %[[alloca_0]][] : memref<i32>
+// CHECK:     cf.br ^bb11
+// CHECK:   ^bb11:
+// CHECK:     return
+// CHECK:   }

--- a/clang/test/CIR/Transforms/return.cir
+++ b/clang/test/CIR/Transforms/return.cir
@@ -1,0 +1,29 @@
+// RUN: cir-opt %s -cir-flatten-cfg="through-mlir=false" -o - | FileCheck --check-prefix=DIRECT %s
+// RUN: cir-opt %s -cir-flatten-cfg="through-mlir=true" -o - | FileCheck --check-prefix=THRUMLIR %s
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.func @needUnifyReturn(%arg0: !s32i) {
+    %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
+    cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
+    cir.scope {
+      %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+      cir.switch (%1 : !s32i) {
+      cir.case (equal, [#cir.int<3> : !s32i]) {
+        cir.return
+      ^bb1:  // no predecessors
+        cir.break
+      }
+      cir.yield
+      }
+    }
+    cir.return
+  }
+// DIRECT-LABEL: cir.func @needUnifyReturn(%arg0: !s32i) {
+// DIRECT-COUNT-2:   cir.return
+// DIRECT-NOT:   cir.return
+// THRUMLIR-LABEL: cir.func @needUnifyReturn(%arg0: !s32i) {
+// THRUMLIR-COUNT-1:   cir.return
+// THRUMLIR-NOT:   cir.return
+}


### PR DESCRIPTION
- Both 'func' and 'scf' have structure control flow constraints, e.g., 'func.return' needs to have 'func.func' parent op. The alternative approach to lower CIR into MLIR standard dialects is to lower CIR into 'cf' dialect and perform structurization on all or selected regions.
- Add 'core-flat' option to enable CFG flattening when lowering CIR into MLIR standard dialects.
- Add 'cir-unify-func-return' pass to unify returns into branches to a trialing block dedicated for function return.
- Fix 'cir.br' and 'cir.return' lowering to MLIR and allow function declarations.