### PR TITLE
[ClangIR] Add support for ParenExpr

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1564,6 +1564,8 @@ LValue CodeGenFunction::EmitLValueHelper(const Expr *E,
     return EmitObjCIsaExpr(cast<ObjCIsaExpr>(E));
   case Expr::BinaryOperatorClass:
     return EmitBinaryOperatorLValue(cast<BinaryOperator>(E));
+  case Expr::ParenExprClass:
+    return EmitLValue(cast<ParenExpr>(E)->getSubExpr());
   case Expr::CompoundAssignOperatorClass: {
     QualType Ty = E->getType();
     if (const AtomicType *AT = Ty->getAs<AtomicType>())
@@ -1592,8 +1594,6 @@ LValue CodeGenFunction::EmitLValueHelper(const Expr *E,
     }
     return EmitLValue(cast<ConstantExpr>(E)->getSubExpr(), IsKnownNonNull);
   }
-  case Expr::ParenExprClass:
-    return EmitLValue(cast<ParenExpr>(E)->getSubExpr(), IsKnownNonNull);
   case Expr::GenericSelectionExprClass:
     return EmitLValue(cast<GenericSelectionExpr>(E)->getResultExpr(),
                       IsKnownNonNull);
@@ -5848,6 +5848,11 @@ LValue CodeGenFunction::EmitBinaryOperatorLValue(const BinaryOperator *E) {
     return EmitAggExprToLValue(E);
   }
   llvm_unreachable("bad evaluation kind");
+}
+
+// Handle parenthesis expressions
+llvm::Value *CodeGenFunction::EmitParenExpr(const ParenExpr *E) {
+  return EmitScalarExpr(E->getSubExpr());
 }
 
 // This function implements trivial copy assignment for HLSL's

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -5370,6 +5370,12 @@ private:
                                                llvm::IntegerType *ResType,
                                                llvm::Value *EmittedE,
                                                bool IsDynamic);
+                                               
+  /// Emit code for a parenthesis expression. This simply emits the
+  /// subexpression without any additional logic, since parentheses
+  /// do not affect the semantics of the expression in IR.
+  llvm::Value *EmitParenExpr(const ParenExpr *E);
+
 
   /// Emits the size of E, as required by __builtin_object_size. This
   /// function is aware of pass_object_size parameters, and will act accordingly

--- a/clang/test/CodeGen/paren-expr.c
+++ b/clang/test/CodeGen/paren-expr.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -emit-llvm -o - %s | FileCheck %s
+
+int f(int a, int b, int c) {
+  // CHECK: add
+  return a + (b + c);
+}


### PR DESCRIPTION
Summary

This pull request adds support for handling ParenExpr nodes in ClangIR by delegating to the inner expression.

Changes:

Updated EmitScalarExpr and EmitLValue to handle ParenExprClass.

Added a test case (paren-expr.c) to verify correct handling of parenthesis expressions.

Notes:

While testing, I encountered an unrelated issue: ClangIR reports "unknown target triple 'unknown'". This seems independent of ParenExpr handling and may require a separate investigation.