### PR TITLE
[CIR][CUDA] Lower __syncthreads

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
@@ -76,8 +76,16 @@ mlir::Value CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId,
   case NVPTX::BI__nvvm_read_ptx_sreg_nctaid_w:
     return getIntrinsic("nvvm.read.ptx.sreg.nctaid.w");
 
+  case NVPTX::BI__syncthreads: {
+    mlir::Type voidTy = cir::VoidType::get(&getMLIRContext());
+    return builder
+        .create<cir::LLVMIntrinsicCallOp>(
+            getLoc(expr->getExprLoc()), builder.getStringAttr("nvvm.barrier0"),
+            voidTy)
+        .getResult();
+  }
   default:
-    llvm_unreachable("NYI");
+    return nullptr;
   }
 }
 

--- a/clang/test/CIR/CodeGen/CUDA/builtin-functions.cu
+++ b/clang/test/CIR/CodeGen/CUDA/builtin-functions.cu
@@ -1,0 +1,17 @@
+#include "../Inputs/cuda.h"
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -fclangir \
+// RUN:            -fcuda-is-device -emit-cir -target-sdk-version=12.3 \
+// RUN:            %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -fclangir \
+// RUN:            -fcuda-is-device -emit-llvm -target-sdk-version=12.3 \
+// RUN:            %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+__device__ void builtins() {
+  __syncthreads();
+  // CIR:  cir.llvm.intrinsic "nvvm.barrier0"
+  // LLVM: call void @llvm.nvvm.barrier0()
+}


### PR DESCRIPTION
I have no idea how that's done in OG: the whole `clang/lib` folder doesn't refer to `NVPTX::BI__syncthreads` anywhere. Here in CIR we just add a switch case on it.

By the way, on the `default` case it should return a null pointer rather than NYI. It will be handled gracefully in `emitBuiltinExpr` as an error message will be emitted there.