### PR TITLE
[CIR][CodeGen] Support for `__builtin_elementwise_atan`

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4737,6 +4737,7 @@ class UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
   let llvmOp = llvmOpName;
 }
 
+def ATanOp : UnaryFPToFPBuiltinOp<"atan", "ATanOp">;
 def CeilOp : UnaryFPToFPBuiltinOp<"ceil", "FCeilOp">;
 def CosOp : UnaryFPToFPBuiltinOp<"cos", "CosOp">;
 def ExpOp : UnaryFPToFPBuiltinOp<"exp", "ExpOp">;

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1405,7 +1405,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_elementwise_asin:
     llvm_unreachable("BI__builtin_elementwise_asin NYI");
   case Builtin::BI__builtin_elementwise_atan:
-    llvm_unreachable("BI__builtin_elementwise_atan NYI");
+    return emitUnaryFPBuiltin<cir::ATanOp>(*this, *E);
   case Builtin::BI__builtin_elementwise_atan2:
     llvm_unreachable("BI__builtin_elementwise_atan2 NYI");
   case Builtin::BI__builtin_elementwise_ceil:

--- a/clang/test/CIR/CodeGen/builtins-elementwise.c
+++ b/clang/test/CIR/CodeGen/builtins-elementwise.c
@@ -58,6 +58,27 @@ void test_builtin_elementwise_acos(float f, double d, vfloat4 vf4,
   vd4 = __builtin_elementwise_acos(vd4);
 }
 
