### PR TITLE
[CIR] Unxfail memory effect attribute test

### DIFF
--- a/clang/test/CIR/CodeGen/call-side-effect.cpp
+++ b/clang/test/CIR/CodeGen/call-side-effect.cpp
@@ -2,7 +2,6 @@
 // RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
-// XFAIL: *
 
 [[gnu::pure]] int pure_func(int x);
 [[gnu::const]] int const_func(int x);
@@ -22,5 +21,5 @@ int test(int x) {
 // LLVM:   %{{.+}} = call i32 @_Z9pure_funci(i32 %{{.+}}) #[[#meta_pure:]]
 // LLVM:   %{{.+}} = call i32 @_Z10const_funci(i32 %{{.+}}) #[[#meta_const:]]
 // LLVM: }
-// LLVM: attributes #[[#meta_pure]] = { nounwind willreturn memory(read) }
+// LLVM: attributes #[[#meta_pure]] = { nounwind willreturn memory(read, errnomem: none) }
 // LLVM: attributes #[[#meta_const]] = { nounwind willreturn memory(none) }


### PR DESCRIPTION
Upstream commit changed behavior https://github.com/llvm/llvm-project/commit/ff585feacf58b384d7525d2b1368298435132fb4
I tested in original clang and it produced the same IR with clangir.
Related: https://github.com/llvm/clangir/issues/1497