### PR TITLE
[CIR] Add ABI lowering pass

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -40,6 +40,9 @@ std::unique_ptr<Pass> createFlattenCFGPass();
 std::unique_ptr<Pass> createHoistAllocasPass();
 std::unique_ptr<Pass> createGotoSolverPass();
 
+/// Create a pass to expand ABI-dependent types and operations.
+std::unique_ptr<Pass> createABILoweringPass();
+
 /// Create a pass to lower ABI-independent function definitions/calls.
 std::unique_ptr<Pass> createCallConvLoweringPass();
 

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -180,6 +180,27 @@ def LibOpt : Pass<"cir-lib-opt"> {
   ];
 }
 
+def ABILowering : Pass<"cir-abi-lowering"> {
+  let summary = "Expands ABI-dependent types and operations";
+  let description = [{
+    This pass expands ABI-dependent CIR types and operations to more "primitive"
+    ABI-independent CIR types and operations according to the target ABI
+    specification.
+
+    Some CIR types, such as pointers to members, may have different layouts and
+    representations under different target ABIs. This pass expands these types
+    to their underlying representations as specified by the target ABI. For
+    example, when targeting Itanium ABI, this pass will replace pointers to
+    member functions with a struct with two ptrdiff_t fields.
+
+    Similarly, some CIR operations may also behave differently under different
+    target ABIs. This pass also expands these operations to more "primitive"
+    CIR operations as specified by the target ABI.
+  }];
+  let constructor = "mlir::createABILoweringPass()";
+  let dependentDialects = ["cir::CIRDialect"];
+}
+
 def CallConvLowering : Pass<"cir-call-conv-lowering"> {
   let summary = "Handle calling conventions for CIR functions";
   let description = [{

--- a/clang/lib/CIR/CodeGen/CIRPasses.cpp
+++ b/clang/lib/CIR/CodeGen/CIRPasses.cpp
@@ -97,6 +97,7 @@ mlir::LogicalResult runCIRToCIRPasses(
 namespace mlir {
 
 void populateCIRPreLoweringPasses(OpPassManager &pm, bool useCCLowering) {
+  pm.addPass(createABILoweringPass());
   if (useCCLowering)
     pm.addPass(createCallConvLoweringPass());
   pm.addPass(createHoistAllocasPass());

--- a/clang/lib/CIR/Dialect/Transforms/ABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/ABILowering.cpp
@@ -1,0 +1,487 @@
+//===- ABILowering.cpp - Expands ABI-dependent types and operations -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the CIR ABI lowering pass which expands ABI-dependent
+// types and operations to equivalent ABI-independent types and operations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TargetLowering/LowerModule.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+
+#define GEN_PASS_DEF_ABILOWERING
+#include "clang/CIR/Dialect/Passes.h.inc"
+
+namespace cir {
+namespace {
+
+template <typename Op>
+class CIROpABILoweringPattern : public mlir::OpConversionPattern<Op> {
+protected:
+  mlir::DataLayout *dataLayout;
+  cir::LowerModule *lowerModule;
+
+public:
+  CIROpABILoweringPattern(mlir::MLIRContext *context,
+                          const mlir::TypeConverter &typeConverter,
+                          mlir::DataLayout &dataLayout,
+                          cir::LowerModule &lowerModule)
+      : mlir::OpConversionPattern<Op>(typeConverter, context),
+        dataLayout(&dataLayout), lowerModule(&lowerModule) {}
+};
+
+#define CIR_ABI_LOWERING_PATTERN(name, operation)                              \
+  struct name : CIROpABILoweringPattern<operation> {                           \
+    using CIROpABILoweringPattern<operation>::CIROpABILoweringPattern;         \
+                                                                               \
+    mlir::LogicalResult                                                        \
+    matchAndRewrite(operation op, OpAdaptor adaptor,                           \
+                    mlir::ConversionPatternRewriter &rewriter) const override; \
+  }
+CIR_ABI_LOWERING_PATTERN(CIRAllocaOpABILowering, cir::AllocaOp);
+CIR_ABI_LOWERING_PATTERN(CIRBaseDataMemberOpABILowering, cir::BaseDataMemberOp);
+CIR_ABI_LOWERING_PATTERN(CIRBaseMethodOpABILowering, cir::BaseMethodOp);
+CIR_ABI_LOWERING_PATTERN(CIRCastOpABILowering, cir::CastOp);
+CIR_ABI_LOWERING_PATTERN(CIRCmpOpABILowering, cir::CmpOp);
+CIR_ABI_LOWERING_PATTERN(CIRConstantOpABILowering, cir::ConstantOp);
+CIR_ABI_LOWERING_PATTERN(CIRDerivedDataMemberOpABILowering,
+                         cir::DerivedDataMemberOp);
+CIR_ABI_LOWERING_PATTERN(CIRDerivedMethodOpABILowering, cir::DerivedMethodOp);
+CIR_ABI_LOWERING_PATTERN(CIRFuncOpABILowering, cir::FuncOp);
+CIR_ABI_LOWERING_PATTERN(CIRGetMethodOpABILowering, cir::GetMethodOp);
+CIR_ABI_LOWERING_PATTERN(CIRGetRuntimeMemberOpABILowering,
+                         cir::GetRuntimeMemberOp);
+CIR_ABI_LOWERING_PATTERN(CIRGlobalOpABILowering, cir::GlobalOp);
+#undef CIR_ABI_LOWERING_PATTERN
+
+/// A generic ABI lowering rewrite pattern. This conversion pattern matches any
+/// CIR dialect operations with at least one operand or result of an
+/// ABI-dependent type. This conversion pattern rewrites the matched operation
+/// by replacing all its ABI-dependent operands and results with their
+/// lowered counterparts.
+class CIRGenericABILoweringPattern : public mlir::ConversionPattern {
+public:
+  CIRGenericABILoweringPattern(mlir::MLIRContext *context,
+                               const mlir::TypeConverter &typeConverter)
+      : mlir::ConversionPattern(typeConverter, MatchAnyOpTypeTag(),
+                                /*benefit=*/1, context) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op, llvm::ArrayRef<mlir::Value> operands,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    // Do not match on operations that have dedicated ABI lowering rewrite rules
+    if (llvm::isa<cir::BaseDataMemberOp, cir::BaseMethodOp, cir::CastOp,
+                  cir::CmpOp, cir::ConstantOp, cir::DerivedDataMemberOp,
+                  cir::DerivedMethodOp, cir::FuncOp, cir::GetMethodOp,
+                  cir::GetRuntimeMemberOp, cir::GlobalOp>(op))
+      return mlir::failure();
+
+    const mlir::TypeConverter *typeConverter = getTypeConverter();
+    assert(typeConverter &&
+           "CIRGenericABILoweringPattern requires a type converter");
+
+    bool operandsAndResultsLegal = typeConverter->isLegal(op);
+    bool regionsLegal =
+        std::all_of(op->getRegions().begin(), op->getRegions().end(),
+                    [typeConverter](mlir::Region &region) {
+                      return typeConverter->isLegal(&region);
+                    });
+    if (operandsAndResultsLegal && regionsLegal) {
+      // The operation does not have any ABI-dependent operands, results, or
+      // regions, the match fails.
+      return mlir::failure();
+    }
+
+    mlir::OperationState loweredOpState(op->getLoc(), op->getName());
+    loweredOpState.addOperands(operands);
+    loweredOpState.addAttributes(op->getAttrs());
+    loweredOpState.addSuccessors(op->getSuccessors());
+
+    // Lower all result types
+    llvm::SmallVector<mlir::Type> loweredResultTypes;
+    loweredResultTypes.reserve(op->getNumResults());
+    for (mlir::Type result : op->getResultTypes())
+      loweredResultTypes.push_back(typeConverter->convertType(result));
+    loweredOpState.addTypes(loweredResultTypes);
+
+    // Lower all regions
+    for (mlir::Region &region : op->getRegions()) {
+      mlir::Region *loweredRegion = loweredOpState.addRegion();
+      rewriter.inlineRegionBefore(region, *loweredRegion, loweredRegion->end());
+      if (mlir::failed(
+              rewriter.convertRegionTypes(loweredRegion, *getTypeConverter())))
+        return mlir::failure();
+    }
+
+    // Clone the operation with lowered operand types, result types, and regions
+    mlir::Operation *loweredOp = rewriter.create(loweredOpState);
+
+    rewriter.replaceOp(op, loweredOp);
+    return mlir::success();
+  }
+};
+
+mlir::LogicalResult CIRAllocaOpABILowering::matchAndRewrite(
+    cir::AllocaOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Type allocaPtrTy = op.getType();
+  mlir::Type allocaTy = op.getAllocaType();
+  mlir::Type loweredAllocaPtrTy = getTypeConverter()->convertType(allocaPtrTy);
+  mlir::Type loweredAllocaTy = getTypeConverter()->convertType(allocaTy);
+
+  cir::AllocaOp loweredOp = cir::AllocaOp::create(
+      rewriter, op.getLoc(), loweredAllocaPtrTy, loweredAllocaTy, op.getName(),
+      op.getAlignmentAttr(), /*dynAllocSize=*/adaptor.getDynAllocSize());
+  loweredOp.setInit(op.getInit());
+  loweredOp.setConstant(op.getConstant());
+  loweredOp.setAnnotationsAttr(op.getAnnotationsAttr());
+
+  rewriter.replaceOp(op, loweredOp);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRBaseDataMemberOpABILowering::matchAndRewrite(
+    cir::BaseDataMemberOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult = lowerModule->getCXXABI().lowerBaseDataMember(
+      op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRBaseMethodOpABILowering::matchAndRewrite(
+    cir::BaseMethodOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult =
+      lowerModule->getCXXABI().lowerBaseMethod(op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRCastOpABILowering::matchAndRewrite(
+    cir::CastOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Type srcTy = op.getSrc().getType();
+  assert((mlir::isa<cir::DataMemberType, cir::MethodType>(srcTy)) &&
+         "input to bitcast in ABI lowering must be a data member or method");
+
+  switch (op.getKind()) {
+  case cir::CastKind::bitcast: {
+    mlir::Type destTy = getTypeConverter()->convertType(op.getType());
+    mlir::Value loweredResult;
+    if (mlir::isa<cir::DataMemberType>(srcTy))
+      loweredResult = lowerModule->getCXXABI().lowerDataMemberBitcast(
+          op, destTy, adaptor.getSrc(), rewriter);
+    else
+      loweredResult = lowerModule->getCXXABI().lowerMethodBitcast(
+          op, destTy, adaptor.getSrc(), rewriter);
+    rewriter.replaceOp(op, loweredResult);
+    return mlir::success();
+  }
+  case cir::CastKind::member_ptr_to_bool: {
+    mlir::Value loweredResult;
+    if (mlir::isa<cir::MethodType>(srcTy))
+      loweredResult = lowerModule->getCXXABI().lowerMethodToBoolCast(
+          op, adaptor.getSrc(), rewriter);
+    else
+      loweredResult = lowerModule->getCXXABI().lowerDataMemberToBoolCast(
+          op, adaptor.getSrc(), rewriter);
+    rewriter.replaceOp(op, loweredResult);
+    return mlir::success();
+  }
+  default:
+    break;
+  }
+
+  return mlir::failure();
+}
+
+mlir::LogicalResult CIRCmpOpABILowering::matchAndRewrite(
+    cir::CmpOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  auto type = op.getLhs().getType();
+  assert((mlir::isa<cir::DataMemberType, cir::MethodType>(type)) &&
+         "input to cmp in ABI lowering must be a data member or method");
+
+  mlir::Value loweredResult;
+  if (mlir::isa<cir::DataMemberType>(type))
+    loweredResult = lowerModule->getCXXABI().lowerDataMemberCmp(
+        op, adaptor.getLhs(), adaptor.getRhs(), rewriter);
+  else
+    loweredResult = lowerModule->getCXXABI().lowerMethodCmp(
+        op, adaptor.getLhs(), adaptor.getRhs(), rewriter);
+
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRConstantOpABILowering::matchAndRewrite(
+    cir::ConstantOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+
+  if (mlir::isa<cir::DataMemberType>(op.getType())) {
+    auto dataMember = mlir::cast<cir::DataMemberAttr>(op.getValue());
+    mlir::DataLayout layout(op->getParentOfType<mlir::ModuleOp>());
+    mlir::TypedAttr abiValue = lowerModule->getCXXABI().lowerDataMemberConstant(
+        dataMember, layout, *getTypeConverter());
+    rewriter.replaceOpWithNewOp<ConstantOp>(op, abiValue);
+    return mlir::success();
+  }
+
+  if (mlir::isa<cir::MethodType>(op.getType())) {
+    auto method = mlir::cast<cir::MethodAttr>(op.getValue());
+    mlir::DataLayout layout(op->getParentOfType<mlir::ModuleOp>());
+    mlir::TypedAttr abiValue = lowerModule->getCXXABI().lowerMethodConstant(
+        method, layout, *getTypeConverter());
+    rewriter.replaceOpWithNewOp<ConstantOp>(op, abiValue);
+    return mlir::success();
+  }
+
+  llvm_unreachable("constant operand is not an ABI-dependent type");
+}
+
+mlir::LogicalResult CIRDerivedDataMemberOpABILowering::matchAndRewrite(
+    cir::DerivedDataMemberOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult = lowerModule->getCXXABI().lowerDerivedDataMember(
+      op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRDerivedMethodOpABILowering::matchAndRewrite(
+    cir::DerivedMethodOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult = lowerModule->getCXXABI().lowerDerivedMethod(
+      op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRFuncOpABILowering::matchAndRewrite(
+    cir::FuncOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  cir::FuncType opFuncType = op.getFunctionType();
+  mlir::TypeConverter::SignatureConversion signatureConversion(
+      opFuncType.getNumInputs());
+
+  for (const auto &[i, argType] : llvm::enumerate(opFuncType.getInputs())) {
+    mlir::Type loweredArgType = getTypeConverter()->convertType(argType);
+    if (!loweredArgType)
+      return mlir::failure();
+    signatureConversion.addInputs(i, loweredArgType);
+  }
+
+  mlir::Type loweredResultType =
+      getTypeConverter()->convertType(opFuncType.getReturnType());
+  if (!loweredResultType)
+    return mlir::failure();
+
+  auto loweredFuncType =
+      cir::FuncType::get(signatureConversion.getConvertedTypes(),
+                         loweredResultType, /*isVarArg=*/opFuncType.isVarArg());
+
+  // Create a new cir.func operation for the ABI-lowered function.
+  cir::FuncOp loweredFuncOp = rewriter.cloneWithoutRegions(op);
+  loweredFuncOp.setFunctionType(loweredFuncType);
+  rewriter.inlineRegionBefore(op.getBody(), loweredFuncOp.getBody(),
+                              loweredFuncOp.end());
+  if (mlir::failed(rewriter.convertRegionTypes(
+          &loweredFuncOp.getBody(), *getTypeConverter(), &signatureConversion)))
+    return mlir::failure();
+
+  rewriter.eraseOp(op);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRGetMethodOpABILowering::matchAndRewrite(
+    cir::GetMethodOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResults[2];
+  lowerModule->getCXXABI().lowerGetMethod(
+      op, loweredResults, adaptor.getMethod(), adaptor.getObject(), rewriter);
+  rewriter.replaceOp(op, loweredResults);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRGetRuntimeMemberOpABILowering::matchAndRewrite(
+    cir::GetRuntimeMemberOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Type resTy = getTypeConverter()->convertType(op.getType());
+  mlir::Operation *llvmOp = lowerModule->getCXXABI().lowerGetRuntimeMember(
+      op, resTy, adaptor.getAddr(), adaptor.getMember(), rewriter);
+  rewriter.replaceOp(op, llvmOp);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRGlobalOpABILowering::matchAndRewrite(
+    cir::GlobalOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Type ty = op.getSymType();
+  mlir::Type loweredTy = getTypeConverter()->convertType(ty);
+  if (!loweredTy)
+    return mlir::failure();
+
+  mlir::DataLayout layout(op->getParentOfType<mlir::ModuleOp>());
+
+  mlir::Attribute loweredInit;
+  if (mlir::isa<cir::DataMemberType>(ty)) {
+    cir::DataMemberAttr init =
+        mlir::cast_if_present<cir::DataMemberAttr>(op.getInitialValueAttr());
+    loweredInit = lowerModule->getCXXABI().lowerDataMemberConstant(
+        init, layout, *getTypeConverter());
+  } else if (mlir::isa<cir::MethodType>(ty)) {
+    cir::MethodAttr init =
+        mlir::cast_if_present<cir::MethodAttr>(op.getInitialValueAttr());
+    loweredInit = lowerModule->getCXXABI().lowerMethodConstant(
+        init, layout, *getTypeConverter());
+  } else {
+    llvm_unreachable(
+        "inputs to cir.global in ABI lowering must be data member or method");
+  }
+
+  auto abiOp = mlir::cast<cir::GlobalOp>(rewriter.clone(*op.getOperation()));
+  abiOp.setInitialValueAttr(loweredInit);
+  abiOp.setSymType(loweredTy);
+  rewriter.replaceOp(op, abiOp);
+  return mlir::success();
+}
+
+static void prepareABITypeConverter(mlir::TypeConverter &converter,
+                                    mlir::DataLayout &dataLayout,
+                                    cir::LowerModule &lowerModule) {
+  converter.addConversion([&](mlir::Type type) -> mlir::Type { return type; });
+  converter.addConversion([&](cir::PointerType type) -> mlir::Type {
+    mlir::Type loweredPointeeType = converter.convertType(type.getPointee());
+    if (!loweredPointeeType)
+      return {};
+    return cir::PointerType::get(type.getContext(), loweredPointeeType,
+                                 type.getAddrSpace());
+  });
+  converter.addConversion([&](cir::DataMemberType type) -> mlir::Type {
+    mlir::Type abiType = lowerModule.getCXXABI().getDataMemberABIType();
+    return converter.convertType(abiType);
+  });
+  converter.addConversion([&](cir::MethodType type) -> mlir::Type {
+    mlir::Type abiType = lowerModule.getCXXABI().getMethodABIType();
+    return converter.convertType(abiType);
+  });
+  converter.addConversion([&](cir::FuncType type) -> mlir::Type {
+    llvm::SmallVector<mlir::Type> loweredInputTypes;
+    loweredInputTypes.reserve(type.getNumInputs());
+    if (mlir::failed(
+            converter.convertTypes(type.getInputs(), loweredInputTypes)))
+      return {};
+
+    mlir::Type loweredReturnType = converter.convertType(type.getReturnType());
+    if (!loweredReturnType)
+      return {};
+
+    return cir::FuncType::get(loweredInputTypes, loweredReturnType,
+                              /*isVarArg=*/type.getVarArg());
+  });
+}
+
+static void
+populateABIConversionTarget(mlir::ConversionTarget &target,
+                            const mlir::TypeConverter &typeConverter) {
+  target.addLegalOp<mlir::ModuleOp>();
+
+  // The ABI lowering pass is interested in CIR operations with operands or
+  // results of ABI-dependent types, or CIR operations with regions whose block
+  // arguments are of ABI-dependent types.
+  target.addDynamicallyLegalDialect<cir::CIRDialect>(
+      [&typeConverter](mlir::Operation *op) {
+        if (!typeConverter.isLegal(op))
+          return false;
+        return std::all_of(op->getRegions().begin(), op->getRegions().end(),
+                           [&typeConverter](mlir::Region &region) {
+                             return typeConverter.isLegal(&region);
+                           });
+      });
+
+  // Some CIR ops needs special checking for legality
+  target.addDynamicallyLegalOp<cir::FuncOp>([&typeConverter](cir::FuncOp op) {
+    return typeConverter.isLegal(op.getFunctionType());
+  });
+  target.addDynamicallyLegalOp<cir::GlobalOp>(
+      [&typeConverter](cir::GlobalOp op) {
+        return typeConverter.isLegal(op.getSymType());
+      });
+}
+
+//===----------------------------------------------------------------------===//
+// The Pass
+//===----------------------------------------------------------------------===//
+
+struct ABILoweringPass : ::impl::ABILoweringBase<ABILoweringPass> {
+  using ABILoweringBase::ABILoweringBase;
+
+  void runOnOperation() override;
+  llvm::StringRef getArgument() const override { return "cir-abi-lowering"; };
+};
+
+void ABILoweringPass::runOnOperation() {
+  auto module = mlir::cast<mlir::ModuleOp>(getOperation());
+  mlir::MLIRContext *ctx = module.getContext();
+
+  // If the triple is not present, e.g. CIR modules parsed from text, we
+  // cannot init LowerModule properly.
+  assert(!cir::MissingFeatures::makeTripleAlwaysPresent());
+  if (!module->hasAttr(cir::CIRDialect::getTripleAttrName())) {
+    // If no target triple is available, skip the ABI lowering pass.
+    return;
+  }
+
+  mlir::PatternRewriter rewriter(ctx);
+  std::unique_ptr<cir::LowerModule> lowerModule =
+      cir::createLowerModule(module, rewriter);
+
+  mlir::DataLayout dataLayout(module);
+  mlir::TypeConverter typeConverter;
+  prepareABITypeConverter(typeConverter, dataLayout, *lowerModule);
+
+  mlir::RewritePatternSet patterns(ctx);
+  patterns.add<CIRGenericABILoweringPattern>(patterns.getContext(),
+                                             typeConverter);
+  patterns.add<
+      // clang-format off
+      CIRAllocaOpABILowering,
+      CIRBaseDataMemberOpABILowering,
+      CIRBaseMethodOpABILowering,
+      CIRCastOpABILowering,
+      CIRCmpOpABILowering,
+      CIRConstantOpABILowering,
+      CIRDerivedDataMemberOpABILowering,
+      CIRDerivedMethodOpABILowering,
+      CIRFuncOpABILowering,
+      CIRGetMethodOpABILowering,
+      CIRGetRuntimeMemberOpABILowering,
+      CIRGlobalOpABILowering
+      // clang-format on
+      >(patterns.getContext(), typeConverter, dataLayout, *lowerModule);
+
+  mlir::ConversionTarget target(*ctx);
+  populateABIConversionTarget(target, typeConverter);
+
+  if (failed(mlir::applyPartialConversion(module, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+} // namespace
+} // namespace cir
+
+std::unique_ptr<mlir::Pass> mlir::createABILoweringPass() {
+  return std::make_unique<cir::ABILoweringPass>();
+}

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_clang_library(MLIRCIRTransforms
   FlattenCFG.cpp
   GotoSolver.cpp
   SCFPrepare.cpp
+  ABILowering.cpp
   CallConvLowering.cpp
   HoistAllocas.cpp
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -66,17 +66,11 @@ public:
   /// FIXME(cir): This expects a CXXRecordDecl! Not any record type.
   virtual RecordArgABI getRecordArgABI(const RecordType RD) const = 0;
 
-  /// Lower the given data member pointer type to its ABI type. The returned
-  /// type is also a CIR type.
-  virtual mlir::Type
-  lowerDataMemberType(cir::DataMemberType type,
-                      const mlir::TypeConverter &typeConverter) const = 0;
+  /// Get the ABI type for a pointer to data member.
+  virtual mlir::Type getDataMemberABIType() const = 0;
 
-  /// Lower the given member function pointer type to its ABI type. The returned
-  /// type is also a CIR type.
-  virtual mlir::Type
-  lowerMethodType(cir::MethodType type,
-                  const mlir::TypeConverter &typeConverter) const = 0;
+  /// Get the ABI type for a pointer to member function.
+  virtual mlir::Type getMethodABIType() const = 0;
 
   /// Lower the given data member pointer constant to a constant of the ABI
   /// type. The returned constant is represented as an attribute as well.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -234,6 +234,12 @@ llvm::LogicalResult LowerModule::rewriteFunctionCall(CallOp callOp,
 // TODO: not to create it every time
 std::unique_ptr<LowerModule>
 createLowerModule(mlir::ModuleOp module, mlir::PatternRewriter &rewriter) {
+  // If the triple is not present, e.g. CIR modules parsed from text, we
+  // cannot init LowerModule properly.
+  assert(!cir::MissingFeatures::makeTripleAlwaysPresent());
+  if (!module->hasAttr(cir::CIRDialect::getTripleAttrName()))
+    return nullptr;
+
   // Fetch target information.
   llvm::Triple triple(mlir::cast<mlir::StringAttr>(
                           module->getAttr(cir::CIRDialect::getTripleAttrName()))

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -95,8 +95,6 @@ void populateCIRToLLVMConversionPatterns(
     llvm::MapVector<mlir::ArrayAttr, mlir::LLVM::GlobalOp> &argsVarMap,
     LLVMBlockAddressInfo &blockAddrInfo);
 
-std::unique_ptr<cir::LowerModule> prepareLowerModule(mlir::ModuleOp module);
-
 void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
                           mlir::DataLayout &dataLayout,
                           cir::LowerModule *lowerModule);
@@ -237,66 +235,6 @@ public:
                   mlir::ConversionPatternRewriter &) const override;
 };
 
-class CIRToLLVMBaseDataMemberOpLowering
-    : public mlir::OpConversionPattern<cir::BaseDataMemberOp> {
-  cir::LowerModule *lowerMod;
-
-public:
-  CIRToLLVMBaseDataMemberOpLowering(const mlir::TypeConverter &typeConverter,
-                                    mlir::MLIRContext *context,
-                                    cir::LowerModule *lowerModule)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
-
-  mlir::LogicalResult
-  matchAndRewrite(cir::BaseDataMemberOp op, OpAdaptor,
-                  mlir::ConversionPatternRewriter &) const override;
-};
-
-class CIRToLLVMDerivedDataMemberOpLowering
-    : public mlir::OpConversionPattern<cir::DerivedDataMemberOp> {
-  cir::LowerModule *lowerMod;
-
-public:
-  CIRToLLVMDerivedDataMemberOpLowering(const mlir::TypeConverter &typeConverter,
-                                       mlir::MLIRContext *context,
-                                       cir::LowerModule *lowerModule)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
-
-  mlir::LogicalResult
-  matchAndRewrite(cir::DerivedDataMemberOp op, OpAdaptor,
-                  mlir::ConversionPatternRewriter &) const override;
-};
-
-class CIRToLLVMBaseMethodOpLowering
-    : public mlir::OpConversionPattern<cir::BaseMethodOp> {
-  cir::LowerModule *lowerMod;
-
-public:
-  CIRToLLVMBaseMethodOpLowering(const mlir::TypeConverter &typeConverter,
-                                mlir::MLIRContext *context,
-                                cir::LowerModule *lowerModule)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
-
-  mlir::LogicalResult
-  matchAndRewrite(cir::BaseMethodOp op, OpAdaptor,
-                  mlir::ConversionPatternRewriter &) const override;
-};
-
-class CIRToLLVMDerivedMethodOpLowering
-    : public mlir::OpConversionPattern<cir::DerivedMethodOp> {
-  cir::LowerModule *lowerMod;
-
-public:
-  CIRToLLVMDerivedMethodOpLowering(const mlir::TypeConverter &typeConverter,
-                                   mlir::MLIRContext *context,
-                                   cir::LowerModule *lowerModule)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
-
-  mlir::LogicalResult
-  matchAndRewrite(cir::DerivedMethodOp op, OpAdaptor,
-                  mlir::ConversionPatternRewriter &) const override;
-};
-
 class CIRToLLVMVTTAddrPointOpLowering
     : public mlir::OpConversionPattern<cir::VTTAddrPointOp> {
 public:
@@ -318,7 +256,6 @@ public:
 };
 
 class CIRToLLVMCastOpLowering : public mlir::OpConversionPattern<cir::CastOp> {
-  cir::LowerModule *lowerMod;
   mlir::DataLayout const &dataLayout;
 
   mlir::Type convertTy(mlir::Type ty) const;
@@ -326,10 +263,8 @@ class CIRToLLVMCastOpLowering : public mlir::OpConversionPattern<cir::CastOp> {
 public:
   CIRToLLVMCastOpLowering(const mlir::TypeConverter &typeConverter,
                           mlir::MLIRContext *context,
-                          cir::LowerModule *lowerModule,
                           mlir::DataLayout const &dataLayout)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule),
-        dataLayout(dataLayout) {}
+      : OpConversionPattern(typeConverter, context), dataLayout(dataLayout) {}
 
   mlir::LogicalResult
   matchAndRewrite(cir::CastOp op, OpAdaptor,
@@ -447,16 +382,13 @@ public:
 
 class CIRToLLVMConstantOpLowering
     : public mlir::OpConversionPattern<cir::ConstantOp> {
-  cir::LowerModule *lowerMod;
   mlir::DataLayout const &dataLayout;
 
 public:
   CIRToLLVMConstantOpLowering(const mlir::TypeConverter &typeConverter,
                               mlir::MLIRContext *context,
-                              cir::LowerModule *lowerModule,
                               mlir::DataLayout const &dataLayout)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule),
-        dataLayout(dataLayout) {
+      : OpConversionPattern(typeConverter, context), dataLayout(dataLayout) {
     setHasBoundedRewriteRecursion();
   }
 
@@ -661,16 +593,13 @@ public:
 
 class CIRToLLVMGlobalOpLowering
     : public mlir::OpConversionPattern<cir::GlobalOp> {
-  cir::LowerModule *lowerMod;
   mlir::DataLayout const &dataLayout;
 
 public:
   CIRToLLVMGlobalOpLowering(const mlir::TypeConverter &typeConverter,
                             mlir::MLIRContext *context,
-                            cir::LowerModule *lowerModule,
                             mlir::DataLayout const &dataLayout)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule),
-        dataLayout(dataLayout) {}
+      : OpConversionPattern(typeConverter, context), dataLayout(dataLayout) {}
 
   mlir::LogicalResult
   matchAndRewrite(cir::GlobalOp op, OpAdaptor,
@@ -767,15 +696,8 @@ public:
 };
 
 class CIRToLLVMCmpOpLowering : public mlir::OpConversionPattern<cir::CmpOp> {
-  cir::LowerModule *lowerMod;
-
 public:
-  CIRToLLVMCmpOpLowering(const mlir::TypeConverter &typeConverter,
-                         mlir::MLIRContext *context,
-                         cir::LowerModule *lowerModule)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {
-    setHasBoundedRewriteRecursion();
-  }
+  using mlir::OpConversionPattern<cir::CmpOp>::OpConversionPattern;
 
   mlir::LogicalResult
   matchAndRewrite(cir::CmpOp op, OpAdaptor,
@@ -1032,36 +954,6 @@ public:
 
   mlir::LogicalResult
   matchAndRewrite(cir::InsertMemberOp op, OpAdaptor,
-                  mlir::ConversionPatternRewriter &) const override;
-};
-
-class CIRToLLVMGetMethodOpLowering
-    : public mlir::OpConversionPattern<cir::GetMethodOp> {
-  cir::LowerModule *lowerMod;
-
-public:
-  CIRToLLVMGetMethodOpLowering(const mlir::TypeConverter &typeConverter,
-                               mlir::MLIRContext *context,
-                               cir::LowerModule *lowerModule)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
-
-  mlir::LogicalResult
-  matchAndRewrite(cir::GetMethodOp op, OpAdaptor,
-                  mlir::ConversionPatternRewriter &) const override;
-};
-
-class CIRToLLVMGetRuntimeMemberOpLowering
-    : public mlir::OpConversionPattern<cir::GetRuntimeMemberOp> {
-  cir::LowerModule *lowerMod;
-
-public:
-  CIRToLLVMGetRuntimeMemberOpLowering(const mlir::TypeConverter &typeConverter,
-                                      mlir::MLIRContext *context,
-                                      cir::LowerModule *lowerModule)
-      : OpConversionPattern(typeConverter, context), lowerMod(lowerModule) {}
-
-  mlir::LogicalResult
-  matchAndRewrite(cir::GetRuntimeMemberOp op, OpAdaptor,
                   mlir::ConversionPatternRewriter &) const override;
 };
 

--- a/clang/test/CIR/Transforms/ABILowering/cast.cir
+++ b/clang/test/CIR/Transforms/ABILowering/cast.cir
@@ -1,0 +1,53 @@
+// RUN: cir-opt --cir-abi-lowering -o %t.cir %s
+// RUN: FileCheck --input-file %t.cir %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!S1 = !cir.record<struct "S1" {!s32i, !s32i, !s32i}>
+!S2 = !cir.record<struct "S2" {!s32i, !s32i, !s32i}>
+!Field1 = !cir.data_member<!s32i in !S1>
+!Field2 = !cir.data_member<!s32i in !S2>
+!Method1 = !cir.method<!cir.func<(!s32i)> in !S1>
+!Method2 = !cir.method<!cir.func<(!s32i)> in !S2>
+
+module attributes {
+  cir.triple = "x86_64-unknown-linux-gnu",
+  dlti.dl_spec = #dlti.dl_spec<i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">
+} {
+  cir.func @bitcast_data_member(%arg0 : !Field1) -> !Field2 {
+    %0 = cir.cast bitcast %arg0: !Field1 -> !Field2
+    cir.return %0 : !Field2
+  }
+  // CHECK:      @bitcast_data_member(%[[ARG:.+]]: !s64i) -> !s64i
+  // CHECK-NEXT:   cir.return %[[ARG]] : !s64i
+  // CHECK-NEXT: }
+
+  cir.func @bitcast_method(%arg0 : !Method1) -> !Method2 {
+    %0 = cir.cast bitcast %arg0: !Method1 -> !Method2
+    cir.return %0 : !Method2
+  }
+  // CHECK:      @bitcast_method(%[[ARG:.+]]: ![[ABI_TY:.+]]) -> ![[ABI_TY]]
+  // CHECK-NEXT:   cir.return %[[ARG]] : ![[ABI_TY]]
+  // CHECK-NEXT: }
+
+  cir.func @data_member_to_bool(%arg0 : !Field1) -> !cir.bool {
+    %0 = cir.cast member_ptr_to_bool %arg0: !Field1 -> !cir.bool
+    cir.return %0 : !cir.bool
+  }
+  // CHECK:      @data_member_to_bool(%[[ARG:.+]]: !s64i) -> !cir.bool
+  // CHECK-NEXT:   %[[NULL:.+]] = cir.const #cir.int<-1> : !s64i
+  // CHECK-NEXT:   %[[RES:.+]] = cir.cmp(ne, %[[ARG]], %[[NULL]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   cir.return %[[RES]] : !cir.bool
+  // CHECK-NEXT: }
+
+  cir.func @method_to_bool(%arg0 : !Method1) -> !cir.bool {
+    %0 = cir.cast member_ptr_to_bool %arg0: !Method1 -> !cir.bool
+    cir.return %0 : !cir.bool
+  }
+  // CHECK:      @method_to_bool(%[[ARG:.+]]: ![[ABI_TY:.+]]) -> !cir.bool
+  // CHECK-NEXT:   %[[NULL:.+]] = cir.const #cir.int<0> : !s64i
+  // CHECK-NEXT:   %[[PTR:.+]] = cir.extract_member %[[ARG]][0] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[RES:.+]] = cir.cmp(ne, %[[PTR]], %[[NULL]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   cir.return %[[RES]] : !cir.bool
+  // CHECK-NEXT: }
+}

--- a/clang/test/CIR/Transforms/ABILowering/cmp.cir
+++ b/clang/test/CIR/Transforms/ABILowering/cmp.cir
@@ -1,0 +1,41 @@
+// RUN: cir-opt --cir-abi-lowering -o %t.cir %s
+// RUN: FileCheck --input-file %t.cir %s
+
+!s32i = !cir.int<s, 32>
+!S = !cir.record<struct "S" {!s32i, !s32i, !s32i}>
+!Field = !cir.data_member<!s32i in !S>
+!Method = !cir.method<!cir.func<(!s32i)> in !S>
+
+module attributes {
+  cir.triple = "x86_64-unknown-linux-gnu",
+  dlti.dl_spec = #dlti.dl_spec<i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">
+} {
+  cir.func @cmp_data_member(%arg0: !Field, %arg1: !Field) -> !cir.bool {
+    %0 = cir.cmp(eq, %arg0, %arg1) : !Field, !cir.bool
+    cir.return %0 : !cir.bool
+  }
+  // CHECK:      @cmp_data_member(%[[ARG0:.+]]: !s64i, %[[ARG1:.+]]: !s64i) -> !cir.bool
+  // CHECK-NEXT:   %[[RES:.+]] = cir.cmp(eq, %[[ARG0]], %[[ARG1]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   cir.return %[[RES]] : !cir.bool
+  // CHECK-NEXT: }
+
+  cir.func @cmp_method(%arg0: !Method, %arg1: !Method) -> !cir.bool {
+    %0 = cir.cmp(eq, %arg0, %arg1) : !Method, !cir.bool
+    cir.return %0 : !cir.bool
+  }
+  // CHECK:      @cmp_method(%[[ARG0:.+]]: ![[ABI_TY:.+]], %[[ARG1:.+]]: ![[ABI_TY]]) -> !cir.bool
+  // CHECK-NEXT:   %[[ZERO:.+]] = cir.const #cir.int<0> : !s64i
+  // CHECK-NEXT:   %[[ARG0_PTR:.+]] = cir.extract_member %[[ARG0]][0] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[ARG1_PTR:.+]] = cir.extract_member %[[ARG1]][0] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[PTR_EQ:.+]] = cir.cmp(eq, %[[ARG0_PTR]], %[[ARG1_PTR]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   %[[ARG0_PTR_NULL:.+]] = cir.cmp(eq, %[[ARG0_PTR]], %[[ZERO]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   %[[ARG0_OFFSET:.+]] = cir.extract_member %[[ARG0]][1] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[ARG1_OFFSET:.+]] = cir.extract_member %[[ARG1]][1] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[OFFSET_EQ:.+]] = cir.cmp(eq, %[[ARG0_OFFSET]], %[[ARG1_OFFSET]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   %[[TRUE:.+]] = cir.const #true
+  // CHECK-NEXT:   %[[FALSE:.+]] = cir.const #false
+  // CHECK-NEXT:   %[[X:.+]] = cir.select if %[[ARG0_PTR_NULL]] then %[[TRUE]] else %[[OFFSET_EQ]] : (!cir.bool, !cir.bool, !cir.bool) -> !cir.bool
+  // CHECK-NEXT:   %[[RES:.+]] = cir.select if %[[X]] then %[[PTR_EQ]] else %[[FALSE]] : (!cir.bool, !cir.bool, !cir.bool) -> !cir.bool
+  // CHECK-NEXT:   cir.return %[[RES]] : !cir.bool
+  // CHECK-NEXT: }
+}

--- a/clang/test/CIR/Transforms/ABILowering/const.cir
+++ b/clang/test/CIR/Transforms/ABILowering/const.cir
@@ -1,0 +1,40 @@
+// RUN: cir-opt --cir-abi-lowering -o %t.cir %s
+// RUN: FileCheck --input-file %t.cir %s
+
+!s32i = !cir.int<s, 32>
+!S = !cir.record<struct "S" {!s32i, !s32i, !s32i}>
+!Field = !cir.data_member<!s32i in !S>
+!Method = !cir.method<!cir.func<(!s32i)> in !S>
+
+module attributes {
+  cir.triple = "x86_64-unknown-linux-gnu",
+  dlti.dl_spec = #dlti.dl_spec<i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">
+} {
+  cir.func @const_data_member() -> !Field {
+    %0 = cir.const #cir.data_member<1> : !Field
+    cir.return %0 : !Field
+  }
+  // CHECK:      @const_data_member() -> !s64i
+  // CHECK-NEXT:   %[[RES:.+]] = cir.const #cir.int<4> : !s64i
+  // CHECK-NEXT:   cir.return %[[RES]] : !s64i
+  // CHECK-NEXT: }
+
+  cir.func private @f(%arg0: !cir.ptr<!S>, %arg1: !s32i)
+  cir.func @const_method_nonvirtual() -> !Method {
+    %0 = cir.const #cir.method<@f> : !Method
+    cir.return %0 : !Method
+  }
+  // CHECK:      @const_method_nonvirtual() -> ![[ABI_TY:.+]] {
+  // CHECK-NEXT:   %[[RES:.+]] = cir.const #cir.const_record<{#cir.global_view<@f> : !s64i, #cir.int<0> : !s64i}> : ![[ABI_TY]]
+  // CHECK-NEXT:   cir.return %[[RES]] : ![[ABI_TY]]
+  // CHECK-NEXT: }
+
+  cir.func @const_method_virtual() -> !Method {
+    %0 = cir.const #cir.method<vtable_offset = 8> : !Method
+    cir.return %0 : !Method
+  }
+  // CHECK:      cir.func @const_method_virtual() -> ![[ABI_TY:.+]] {
+  // CHECK-NEXT:   %[[RES:.+]] = cir.const #cir.const_record<{#cir.int<9> : !s64i, #cir.int<0> : !s64i}> : ![[ABI_TY]]
+  // CHECK-NEXT:   cir.return %[[RES]] : ![[ABI_TY]]
+  // CHECK-NEXT: }
+}

--- a/clang/test/CIR/Transforms/ABILowering/func.cir
+++ b/clang/test/CIR/Transforms/ABILowering/func.cir
@@ -1,0 +1,28 @@
+// RUN: cir-opt --cir-abi-lowering -o %t.cir %s
+// RUN: FileCheck --input-file %t.cir %s
+
+!s32i = !cir.int<s, 32>
+!S = !cir.record<struct "S" {!s32i, !s32i, !s32i}>
+!Field = !cir.data_member<!s32i in !S>
+!Method = !cir.method<!cir.func<(!s32i)> in !S>
+
+module attributes {
+  cir.triple = "x86_64-unknown-linux-gnu",
+  dlti.dl_spec = #dlti.dl_spec<i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">
+} {
+  cir.func @foo(%arg0 : !Field, %arg1: !Method) -> !Field {
+    cir.return %arg0 : !Field
+  }
+  // CHECK:      @foo(%[[ARG0:.+]]: !s64i, %[[ARG1:.+]]: ![[METHOD_ABI_TY:.+]]) -> !s64i
+  // CHECK-NEXT:   cir.return %[[ARG0]] : !s64i
+  // CHECK-NEXT: }
+
+  cir.func @no_args() -> !Field {
+    %0 = cir.const #cir.data_member<1> : !Field
+    cir.return %0 : !Field
+  }
+  // CHECK:      @no_args() -> !s64i
+  // CHECK-NEXT:   %[[RES:.+]] = cir.const #cir.int<4> : !s64i
+  // CHECK-NEXT:   cir.return %[[RES]] : !s64i
+  // CHECK-NEXT: }
+}

--- a/clang/test/CIR/Transforms/ABILowering/global.cir
+++ b/clang/test/CIR/Transforms/ABILowering/global.cir
@@ -1,0 +1,22 @@
+// RUN: cir-opt --cir-abi-lowering -o %t.cir %s
+// RUN: FileCheck --input-file %t.cir %s
+
+!s32i = !cir.int<s, 32>
+!S = !cir.record<struct "S" {!s32i, !s32i, !s32i}>
+!Field = !cir.data_member<!s32i in !S>
+!Method = !cir.method<!cir.func<(!s32i)> in !S>
+
+module attributes {
+  cir.triple = "x86_64-unknown-linux-gnu",
+  dlti.dl_spec = #dlti.dl_spec<i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">
+} {
+  cir.global external @const_data_member = #cir.data_member<1> : !Field
+  // CHECK: cir.global external @const_data_member = #cir.int<4> : !s64i
+
+  cir.func private @f(%arg0: !cir.ptr<!S>, %arg1: !s32i)
+  cir.global external @const_method_nonvirtual = #cir.method<@f> : !Method
+  // CHECK: cir.global external @const_method_nonvirtual = #cir.const_record<{#cir.global_view<@f> : !s64i, #cir.int<0> : !s64i}> : !{{.+}}
+
+  cir.global external @const_method_virtual = #cir.method<vtable_offset = 8> : !Method
+  // CHECK: cir.global external @const_method_virtual = #cir.const_record<{#cir.int<9> : !s64i, #cir.int<0> : !s64i}> : !{{.+}}
+}

--- a/clang/test/CIR/Transforms/ABILowering/member-ptr.cir
+++ b/clang/test/CIR/Transforms/ABILowering/member-ptr.cir
@@ -1,0 +1,106 @@
+// RUN: cir-opt --cir-abi-lowering -o %t.cir %s
+// RUN: FileCheck --input-file %t.cir %s
+
+!void = !cir.void
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!Base = !cir.record<struct "Base" {!s32i, !s32i, !s32i}>
+!Derived = !cir.record<struct "Derived" {!Base, !s32i}>
+!BaseField = !cir.data_member<!s32i in !Base>
+!DerivedField = !cir.data_member<!s32i in !Derived>
+!BaseMethod = !cir.method<!cir.func<(!s32i)> in !Base>
+!DerivedMethod = !cir.method<!cir.func<(!s32i)> in !Derived>
+
+module attributes {
+  cir.triple = "x86_64-unknown-linux-gnu",
+  dlti.dl_spec = #dlti.dl_spec<i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little">
+} {
+  cir.func @get_runtime_member(%arg0: !cir.ptr<!Base>, %arg1: !BaseField) -> !cir.ptr<!s32i> {
+    %0 = cir.get_runtime_member %arg0[%arg1 : !BaseField] : !cir.ptr<!Base> -> !cir.ptr<!s32i>
+    cir.return %0 : !cir.ptr<!s32i>
+  }
+  // CHECK:      cir.func @get_runtime_member(%[[ARG0:.+]]: !cir.ptr<!rec_Base>, %[[ARG1:.+]]: !s64i) -> !cir.ptr<!s32i> {
+  // CHECK-NEXT:   %[[BYTE_PTR:.+]] = cir.cast bitcast %[[ARG0]] : !cir.ptr<!rec_Base> -> !cir.ptr<!s8i>
+  // CHECK-NEXT:   %[[COMPUTED:.+]] = cir.ptr_stride %[[BYTE_PTR]], %[[ARG1]] : (!cir.ptr<!s8i>, !s64i) -> !cir.ptr<!s8i>
+  // CHECK-NEXT:   %[[RESULT:.+]] = cir.cast bitcast %[[COMPUTED]] : !cir.ptr<!s8i> -> !cir.ptr<!s32i>
+  // CHECK-NEXT:   cir.return %[[RESULT]] : !cir.ptr<!s32i>
+  // CHECK-NEXT: }
+
+  cir.func @get_method(%arg0: !cir.ptr<!Base>, %arg1: !BaseMethod) {
+    %0, %1 = cir.get_method %arg1, %arg0 : (!BaseMethod, !cir.ptr<!Base>) -> (!cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>, !cir.ptr<!void>)
+    cir.return
+  }
+  // CHECK:      cir.func @get_method(%[[ARG0:.+]]: !cir.ptr<!rec_Base>, %[[ARG1:.+]]: ![[ABI_TY:.+]]) {
+  // CHECK-NEXT:   %[[MASK:.+]] = cir.const #cir.int<1> : !s64i
+  // CHECK-NEXT:   %[[OFFSET:.+]] = cir.extract_member %[[ARG1]][1] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[THIS:.+]] = cir.cast bitcast %[[ARG0]] : !cir.ptr<!rec_Base> -> !cir.ptr<!void>
+  // CHECK-NEXT:   %{{.+}} = cir.ptr_stride %[[THIS]], %[[OFFSET]] : (!cir.ptr<!void>, !s64i) -> !cir.ptr<!void>
+  // CHECK-NEXT:   %[[PTR:.+]] = cir.extract_member %[[ARG1]][0] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[PTR_MASKED:.+]] = cir.binop(and, %[[PTR]], %[[MASK]]) : !s64i
+  // CHECK-NEXT:   %[[IS_VIRT:.+]] = cir.cmp(eq, %[[PTR_MASKED]], %[[MASK]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   cir.brcond %[[IS_VIRT]] ^[[BLK_VIRT:.+]], ^[[BLK_NON_VIRT:.+]]
+  // CHECK-NEXT: ^[[BLK_VIRT]]:
+  // CHECK-NEXT:   %[[VPTR_PTR:.+]] = cir.cast bitcast %[[ARG0]] : !cir.ptr<!rec_Base> -> !cir.ptr<!cir.ptr<!s8i>>
+  // CHECK-NEXT:   %[[VPTR:.+]] = cir.load %[[VPTR_PTR]] : !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!s8i>
+  // CHECK-NEXT:   %[[VPTR_OFFSET:.+]] = cir.binop(sub, %[[PTR]], %[[MASK]]) : !s64i
+  // CHECK-NEXT:   %[[VELEM_PTR:.+]] = cir.ptr_stride %[[VPTR]], %[[VPTR_OFFSET]] : (!cir.ptr<!s8i>, !s64i) -> !cir.ptr<!s8i>
+  // CHECK-NEXT:   %[[VFPTR_PTR:.+]] = cir.cast bitcast %[[VELEM_PTR]] : !cir.ptr<!s8i> -> !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>>
+  // CHECK-NEXT:   %[[VFPTR:.+]] = cir.load %[[VFPTR_PTR]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>>, !cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>
+  // CHECK-NEXT:   cir.br ^[[BLK_CONT:.+]](%[[VFPTR]] : !cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>)
+  // CHECK-NEXT: ^[[BLK_NON_VIRT]]:
+  // CHECK-NEXT:   %[[FPTR:.+]] = cir.cast int_to_ptr %[[PTR]] : !s64i -> !cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>
+  // CHECK-NEXT:   cir.br ^[[BLK_CONT]](%[[FPTR]] : !cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>)
+  // CHECK-NEXT: ^[[BLK_CONT]](%14: !cir.ptr<!cir.func<(!cir.ptr<!void>, !s32i)>>):
+  // CHECK-NEXT:   cir.return
+  // CHECK-NEXT: }
+
+  cir.func @data_member_derived_to_base(%arg0: !DerivedField) -> !BaseField {
+    %0 = cir.base_data_member %arg0 : !DerivedField [8] -> !BaseField
+    cir.return %0 : !BaseField
+  }
+  // CHECK:      @data_member_derived_to_base(%[[ARG:.+]]: !s64i) -> !s64i {
+  // CHECK-NEXT:   %[[NULL:.+]] = cir.const #cir.int<-1> : !s64i
+  // CHECK-NEXT:   %[[IS_NULL:.+]] = cir.cmp(eq, %[[ARG]], %[[NULL]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   %[[OFFSET:.+]] = cir.const #cir.int<8> : !s64i
+  // CHECK-NEXT:   %[[COMPUTED:.+]] = cir.binop(sub, %[[ARG]], %[[OFFSET]]) : !s64i
+  // CHECK-NEXT:   %[[RES:.+]] = cir.select if %[[IS_NULL]] then %[[NULL]] else %[[COMPUTED]] : (!cir.bool, !s64i, !s64i) -> !s64i
+  // CHECK-NEXT:   cir.return %[[RES]] : !s64i
+  // CHECK-NEXT: }
+
+  cir.func @data_member_base_to_derived(%arg0: !BaseField) -> !DerivedField {
+    %0 = cir.derived_data_member %arg0 : !BaseField [8] -> !DerivedField
+    cir.return %0 : !DerivedField
+  }
+  // CHECK:      @data_member_base_to_derived(%[[ARG:.+]]: !s64i) -> !s64i {
+  // CHECK-NEXT:   %[[NULL:.+]] = cir.const #cir.int<-1> : !s64i
+  // CHECK-NEXT:   %[[IS_NULL:.+]] = cir.cmp(eq, %[[ARG]], %[[NULL]]) : !s64i, !cir.bool
+  // CHECK-NEXT:   %[[OFFSET:.+]] = cir.const #cir.int<8> : !s64i
+  // CHECK-NEXT:   %[[COMPUTED:.+]] = cir.binop(add, %[[ARG]], %[[OFFSET]]) : !s64i
+  // CHECK-NEXT:   %[[RES:.+]] = cir.select if %[[IS_NULL]] then %[[NULL]] else %[[COMPUTED]] : (!cir.bool, !s64i, !s64i) -> !s64i
+  // CHECK-NEXT:   cir.return %[[RES]] : !s64i
+  // CHECK-NEXT: }
+
+  cir.func @method_derived_to_base(%arg0: !DerivedMethod) -> !BaseMethod {
+    %0 = cir.base_method %arg0 : !DerivedMethod [8] -> !BaseMethod
+    cir.return %0 : !BaseMethod
+  }
+  // CHECK:      @method_derived_to_base(%[[ARG:.+]]: ![[ABI_TY:.+]]) -> ![[ABI_TY]] {
+  // CHECK-NEXT:   %[[THIS_OFFSET:.+]] = cir.extract_member %[[ARG]][1] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[BASE_OFFSET:.+]] = cir.const #cir.int<8> : !s64i
+  // CHECK-NEXT:   %[[COMPUTED:.+]] = cir.binop(sub, %[[THIS_OFFSET]], %[[BASE_OFFSET]]) : !s64i
+  // CHECK-NEXT:   %[[RES:.+]] = cir.insert_member %[[ARG]][1], %[[COMPUTED]] : ![[ABI_TY]], !s64i
+  // CHECK-NEXT:   cir.return %[[RES]] : ![[ABI_TY]]
+  // CHECK-NEXT: }
+
+  cir.func @method_base_to_derived(%arg0: !BaseMethod) -> !DerivedMethod {
+    %0 = cir.derived_method %arg0 : !BaseMethod [8] -> !DerivedMethod
+    cir.return %0 : !DerivedMethod
+  }
+  // CHECK:      @method_base_to_derived(%[[ARG:.+]]: ![[ABI_TY:.+]]) -> ![[ABI_TY]] {
+  // CHECK-NEXT:   %[[THIS_OFFSET:.+]] = cir.extract_member %[[ARG]][1] : ![[ABI_TY]] -> !s64i
+  // CHECK-NEXT:   %[[BASE_OFFSET:.+]] = cir.const #cir.int<8> : !s64i
+  // CHECK-NEXT:   %[[COMPUTED:.+]] = cir.binop(add, %[[THIS_OFFSET]], %[[BASE_OFFSET]]) : !s64i
+  // CHECK-NEXT:   %[[RES:.+]] = cir.insert_member %[[ARG]][1], %[[COMPUTED]] : ![[ABI_TY]], !s64i
+  // CHECK-NEXT:   cir.return %[[RES]] : ![[ABI_TY]]
+  // CHECK-NEXT: }
+}

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -80,6 +80,10 @@ int main(int argc, char **argv) {
     return mlir::createReconcileUnrealizedCastsPass();
   });
 
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createABILoweringPass();
+  });
+
   mlir::registerAllPasses();
 
   return failed(MlirOptMain(


### PR DESCRIPTION
This PR attempts to add a new pass `cir-abi-lowering` to the CIR dialect. This pass runs before the CallConvLowering pass, and it expands all ABI-dependent types and operations inside a function to their ABI-independent equivalences according to the ABI specification.

The patch also moves the lowering code of the following types and operations from the LLVM lowering conversion to the new pass:
  - The pointer-to-data-member type `cir.data_member`;
  - The pointer-to-member-function type `cir.method`;
  - All operations working on operands of the above types.