### PR TITLE
[CIR][NFC] Simplify struct type name creation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -63,9 +63,10 @@ std::string CIRGenTypes::getRecordTypeName(const clang::RecordDecl *recordDecl,
   policy.SuppressInlineNamespace = false;
   policy.AlwaysIncludeTypeForTemplateArgument = true;
   policy.PrintCanonicalTypes = true;
+  policy.SuppressTagKeyword = true;
 
   if (recordDecl->getIdentifier()) {
-    recordDecl->getNameForDiagnostic(outStream, policy, true);
+    astContext.getRecordType(recordDecl).print(outStream, policy);
   } else if (auto *typedefNameDecl = recordDecl->getTypedefNameForAnonDecl()) {
     typedefNameDecl->printQualifiedName(outStream, policy);
   } else {

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -61,31 +61,13 @@ std::string CIRGenTypes::getRecordTypeName(const clang::RecordDecl *recordDecl,
 
   PrintingPolicy policy = recordDecl->getASTContext().getPrintingPolicy();
   policy.SuppressInlineNamespace = false;
+  policy.AlwaysIncludeTypeForTemplateArgument = true;
+  policy.PrintCanonicalTypes = true;
 
   if (recordDecl->getIdentifier()) {
-    if (recordDecl->getDeclContext())
-      recordDecl->printQualifiedName(outStream, policy);
-    else
-      recordDecl->printName(outStream, policy);
-
-    // Ensure each template specialization has a unique name.
-    if (auto *templateSpecialization =
-            llvm::dyn_cast<ClassTemplateSpecializationDecl>(recordDecl)) {
-      outStream << '<';
-      const auto args = templateSpecialization->getTemplateArgs().asArray();
-      const auto printer = [&policy, &outStream](const TemplateArgument &arg) {
-        /// Print this template argument to the given output stream.
-        arg.print(policy, outStream, /*IncludeType=*/true);
-      };
-      llvm::interleaveComma(args, outStream, printer);
-      outStream << '>';
-    }
-
+    recordDecl->getNameForDiagnostic(outStream, policy, true);
   } else if (auto *typedefNameDecl = recordDecl->getTypedefNameForAnonDecl()) {
-    if (typedefNameDecl->getDeclContext())
-      typedefNameDecl->printQualifiedName(outStream, policy);
-    else
-      typedefNameDecl->printName(outStream);
+    typedefNameDecl->printQualifiedName(outStream, policy);
   } else {
     outStream << Builder.getUniqueAnonRecordName();
   }


### PR DESCRIPTION
During review of a patch for upstreaming the cir.struct type support, Erich Keane observed that the code we use for creating our type name for structures with templates was likely to be error prone. He recommended using getNameForDiagnostic instead.

After some experimentation, I found that with a couple of changes to the printing policy, I could get the same strings we currently produce by calling getNameForDiagnostic. This change does that.

Erich also pointed out that RecordDecls always have a DeclContext so a few other lines could be eliminated where that was checked.