+void test_builtin_elementwise_atan(float f, double d, vfloat4 vf4,
+  vdouble4  vd4) {
+// CIR-LABEL: test_builtin_elementwise_atan
+// LLVM-LABEL: test_builtin_elementwise_atan
+// CIR: {{%.*}} = cir.atan {{%.*}} : !cir.float
+// LLVM: {{%.*}} = call float @llvm.atan.f32(float {{%.*}})
+f = __builtin_elementwise_atan(f);
+
+// CIR: {{%.*}} = cir.atan {{%.*}} : !cir.double
+// LLVM: {{%.*}} = call double @llvm.atan.f64(double {{%.*}})
+d = __builtin_elementwise_atan(d);
+
+// CIR: {{%.*}} = cir.atan {{%.*}} : !cir.vector<!cir.float x 4>
+// LLVM: {{%.*}} = call <4 x float> @llvm.atan.v4f32(<4 x float> {{%.*}})
+vf4 = __builtin_elementwise_atan(vf4);
+
+// CIR: {{%.*}} = cir.atan {{%.*}} : !cir.vector<!cir.double x 4>
+// LLVM: {{%.*}} = call <4 x double> @llvm.atan.v4f64(<4 x double> {{%.*}})
+vd4 = __builtin_elementwise_atan(vd4);
+}
+
 void test_builtin_elementwise_exp(float f, double d, vfloat4 vf4,
                                   vdouble4  vd4) {
   // CIR-LABEL: test_builtin_elementwise_exp

--- a/clang/test/CIR/CodeGen/builtins-elementwise.c
+++ b/clang/test/CIR/CodeGen/builtins-elementwise.c
@@ -10,31 +10,31 @@ typedef double vdouble4 __attribute__((ext_vector_type(4)));
 
 void test_builtin_elementwise_abs(vint4 vi4, int i, float f, double d, 
                                   vfloat4 vf4, vdouble4  vd4) {
-// CIR-LABEL: test_builtin_elementwise_abs
-// LLVM-LABEL: test_builtin_elementwise_abs
-// CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.float
-// LLVM: {{%.*}} = call float @llvm.fabs.f32(float {{%.*}})
-f = __builtin_elementwise_abs(f);
-
-// CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.double
-// LLVM: {{%.*}} = call double @llvm.fabs.f64(double {{%.*}})
-d = __builtin_elementwise_abs(d);
-
-// CIR: {{%.*}} = cir.abs {{%.*}} : !cir.vector<!s32i x 4>
-// LLVM: {{%.*}} = call <4 x i32> @llvm.abs.v4i32(<4 x i32> {{%.*}}, i1 false)
-vi4 = __builtin_elementwise_abs(vi4);
-
-// CIR: {{%.*}} = cir.abs {{%.*}} : !s32
-// LLVM: {{%.*}} = call i32 @llvm.abs.i32(i32 {{%.*}}, i1 false)
-i = __builtin_elementwise_abs(i);
-
-// CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.float x 4>
-// LLVM: {{%.*}} = call <4 x float> @llvm.fabs.v4f32(<4 x float> {{%.*}})
-vf4 = __builtin_elementwise_abs(vf4);
-
-// CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.double x 4>
-// LLVM: {{%.*}} = call <4 x double> @llvm.fabs.v4f64(<4 x double> {{%.*}})
-vd4 = __builtin_elementwise_abs(vd4);
+    // CIR-LABEL: test_builtin_elementwise_abs
+    // LLVM-LABEL: test_builtin_elementwise_abs
+    // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.float
+    // LLVM: {{%.*}} = call float @llvm.fabs.f32(float {{%.*}})
+    f = __builtin_elementwise_abs(f);
+    
+    // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.double
+    // LLVM: {{%.*}} = call double @llvm.fabs.f64(double {{%.*}})
+    d = __builtin_elementwise_abs(d);
+    
+    // CIR: {{%.*}} = cir.abs {{%.*}} : !cir.vector<!s32i x 4>
+    // LLVM: {{%.*}} = call <4 x i32> @llvm.abs.v4i32(<4 x i32> {{%.*}}, i1 false)
+    vi4 = __builtin_elementwise_abs(vi4);
+    
+    // CIR: {{%.*}} = cir.abs {{%.*}} : !s32
+    // LLVM: {{%.*}} = call i32 @llvm.abs.i32(i32 {{%.*}}, i1 false)
+    i = __builtin_elementwise_abs(i);
+    
+    // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.float x 4>
+    // LLVM: {{%.*}} = call <4 x float> @llvm.fabs.v4f32(<4 x float> {{%.*}})
+    vf4 = __builtin_elementwise_abs(vf4);
+    
+    // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.double x 4>
+    // LLVM: {{%.*}} = call <4 x double> @llvm.fabs.v4f64(<4 x double> {{%.*}})
+    vd4 = __builtin_elementwise_abs(vd4);
 }
 
 void test_builtin_elementwise_acos(float f, double d, vfloat4 vf4,

--- a/clang/test/CIR/CodeGen/builtins-elementwise.c
+++ b/clang/test/CIR/CodeGen/builtins-elementwise.c
@@ -15,23 +15,23 @@ void test_builtin_elementwise_abs(vint4 vi4, int i, float f, double d,
     // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.float
     // LLVM: {{%.*}} = call float @llvm.fabs.f32(float {{%.*}})
     f = __builtin_elementwise_abs(f);
-    
+
     // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.double
     // LLVM: {{%.*}} = call double @llvm.fabs.f64(double {{%.*}})
     d = __builtin_elementwise_abs(d);
-    
+
     // CIR: {{%.*}} = cir.abs {{%.*}} : !cir.vector<!s32i x 4>
     // LLVM: {{%.*}} = call <4 x i32> @llvm.abs.v4i32(<4 x i32> {{%.*}}, i1 false)
     vi4 = __builtin_elementwise_abs(vi4);
-    
+
     // CIR: {{%.*}} = cir.abs {{%.*}} : !s32
     // LLVM: {{%.*}} = call i32 @llvm.abs.i32(i32 {{%.*}}, i1 false)
     i = __builtin_elementwise_abs(i);
-    
+
     // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.float x 4>
     // LLVM: {{%.*}} = call <4 x float> @llvm.fabs.v4f32(<4 x float> {{%.*}})
     vf4 = __builtin_elementwise_abs(vf4);
-    
+
     // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.double x 4>
     // LLVM: {{%.*}} = call <4 x double> @llvm.fabs.v4f64(<4 x double> {{%.*}})
     vd4 = __builtin_elementwise_abs(vd4);

--- a/clang/test/CIR/CodeGen/builtins-elementwise.c
+++ b/clang/test/CIR/CodeGen/builtins-elementwise.c
@@ -10,31 +10,31 @@ typedef double vdouble4 __attribute__((ext_vector_type(4)));
 
 void test_builtin_elementwise_abs(vint4 vi4, int i, float f, double d, 
                                   vfloat4 vf4, vdouble4  vd4) {
-  // CIR-LABEL: test_builtin_elementwise_abs
-  // LLVM-LABEL: test_builtin_elementwise_abs
-  // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.float
-  // LLVM: {{%.*}} = call float @llvm.fabs.f32(float {{%.*}})
-  f = __builtin_elementwise_abs(f);
+// CIR-LABEL: test_builtin_elementwise_abs
+// LLVM-LABEL: test_builtin_elementwise_abs
+// CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.float
+// LLVM: {{%.*}} = call float @llvm.fabs.f32(float {{%.*}})
+f = __builtin_elementwise_abs(f);
 
-  // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.double
-  // LLVM: {{%.*}} = call double @llvm.fabs.f64(double {{%.*}})
-  d = __builtin_elementwise_abs(d);
+// CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.double
+// LLVM: {{%.*}} = call double @llvm.fabs.f64(double {{%.*}})
+d = __builtin_elementwise_abs(d);
 
-  // CIR: {{%.*}} = cir.abs {{%.*}} : !cir.vector<!s32i x 4>
-  // LLVM: {{%.*}} = call <4 x i32> @llvm.abs.v4i32(<4 x i32> {{%.*}}, i1 false)
-  vi4 = __builtin_elementwise_abs(vi4);
+// CIR: {{%.*}} = cir.abs {{%.*}} : !cir.vector<!s32i x 4>
+// LLVM: {{%.*}} = call <4 x i32> @llvm.abs.v4i32(<4 x i32> {{%.*}}, i1 false)
+vi4 = __builtin_elementwise_abs(vi4);
 
-  // CIR: {{%.*}} = cir.abs {{%.*}} : !s32
-  // LLVM: {{%.*}} = call i32 @llvm.abs.i32(i32 {{%.*}}, i1 false)
-  i = __builtin_elementwise_abs(i);
+// CIR: {{%.*}} = cir.abs {{%.*}} : !s32
+// LLVM: {{%.*}} = call i32 @llvm.abs.i32(i32 {{%.*}}, i1 false)
+i = __builtin_elementwise_abs(i);
 
-  // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.float x 4>
-  // LLVM: {{%.*}} = call <4 x float> @llvm.fabs.v4f32(<4 x float> {{%.*}})
-  vf4 = __builtin_elementwise_abs(vf4);
+// CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.float x 4>
+// LLVM: {{%.*}} = call <4 x float> @llvm.fabs.v4f32(<4 x float> {{%.*}})
+vf4 = __builtin_elementwise_abs(vf4);
 
-  // CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.double x 4>
-  // LLVM: {{%.*}} = call <4 x double> @llvm.fabs.v4f64(<4 x double> {{%.*}})
-  vd4 = __builtin_elementwise_abs(vd4);
+// CIR: {{%.*}} = cir.fabs {{%.*}} : !cir.vector<!cir.double x 4>
+// LLVM: {{%.*}} = call <4 x double> @llvm.fabs.v4f64(<4 x double> {{%.*}})
+vd4 = __builtin_elementwise_abs(vd4);
 }
 
 void test_builtin_elementwise_acos(float f, double d, vfloat4 vf4,


### PR DESCRIPTION
Sub-issue of https://github.com/llvm/clangir/issues/1192. Adds CIR_ATanOp and support for __builtin_elementwise_atan.