### PR TITLE
[CIR][CodeGen] Add InsertionGuard for tryBodyScope

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -382,6 +382,7 @@ CIRGenFunction::emitCXXTryStmtUnderScope(const CXXTryStmt &S) {
       enterCXXTryStmt(S, tryOp);
       // Emit the body for the `try {}` part.
       {
+        mlir::OpBuilder::InsertionGuard guard(getBuilder());
         CIRGenFunction::LexicalScope tryBodyScope{
             *this, loc, getBuilder().getInsertionBlock()};
         if (emitStmt(S.getTryBlock(), /*useCurrentScope=*/true).failed())

--- a/clang/test/CIR/CodeGen/try-catch.cpp
+++ b/clang/test/CIR/CodeGen/try-catch.cpp
@@ -149,3 +149,22 @@ void tc6() {
 // CHECK:     cir.yield
 // CHECK:   }
 // CHECK: }
+
+// CHECK: cir.func @_Z3tc7v()
+void tc7() {
+  int r = 1;
+  try {
+    ++r;
+    return;
+  } catch (...) {
+  }
+}
+
+// CHECK: cir.scope {
+// CHECK:   cir.try {
+// CHECK:     %[[V2:.*]] = cir.load {{.*}} : !cir.ptr<!s32i>, !s32i
+// CHECK:     %[[V3:.*]] = cir.unary(inc, %[[V2]]) : !s32i, !s32i
+// CHECK:     cir.store %[[V3]], {{.*}} : !s32i, !cir.ptr<!s32i>
+// CHECK:     cir.return
+// CHECK:   }
+// CHECK: }


### PR DESCRIPTION
This PR adds an insertion guard for the try body scope for try-catch. Currently, the following code snippet fails during CodeGen: 

```
void foo() {
  int r = 1;
  try {
    ++r;
    return;
  } catch (...) {
  }
}
```

The insertion point doesn't get reset properly and the cleanup is being ran for a wrong/deleted block causing a segmentation fault. I also added a test.