### PR TITLE
[CIR] Backport support zero init attr for all FP types

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -135,14 +135,8 @@ public:
   mlir::TypedAttr getZeroInitAttr(mlir::Type ty) {
     if (mlir::isa<cir::IntType>(ty))
       return cir::IntAttr::get(ty, 0);
-    if (auto fltType = mlir::dyn_cast<cir::SingleType>(ty))
-      return cir::FPAttr::getZero(fltType);
-    if (auto fltType = mlir::dyn_cast<cir::DoubleType>(ty))
-      return cir::FPAttr::getZero(fltType);
-    if (auto fltType = mlir::dyn_cast<cir::FP16Type>(ty))
-      return cir::FPAttr::getZero(fltType);
-    if (auto fltType = mlir::dyn_cast<cir::BF16Type>(ty))
-      return cir::FPAttr::getZero(fltType);
+    if (cir::isAnyFloatingPointType(ty))
+      return cir::FPAttr::getZero(ty);
     if (auto complexType = mlir::dyn_cast<cir::ComplexType>(ty))
       return getZeroAttr(complexType);
     if (auto arrTy = mlir::dyn_cast<cir::ArrayType>(ty))

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -498,6 +498,8 @@ mlir::Type CIRGenTypes::convertType(QualType T) {
       ResultType = Builder.getLongDoubleTy(astContext.getFloatTypeSemantics(T));
       break;
     case BuiltinType::Float128:
+      ResultType = CGM.FP128Ty;
+      break;
     case BuiltinType::Ibm128:
       // FIXME: look at astContext.getFloatTypeSemantics(T) and getTypeForFormat
       // on LLVM codegen.

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -705,7 +705,7 @@ LongDoubleType::verify(function_ref<InFlightDiagnostic()> emitError,
 
 bool cir::isAnyFloatingPointType(mlir::Type t) {
   return isa<cir::SingleType, cir::DoubleType, cir::LongDoubleType,
-             cir::FP80Type>(t);
+             cir::FP80Type, cir::BF16Type, cir::FP16Type, cir::FP128Type>(t);
 }
 
 bool cir::isScalarType(mlir::Type ty) {

--- a/clang/test/CIR/global-var-simple.cpp
+++ b/clang/test/CIR/global-var-simple.cpp
@@ -1,5 +1,6 @@
 // Global variables of intergal types
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: cat %t.cir
 // RUN: FileCheck %s --input-file=%t.cir
 
 char c;
@@ -60,19 +61,19 @@ unsigned _BitInt(48) ub48;
 // CHECK: external @ub48 = #cir.int<0> : !u48i
 
 _Float16 f16;
-// CHECK: @f16 = dso_local global half
+// CHECK: cir.global external @f16 = #cir.fp<0.000000e+00> : !cir.f16
 
 __bf16 bf16;
-// CHECK: @bf16 = dso_local global bfloat
+// CHECK: cir.global external @bf16 = #cir.fp<0.000000e+00> : !cir.bf16
 
 float f;
-// CHECK: @f = dso_local global float 0.000000e+00
+// CHECK: cir.global external @f = #cir.fp<0.000000e+00> : !cir.float
 
 double d = 1.25;
-// CHECK: @d = dso_local global double 1.250000e+00
+// CHECK: cir.global external @d = #cir.fp<1.250000e+00> : !cir.double
 
 long double ld;
-// CHECK: @ld = dso_local global x86_fp80 0xK00
+// CHECK: cir.global external @ld = #cir.fp<0.000000e+00> : !cir.long_double<!cir.f80>
 
 __float128 f128;
-// CHECK: @f128 = dso_local global fp128 0xL00
+// CHECK: cir.global external @f128 = #cir.fp<0.000000e+00> : !cir.f128

--- a/clang/test/CIR/global-var-simple.cpp
+++ b/clang/test/CIR/global-var-simple.cpp
@@ -1,6 +1,5 @@
 // Global variables of intergal types
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: cat %t.cir
 // RUN: FileCheck %s --input-file=%t.cir
 
 char c;

--- a/clang/test/CIR/global-var-simple.cpp
+++ b/clang/test/CIR/global-var-simple.cpp
@@ -58,3 +58,21 @@ _BitInt(20) sb20;
 
 unsigned _BitInt(48) ub48;
 // CHECK: external @ub48 = #cir.int<0> : !u48i
+
+_Float16 f16;
+// CHECK: @f16 = dso_local global half
+
+__bf16 bf16;
+// CHECK: @bf16 = dso_local global bfloat
+
+float f;
+// CHECK: @f = dso_local global float 0.000000e+00
+
+double d = 1.25;
+// CHECK: @d = dso_local global double 1.250000e+00
+
+long double ld;
+// CHECK: @ld = dso_local global x86_fp80 0xK00
+
+__float128 f128;
+// CHECK: @f128 = dso_local global fp128 0xL00


### PR DESCRIPTION
Update getZeroInitAttr to cover more FP types, Backport from (https://github.com/llvm/llvm-project/pull/133100)