### PR TITLE
[CIR][NFC] Sort emit functions in CIRGenFunction.h

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -608,9 +608,7 @@ public:
 
   bool shouldNullCheckClassCastValue(const CastExpr *CE);
 
-
   mlir::Value createLoad(const clang::VarDecl *VD, const char *Name);
-
 
   // Wrapper for function prototype sources. Wraps either a FunctionProtoType or
   // an ObjCMethodDecl.
@@ -660,7 +658,6 @@ public:
   llvm::SmallDenseMap<const ParmVarDecl *, const ImplicitParamDecl *, 2>
       SizeArguments;
 
-
   struct VlaSizePair {
     mlir::Value NumElts;
     QualType Type;
@@ -680,9 +677,7 @@ public:
                                               mlir::Value EmittedE,
                                               bool IsDynamic);
 
-
   int64_t getAccessedFieldNo(unsigned idx, const mlir::ArrayAttr elts);
-
 
   void checkTargetFeatures(const CallExpr *E, const FunctionDecl *TargetDecl);
   void checkTargetFeatures(SourceLocation Loc, const FunctionDecl *TargetDecl);
@@ -830,7 +825,6 @@ public:
 
   const CaseStmt *foldCaseStmt(const clang::CaseStmt &S, mlir::Type condType,
                                mlir::ArrayAttr &value, cir::CaseOpKind &kind);
-
 
   cir::FuncOp generateCode(clang::GlobalDecl GD, cir::FuncOp Fn,
                            const CIRGenFunctionInfo &FnInfo);
@@ -1082,7 +1076,6 @@ public:
                      cir::FuncOp Fn, const CIRGenFunctionInfo &FnInfo,
                      const FunctionArgList &Args, clang::SourceLocation Loc,
                      clang::SourceLocation StartLoc);
-
 
   LValue makeAddrLValue(Address addr, clang::QualType ty,
                         LValueBaseInfo baseInfo, TBAAAccessInfo tbaaInfo) {

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -693,7 +693,6 @@ public:
     return getAsNaturalAddressOf(Addr, PointeeType).getBasePointer();
   }
 
-
   void finishFunction(SourceLocation EndLoc);
 
   // Many of MSVC builtins are on x64, ARM and AArch64; to avoid repeating code,
@@ -1691,7 +1690,7 @@ private:
   /// the function metadata.
   void emitKernelMetadata(const FunctionDecl *FD, cir::FuncOp Fn);
   void emitAndUpdateRetAlloca(clang::QualType ty, mlir::Location loc,
-    clang::CharUnits alignment);
+                              clang::CharUnits alignment);
 
 public:
   mlir::Value emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
@@ -1739,17 +1738,17 @@ public:
 
   // FIXME(cir): move this to CIRGenBuider.h
   mlir::Value emitAlloca(llvm::StringRef name, clang::QualType ty,
-    mlir::Location loc, clang::CharUnits alignment,
-    bool insertIntoFnEntryBlock = false,
-    mlir::Value arraySize = nullptr);
+                         mlir::Location loc, clang::CharUnits alignment,
+                         bool insertIntoFnEntryBlock = false,
+                         mlir::Value arraySize = nullptr);
   mlir::Value emitAlloca(llvm::StringRef name, mlir::Type ty,
-    mlir::Location loc, clang::CharUnits alignment,
-    bool insertIntoFnEntryBlock = false,
-    mlir::Value arraySize = nullptr);
+                         mlir::Location loc, clang::CharUnits alignment,
+                         bool insertIntoFnEntryBlock = false,
+                         mlir::Value arraySize = nullptr);
   mlir::Value emitAlloca(llvm::StringRef name, mlir::Type ty,
-    mlir::Location loc, clang::CharUnits alignment,
-    mlir::OpBuilder::InsertPoint ip,
-    mlir::Value arraySize = nullptr);
+                         mlir::Location loc, clang::CharUnits alignment,
+                         mlir::OpBuilder::InsertPoint ip,
+                         mlir::Value arraySize = nullptr);
 
   /// Emit code to compute the specified expression which can have any type. The
   /// result is returned as an RValue struct. If this is an aggregate
