### PR TITLE
[CIR][CIRGen][NFC] Handle `PragmaComment` in `emitTopLevelDecl`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2035,6 +2035,24 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
         emitTopLevelDecl(childDecl);
     break;
   }
+  case Decl::PragmaComment: {
+    const auto *PCD = cast<PragmaCommentDecl>(decl);
+    switch (PCD->getCommentKind()) {
+      case PCK_Unknown:
+        llvm_unreachable("unexpected pragma comment kind");
+      case PCK_Linker:
+        assert(!MissingFeatures::emitModuleLinkOptions() && "NYI");
+        break;
+      case PCK_Lib:
+        assert(!MissingFeatures::elfDependentLibraries() && "NYI");
+        break;
+      case PCK_Compiler:
+      case PCK_ExeStr:
+      case PCK_User:
+        break; // We ignore all of these.
+    }
+    break;
+  }
   // No code generation needed.
   case Decl::UsingShadow:
   case Decl::ClassTemplate:

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2038,18 +2038,18 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
   case Decl::PragmaComment: {
     const auto *PCD = cast<PragmaCommentDecl>(decl);
     switch (PCD->getCommentKind()) {
-      case PCK_Unknown:
-        llvm_unreachable("unexpected pragma comment kind");
-      case PCK_Linker:
-        assert(!MissingFeatures::emitModuleLinkOptions() && "NYI");
-        break;
-      case PCK_Lib:
-        assert(!MissingFeatures::elfDependentLibraries() && "NYI");
-        break;
-      case PCK_Compiler:
-      case PCK_ExeStr:
-      case PCK_User:
-        break; // We ignore all of these.
+    case PCK_Unknown:
+      llvm_unreachable("unexpected pragma comment kind");
+    case PCK_Linker:
+      assert(!MissingFeatures::emitModuleLinkOptions() && "NYI");
+      break;
+    case PCK_Lib:
+      assert(!MissingFeatures::elfDependentLibraries() && "NYI");
+      break;
+    case PCK_Compiler:
+    case PCK_ExeStr:
+    case PCK_User:
+      break; // We ignore all of these.
     }
     break;
   }


### PR DESCRIPTION
- Part of #70

This is not very useful now, as both branches of interest are NYI. I will try to implement the real features in subsequent patches.

