### PR TITLE
[CIR] Add support for nontemporal loads and stores

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -160,13 +160,15 @@ public:
   }
 
   cir::LoadOp createLoad(mlir::Location loc, mlir::Value ptr,
-                         bool isVolatile = false, uint64_t alignment = 0) {
+                         bool isVolatile = false, bool isNontemporal = false,
+                         uint64_t alignment = 0) {
     mlir::IntegerAttr intAttr;
     if (alignment)
       intAttr = mlir::IntegerAttr::get(
           mlir::IntegerType::get(ptr.getContext(), 64), alignment);
 
     return create<cir::LoadOp>(loc, ptr, /*isDeref=*/false, isVolatile,
+                               isNontemporal,
                                /*alignment=*/intAttr,
                                /*mem_order=*/
                                cir::MemOrderAttr{},
@@ -175,7 +177,8 @@ public:
 
   mlir::Value createAlignedLoad(mlir::Location loc, mlir::Value ptr,
                                 uint64_t alignment) {
-    return createLoad(loc, ptr, /*isVolatile=*/false, alignment);
+    return createLoad(loc, ptr, /*isVolatile=*/false, /*isNontemporal=*/false,
+                      alignment);
   }
 
   mlir::Value createNot(mlir::Value value) {
@@ -350,13 +353,14 @@ public:
   }
 
   cir::StoreOp createStore(mlir::Location loc, mlir::Value val, mlir::Value dst,
-                           bool _volatile = false,
+                           bool isVolatile = false, bool isNontemporal = false,
                            ::mlir::IntegerAttr align = {},
                            cir::MemOrderAttr order = {}) {
     if (mlir::cast<cir::PointerType>(dst.getType()).getPointee() !=
         val.getType())
       dst = createPtrBitcast(dst, val.getType());
-    return create<cir::StoreOp>(loc, val, dst, _volatile, align, order,
+    return create<cir::StoreOp>(loc, val, dst, isVolatile, isNontemporal, align,
+                                order,
                                 /*tbaa=*/cir::TBAAAttr{});
   }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -587,6 +587,7 @@ def LoadOp : CIR_Op<"load", [
   let arguments = (ins Arg<CIR_PointerType, "the address to load from",
                            [MemRead]>:$addr, UnitAttr:$isDeref,
                        UnitAttr:$is_volatile,
+                       UnitAttr:$is_nontemporal,
                        OptionalAttr<I64Attr>:$alignment,
                        OptionalAttr<MemOrder>:$mem_order,
                        OptionalAttr<CIR_AnyTBAAAttr>:$tbaa
@@ -596,6 +597,7 @@ def LoadOp : CIR_Op<"load", [
   let assemblyFormat = [{
     (`deref` $isDeref^)?
     (`volatile` $is_volatile^)?
+    (`nontemporal` $is_nontemporal^)?
     (`align` `(` $alignment^ `)`)?
     (`atomic` `(` $mem_order^ `)`)?
     $addr `:` qualified(type($addr)) `,` type($result) attr-dict
@@ -656,12 +658,14 @@ def StoreOp : CIR_Op<"store", [
                        Arg<CIR_PointerType, "the address to store the value",
                            [MemWrite]>:$addr,
                        UnitAttr:$is_volatile,
+                       UnitAttr:$is_nontemporal,
                        OptionalAttr<I64Attr>:$alignment,
                        OptionalAttr<MemOrder>:$mem_order,
                        OptionalAttr<CIR_AnyTBAAAttr>:$tbaa);
 
   let assemblyFormat = [{
     (`volatile` $is_volatile^)?
+    (`nontemporal` $is_nontemporal^)?
     (`align` `(` $alignment^ `)`)?
     (`atomic` `(` $mem_order^ `)`)?
     $value `,` $addr attr-dict `:` type($value) `,` qualified(type($addr))

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -619,6 +619,7 @@ static void emitAtomicOp(CIRGenFunction &CGF, AtomicExpr *E, Address Dest,
     // FIXME(cir): add scope information.
     assert(!cir::MissingFeatures::syncScopeID());
     builder.createStore(loc, loadVal1, Ptr, E->isVolatile(),
+                        /*isNontemporal=*/false,
                         /*alignment=*/mlir::IntegerAttr{}, orderAttr);
     return;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -662,11 +662,8 @@ void CIRGenFunction::emitStoreOfScalar(mlir::Value value, Address addr,
   }
 
   assert(currSrcLoc && "must pass in source location");
-  auto storeOp = builder.createStore(*currSrcLoc, value, addr, isVolatile);
-
-  if (isNontemporal) {
-    llvm_unreachable("NYI");
-  }
+  auto storeOp =
+      builder.createStore(*currSrcLoc, value, addr, isVolatile, isNontemporal);
 
   CGM.decorateOperationWithTBAA(storeOp, tbaaInfo);
 }
@@ -2962,11 +2959,9 @@ mlir::Value CIRGenFunction::emitLoadOfScalar(Address addr, bool isVolatile,
     Ptr = builder.create<cir::CastOp>(loc, ElemPtrTy, cir::CastKind::bitcast,
                                       Ptr);
   }
-  auto loadOp = builder.CIRBaseBuilderTy::createLoad(loc, Ptr, isVolatile);
+  auto loadOp =
+      builder.CIRBaseBuilderTy::createLoad(loc, Ptr, isVolatile, isNontemporal);
 
-  if (isNontemporal) {
-    llvm_unreachable("NYI");
-  }
   CGM.decorateOperationWithTBAA(loadOp, tbaaInfo);
 
   assert(!cir::MissingFeatures::emitScalarRangeCheck() && "NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -2041,7 +2041,7 @@ public:
       builder.restoreInsertionPoint(OutermostConditional->getInsertPoint());
       builder.createStore(
           value.getLoc(), value, addr,
-          /*volatile*/ false,
+          /*isVolatile=*/false, /*isNontemporal=*/false,
           mlir::IntegerAttr::get(
               mlir::IntegerType::get(value.getContext(), 64),
               (uint64_t)addr.getAlignment().getAsAlign().value()));

--- a/clang/lib/CIR/CodeGen/CIRGenValue.h
+++ b/clang/lib/CIR/CodeGen/CIRGenValue.h
@@ -235,6 +235,7 @@ public:
   void setNonGC(bool Value) { NonGC = Value; }
 
   bool isNontemporal() const { return Nontemporal; }
+  void setNontemporal(bool value) { Nontemporal = value; }
 
   bool isObjCWeak() const {
     return Quals.getObjCGCAttr() == clang::Qualifiers::Weak;

--- a/clang/lib/CIR/Dialect/IR/CIRMemorySlot.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRMemorySlot.cpp
@@ -149,9 +149,10 @@ DeletionKind cir::CopyOp::removeBlockingUses(
     OpBuilder &builder, Value reachingDefinition,
     const DataLayout &dataLayout) {
   if (loadsFrom(slot))
-    builder.create<cir::StoreOp>(getLoc(), reachingDefinition, getDst(), false,
-                                 mlir::IntegerAttr{}, cir::MemOrderAttr(),
-                                 cir::TBAAAttr{});
+    builder.create<cir::StoreOp>(getLoc(), reachingDefinition, getDst(),
+                                 /*is_volatile=*/false,
+                                 /*is_nontemporal=*/false, mlir::IntegerAttr{},
+                                 cir::MemOrderAttr(), cir::TBAAAttr{});
   return DeletionKind::Delete;
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ItaniumCXXABI.cpp
@@ -384,6 +384,7 @@ void ItaniumCXXABI::lowerGetMethod(
         op.getLoc(), vtablePtrPtrTy, cir::CastKind::bitcast, loweredObjectPtr);
     mlir::Value vtablePtr = rewriter.create<cir::LoadOp>(
         op.getLoc(), vtablePtrPtr, /*isDeref=*/false, /*isVolatile=*/false,
+        /*isNontemporal=*/false,
         /*alignment=*/mlir::IntegerAttr(), /*mem_order=*/cir::MemOrderAttr(),
         /*tbaa=*/mlir::ArrayAttr());
 
@@ -418,6 +419,7 @@ void ItaniumCXXABI::lowerGetMethod(
             op.getLoc(), vfpPtrTy, cir::CastKind::bitcast, vfpAddr);
         funcPtr = rewriter.create<cir::LoadOp>(
             op.getLoc(), vfpPtr, /*isDeref=*/false, /*isVolatile=*/false,
+            /*isNontemporal=*/false,
             /*alignment=*/mlir::IntegerAttr(),
             /*mem_order=*/cir::MemOrderAttr(),
             /*tbaa=*/mlir::ArrayAttr());

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1680,7 +1680,7 @@ mlir::LogicalResult CIRToLLVMLoadOpLowering::matchAndRewrite(
   // TODO: nontemporal, syncscope.
   auto newLoad = rewriter.create<mlir::LLVM::LoadOp>(
       op->getLoc(), llvmTy, adaptor.getAddr(), /* alignment */ alignment,
-      op.getIsVolatile(), /* nontemporal */ false,
+      op.getIsVolatile(), /* nontemporal */ op.getIsNontemporal(),
       /* invariant */ false, /* invariantGroup */ invariant, ordering);
 
   // Convert adapted result to its original type if needed.
@@ -1722,7 +1722,8 @@ mlir::LogicalResult CIRToLLVMStoreOpLowering::matchAndRewrite(
   // TODO: nontemporal, syncscope.
   auto storeOp = rewriter.create<mlir::LLVM::StoreOp>(
       op->getLoc(), value, adaptor.getAddr(), alignment, op.getIsVolatile(),
-      /* nontemporal */ false, /* invariantGroup */ invariant, ordering);
+      /* nontemporal */ op.getIsNontemporal(), /* invariantGroup */ invariant,
+      ordering);
   rewriter.replaceOp(op, storeOp);
   if (auto tbaa = op.getTbaaAttr()) {
     storeOp.setTBAATags(lowerCIRTBAAAttr(tbaa, rewriter, lowerMod));

--- a/clang/test/CIR/CodeGen/builtin-nontemporal.cpp
+++ b/clang/test/CIR/CodeGen/builtin-nontemporal.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+int nontemporal_load(const int *ptr) {
+  return __builtin_nontemporal_load(ptr);
+}
+
+// CIR-LABEL: @_Z16nontemporal_loadPKi
+// CIR: %{{.+}} = cir.load nontemporal %{{.+}} : !cir.ptr<!s32i>, !s32i
+
+// LLVM-LABEL: @_Z16nontemporal_loadPKi
+// LLVM: %{{.+}} = load i32, ptr %{{.+}}, align 4, !nontemporal !1
+
+void nontemporal_store(int *ptr, int value) {
+  __builtin_nontemporal_store(value, ptr);
+}
+
+// CIR-LABEL: @_Z17nontemporal_storePii
+// CIR: cir.store nontemporal %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
+
+// LLVM-LABEL: @_Z17nontemporal_storePii
+// LLVM: store i32 %{{.+}}, ptr %{{.+}}, align 4, !nontemporal !1


### PR DESCRIPTION
This PR adds a new boolean flag to the `cir.load` and the `cir.store` operation that distinguishes nontemporal loads and stores. Besides, this PR also adds support for the `__builtin_nontemporal_load` and the `__builtin_nontemporal_store` intrinsic function.