@@ -1841,8 +1840,8 @@ public:
                                   const CallExpr *theCallExpr, bool isDelete);
 
   mlir::Value emitBuiltinObjectSize(const Expr *E, unsigned Type,
-    cir::IntType ResType, mlir::Value EmittedE,
-    bool IsDynamic);
+                                    cir::IntType ResType, mlir::Value EmittedE,
+                                    bool IsDynamic);
   template <uint32_t N>
   [[maybe_unused]] RValue
   emitBuiltinWithOneOverloadedType(const CallExpr *E, llvm::StringRef Name) {
@@ -2117,11 +2116,11 @@ public:
   /// Emits try/catch information for the current EH stack.
   void emitEHResumeBlock(bool isCleanup, mlir::Block *ehResumeBlock,
                          mlir::Location loc);
-                         void emitDestroy(Address addr, QualType type, Destroyer *destroyer,
-                          bool useEHCleanupForArray);
-                          template <typename FuncTy>
-                          ConditionalInfo emitConditionalBlocks(const AbstractConditionalOperator *E,
-                                                                const FuncTy &BranchGenFunc);
+  void emitDestroy(Address addr, QualType type, Destroyer *destroyer,
+                   bool useEHCleanupForArray);
+  template <typename FuncTy>
+  ConditionalInfo emitConditionalBlocks(const AbstractConditionalOperator *E,
+                                        const FuncTy &BranchGenFunc);
 
   /// Emit an expression as an initializer for an object (variable, field, etc.)
   /// at the given location.  The expression is not necessarily the normal
@@ -2141,7 +2140,7 @@ public:
   mlir::LogicalResult emitForStmt(const clang::ForStmt &S);
 
   void emitForwardingCallToLambda(const CXXMethodDecl *LambdaCallOperator,
-      CallArgList &CallArgs);
+                                  CallArgList &CallArgs);
 
   /// Given a value and its clang type, returns the value casted from its memory
   /// representation.
@@ -2422,12 +2421,10 @@ public:
 
   LValue emitStringLiteralLValue(const StringLiteral *E);
 
-
   mlir::LogicalResult emitSwitchBody(const clang::Stmt *S);
   mlir::LogicalResult emitSwitchCase(const clang::SwitchCase &S,
                                      bool buildingTopLevelCase);
   mlir::LogicalResult emitSwitchStmt(const clang::SwitchStmt &S);
-
 
   mlir::Value emitTargetBuiltinExpr(unsigned BuiltinID,
                                     const clang::CallExpr *E,
@@ -2453,7 +2450,7 @@ public:
   /// that VTable is a member of RD's type identifier. Or, if vptr CFI is
   /// enabled, emit a check that VTable is a member of RD's type identifier.
   void emitTypeMetadataCodeForVCall(const CXXRecordDecl *RD, mlir::Value VTable,
-    SourceLocation Loc);
+                                    SourceLocation Loc);
 
   LValue emitUnaryOpLValue(const clang::UnaryOperator *E);
 
@@ -2499,11 +2496,10 @@ public:
   mlir::LogicalResult emitWhileStmt(const clang::WhileStmt &S);
 
   mlir::Value emitX86BuiltinExpr(unsigned BuiltinID, const CallExpr *E);
-                        
+
   /// CIR build helpers
   /// -----------------
 public:
-
   /// This creates an alloca and inserts it into the entry block if \p ArraySize
   /// is nullptr,
   ///


### PR DESCRIPTION
This change moves all declarations of emit* functions in CIRGenFunction.h into a common location and sorts them alphabetically. The goal of this change is to make it easier to keep upstream and incubator code in a consistent location, making functions easier to find for upstreaming and minimizing conflicts in the incubator when rebasing.

I did most of this sort manually, and I've probably been inconsistent in how I treat sorting of uppercase versus lowercase. I made no attempt to provide a rule for ordering different declarations of functions with the same name. We can improve on that over time if anyone feels the need.

I tried very hard not to drop comments (one of the reasons I had to do this manually), but I may have lost a few.

This change loses the grouping of some declarations that were co-located by common purpose, but most of the declarations lacked a coherent ordering, so I think this is a step forward overall.