### PR TITLE
[CIR][CIRGen][builtin] handle `__popcnt`

### DIFF
--- a/clang/test/CIR/CodeGen/ms-intrinsics-other.c
+++ b/clang/test/CIR/CodeGen/ms-intrinsics-other.c
@@ -3,12 +3,14 @@
 // RUN: %clang_cc1 -ffreestanding -fms-extensions -Wno-implicit-function-declaration -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck %s --check-prefix=LLVM --input-file=%t.ll
 
+// This test mimics clang/test/CodeGen/ms-intrinsics-other.c, which eventually
+// CIR shall be able to support fully.
+
 unsigned short test__lzcnt16(unsigned short x) {
   return __lzcnt16(x);
 }
 // CIR-LABEL: test__lzcnt16
 // CIR: {{%.*}} = cir.bit.clz({{%.*}} : !u16i) : !u16i
-
 // LLVM-LABEL: test__lzcnt16
 // LLVM: {{%.*}} = call i16 @llvm.ctlz.i16(i16 {{%.*}}, i1 false)
 
@@ -17,7 +19,6 @@ unsigned int test__lzcnt(unsigned int x) {
 }
 // CIR-LABEL: test__lzcnt
 // CIR: {{%.*}} = cir.bit.clz({{%.*}} : !u32i) : !u32i
-
 // LLVM-LABEL: test__lzcnt
 // LLVM:  {{%.*}} = call i32 @llvm.ctlz.i32(i32 {{%.*}}, i1 false)
 
@@ -26,6 +27,29 @@ unsigned __int64 test__lzcnt64(unsigned __int64 x) {
 }
 // CIR-LABEL: test__lzcnt64
 // CIR: {{%.*}} = cir.bit.clz({{%.*}} : !u64i) : !u64i
-
 // LLVM-LABEL: test__lzcnt64
 // LLVM: {{%.*}} = call i64 @llvm.ctlz.i64(i64 {{%.*}}, i1 false)
+
+unsigned short test__popcnt16(unsigned short x) {
+  return __popcnt16(x);
+}
+// CIR-LABEL: test__popcnt16
+// CIR: {{%.*}} = cir.bit.popcount({{%.*}} : !u16i) : !u16i
+// LLVM-LABEL: test__popcnt16
+// LLVM: {{%.*}} = call i16 @llvm.ctpop.i16(i16 {{%.*}})
+
+unsigned int test__popcnt(unsigned int x) {
+  return __popcnt(x);
+}
+// CIR-LABEL: test__popcnt
+// CIR: {{%.*}} = cir.bit.popcount({{%.*}} : !u32i) : !u32i
+// LLVM-LABEL: test__popcnt
+// LLVM: {{%.*}} = call i32 @llvm.ctpop.i32(i32 {{%.*}})
+
+unsigned __int64 test__popcnt64(unsigned __int64 x) {
+  return __popcnt64(x);
+}
+// CIR-LABEL: test__popcnt64
+// CIR: {{%.*}} = cir.bit.popcount({{%.*}} : !u64i) : !u64i
+// LLVM-LABEL: test__popcnt64
+// LLVM: {{%.*}} = call i64 @llvm.ctpop.i64(i64 {{%.*}})


### PR DESCRIPTION
This PR just removes a useless argument `convertToInt`.

I realized I committed a new file with CRLF before. Really sorry about that >_<