### PR TITLE
[CIR] Lower `signext` and `zeroext` attributes

### DIFF
--- a/clang/test/CIR/Lowering/attribute-lowering.cir
+++ b/clang/test/CIR/Lowering/attribute-lowering.cir
@@ -1,6 +1,8 @@
 // RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
+!s8i = !cir.int<u, 8>
+!u8i = !cir.int<u, 8>
 
 module {
   cir.global "private" internal @const_array = #cir.const_array<[#cir.int<1> : !s32i]> : !cir.array<!s32i x 1> {section = ".abc"}
@@ -8,4 +10,14 @@ module {
 
   cir.global "private" internal @const_struct = #cir.const_struct<{#cir.int<1> : !s32i}> : !cir.struct<struct {!s32i}> {section = ".abc"}
   // LLVM: @const_struct = internal global { i32 } { i32 1 }, section ".abc"
+
+  cir.func @func_zeroext(%arg0: !u8i {cir.zeroext}) -> (!u8i {cir.zeroext}) {
+    cir.return %arg0 : !u8i
+  }
+  // LLVM: define zeroext i8 @func_zeroext(i8 zeroext %0) 
+
+  cir.func @func_signext(%arg0: !s8i {cir.signext}) -> (!s8i {cir.signext}) {
+    cir.return %arg0 : !s8i
+  }
+  // LLVM: define signext i8 @func_signext(i8 signext %0) 
 }


### PR DESCRIPTION
CIR is currently ignoring the `signext` and `zeroext` for function arguments and return types produced by CallConvLowering.

This PR lowers them to LLVM IR.