### PR TITLE
[CIR][CodeGen] Support for `__builtin_elementwise_asin`

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4737,6 +4737,7 @@ class UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
   let llvmOp = llvmOpName;
 }
 
+def ASinOp : UnaryFPToFPBuiltinOp<"asin", "ASinOp">;
 def CeilOp : UnaryFPToFPBuiltinOp<"ceil", "FCeilOp">;
 def CosOp : UnaryFPToFPBuiltinOp<"cos", "CosOp">;
 def ExpOp : UnaryFPToFPBuiltinOp<"exp", "ExpOp">;

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1403,7 +1403,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     return emitBuiltinWithOneOverloadedType<1>(E, "acos");
   }
   case Builtin::BI__builtin_elementwise_asin:
-    llvm_unreachable("BI__builtin_elementwise_asin NYI");
+    return emitUnaryFPBuiltin<cir::ASinOp>(*this, *E);
   case Builtin::BI__builtin_elementwise_atan:
     llvm_unreachable("BI__builtin_elementwise_atan NYI");
   case Builtin::BI__builtin_elementwise_atan2:

--- a/clang/test/CIR/CodeGen/builtins-elementwise.c
+++ b/clang/test/CIR/CodeGen/builtins-elementwise.c
@@ -58,6 +58,27 @@ void test_builtin_elementwise_acos(float f, double d, vfloat4 vf4,
   vd4 = __builtin_elementwise_acos(vd4);
 }
 
+void test_builtin_elementwise_asin(float f, double d, vfloat4 vf4,
+  vdouble4  vd4) {
+// CIR-LABEL: test_builtin_elementwise_asin
+// LLVM-LABEL: test_builtin_elementwise_asin
+// CIR: {{%.*}} = cir.asin {{%.*}} : !cir.float
+// LLVM: {{%.*}} = call float @llvm.asin.f32(float {{%.*}})
+f = __builtin_elementwise_asin(f);
+
+// CIR: {{%.*}} = cir.asin {{%.*}} : !cir.double
+// LLVM: {{%.*}} = call double @llvm.asin.f64(double {{%.*}})
+d = __builtin_elementwise_asin(d);
+
+// CIR: {{%.*}} = cir.asin {{%.*}} : !cir.vector<!cir.float x 4>
+// LLVM: {{%.*}} = call <4 x float> @llvm.asin.v4f32(<4 x float> {{%.*}})
+vf4 = __builtin_elementwise_asin(vf4);
+
+// CIR: {{%.*}} = cir.asin {{%.*}} : !cir.vector<!cir.double x 4>
+// LLVM: {{%.*}} = call <4 x double> @llvm.asin.v4f64(<4 x double> {{%.*}})
+vd4 = __builtin_elementwise_asin(vd4);
+}
+
 void test_builtin_elementwise_exp(float f, double d, vfloat4 vf4,
                                   vdouble4  vd4) {
   // CIR-LABEL: test_builtin_elementwise_exp


### PR DESCRIPTION
Sub-issue of https://github.com/llvm/clangir/issues/1192. Adds CIR_ASinOp and support for __builtin_elementwise_asin.
