### PR TITLE
cir-translate: Use default target triple instead of x86 if no target was set explicitly

### DIFF
--- a/clang/test/CIR/Lowering/OpenMP/barrier.cir
+++ b/clang/test/CIR/Lowering/OpenMP/barrier.cir
@@ -1,5 +1,5 @@
 
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering | FileCheck %s
 
 
 module {

--- a/clang/test/CIR/Lowering/OpenMP/parallel.cir
+++ b/clang/test/CIR/Lowering/OpenMP/parallel.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 module {

--- a/clang/test/CIR/Lowering/OpenMP/taskwait.cir
+++ b/clang/test/CIR/Lowering/OpenMP/taskwait.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering | FileCheck %s
 
 
 module {

--- a/clang/test/CIR/Lowering/OpenMP/taskyield.cir
+++ b/clang/test/CIR/Lowering/OpenMP/taskyield.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering | FileCheck %s
 
 
 module {

--- a/clang/test/CIR/Lowering/array.cir
+++ b/clang/test/CIR/Lowering/array.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 !ty_S = !cir.struct<struct "S" {!s32i} #cir.record.decl.ast>

--- a/clang/test/CIR/Lowering/attribute-lowering.cir
+++ b/clang/test/CIR/Lowering/attribute-lowering.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 !s8i = !cir.int<u, 8>

--- a/clang/test/CIR/Lowering/binop-fp.cir
+++ b/clang/test/CIR/Lowering/binop-fp.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 module {
   cir.func @foo() {

--- a/clang/test/CIR/Lowering/binop-overflow.cir
+++ b/clang/test/CIR/Lowering/binop-overflow.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !u32i = !cir.int<u, 32>
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/binop-unsigned-int.cir
+++ b/clang/test/CIR/Lowering/binop-unsigned-int.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !u32i = !cir.int<u, 32>
 
 module {

--- a/clang/test/CIR/Lowering/bitint.cir
+++ b/clang/test/CIR/Lowering/bitint.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 

--- a/clang/test/CIR/Lowering/bool-to-int.cir
+++ b/clang/test/CIR/Lowering/bool-to-int.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 #false = #cir.bool<false> : !cir.bool

--- a/clang/test/CIR/Lowering/bool.cir
+++ b/clang/test/CIR/Lowering/bool.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 #false = #cir.bool<false> : !cir.bool
 #true = #cir.bool<true> : !cir.bool

--- a/clang/test/CIR/Lowering/branch.cir
+++ b/clang/test/CIR/Lowering/branch.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 cir.func @foo(%arg0: !cir.bool) -> !s32i {

--- a/clang/test/CIR/Lowering/brcond.cir
+++ b/clang/test/CIR/Lowering/brcond.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 #fn_attr = #cir<extra({inline = #cir.inline<no>, nothrow = #cir.nothrow, optnone = #cir.optnone})>

--- a/clang/test/CIR/Lowering/bswap.cir
+++ b/clang/test/CIR/Lowering/bswap.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !u32i = !cir.int<u, 32>
 

--- a/clang/test/CIR/Lowering/call-op-call-conv.cir
+++ b/clang/test/CIR/Lowering/call-op-call-conv.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering %s -o %t.ll
+// RUN: cir-translate -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/call.cir
+++ b/clang/test/CIR/Lowering/call.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 // XFAIL: *
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/cmp3way.cir
+++ b/clang/test/CIR/Lowering/cmp3way.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s8i = !cir.int<s, 8>
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/complex.cir
+++ b/clang/test/CIR/Lowering/complex.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o %t.ll %s
+// RUN: cir-translate -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o %t.ll %s
 // RUN: FileCheck --input-file %t.ll -check-prefix=LLVM %s
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/const-array.cir
+++ b/clang/test/CIR/Lowering/const-array.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !u8i = !cir.int<u, 8>
 #false = #cir.bool<false> : !cir.bool

--- a/clang/test/CIR/Lowering/expect.cir
+++ b/clang/test/CIR/Lowering/expect.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s64i = !cir.int<s, 64>
 module {

--- a/clang/test/CIR/Lowering/func-call-conv.cir
+++ b/clang/test/CIR/Lowering/func-call-conv.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o %t.ll
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll --check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-to-llvm -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o %t.ll
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 !void = !cir.void

--- a/clang/test/CIR/Lowering/if.cir
+++ b/clang/test/CIR/Lowering/if.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !s32i = !cir.int<s, 32>
 
 module {

--- a/clang/test/CIR/Lowering/int-wrap.cir
+++ b/clang/test/CIR/Lowering/int-wrap.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 module {

--- a/clang/test/CIR/Lowering/intrinsics.cir
+++ b/clang/test/CIR/Lowering/intrinsics.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 
 module {
   cir.func @test_unreachable() {

--- a/clang/test/CIR/Lowering/ptrdiff.cir
+++ b/clang/test/CIR/Lowering/ptrdiff.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 !u64i = !cir.int<u, 64>

--- a/clang/test/CIR/Lowering/region-simplify.cir
+++ b/clang/test/CIR/Lowering/region-simplify.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -canonicalize -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-opt %s -canonicalize -o - | cir-translate -cir-to-llvmir --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
+// RUN: cir-opt %s -canonicalize -o - | cir-translate -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
 
 !u32i = !cir.int<u, 32>
 

--- a/clang/test/CIR/Lowering/scope.cir
+++ b/clang/test/CIR/Lowering/scope.cir
@@ -1,6 +1,6 @@
 // RUN: cir-opt %s -cir-to-llvm -o %t.cir
 // RUN: FileCheck %s --input-file=%t.cir -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !u32i = !cir.int<u, 32>
 
 module {

--- a/clang/test/CIR/Lowering/select.cir
+++ b/clang/test/CIR/Lowering/select.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o %t.ll %s
+// RUN: cir-translate -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll -check-prefix=LLVM %s
 
 !s32i = !cir.int<s, 32>

--- a/clang/test/CIR/Lowering/syncscope.cir
+++ b/clang/test/CIR/Lowering/syncscope.cir
@@ -1,4 +1,4 @@
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
 #fn_attr = #cir<extra({inline = #cir.inline<no>, nothrow = #cir.nothrow, optnone = #cir.optnone})>

--- a/clang/test/CIR/Lowering/unary-inc-dec.cir
+++ b/clang/test/CIR/Lowering/unary-inc-dec.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !s32i = !cir.int<s, 32>
 module {
   cir.func @foo() {

--- a/clang/test/CIR/Lowering/unary-not.cir
+++ b/clang/test/CIR/Lowering/unary-not.cir
@@ -1,5 +1,5 @@
 // RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
+// RUN: cir-translate %s -cir-to-llvmir --target x86_64-unknown-linux-gnu --disable-cc-lowering  | FileCheck %s -check-prefix=LLVM
 !s32i = !cir.int<s, 32>
 module {
     cir.func @foo() -> !s32i  {

--- a/clang/test/CIR/Tools/cir-translate/no-triple-has-data-layout.cir
+++ b/clang/test/CIR/Tools/cir-translate/no-triple-has-data-layout.cir
@@ -2,8 +2,6 @@
 // RUN: FileCheck %s -input-file %t.x86.ll -check-prefix=X86
 // RUN: cir-translate --cir-to-llvmir --target spirv64-unknown-unknown --disable-cc-lowering %s -o %t.spirv64.ll
 // RUN: FileCheck %s -input-file %t.spirv64.ll -check-prefix=SPIRV64
-// RUN: cir-translate --cir-to-llvmir --disable-cc-lowering %s -o %t.default.ll
-// RUN: FileCheck %s -input-file %t.default.ll -check-prefix=DEFAULT
 
 module attributes {
   dlti.dl_spec = #dlti.dl_spec<"dlti.global_memory_space" = 7 : ui64>
@@ -18,6 +16,3 @@ module attributes {
 
 // SPIRV64-NOT: target datalayout = "G7"
 // SPIRV64-DAG: target triple = "spirv64-unknown-unknown"
-
-// DEFAULT-NOT: target datalayout = "G7"
-// DEFAULT-DAG: target triple = "x86_64-unknown-linux-gnu"

--- a/clang/test/CIR/Tools/cir-translate/no-triple-no-data-layout.cir
+++ b/clang/test/CIR/Tools/cir-translate/no-triple-no-data-layout.cir
@@ -2,8 +2,6 @@
 // RUN: FileCheck %s -input-file %t.x86.ll -check-prefix=X86
 // RUN: cir-translate --cir-to-llvmir --target spirv64-unknown-unknown --disable-cc-lowering %s -o %t.spirv64.ll
 // RUN: FileCheck %s -input-file %t.spirv64.ll -check-prefix=SPIRV64
-// RUN: cir-translate --cir-to-llvmir --disable-cc-lowering %s -o %t.default.ll
-// RUN: FileCheck %s -input-file %t.default.ll -check-prefix=DEFAULT
 
 module {
   cir.func @foo() {
@@ -16,6 +14,3 @@ module {
 
 // SPIRV64-DAG: target triple = "spirv64-unknown-unknown"
 // SPIRV64-DAG: target datalayout = "{{.*}}"
-
-// DEFAULT-DAG: target triple = "x86_64-unknown-linux-gnu"
-// DEFAULT-DAG: target datalayout = "{{.*}}"

--- a/clang/test/CIR/Tools/cir-translate/warn-default-triple.cir
+++ b/clang/test/CIR/Tools/cir-translate/warn-default-triple.cir
@@ -2,7 +2,5 @@
 
 // expected-warning@below {{no target triple provided, assuming}}
 module {
-  cir.func @foo() {
-    cir.return
-  }
+
 }

--- a/clang/test/CIR/Tools/cir-translate/warn-default-triple.cir
+++ b/clang/test/CIR/Tools/cir-translate/warn-default-triple.cir
@@ -1,6 +1,6 @@
 // RUN: cir-translate -verify-diagnostics --cir-to-llvmir --disable-cc-lowering %s
 
-// expected-warning@below {{no target triple provided, assuming x86_64-unknown-linux-gnu}}
+// expected-warning@below {{no target triple provided, assuming}}
 module {
   cir.func @foo() {
     cir.return

--- a/clang/test/CIR/Tools/cir-translate/warn-default-triple.cir
+++ b/clang/test/CIR/Tools/cir-translate/warn-default-triple.cir
@@ -1,6 +1,9 @@
-// RUN: cir-translate -verify-diagnostics --cir-to-llvmir --disable-cc-lowering %s
+// XFAIL: target={{.*windows.*}}
+// RUN: cir-translate -verify-diagnostics --cir-to-llvmir --disable-cc-lowering %s 2>&1
 
 // expected-warning@below {{no target triple provided, assuming}}
 module {
-
+  cir.func @foo() {
+    cir.return
+  }
 }

--- a/clang/tools/cir-translate/cir-translate.cpp
+++ b/clang/tools/cir-translate/cir-translate.cpp
@@ -69,9 +69,7 @@ std::string prepareCIRModuleTriple(mlir::ModuleOp mod) {
 
   // Treat "" as the default target machine.
   if (triple.empty()) {
-    // Currently ClangIR only supports a couple of targets. Not specifying a
-    // target triple will default to x86_64-unknown-linux-gnu.
-    triple = "x86_64-unknown-linux-gnu";
+    triple = llvm::sys::getDefaultTargetTriple();
 
     mod.emitWarning() << "no target triple provided, assuming " << triple;
   }


### PR DESCRIPTION
This is backported from a change made in https://github.com/llvm/llvm-project/pull/131181