### PR TITLE
[CIR] Rename `cir.struct` to `cir.record` and associated changes

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -143,8 +143,8 @@ public:
       return getZeroAttr(arrTy);
     if (auto ptrTy = mlir::dyn_cast<cir::PointerType>(ty))
       return getConstNullPtrAttr(ptrTy);
-    if (auto structTy = mlir::dyn_cast<cir::StructType>(ty))
-      return getZeroAttr(structTy);
+    if (auto RecordTy = mlir::dyn_cast<cir::RecordType>(ty))
+      return getZeroAttr(RecordTy);
     if (auto methodTy = mlir::dyn_cast<cir::MethodType>(ty))
       return getNullMethodAttr(methodTy);
     if (mlir::isa<cir::BoolType>(ty)) {
@@ -496,16 +496,16 @@ public:
     return createCast(cir::CastKind::int_to_ptr, src, newTy);
   }
 
-  mlir::Value createGetMemberOp(mlir::Location &loc, mlir::Value structPtr,
+  mlir::Value createGetMemberOp(mlir::Location &loc, mlir::Value recordPtr,
                                 const char *fldName, unsigned idx) {
 
-    assert(mlir::isa<cir::PointerType>(structPtr.getType()));
-    auto structBaseTy =
-        mlir::cast<cir::PointerType>(structPtr.getType()).getPointee();
-    assert(mlir::isa<cir::StructType>(structBaseTy));
-    auto fldTy = mlir::cast<cir::StructType>(structBaseTy).getMembers()[idx];
+    assert(mlir::isa<cir::PointerType>(recordPtr.getType()));
+    auto recordBaseTy =
+        mlir::cast<cir::PointerType>(recordPtr.getType()).getPointee();
+    assert(mlir::isa<cir::RecordType>(recordBaseTy));
+    auto fldTy = mlir::cast<cir::RecordType>(recordBaseTy).getMembers()[idx];
     auto fldPtrTy = cir::PointerType::get(getContext(), fldTy);
-    return create<cir::GetMemberOp>(loc, fldPtrTy, structPtr, fldName, idx);
+    return create<cir::GetMemberOp>(loc, fldPtrTy, recordPtr, fldName, idx);
   }
 
   mlir::Value createPtrToInt(mlir::Value src, mlir::Type newTy) {

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.h
@@ -37,7 +37,7 @@ class RecordDecl;
 
 namespace cir {
 class ArrayType;
-class StructType;
+class RecordType;
 class BoolType;
 } // namespace cir
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -331,12 +331,12 @@ def ConstVectorAttr : CIR_Attr<"ConstVector", "const_vector",
 }
 
 //===----------------------------------------------------------------------===//
-// ConstStructAttr
+// ConstRecordAttr
 //===----------------------------------------------------------------------===//
 
-def ConstStructAttr : CIR_Attr<"ConstStruct", "const_struct",
+def ConstRecordAttr : CIR_Attr<"ConstRecord", "const_record",
                                [TypedAttrInterface]> {
-  let summary = "Represents a constant struct";
+  let summary = "Represents a constant record";
   let description = [{
     Effectively supports "struct-like" constants. It's must be built from
     an `mlir::ArrayAttr `instance where each elements is a typed attribute
@@ -344,9 +344,9 @@ def ConstStructAttr : CIR_Attr<"ConstStruct", "const_struct",
 
     Example:
     ```
-    cir.global external @rgb2 = #cir.const_struct<{0 : i8,
+    cir.global external @rgb2 = #cir.const_record<{0 : i8,
                                                    5 : i64, #cir.null : !cir.ptr<i8>
-                                                  }> : !cir.struct<"", i8, i64, !cir.ptr<i8>>
+                                                  }> : !cir.record<"", i8, i64, !cir.ptr<i8>>
     ```
   }];
 
@@ -354,14 +354,14 @@ def ConstStructAttr : CIR_Attr<"ConstStruct", "const_struct",
                         "mlir::ArrayAttr":$members);
 
   let builders = [
-    AttrBuilderWithInferredContext<(ins "cir::StructType":$type,
+    AttrBuilderWithInferredContext<(ins "cir::RecordType":$type,
                                         "mlir::ArrayAttr":$members), [{
       return $_get(type.getContext(), type, members);
     }]>
   ];
 
   let assemblyFormat = [{
-    `<` custom<StructMembers>($members) `>`
+    `<` custom<RecordMembers>($members) `>`
   }];
 
   let genVerifyDecl = 1;
@@ -576,7 +576,7 @@ def DataMemberAttr : CIR_Attr<"DataMember", "data_member",
     pointer-to-data-member value.
 
     The `member_index` parameter represents the index of the pointed-to member
-    within its containing struct. It is an optional parameter; lack of this
+    within its containing record. It is an optional parameter; lack of this
     parameter indicates a null pointer-to-data-member value.
 
     Example:
@@ -687,7 +687,7 @@ def GlobalViewAttr : CIR_Attr<"GlobalView", "global_view", [TypedAttrInterface]>
 
     A list of indices can be optionally passed and each element subsequently
     indexes underlying types. For `symbol` types like `!cir.array`
-    and `!cir.struct`, it leads to the constant address of sub-elements, while
+    and `!cir.record`, it leads to the constant address of sub-elements, while
     for `!cir.ptr`, an offset is applied. The first index is relative to the
     original symbol type, not the produced one.
 
@@ -764,9 +764,9 @@ def TypeInfoAttr : CIR_Attr<"TypeInfo", "typeinfo", [TypedAttrInterface]> {
     layout is determined by the C++ ABI used (clang only implements
     itanium on CIRGen).
 
-    The verifier enforces that the output type is always a `!cir.struct`,
+    The verifier enforces that the output type is always a `!cir.record`,
     and that the ArrayAttr element types match the equivalent member type
-    for the resulting struct, i.e, a GlobalViewAttr for symbol reference or
+    for the resulting record, i.e, a GlobalViewAttr for symbol reference or
     an IntAttr for flags.
 
     Example:
@@ -776,7 +776,7 @@ def TypeInfoAttr : CIR_Attr<"TypeInfo", "typeinfo", [TypedAttrInterface]> {
 
     cir.global external @type_info_B = #cir.typeinfo<<
       {#cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<i8>}
-    >> : !cir.struct<"", !cir.ptr<i8>>
+    >> : !cir.record<"", !cir.ptr<i8>>
     ```
   }];
 
@@ -790,11 +790,11 @@ def TypeInfoAttr : CIR_Attr<"TypeInfo", "typeinfo", [TypedAttrInterface]> {
     }]>
   ];
 
-  // Checks struct element types should match the array for every equivalent
+  // Checks record element types should match the array for every equivalent
   // element type.
   let genVerifyDecl = 1;
   let assemblyFormat = [{
-    `<` custom<StructMembers>($data) `>`
+    `<` custom<RecordMembers>($data) `>`
   }];
 }
 
@@ -805,7 +805,7 @@ def TypeInfoAttr : CIR_Attr<"TypeInfo", "typeinfo", [TypedAttrInterface]> {
 def VTableAttr : CIR_Attr<"VTable", "vtable", [TypedAttrInterface]> {
   let summary = "Represents a C++ vtable";
   let description = [{
-    Wraps a #cir.const_struct containing vtable data.
+    Wraps a #cir.const_record containing vtable data.
 
     Example:
     ```
@@ -816,11 +816,11 @@ def VTableAttr : CIR_Attr<"VTable", "vtable", [TypedAttrInterface]> {
          #cir.global_view<@_ZN1BD0Ev> : !cir.ptr<i8>,
          #cir.global_view<@_ZNK1A5quackEv> : !cir.ptr<i8>]>
          : !cir.array<!cir.ptr<i8> x 5>}>>
-      : !cir.struct<"", !cir.array<!cir.ptr<i8> x 5>>
+      : !cir.record<"", !cir.array<!cir.ptr<i8> x 5>>
     ```
   }];
 
-  // `vtable_data` is const struct with one element, containing an array of
+  // `vtable_data` is const record with one element, containing an array of
   // vtable information.
   let parameters = (ins AttributeSelfTypeParameter<"">:$type,
                         "mlir::ArrayAttr":$vtable_data);
@@ -834,21 +834,21 @@ def VTableAttr : CIR_Attr<"VTable", "vtable", [TypedAttrInterface]> {
 
   let genVerifyDecl = 1;
   let assemblyFormat = [{
-    `<` custom<StructMembers>($vtable_data) `>`
+    `<` custom<RecordMembers>($vtable_data) `>`
   }];
 }
 
 //===----------------------------------------------------------------------===//
-// StructLayoutAttr
+// RecordLayoutAttr
 //===----------------------------------------------------------------------===//
 
-// Used to decouple layout information from the struct type. StructType's
+// Used to decouple layout information from the record type. RecordType's
 // uses this attribute to cache that information.
 
-def StructLayoutAttr : CIR_Attr<"StructLayout", "struct_layout"> {
-  let summary = "ABI specific information about a struct layout";
+def RecordLayoutAttr : CIR_Attr<"RecordLayout", "record_layout"> {
+  let summary = "ABI specific information about a record layout";
   let description = [{
-    Holds layout information often queried by !cir.struct users
+    Holds layout information often queried by !cir.record users
     during lowering passes and optimizations.
   }];
 
@@ -888,7 +888,7 @@ def DynamicCastInfoAttr
     Provide ABI specific information about a dynamic cast operation.
 
     The `srcRtti` and the `destRtti` parameters give the RTTI of the source
-    struct type and the destination struct type, respectively.
+    record type and the destination record type, respectively.
 
     The `runtimeFunc` parameter gives the `__dynamic_cast` function which is
     provided by the runtime. The `badCastFunc` parameter gives the

--- a/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDataLayout.h
@@ -22,7 +22,7 @@
 
 namespace cir {
 
-class StructLayout;
+class RecordLayout;
 
 // FIXME(cir): This might be replaced by a CIRDataLayout interface which can
 // provide the same functionalities.
@@ -31,9 +31,9 @@ class CIRDataLayout {
 
   /// Primitive type alignment data. This is sorted by type and bit
   /// width during construction.
-  llvm::DataLayout::PrimitiveSpec StructAlignment;
+  llvm::DataLayout::PrimitiveSpec RecordAlignment;
 
-  // The StructType -> StructLayout map.
+  // The RecordType -> RecordLayout map.
   mutable void *LayoutMap = nullptr;
 
   TypeSizeInfoAttr typeSizeInfo;
@@ -52,11 +52,11 @@ public:
 
   bool isBigEndian() const { return bigEndian; }
 
-  /// Returns a StructLayout object, indicating the alignment of the
-  /// struct, its size, and the offsets of its fields.
+  /// Returns a RecordLayout object, indicating the alignment of the
+  /// record, its size, and the offsets of its fields.
   ///
   /// Note that this information is lazily cached.
-  const StructLayout *getStructLayout(cir::StructType Ty) const;
+  const RecordLayout *getRecordLayout(cir::RecordType Ty) const;
 
   /// Internal helper method that returns requested alignment for type.
   llvm::Align getAlignment(mlir::Type Ty, bool abiOrPref) const;
@@ -121,21 +121,21 @@ public:
 
 /// Used to lazily calculate structure layout information for a target machine,
 /// based on the DataLayout structure.
-class StructLayout final
-    : public llvm::TrailingObjects<StructLayout, llvm::TypeSize> {
-  llvm::TypeSize StructSize;
-  llvm::Align StructAlignment;
+class RecordLayout final
+    : public llvm::TrailingObjects<RecordLayout, llvm::TypeSize> {
+  llvm::TypeSize RecordSize;
+  llvm::Align RecordAlignment;
   unsigned IsPadded : 1;
   unsigned NumElements : 31;
 
 public:
-  llvm::TypeSize getSizeInBytes() const { return StructSize; }
+  llvm::TypeSize getSizeInBytes() const { return RecordSize; }
 
-  llvm::TypeSize getSizeInBits() const { return 8 * StructSize; }
+  llvm::TypeSize getSizeInBits() const { return 8 * RecordSize; }
 
-  llvm::Align getAlignment() const { return StructAlignment; }
+  llvm::Align getAlignment() const { return RecordAlignment; }
 
-  /// Returns whether the struct has padding or not between its fields.
+  /// Returns whether the record has padding or not between its fields.
   /// NB: Padding in nested element is not taken into account.
   bool hasPadding() const { return IsPadded; }
 
@@ -164,7 +164,7 @@ public:
 private:
   friend class CIRDataLayout; // Only DataLayout can create this class
 
-  StructLayout(cir::StructType ST, const CIRDataLayout &DL);
+  RecordLayout(cir::RecordType ST, const CIRDataLayout &DL);
 
   size_t numTrailingObjects(OverloadToken<llvm::TypeSize>) const {
     return NumElements;

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -210,18 +210,18 @@ def DynamicCastKind : I32EnumAttr<
 }
 
 def DynamicCastOp : CIR_Op<"dyn_cast"> {
-  let summary = "Perform dynamic cast on struct pointers";
+  let summary = "Perform dynamic cast on record pointers";
   let description = [{
     The `cir.dyn_cast` operation models part of the semantics of the
     `dynamic_cast` operator in C++. It can be used to perform 3 kinds of casts
-    on struct pointers:
+    on record pointers:
 
     - Down-cast, which casts a base class pointer to a derived class pointer;
     - Side-cast, which casts a class pointer to a sibling class pointer;
     - Cast-to-complete, which casts a class pointer to a void pointer.
 
-    The input of the operation must be a struct pointer. The result of the
-    operation is either a struct pointer or a void pointer.
+    The input of the operation must be a record pointer. The result of the
+    operation is either a record pointer or a void pointer.
 
     The parameter `kind` specifies the semantics of this operation. If its value
     is `ptr`, then the operation models dynamic casts on pointers. Otherwise, if
@@ -246,7 +246,7 @@ def DynamicCastOp : CIR_Op<"dyn_cast"> {
   }];
 
   let arguments = (ins DynamicCastKind:$kind,
-                       StructPtr:$src,
+                       RecordPtr:$src,
                        OptionalAttr<DynamicCastInfoAttr>:$info,
                        UnitAttr:$relative_layout);
   let results = (outs CIR_PointerType:$result);
@@ -2704,12 +2704,12 @@ def SetBitfieldOp : CIR_Op<"set_bitfield"> {
 
     ```mlir
     // 'd' is in the storage with the index 1
-    !struct_type = !cir.struct<struct "S" {!cir.int<u, 32>, !cir.int<u, 32>, !cir.int<u, 16>} #cir.record.decl.ast>
+    !record_type = !cir.record<struct "S" {!cir.int<u, 32>, !cir.int<u, 32>, !cir.int<u, 16>} #cir.record.decl.ast>
     #bfi_d = #cir.bitfield_info<name = "d", storage_type = !u32i, size = 2, offset = 17, is_signed = true>
 
     %1 = cir.const #cir.int<3> : !s32i
-    %2 = cir.load %0 : !cir.ptr<!cir.ptr<!struct_type>>, !cir.ptr<!struct_type>
-    %3 = cir.get_member %2[1] {name = "d"} : !cir.ptr<!struct_type> -> !cir.ptr<!u32i>
+    %2 = cir.load %0 : !cir.ptr<!cir.ptr<!record_type>>, !cir.ptr<!record_type>
+    %3 = cir.get_member %2[1] {name = "d"} : !cir.ptr<!record_type> -> !cir.ptr<!u32i>
     %4 = cir.set_bitfield(#bfi_d, %3 : !cir.ptr<!u32i>, %1 : !s32i) -> !s32i
     ```
    }];
@@ -2784,11 +2784,11 @@ def GetBitfieldOp : CIR_Op<"get_bitfield"> {
 
     ```mlir
     // 'd' is in the storage with the index 1
-    !struct_type = !cir.struct<struct "S" {!cir.int<u, 32>, !cir.int<u, 32>, !cir.int<u, 16>} #cir.record.decl.ast>
+    !record_type = !cir.record<struct "S" {!cir.int<u, 32>, !cir.int<u, 32>, !cir.int<u, 16>} #cir.record.decl.ast>
     #bfi_d = #cir.bitfield_info<name = "d", storage_type = !u32i, size = 2, offset = 17, is_signed = true>
 
-    %2 = cir.load %0 : !cir.ptr<!cir.ptr<!struct_type>>, !cir.ptr<!struct_type>
-    %3 = cir.get_member %2[1] {name = "d"} : !cir.ptr<!struct_type> -> !cir.ptr<!u32i>
+    %2 = cir.load %0 : !cir.ptr<!cir.ptr<!record_type>>, !cir.ptr<!record_type>
+    %3 = cir.get_member %2[1] {name = "d"} : !cir.ptr<!record_type> -> !cir.ptr<!u32i>
     %4 = cir.get_bitfield(#bfi_d, %3 : !cir.ptr<!u32i>) -> !s32i
     ```
     }];
@@ -2829,7 +2829,7 @@ def GetBitfieldOp : CIR_Op<"get_bitfield"> {
 //===----------------------------------------------------------------------===//
 
 def GetMemberOp : CIR_Op<"get_member"> {
-  let summary = "Get the address of a member of a struct";
+  let summary = "Get the address of a member of a record";
   let description = [{
     The `cir.get_member` operation gets the address of a particular named
     member from the input record.
@@ -2839,13 +2839,13 @@ def GetMemberOp : CIR_Op<"get_member"> {
 
     Example:
     ```mlir
-    // Suppose we have a struct with multiple members.
+    // Suppose we have a record with multiple members.
     !s32i = !cir.int<s, 32>
     !s8i = !cir.int<s, 32>
-    !struct_ty = !cir.struct<"struct.Bar" {!s32i, !s8i}>
+    !record_ty = !cir.record<"struct.Bar" {!s32i, !s8i}>
 
     // Get the address of the member at index 1.
-    %1 = cir.get_member %0[1] {name = "i"} : (!cir.ptr<!struct_ty>) -> !cir.ptr<!s8i>
+    %1 = cir.get_member %0[1] {name = "i"} : (!cir.ptr<!record_ty>) -> !cir.ptr<!s8i>
     ```
   }];
 
@@ -2873,7 +2873,7 @@ def GetMemberOp : CIR_Op<"get_member"> {
   ];
 
   let extraClassDeclaration = [{
-    /// Return the index of the struct member being accessed.
+    /// Return the index of the record member being accessed.
     uint64_t getIndex() { return getIndexAttr().getZExtValue(); }
 
     /// Return the record type pointed by the base pointer.
@@ -2893,7 +2893,7 @@ def GetMemberOp : CIR_Op<"get_member"> {
 //===----------------------------------------------------------------------===//
 
 def ExtractMemberOp : CIR_Op<"extract_member", [Pure]> {
-  let summary = "Extract the value of a member of a struct value";
+  let summary = "Extract the value of a member of a record value";
   let description = [{
     The `cir.extract_member` operation extracts the value of a particular member
     from the input record. Unlike `cir.get_member` which derives pointers, this
@@ -2905,20 +2905,20 @@ def ExtractMemberOp : CIR_Op<"extract_member", [Pure]> {
     Example:
 
     ```mlir
-    // Suppose we have a struct with multiple members.
+    // Suppose we have a record with multiple members.
     !s32i = !cir.int<s, 32>
     !s8i = !cir.int<s, 32>
-    !struct_ty = !cir.struct<"struct.Bar" {!s32i, !s8i}>
+    !record_ty = !cir.record<"struct.Bar" {!s32i, !s8i}>
 
-    // And suppose we have a value of the struct type.
-    %0 = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s8i}> : !struct_ty
+    // And suppose we have a value of the record type.
+    %0 = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s8i}> : !record_ty
 
-    // Extract the value of the second member of the struct.
-    %1 = cir.extract_member %0[1] : !struct_ty -> !s8i
+    // Extract the value of the second member of the record.
+    %1 = cir.extract_member %0[1] : !record_ty -> !s8i
     ```
   }];
 
-  let arguments = (ins CIRStructType:$record, IndexAttr:$index_attr);
+  let arguments = (ins CIRRecordType:$record, IndexAttr:$index_attr);
   let results = (outs CIR_AnyType:$result);
 
   let assemblyFormat = [{
@@ -2932,14 +2932,14 @@ def ExtractMemberOp : CIR_Op<"extract_member", [Pure]> {
       build($_builder, $_state, type, record, fieldIdx);
     }]>,
     OpBuilder<(ins "mlir::Value":$record, "uint64_t":$index), [{
-      auto recordTy = mlir::cast<cir::StructType>(record.getType());
+      auto recordTy = mlir::cast<cir::RecordType>(record.getType());
       mlir::Type memberTy = recordTy.getMembers()[index];
       build($_builder, $_state, memberTy, record, index);
     }]>
   ];
 
   let extraClassDeclaration = [{
-    /// Get the index of the struct member being accessed.
+    /// Get the index of the record member being accessed.
     uint64_t getIndex() { return getIndexAttr().getZExtValue(); }
   }];
 
@@ -2952,11 +2952,11 @@ def ExtractMemberOp : CIR_Op<"extract_member", [Pure]> {
 
 def InsertMemberOp : CIR_Op<"insert_member",
                             [Pure, AllTypesMatch<["record", "result"]>]> {
-  let summary = "Overwrite the value of a member of a struct value";
+  let summary = "Overwrite the value of a member of a record value";
   let description = [{
     The `cir.insert_member` operation overwrites the value of a particular
-    member in the input struct value, and returns the modified struct value. The
-    result of this operation is equal to the input struct value, except for the
+    member in the input record value, and returns the modified record value. The
+    result of this operation is equal to the input record value, except for the
     member specified by `index_attr` whose value is equal to the given value.
 
     This operation is named after the LLVM instruction `insertvalue`.
@@ -2966,25 +2966,25 @@ def InsertMemberOp : CIR_Op<"insert_member",
     Example:
 
     ```mlir
-    // Suppose we have a struct with multiple members.
+    // Suppose we have a record with multiple members.
     !s32i = !cir.int<s, 32>
     !s8i = !cir.int<s, 32>
-    !struct_ty = !cir.struct<"struct.Bar" {!s32i, !s8i}>
+    !record_ty = !cir.record<"struct.Bar" {!s32i, !s8i}>
 
-    // And suppose we have a value of the struct type.
-    %0 = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s8i}> : !struct_ty
+    // And suppose we have a value of the record type.
+    %0 = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s8i}> : !record_ty
     // %0 is {1, 2}
 
-    // Overwrite the second member of the struct value.
+    // Overwrite the second member of the record value.
     %1 = cir.const #cir.int<3> : !s8i
-    %2 = cir.insert_member %0[1], %1 : !struct_ty, !s8i
+    %2 = cir.insert_member %0[1], %1 : !record_ty, !s8i
     // %2 is {1, 3}
     ```
   }];
 
-  let arguments = (ins CIRStructType:$record, IndexAttr:$index_attr,
+  let arguments = (ins CIRRecordType:$record, IndexAttr:$index_attr,
                        CIR_AnyType:$value);
-  let results = (outs CIRStructType:$result);
+  let results = (outs CIRRecordType:$result);
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$record, "uint64_t":$index,
@@ -2995,7 +2995,7 @@ def InsertMemberOp : CIR_Op<"insert_member",
   ];
 
   let extraClassDeclaration = [{
-    /// Get the index of the struct member being accessed.
+    /// Get the index of the record member being accessed.
     uint64_t getIndex() { return getIndexAttr().getZExtValue(); }
   }];
 
@@ -3012,7 +3012,7 @@ def InsertMemberOp : CIR_Op<"insert_member",
 //===----------------------------------------------------------------------===//
 
 def GetRuntimeMemberOp : CIR_Op<"get_runtime_member"> {
-  let summary = "Get the address of a member of a struct";
+  let summary = "Get the address of a member of a record";
   let description = [{
     The `cir.get_runtime_member` operation gets the address of a member from
     the input record. The target member is given by a value of type
@@ -3051,7 +3051,7 @@ def GetRuntimeMemberOp : CIR_Op<"get_runtime_member"> {
   }];
 
   let arguments = (ins
-    Arg<StructPtr, "address of the struct object", [MemRead]>:$addr,
+    Arg<RecordPtr, "address of the record object", [MemRead]>:$addr,
     Arg<CIR_DataMemberType, "pointer to the target member">:$member);
 
   let results = (outs Res<CIR_PointerType, "">:$result);
@@ -3105,7 +3105,7 @@ def GetMethodOp : CIR_Op<"get_method"> {
       method.
   }];
 
-  let arguments = (ins CIR_MethodType:$method, StructPtr:$object);
+  let arguments = (ins CIR_MethodType:$method, RecordPtr:$object);
   let results = (outs FuncPtr:$callee, VoidPtr:$adjusted_this);
 
   let assemblyFormat = [{
@@ -4417,8 +4417,8 @@ def CopyOp : CIR_Op<"copy",
     Examples:
 
     ```mlir
-      // Copying contents from one struct to another:
-      cir.copy %0 to %1 : !cir.ptr<!struct_ty>
+      // Copying contents from one record to another:
+      cir.copy %0 to %1 : !cir.ptr<!record_ty>
     ```
   }];
 
@@ -4463,9 +4463,9 @@ def MemCpyOp : CIR_MemOp<"libc.memcpy"> {
     Examples:
 
     ```mlir
-      // Copying 2 bytes from one array to a struct:
+      // Copying 2 bytes from one array to a record:
       %2 = cir.const #cir.int<2> : !u32i
-      cir.libc.memcpy %2 bytes from %arr to %struct : !cir.ptr<!arr> -> !cir.ptr<!struct>
+      cir.libc.memcpy %2 bytes from %arr to %record : !cir.ptr<!arr> -> !cir.ptr<!record>
     ```
   }];
 
@@ -4493,9 +4493,9 @@ def MemMoveOp : CIR_MemOp<"libc.memmove"> {
     Examples:
 
     ```mlir
-      // Copying 2 bytes from one array to a struct:
+      // Copying 2 bytes from one array to a record:
       %2 = cir.const #cir.int<2> : !u32i
-      cir.libc.memmove %2 bytes from %arr to %struct : !cir.ptr<!void>, !u64i
+      cir.libc.memmove %2 bytes from %arr to %record : !cir.ptr<!void>, !u64i
     ```
   }];
 
@@ -4529,8 +4529,8 @@ def MemCpyInlineOp : CIR_MemOp<"memcpy_inline"> {
     Examples:
 
     ```mlir
-      // Copying 2 bytes from one array to a struct:
-      cir.memcpy_inline 2 bytes from %arr to %struct : !cir.ptr<!arr> -> !cir.ptr<!struct>
+      // Copying 2 bytes from one array to a record:
+      cir.memcpy_inline 2 bytes from %arr to %record : !cir.ptr<!arr> -> !cir.ptr<!record>
     ```
   }];
 
@@ -4558,11 +4558,11 @@ def MemSetOp : CIR_Op<"libc.memset"> {
     Examples:
 
     ```mlir
-      // Set 2 bytes from a struct to 0:
+      // Set 2 bytes from a record to 0:
       %2 = cir.const #cir.int<2> : !u32i
       %3 = cir.const #cir.int<0> : !u32i
       %zero = cir.cast(integral, %3 : !s32i), !u8i
-      cir.libc.memset %2 bytes from %struct set to %zero : !cir.ptr<!void>, !s32i, !u64i
+      cir.libc.memset %2 bytes from %record set to %zero : !cir.ptr<!void>, !s32i, !u64i
     ```
   }];
 
@@ -4593,8 +4593,8 @@ def MemSetInlineOp : CIR_Op<"memset_inline"> {
     Examples:
 
     ```mlir
-      // Set 2 bytes from a struct to 0
-      cir.memset_inline 2 bytes from %struct set to %zero : !cir.ptr<!void>, !s32i
+      // Set 2 bytes from a record to 0
+      cir.memset_inline 2 bytes from %record set to %zero : !cir.ptr<!void>, !s32i
     ```
   }];
 
@@ -5039,11 +5039,11 @@ def FreeExceptionOp : CIR_Op<"free.exception"> {
     Example:
 
     ```mlir
-    %0 = cir.alloc.exception 16 -> !cir.ptr<!some_struct>
-    %1 = cir.get_global @d2 : !cir.ptr<!some_struct>
+    %0 = cir.alloc.exception 16 -> !cir.ptr<!some_record>
+    %1 = cir.get_global @d2 : !cir.ptr<!some_record>
     cir.try synthetic cleanup {
-      cir.call exception @_ZN7test2_DC1ERKS_(%0, %1) : (!cir.ptr<!some_struct>, !cir.ptr<!some_struct>) -> () cleanup {
-        %2 = cir.cast(bitcast, %0 : !cir.ptr<!some_struct>), !cir.ptr<!void>
+      cir.call exception @_ZN7test2_DC1ERKS_(%0, %1) : (!cir.ptr<!some_record>, !cir.ptr<!some_record>) -> () cleanup {
+        %2 = cir.cast(bitcast, %0 : !cir.ptr<!some_record>), !cir.ptr<!void>
         cir.free.exception %2
         cir.yield
       }
@@ -5180,7 +5180,7 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     output, input and then in/out operands.
 
     Note, when several output operands are present, the result type may be represented as
-    an anon struct type.
+    an anon record type.
 
     Example:
     ```C++
@@ -5190,8 +5190,8 @@ def CIR_InlineAsmOp : CIR_Op<"asm", [RecursiveMemoryEffects]> {
     ```
 
     ```mlir
-    !ty_22anon2E022 = !cir.struct<struct "anon.0" {!cir.int<s, 32>, !cir.int<s, 32>}>
-    !ty_22anon2E122 = !cir.struct<struct "anon.1" {!cir.int<s, 32>, !cir.int<s, 32>}>
+    !ty_22anon2E022 = !cir.record<struct "anon.0" {!cir.int<s, 32>, !cir.int<s, 32>}>
+    !ty_22anon2E122 = !cir.record<struct "anon.1" {!cir.int<s, 32>, !cir.int<s, 32>}>
     ...
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]
     %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["y", init]
@@ -5569,7 +5569,7 @@ def AtomicXchg : CIR_Op<"atomic.xchg", [AllTypesMatch<["result", "val"]>]> {
     `__atomic_exchange`and `__atomic_exchange_n`.
 
     Example:
-    %res = cir.atomic.xchg(%ptr : !cir.ptr<!some_struct>,
+    %res = cir.atomic.xchg(%ptr : !cir.ptr<!some_record>,
                            %val : !u64i, seq_cst) : !u64i
   }];
   let results = (outs CIR_AnyType:$result);
@@ -5610,7 +5610,7 @@ def AtomicCmpXchg : CIR_Op<"atomic.cmp_xchg",
     `__atomic_compare_exchange_n` and `__atomic_compare_exchange`.
 
     Example:
-    %old, %cmp = cir.atomic.cmp_xchg(%ptr : !cir.ptr<!some_struct>,
+    %old, %cmp = cir.atomic.cmp_xchg(%ptr : !cir.ptr<!some_record>,
                                      %expected : !u64i,
                                      %desired : !u64i,
                                      success = seq_cst,

--- a/clang/include/clang/CIR/Dialect/IR/CIRTBAAAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTBAAAttrs.td
@@ -86,7 +86,7 @@ def CIR_TBAAMemberAttr : CIR_Attr<"TBAAMember", "tbaa_member", []> {
 
     Example:
     ```mlir
-    !ty_StructS = !cir.struct<struct "StructS" {!u16i, !u32i} #cir.record.decl.ast>
+    !ty_StructS = !cir.record<struct "StructS" {!u16i, !u32i} #cir.record.decl.ast>
     #tbaa_scalar = #cir.tbaa_scalar<id = "int", type = !s32i>
     #tbaa_scalar1 = #cir.tbaa_scalar<id = "short", type = !s16i>
     #tbaa_struct = #cir.tbaa_struct<id = "_ZTS7StructS", members = {<#tbaa_scalar1, 0>, <#tbaa_scalar, 4>}>
@@ -135,7 +135,7 @@ def CIR_TBAAStructAttr : CIR_Attr<"TBAAStruct",
 
     Example:
     ```mlir
-    !ty_StructS = !cir.struct<struct "StructS" {!u16i, !u32i} #cir.record.decl.ast>
+    !ty_StructS = !cir.record<struct "StructS" {!u16i, !u32i} #cir.record.decl.ast>
     #tbaa_scalar = #cir.tbaa_scalar<id = "int", type = !s32i>
     #tbaa_scalar1 = #cir.tbaa_scalar<id = "short", type = !s16i>
     // CIR_TBAAStructAttr

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -22,7 +22,7 @@
 
 namespace cir {
 namespace detail {
-struct StructTypeStorage;
+struct RecordTypeStorage;
 } // namespace detail
 
 bool isAnyFloatingPointType(mlir::Type t);

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -295,11 +295,11 @@ def CIR_DataMemberType : CIR_Type<"DataMember", "data_member",
   let description = [{
     `cir.member_ptr` models the pointer-to-data-member type in C++. Values of
     this type are essentially offsets of the pointed-to member within one of
-    its containing struct.
+    its containing record.
   }];
 
   let parameters = (ins "mlir::Type":$memberTy,
-                        "cir::StructType":$clsTy);
+                        "cir::RecordType":$clsTy);
 
   let assemblyFormat = [{
     `<` $memberTy `in` $clsTy `>`
@@ -450,7 +450,7 @@ def CIR_MethodType : CIR_Type<"Method", "method",
   }];
 
   let parameters = (ins "cir::FuncType":$memberFuncTy,
-                        "cir::StructType":$clsTy);
+                        "cir::RecordType":$clsTy);
 
   let assemblyFormat = [{
     `<` qualified($memberFuncTy) `in` $clsTy `>`
@@ -524,13 +524,13 @@ def ComplexPtr : Type<
     ]>, "!cir.complex*"> {
 }
 
-// Pointer to struct
-def StructPtr : Type<
+// Pointer to record
+def RecordPtr : Type<
     And<[
       CPred<"::mlir::isa<::cir::PointerType>($_self)">,
-      CPred<"::mlir::isa<::cir::StructType>("
+      CPred<"::mlir::isa<::cir::RecordType>("
             "::mlir::cast<::cir::PointerType>($_self).getPointee())">
-    ]>, "!cir.struct*"> {
+    ]>, "!cir.record*"> {
 }
 
 // Pointer to exception info
@@ -603,52 +603,51 @@ def FuncPtr : Type<
 }
 
 //===----------------------------------------------------------------------===//
-// StructType
+// RecordType
 //
 // The base type for all RecordDecls.
 //===----------------------------------------------------------------------===//
 
-def CIR_StructType : CIR_Type<"Struct", "struct",
+def CIR_RecordType : CIR_Type<"Record", "record",
     [
       DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
       MutableType,
     ]> {
-  let summary = "CIR struct type";
+  let summary = "CIR record type";
   let description = [{
-    Each unique clang::RecordDecl is mapped to a `cir.struct` and any object in
-    C/C++ that has a struct type will have a `cir.struct` in CIR.
+    Each unique clang::RecordDecl is mapped to a `cir.record` and any object in
+    C/C++ that has a struct or class type will have a `cir.record` in CIR.
 
     There are three possible formats for this type:
 
-     - Identified and complete structs: unique name and a known body.
-     - Identified and incomplete structs: unique name and unknown body.
-     - Anonymous structs: no name and a known body.
+     - Identified and complete records: unique name and a known body.
+     - Identified and incomplete records: unique name and unknown body.
+     - Anonymous records: no name and a known body.
 
-    Identified structs are uniqued by their name, and anonymous structs are
-    uniqued by their body. This means that two anonymous structs with the same
-    body will be the same type, and two identified structs with the same name
-    will be the same type. Attempting to build a struct with an existing name,
+    Identified records are uniqued by their name, and anonymous records are
+    uniqued by their body. This means that two anonymous records with the same
+    body will be the same type, and two identified records with the same name
+    will be the same type. Attempting to build a record with an existing name,
     but a different body will result in an error.
 
     A few examples:
 
     ```mlir
-        !complete = !cir.struct<struct "complete" {!cir.int<u, 8>}>
-        !incomplete = !cir.struct<struct "incomplete" incomplete>
-        !anonymous = !cir.struct<struct {!cir.int<u, 8>}>
+        !complete = !cir.record<struct {!cir.int<u, 8>}>
+        !incomplete = !cir.record<struct "incomplete" incomplete>
+        !anonymous = !cir.record<struct {!cir.int<u, 8>}>
     ```
 
-    Incomplete structs are mutable, meaning they can be later completed with a
+    Incomplete records are mutable, meaning they can be later completed with a
     body automatically updating in place every type in the code that uses the
-    incomplete struct. Mutability allows for recursive types to be represented,
-    meaning the struct can have members that refer to itself. This is useful for
+    incomplete record. Mutability allows for recursive types to be represented,
+    meaning the record can have members that refer to itself. This is useful for
     representing recursive records and is implemented through a special syntax.
-    In the example below, the `Node` struct has a member that is a pointer to a
-    `Node` struct:
+    In the example below, the `Node` record has a member that is a pointer to a
+    `Node` record:
 
     ```mlir
-        !struct = !cir.struct<struct "Node" {!cir.ptr<!cir.struct<struct
-        "Node">>}>
+        !s = !cir.record<struct "Node" {!cir.ptr<!cir.record<struct "Node">>}>
     ```
   }];
 
@@ -658,19 +657,19 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
     "bool":$incomplete,
     "bool":$packed,
     "bool":$padded,
-    "StructType::RecordKind":$kind,
+    "RecordType::RecordKind":$kind,
     OptionalParameter<"ASTRecordDeclInterface">:$ast
   );
 
   // StorageClass is defined in C++ for mutability.
-  let storageClass = "StructTypeStorage";
+  let storageClass = "RecordTypeStorage";
   let genStorageClass = 0;
 
   let skipDefaultBuilders = 1;
   let genVerifyDecl = 1;
 
   let builders = [
-    // Create an identified and complete struct type.
+    // Create an identified and complete record type.
     TypeBuilder<(ins
       "llvm::ArrayRef<mlir::Type>":$members,
       "mlir::StringAttr":$name,
@@ -683,7 +682,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
                        kind, ast);    
     }]>,
 
-    // Create an identified and incomplete struct type.
+    // Create an identified and incomplete record type.
     TypeBuilder<(ins
       "mlir::StringAttr":$name,
       "RecordKind":$kind
@@ -694,7 +693,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
                          /*ast=*/ASTRecordDeclInterface{});    
     }]>,
 
-    // Create an anonymous struct type (always complete).
+    // Create an anonymous record type (always complete).
     TypeBuilder<(ins
       "llvm::ArrayRef<mlir::Type>":$members,
       "bool":$packed,
@@ -730,7 +729,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
       case RecordKind::Struct:
         return "struct";
       }
-      llvm_unreachable("Invalid value for StructType::getKind()");
+      llvm_unreachable("Invalid value for RecordType::getKind()");
     }
     std::string getPrefixedName() {
       return getKindAsStr() + "." + getName().getValue().str();
@@ -742,11 +741,11 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
     uint64_t getElementOffset(const mlir::DataLayout &dataLayout,
               unsigned idx) const;
 
-    bool isLayoutIdentical(const StructType &other);
+    bool isLayoutIdentical(const RecordType &other);
 
   // Utilities for lazily computing and cacheing data layout info.
   // FIXME: currently opaque because there's a cycle if CIRTypes.types include
-  // from CIRAttrs.h. The implementation operates in terms of StructLayoutAttr
+  // from CIRAttrs.h. The implementation operates in terms of RecordLayoutAttr
   // instead.
   private:
     mutable mlir::Attribute layoutInfo;
@@ -757,10 +756,10 @@ def CIR_StructType : CIR_Type<"Struct", "struct",
   let hasCustomAssemblyFormat = 1;
 }
 
-// Note CIRStructType is used instead of CIR_StructType
+// Note CIRRecordType is used instead of CIR_RecordType
 // because of tablegen conflicts.
-def CIRStructType : Type<
-  CPred<"::mlir::isa<::cir::StructType>($_self)">, "CIR struct type">;
+def CIRRecordType : Type<
+  CPred<"::mlir::isa<::cir::RecordType>($_self)">, "CIR record type">;
 
 //===----------------------------------------------------------------------===//
 // Global type constraints
@@ -769,7 +768,7 @@ def CIRStructType : Type<
 def CIR_AnyType : AnyTypeOf<[
   CIR_IntType, CIR_PointerType, CIR_DataMemberType, CIR_MethodType,
   CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_FuncType, CIR_VoidType,
-  CIR_StructType, CIR_ExceptionType, CIR_AnyFloat, CIR_FP16, CIR_BFloat16,
+  CIR_RecordType, CIR_ExceptionType, CIR_AnyFloat, CIR_FP16, CIR_BFloat16,
   CIR_ComplexType
 ]>;
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
@@ -22,23 +22,23 @@ namespace cir {
 namespace detail {
 
 //===----------------------------------------------------------------------===//
-// CIR StructTypeStorage
+// CIR RecordTypeStorage
 //===----------------------------------------------------------------------===//
 
 /// Type storage for CIR record types.
-struct StructTypeStorage : public mlir::TypeStorage {
+struct RecordTypeStorage : public mlir::TypeStorage {
   struct KeyTy {
     llvm::ArrayRef<mlir::Type> members;
     mlir::StringAttr name;
     bool incomplete;
     bool packed;
     bool padded;
-    StructType::RecordKind kind;
+    RecordType::RecordKind kind;
     ASTRecordDeclInterface ast;
 
     KeyTy(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
           bool incomplete, bool packed, bool padded,
-          StructType::RecordKind kind, ASTRecordDeclInterface ast)
+          RecordType::RecordKind kind, ASTRecordDeclInterface ast)
         : members(members), name(name), incomplete(incomplete), packed(packed),
           padded(padded), kind(kind), ast(ast) {}
   };
@@ -48,12 +48,12 @@ struct StructTypeStorage : public mlir::TypeStorage {
   bool incomplete;
   bool packed;
   bool padded;
-  StructType::RecordKind kind;
+  RecordType::RecordKind kind;
   ASTRecordDeclInterface ast;
 
-  StructTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
+  RecordTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
                     bool incomplete, bool packed, bool padded,
-                    StructType::RecordKind kind, ASTRecordDeclInterface ast)
+                    RecordType::RecordKind kind, ASTRecordDeclInterface ast)
       : members(members), name(name), incomplete(incomplete), packed(packed),
         padded(padded), kind(kind), ast(ast) {}
 
@@ -76,33 +76,33 @@ struct StructTypeStorage : public mlir::TypeStorage {
                               key.padded, key.kind, key.ast);
   }
 
-  static StructTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
+  static RecordTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
                                       const KeyTy &key) {
-    return new (allocator.allocate<StructTypeStorage>()) StructTypeStorage(
+    return new (allocator.allocate<RecordTypeStorage>()) RecordTypeStorage(
         allocator.copyInto(key.members), key.name, key.incomplete, key.packed,
         key.padded, key.kind, key.ast);
   }
 
-  /// Mutates the members and attributes an identified struct.
+  /// Mutates the members and attributes an identified record.
   ///
   /// Once a record is mutated, it is marked as complete, preventing further
-  /// mutations. Anonymous structs are always complete and cannot be mutated.
-  /// This method does not fail if a mutation of a complete struct does not
-  /// change the struct.
+  /// mutations. Anonymous records are always complete and cannot be mutated.
+  /// This method does not fail if a mutation of a complete record does not
+  /// change the record.
   llvm::LogicalResult mutate(mlir::TypeStorageAllocator &allocator,
                              llvm::ArrayRef<mlir::Type> members, bool packed,
                              bool padded, ASTRecordDeclInterface ast) {
-    // Anonymous structs cannot mutate.
+    // Anonymous records cannot mutate.
     if (!name)
       return llvm::failure();
 
-    // Mutation of complete structs are allowed if they change nothing.
+    // Mutation of complete records are allowed if they change nothing.
     if (!incomplete)
       return mlir::success((this->members == members) &&
                            (this->packed == packed) &&
                            (this->padded == padded) && (this->ast == ast));
 
-    // Mutate incomplete struct.
+    // Mutate incomplete record.
     this->members = allocator.copyInto(members);
     this->packed = packed;
     this->ast = ast;

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -10,7 +10,7 @@ using namespace clang::CIRGen;
 using namespace cir;
 
 static bool isAggregateType(mlir::Type typ) {
-  return isa<cir::StructType, cir::ArrayType>(typ);
+  return isa<cir::RecordType, cir::ArrayType>(typ);
 }
 
 static AsmFlavor inferFlavor(const CIRGenModule &cgm, const AsmStmt &S) {
@@ -621,7 +621,7 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
     ResultType = ResultRegTypes[0];
   else if (ResultRegTypes.size() > 1) {
     auto sname = builder.getUniqueAnonRecordName();
-    ResultType = builder.getCompleteStructTy(ResultRegTypes, sname, false,
+    ResultType = builder.getCompleteRecordTy(ResultRegTypes, sname, false,
                                              false, nullptr);
   }
 
@@ -677,7 +677,7 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
       RegResults.push_back(result);
     } else if (ResultRegTypes.size() > 1) {
       auto alignment = CharUnits::One();
-      auto sname = cast<cir::StructType>(ResultType).getName();
+      auto sname = cast<cir::RecordType>(ResultType).getName();
       auto dest = emitAlloca(sname, ResultType, getLoc(S.getAsmLoc()),
                              alignment, false);
       auto addr = Address(dest, alignment);

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -87,14 +87,14 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
     const auto [Index, NewOffset] = getIndexAndNewOffset(Offset, EltSize);
     Indices.push_back(Index);
     Offset = NewOffset;
-  } else if (auto StructTy = mlir::dyn_cast<cir::StructType>(Ty)) {
-    auto Elts = StructTy.getMembers();
+  } else if (auto RecordTy = mlir::dyn_cast<cir::RecordType>(Ty)) {
+    auto Elts = RecordTy.getMembers();
     int64_t Pos = 0;
     for (size_t I = 0; I < Elts.size(); ++I) {
       int64_t EltSize =
           (int64_t)Layout.getTypeAllocSize(Elts[I]).getFixedValue();
       unsigned AlignMask = Layout.getABITypeAlign(Elts[I]).value() - 1;
-      if (StructTy.getPacked())
+      if (RecordTy.getPacked())
         AlignMask = 0;
       Pos = (Pos + AlignMask) & ~AlignMask;
       assert(Offset >= 0);
@@ -120,7 +120,7 @@ uint64_t CIRGenBuilderTy::computeOffsetFromGlobalViewIndices(
 
   int64_t offset = 0;
   for (int64_t idx : indexes) {
-    if (auto sTy = dyn_cast<cir::StructType>(typ)) {
+    if (auto sTy = dyn_cast<cir::RecordType>(typ)) {
       offset += sTy.getElementOffset(layout.layout, idx);
       assert(idx < (int64_t)sTy.getMembers().size());
       typ = sTy.getMembers()[idx];

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
@@ -87,12 +87,12 @@ mlir::Value packArgsIntoNVPTXFormatBuffer(CIRGenFunction &cgf,
   for (auto arg : llvm::drop_begin(args))
     argTypes.push_back(arg.getRValue(cgf, loc).getScalarVal().getType());
 
-  // We can directly store the arguments into a struct, and the alignment
+  // We can directly store the arguments into a record, and the alignment
   // would automatically be correct. That's because vprintf does not
   // accept aggregates.
   mlir::Type allocaTy =
-      cir::StructType::get(&cgf.getMLIRContext(), argTypes, /*packed=*/false,
-                           /*padded=*/false, StructType::Struct);
+      cir::RecordType::get(&cgf.getMLIRContext(), argTypes, /*packed=*/false,
+                           /*padded=*/false, cir::RecordType::Struct);
   mlir::Value alloca =
       cgf.CreateTempAlloca(allocaTy, loc, "printf_args", nullptr);
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1670,7 +1670,7 @@ static bool isPreserveAIArrayBase(CIRGenFunction &CGF, const Expr *ArrayBase) {
 
     const auto *PointeeT =
         PtrT->getPointeeType()->getUnqualifiedDesugaredType();
-    if (const auto *RecT = dyn_cast<RecordType>(PointeeT))
+    if (const auto *RecT = dyn_cast<clang::RecordType>(PointeeT))
       return RecT->getDecl()->hasAttr<BPFPreserveAccessIndexAttr>();
     return false;
   }
@@ -2007,7 +2007,7 @@ LValue CIRGenFunction::emitCastLValue(const CastExpr *E) {
   case CK_UncheckedDerivedToBase:
   case CK_DerivedToBase: {
     const auto *DerivedClassTy =
-        E->getSubExpr()->getType()->castAs<RecordType>();
+        E->getSubExpr()->getType()->castAs<clang::RecordType>();
     auto *DerivedClassDecl = cast<CXXRecordDecl>(DerivedClassTy->getDecl());
 
     LValue LV = emitLValue(E->getSubExpr());
@@ -2263,8 +2263,8 @@ static void pushTemporaryCleanup(CIRGenFunction &CGF,
   }
 
   CXXDestructorDecl *ReferenceTemporaryDtor = nullptr;
-  if (const RecordType *RT =
-          E->getType()->getBaseElementTypeUnsafe()->getAs<RecordType>()) {
+  if (const clang::RecordType *RT =
+          E->getType()->getBaseElementTypeUnsafe()->getAs<clang::RecordType>()) {
     // Get the destructor for the reference temporary.
     auto *ClassDecl = cast<CXXRecordDecl>(RT->getDecl());
     if (!ClassDecl->hasTrivialDestructor())
@@ -3146,7 +3146,7 @@ static bool isConstantEmittableObjectType(QualType type) {
 
   // Otherwise, all object types satisfy this except C++ classes with
   // mutable subobjects or non-trivial copy/destroy behavior.
-  if (const auto *RT = dyn_cast<RecordType>(type))
+  if (const auto *RT = dyn_cast<clang::RecordType>(type))
     if (const auto *RD = dyn_cast<CXXRecordDecl>(RT->getDecl()))
       if (RD->hasMutableFields() || !RD->isTrivial())
         return false;

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2263,8 +2263,9 @@ static void pushTemporaryCleanup(CIRGenFunction &CGF,
   }
 
   CXXDestructorDecl *ReferenceTemporaryDtor = nullptr;
-  if (const clang::RecordType *RT =
-          E->getType()->getBaseElementTypeUnsafe()->getAs<clang::RecordType>()) {
+  if (const clang::RecordType *RT = E->getType()
+                                        ->getBaseElementTypeUnsafe()
+                                        ->getAs<clang::RecordType>()) {
     // Get the destructor for the reference temporary.
     auto *ClassDecl = cast<CXXRecordDecl>(RT->getDecl());
     if (!ClassDecl->hasTrivialDestructor())

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -2086,11 +2086,9 @@ mlir::Attribute ConstantEmitter::emitNullForMemory(mlir::Location loc,
   return emitForMemory(CGM, cstOp.getValue(), T);
 }
 
-static mlir::TypedAttr emitNullConstant(CIRGenModule &CGM,
-                                        const RecordDecl *rd,
+static mlir::TypedAttr emitNullConstant(CIRGenModule &CGM, const RecordDecl *rd,
                                         bool asCompleteObject) {
-  const CIRGenRecordLayout &layout =
-      CGM.getTypes().getCIRGenRecordLayout(rd);
+  const CIRGenRecordLayout &layout = CGM.getTypes().getCIRGenRecordLayout(rd);
   mlir::Type ty = (asCompleteObject ? layout.getCIRType()
                                     : layout.getBaseSubobjectCIRType());
   auto record = dyn_cast<cir::RecordType>(ty);

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -91,7 +91,7 @@ struct ConstantAggregateBuilderUtils {
   }
 };
 
-/// Incremental builder for an mlir::TypedAttr holding a struct or array
+/// Incremental builder for an mlir::TypedAttr holding a record or array
 /// constant.
 class ConstantAggregateBuilder : private ConstantAggregateBuilderUtils {
   /// The elements of the constant. These two arrays must have the same size;
@@ -372,7 +372,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
     DesiredSize = Size;
   }
 
-  // The natural alignment of an unpacked CIR struct with the given elements.
+  // The natural alignment of an unpacked CIR record with the given elements.
   CharUnits Align = CharUnits::One();
   for (auto e : Elems) {
     // FIXME(cir): migrate most of this file to use mlir::TypedAttr directly.
@@ -402,7 +402,7 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
 
   // If we don't have a natural layout, insert padding as necessary.
   // As we go, double-check to see if we can actually just emit Elems
-  // as a non-packed struct and do so opportunistically if possible.
+  // as a non-packed record and do so opportunistically if possible.
   llvm::SmallVector<mlir::Attribute, 32> PackedElems;
   if (!NaturalLayout) {
     CharUnits SizeSoFar = CharUnits::Zero();
@@ -437,12 +437,12 @@ mlir::Attribute ConstantAggregateBuilder::buildFrom(
   auto arrAttr = mlir::ArrayAttr::get(builder.getContext(),
                                       Packed ? PackedElems : UnpackedElems);
 
-  auto strType = builder.getCompleteStructType(arrAttr, Packed);
-  if (auto desired = dyn_cast<cir::StructType>(DesiredTy))
+  auto strType = builder.getCompleteRecordType(arrAttr, Packed);
+  if (auto desired = dyn_cast<cir::RecordType>(DesiredTy))
     if (desired.isLayoutIdentical(strType))
       strType = desired;
 
-  return builder.getConstStructOrZeroAttr(arrAttr, Packed, Padded, strType);
+  return builder.getConstRecordOrZeroAttr(arrAttr, Packed, Padded, strType);
 }
 
 void ConstantAggregateBuilder::condense(CharUnits Offset,
@@ -467,7 +467,7 @@ void ConstantAggregateBuilder::condense(CharUnits Offset,
   mlir::TypedAttr C = mlir::dyn_cast<mlir::TypedAttr>(Elems[First]);
   assert(C && "expected typed attribute");
   if (Length == 1 && Offsets[First] == Offset && getSize(C) == Size) {
-    // Re-wrap single element structs if necessary. Otherwise, leave any single
+    // Re-wrap single element records if necessary. Otherwise, leave any single
     // element constant of the right size alone even if it has the wrong type.
     llvm_unreachable("NYI");
   }
@@ -481,26 +481,26 @@ void ConstantAggregateBuilder::condense(CharUnits Offset,
 }
 
 //===----------------------------------------------------------------------===//
-//                            ConstStructBuilder
+//                            ConstRecordBuilder
 //===----------------------------------------------------------------------===//
 
-class ConstStructBuilder {
+class ConstRecordBuilder {
   CIRGenModule &CGM;
   ConstantEmitter &Emitter;
   ConstantAggregateBuilder &Builder;
   CharUnits StartOffset;
 
 public:
-  static mlir::Attribute BuildStruct(ConstantEmitter &Emitter,
-                                     InitListExpr *ILE, QualType StructTy);
-  static mlir::Attribute BuildStruct(ConstantEmitter &Emitter,
+  static mlir::Attribute BuildRecord(ConstantEmitter &Emitter,
+                                     InitListExpr *ILE, QualType RecordTy);
+  static mlir::Attribute BuildRecord(ConstantEmitter &Emitter,
                                      const APValue &Value, QualType ValTy);
-  static bool UpdateStruct(ConstantEmitter &Emitter,
+  static bool UpdateRecord(ConstantEmitter &Emitter,
                            ConstantAggregateBuilder &Const, CharUnits Offset,
                            InitListExpr *Updater);
 
 private:
-  ConstStructBuilder(ConstantEmitter &Emitter,
+  ConstRecordBuilder(ConstantEmitter &Emitter,
                      ConstantAggregateBuilder &Builder, CharUnits StartOffset)
       : CGM(Emitter.CGM), Emitter(Emitter), Builder(Builder),
         StartOffset(StartOffset) {}
@@ -528,7 +528,7 @@ private:
   mlir::Attribute Finalize(QualType Ty);
 };
 
-bool ConstStructBuilder::AppendField(const FieldDecl *Field,
+bool ConstRecordBuilder::AppendField(const FieldDecl *Field,
                                      uint64_t FieldOffset,
                                      mlir::Attribute InitCst,
                                      bool AllowOverwrite) {
@@ -539,13 +539,13 @@ bool ConstStructBuilder::AppendField(const FieldDecl *Field,
   return AppendBytes(FieldOffsetInChars, InitCst, AllowOverwrite);
 }
 
-bool ConstStructBuilder::AppendBytes(CharUnits FieldOffsetInChars,
+bool ConstRecordBuilder::AppendBytes(CharUnits FieldOffsetInChars,
                                      mlir::Attribute InitCst,
                                      bool AllowOverwrite) {
   return Builder.add(InitCst, StartOffset + FieldOffsetInChars, AllowOverwrite);
 }
 
-bool ConstStructBuilder::AppendBitField(const FieldDecl *Field,
+bool ConstRecordBuilder::AppendBitField(const FieldDecl *Field,
                                         uint64_t FieldOffset, cir::IntAttr CI,
                                         bool AllowOverwrite) {
   const auto &RL = CGM.getTypes().getCIRGenRecordLayout(Field->getParent());
@@ -573,7 +573,7 @@ static bool EmitDesignatedInitUpdater(ConstantEmitter &Emitter,
                                       CharUnits Offset, QualType Type,
                                       InitListExpr *Updater) {
   if (Type->isRecordType())
-    return ConstStructBuilder::UpdateStruct(Emitter, Const, Offset, Updater);
+    return ConstRecordBuilder::UpdateRecord(Emitter, Const, Offset, Updater);
 
   auto CAT = Emitter.CGM.getASTContext().getAsConstantArrayType(Type);
   if (!CAT)
@@ -617,8 +617,8 @@ static bool EmitDesignatedInitUpdater(ConstantEmitter &Emitter,
   return true;
 }
 
-bool ConstStructBuilder::Build(InitListExpr *ILE, bool AllowOverwrite) {
-  RecordDecl *RD = ILE->getType()->castAs<RecordType>()->getDecl();
+bool ConstRecordBuilder::Build(InitListExpr *ILE, bool AllowOverwrite) {
+  RecordDecl *RD = ILE->getType()->castAs<clang::RecordType>()->getDecl();
   const ASTRecordLayout &Layout = CGM.getASTContext().getASTRecordLayout(RD);
 
   unsigned FieldNo = -1;
@@ -647,7 +647,7 @@ bool ConstStructBuilder::Build(InitListExpr *ILE, bool AllowOverwrite) {
     if (Field->isUnnamedBitField())
       continue;
 
-    // Get the initializer.  A struct can include fields without initializers,
+    // Get the initializer.  A record can include fields without initializers,
     // we just use explicit null values for them.
     Expr *Init = nullptr;
     if (ElementNo < ILE->getNumInits())
@@ -656,7 +656,7 @@ bool ConstStructBuilder::Build(InitListExpr *ILE, bool AllowOverwrite) {
       continue;
 
     // Zero-sized fields are not emitted, but their initializers may still
-    // prevent emission of this struct as a constant.
+    // prevent emission of this record as a constant.
     if (Field->isZeroSize(CGM.getASTContext())) {
       if (Init->HasSideEffects(CGM.getASTContext()))
         return false;
@@ -739,7 +739,7 @@ struct BaseInfo {
 };
 } // namespace
 
-bool ConstStructBuilder::Build(const APValue &Val, const RecordDecl *RD,
+bool ConstRecordBuilder::Build(const APValue &Val, const RecordDecl *RD,
                                bool IsPrimaryBase,
                                const CXXRecordDecl *VTableClass,
                                CharUnits Offset) {
@@ -828,7 +828,7 @@ bool ConstStructBuilder::Build(const APValue &Val, const RecordDecl *RD,
   return true;
 }
 
-bool ConstStructBuilder::ApplyZeroInitPadding(
+bool ConstRecordBuilder::ApplyZeroInitPadding(
     const ASTRecordLayout &Layout, unsigned FieldNo, const FieldDecl &Field,
     bool AllowOverwrite, CharUnits &SizeSoFar, bool &ZeroFieldSize) {
 
@@ -860,7 +860,7 @@ bool ConstStructBuilder::ApplyZeroInitPadding(
   return true;
 }
 
-bool ConstStructBuilder::ApplyZeroInitPadding(const ASTRecordLayout &Layout,
+bool ConstRecordBuilder::ApplyZeroInitPadding(const ASTRecordLayout &Layout,
                                               bool AllowOverwrite,
                                               CharUnits SizeSoFar) {
   CharUnits TotalSize = Layout.getSize();
@@ -873,18 +873,18 @@ bool ConstStructBuilder::ApplyZeroInitPadding(const ASTRecordLayout &Layout,
   return true;
 }
 
-mlir::Attribute ConstStructBuilder::Finalize(QualType Type) {
+mlir::Attribute ConstRecordBuilder::Finalize(QualType Type) {
   Type = Type.getNonReferenceType();
-  RecordDecl *RD = Type->castAs<RecordType>()->getDecl();
+  RecordDecl *RD = Type->castAs<clang::RecordType>()->getDecl();
   mlir::Type ValTy = CGM.convertType(Type);
   return Builder.build(ValTy, RD->hasFlexibleArrayMember());
 }
 
-mlir::Attribute ConstStructBuilder::BuildStruct(ConstantEmitter &Emitter,
+mlir::Attribute ConstRecordBuilder::BuildRecord(ConstantEmitter &Emitter,
                                                 InitListExpr *ILE,
                                                 QualType ValTy) {
   ConstantAggregateBuilder Const(Emitter.CGM);
-  ConstStructBuilder Builder(Emitter, Const, CharUnits::Zero());
+  ConstRecordBuilder Builder(Emitter, Const, CharUnits::Zero());
 
   if (!Builder.Build(ILE, /*AllowOverwrite*/ false))
     return nullptr;
@@ -892,13 +892,13 @@ mlir::Attribute ConstStructBuilder::BuildStruct(ConstantEmitter &Emitter,
   return Builder.Finalize(ValTy);
 }
 
-mlir::Attribute ConstStructBuilder::BuildStruct(ConstantEmitter &Emitter,
+mlir::Attribute ConstRecordBuilder::BuildRecord(ConstantEmitter &Emitter,
                                                 const APValue &Val,
                                                 QualType ValTy) {
   ConstantAggregateBuilder Const(Emitter.CGM);
-  ConstStructBuilder Builder(Emitter, Const, CharUnits::Zero());
+  ConstRecordBuilder Builder(Emitter, Const, CharUnits::Zero());
 
-  const RecordDecl *RD = ValTy->castAs<RecordType>()->getDecl();
+  const RecordDecl *RD = ValTy->castAs<clang::RecordType>()->getDecl();
   const CXXRecordDecl *CD = dyn_cast<CXXRecordDecl>(RD);
   if (!Builder.Build(Val, RD, false, CD, CharUnits::Zero()))
     return nullptr;
@@ -906,10 +906,10 @@ mlir::Attribute ConstStructBuilder::BuildStruct(ConstantEmitter &Emitter,
   return Builder.Finalize(ValTy);
 }
 
-bool ConstStructBuilder::UpdateStruct(ConstantEmitter &Emitter,
+bool ConstRecordBuilder::UpdateRecord(ConstantEmitter &Emitter,
                                       ConstantAggregateBuilder &Const,
                                       CharUnits Offset, InitListExpr *Updater) {
-  return ConstStructBuilder(Emitter, Const, Offset)
+  return ConstRecordBuilder(Emitter, Const, Offset)
       .Build(Updater, /*AllowOverwrite*/ true);
 }
 
@@ -1140,12 +1140,12 @@ public:
       if (!desiredArrayType)
         return false;
 
-      auto elementStructType =
-          dyn_cast<cir::StructType>(desiredArrayType.getEltType());
-      if (!elementStructType)
+      auto elementRecordType =
+          dyn_cast<cir::RecordType>(desiredArrayType.getEltType());
+      if (!elementRecordType)
         return false;
 
-      return elementStructType.isUnion();
+      return elementRecordType.isUnion();
     }();
 
     // Emit initializer elements as MLIR attributes and check for common type.
@@ -1171,7 +1171,7 @@ public:
   }
 
   mlir::Attribute EmitRecordInitialization(InitListExpr *ILE, QualType T) {
-    return ConstStructBuilder::BuildStruct(Emitter, ILE, T);
+    return ConstRecordBuilder::BuildRecord(Emitter, ILE, T);
   }
 
   mlir::Attribute EmitVectorInitialization(InitListExpr *ILE, QualType T) {
@@ -1306,7 +1306,7 @@ emitArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
         cir::ArrayType::get(builder.getContext(), CommonElementType,
                             ArrayBound));
     // TODO(cir): If all the elements had the same type up to the trailing
-    // zeroes, emit a struct of two arrays (the nonzero data and the
+    // zeroes, emit a record of two arrays (the nonzero data and the
     // zeroinitializer). Use DesiredType to get the element type.
   } else if (Elements.size() != ArrayBound) {
     // Otherwise pad to the right size with the filler if necessary.
@@ -1334,7 +1334,7 @@ emitArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
     Eles.push_back(Element);
 
   auto arrAttr = mlir::ArrayAttr::get(builder.getContext(), Eles);
-  return builder.getAnonConstStruct(arrAttr, false);
+  return builder.getAnonConstRecord(arrAttr, false);
 }
 
 } // end anonymous namespace.
@@ -1835,7 +1835,7 @@ mlir::Attribute ConstantEmitter::emitForMemory(CIRGenModule &CGM,
                             (outerSize - innerSize) / 8));
     SmallVector<mlir::Attribute, 4> anonElts = {C, zeroArray};
     auto arrAttr = mlir::ArrayAttr::get(builder.getContext(), anonElts);
-    return builder.getAnonConstStruct(arrAttr, false);
+    return builder.getAnonConstRecord(arrAttr, false);
   }
 
   // Zero-extend bool.
@@ -1992,7 +1992,7 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
     return ConstantLValueEmitter(*this, Value, DestType).tryEmit();
   case APValue::Struct:
   case APValue::Union:
-    return ConstStructBuilder::BuildStruct(*this, Value, DestType);
+    return ConstRecordBuilder::BuildRecord(*this, Value, DestType);
   case APValue::FixedPoint:
   case APValue::ComplexInt:
   case APValue::ComplexFloat:
@@ -2015,7 +2015,7 @@ mlir::Value CIRGenModule::emitNullConstant(QualType T, mlir::Location loc) {
     llvm_unreachable("NYI");
   }
 
-  if (const RecordType *RT = T->getAs<RecordType>())
+  if (const clang::RecordType *RT = T->getAs<clang::RecordType>())
     llvm_unreachable("NYI");
 
   assert(T->isMemberDataPointerType() &&
@@ -2087,19 +2087,19 @@ mlir::Attribute ConstantEmitter::emitNullForMemory(mlir::Location loc,
 }
 
 static mlir::TypedAttr emitNullConstant(CIRGenModule &CGM,
-                                        const RecordDecl *record,
+                                        const RecordDecl *rd,
                                         bool asCompleteObject) {
   const CIRGenRecordLayout &layout =
-      CGM.getTypes().getCIRGenRecordLayout(record);
+      CGM.getTypes().getCIRGenRecordLayout(rd);
   mlir::Type ty = (asCompleteObject ? layout.getCIRType()
                                     : layout.getBaseSubobjectCIRType());
-  auto structure = dyn_cast<cir::StructType>(ty);
-  assert(structure && "expected");
+  auto record = dyn_cast<cir::RecordType>(ty);
+  assert(record && "expected");
 
-  unsigned numElements = structure.getNumElements();
+  unsigned numElements = record.getNumElements();
   SmallVector<mlir::Attribute, 4> elements(numElements);
 
-  auto CXXR = dyn_cast<CXXRecordDecl>(record);
+  auto CXXR = dyn_cast<CXXRecordDecl>(rd);
   // Fill in all the bases.
   if (CXXR) {
     for (const auto &I : CXXR->bases()) {
@@ -2113,7 +2113,7 @@ static mlir::TypedAttr emitNullConstant(CIRGenModule &CGM,
   }
 
   // Fill in all the fields.
-  for (const auto *Field : record->fields()) {
+  for (const auto *Field : rd->fields()) {
     // Fill in non-bitfields. (Bitfields always use a zero pattern, which we
     // will fill in later.)
     if (!Field->isBitField()) {
@@ -2122,7 +2122,7 @@ static mlir::TypedAttr emitNullConstant(CIRGenModule &CGM,
     }
 
     // For unions, stop after the first named field.
-    if (record->isUnion()) {
+    if (rd->isUnion()) {
       if (Field->getIdentifier())
         break;
       if (const auto *FieldRD = Field->getType()->getAsRecordDecl())
@@ -2145,8 +2145,8 @@ static mlir::TypedAttr emitNullConstant(CIRGenModule &CGM,
     }
   }
 
-  mlir::MLIRContext *mlirContext = structure.getContext();
-  return cir::ConstStructAttr::get(mlirContext, structure,
+  mlir::MLIRContext *mlirContext = record.getContext();
+  return cir::ConstRecordAttr::get(mlirContext, record,
                                    mlir::ArrayAttr::get(mlirContext, elements));
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
@@ -129,8 +129,8 @@ class CIRGenFunctionInfo final
   /// TODO: think about modeling this properly, this is just a dumb subsitution
   /// for now since we arent supporting anything other than arguments in
   /// registers atm
-  cir::StructType *ArgStruct;
-  unsigned ArgStructAlign : 31;
+  cir::RecordType *ArgRecord;
+  unsigned ArgRecordAlign : 31;
   unsigned HasExtParameterInfos : 1;
 
   unsigned NumArgs;
@@ -275,10 +275,10 @@ public:
     return isVariadic() ? getRequiredArgs().getNumRequiredArgs() : arg_size();
   }
 
-  cir::StructType *getArgStruct() const { return ArgStruct; }
+  cir::RecordType *getArgRecord() const { return ArgRecord; }
 
   /// Return true if this function uses inalloca arguments.
-  bool usesInAlloca() const { return ArgStruct; }
+  bool usesInAlloca() const { return ArgRecord; }
 };
 
 } // namespace clang::CIRGen

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -2132,7 +2132,7 @@ void CIRGenItaniumCXXABI::emitVTableDefinitions(CIRGenVTables &CGVT,
 
   // Create and set the initializer.
   ConstantInitBuilder builder(CGM);
-  auto components = builder.beginStruct();
+  auto components = builder.beginRecord();
 
   CGVT.createVTableInitializer(components, VTLayout, RTTI,
                                cir::isLocalLinkage(Linkage));

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -4070,8 +4070,8 @@ CharUnits CIRGenModule::computeNonVirtualBaseClassOffset(
     // Get the layout.
     const ASTRecordLayout &layout = astContext.getASTRecordLayout(rd);
 
-    const auto *baseDecl =
-        cast<CXXRecordDecl>(base->getType()->castAs<clang::RecordType>()->getDecl());
+    const auto *baseDecl = cast<CXXRecordDecl>(
+        base->getType()->castAs<clang::RecordType>()->getDecl());
 
     // Add the offset.
     offset += layout.getBaseClassOffset(baseDecl);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -955,7 +955,7 @@ static GlobalViewAttr createNewGlobalView(CIRGenModule &cgm, GlobalOp newGlob,
   bld.computeGlobalViewIndicesFromFlatOffset(offset, newTy, layout, newInds);
   cir::PointerType newPtrTy;
 
-  if (isa<cir::StructType>(oldTy))
+  if (isa<cir::RecordType>(oldTy))
     newPtrTy = cir::PointerType::get(ctxt, newTy);
   else if (cir::ArrayType oldArTy = dyn_cast<cir::ArrayType>(oldTy))
     newPtrTy = dyn_cast<cir::PointerType>(attr.getType());
@@ -2171,7 +2171,7 @@ static bool isVarDeclStrongDefinition(const ASTContext &astContext,
     if (astContext.isAlignmentRequired(varType))
       return true;
 
-    if (const auto *rt = varType->getAs<RecordType>()) {
+    if (const auto *rt = varType->getAs<clang::RecordType>()) {
       const RecordDecl *rd = rt->getDecl();
       for (const FieldDecl *fd : rd->fields()) {
         if (fd->isBitField())
@@ -3067,7 +3067,7 @@ cir::FuncOp CIRGenModule::GetOrCreateCIRFunction(
   }
 
   // This function doesn't have a complete type (for example, the return type is
-  // an incomplete struct). Use a fake type instead, and make sure not to try to
+  // an incomplete record). Use a fake type instead, and make sure not to try to
   // set attributes.
   bool isIncompleteFunction = false;
 
@@ -4071,7 +4071,7 @@ CharUnits CIRGenModule::computeNonVirtualBaseClassOffset(
     const ASTRecordLayout &layout = astContext.getASTRecordLayout(rd);
 
     const auto *baseDecl =
-        cast<CXXRecordDecl>(base->getType()->castAs<RecordType>()->getDecl());
+        cast<CXXRecordDecl>(base->getType()->castAs<clang::RecordType>()->getDecl());
 
     // Add the offset.
     offset += layout.getBaseClassOffset(baseDecl);

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
@@ -16,7 +16,7 @@
 
 namespace clang::CIRGen {
 
-/// Structure with information about how a bitfield should be accessed. This is
+/// Record with information about how a bitfield should be accessed. This is
 /// very similar to what LLVM codegen does, once CIR evolves it's possible we
 /// can use a more higher level representation.
 /// TODO(cir): the comment below is extracted from LLVM, build a CIR version of
@@ -31,7 +31,7 @@ namespace clang::CIRGen {
 /// Then accessing a particular bitfield involves converting this byte array
 /// into a single integer of that size (i24 or i40 -- may not be power-of-two
 /// size), loading it, and shifting and masking to extract the particular
-/// subsequence of bits which make up that particular bitfield. This structure
+/// subsequence of bits which make up that particular bitfield. This record
 /// encodes the information used to construct the extraction code sequences.
 /// The CIRGenRecordLayout also has a field index which encodes which
 /// byte-sequence this bitfield falls within. Let's assume the following C
@@ -76,7 +76,7 @@ struct CIRGenBitFieldInfo {
   /// bitfield.
   unsigned StorageSize;
 
-  /// The offset of the bitfield storage from the start of the struct.
+  /// The offset of the bitfield storage from the start of the record.
   clang::CharUnits StorageOffset;
 
   /// The offset within a contiguous run of bitfields that are represented as a
@@ -88,7 +88,7 @@ struct CIRGenBitFieldInfo {
   /// bitfield.
   unsigned VolatileStorageSize;
 
-  /// The offset of the bitfield storage from the start of the struct.
+  /// The offset of the bitfield storage from the start of the record.
   clang::CharUnits VolatileStorageOffset;
 
   /// The name of a bitfield
@@ -119,7 +119,7 @@ struct CIRGenBitFieldInfo {
                                      clang::CharUnits StorageOffset);
 };
 
-/// This class handles struct and union layout info while lowering AST types
+/// This class handles record and union layout info while lowering AST types
 /// to CIR types.
 ///
 /// These layout objects are only created on demand as CIR generation requires.
@@ -132,17 +132,17 @@ class CIRGenRecordLayout {
 private:
   /// The CIR type corresponding to this record layout; used when laying it out
   /// as a complete object.
-  cir::StructType CompleteObjectType;
+  cir::RecordType CompleteObjectType;
 
   /// The CIR type for the non-virtual part of this record layout; used when
   /// laying it out as a base subobject.
-  cir::StructType BaseSubobjectType;
+  cir::RecordType BaseSubobjectType;
 
-  /// Map from (non-bit-field) struct field to the corresponding cir struct type
+  /// Map from (non-bit-field) record field to the corresponding cir record type
   /// field no. This info is populated by the record builder.
   llvm::DenseMap<const clang::FieldDecl *, unsigned> FieldInfo;
 
-  /// Map from (bit-field) struct field to the corresponding CIR struct type
+  /// Map from (bit-field) record field to the corresponding CIR record type
   /// field no. This info is populated by record builder.
   /// TODO(CIR): value is an int for now, fix when we support bitfields
   llvm::DenseMap<const clang::FieldDecl *, CIRGenBitFieldInfo> BitFields;
@@ -165,8 +165,8 @@ private:
   bool IsZeroInitializableAsBase : 1;
 
 public:
-  CIRGenRecordLayout(cir::StructType CompleteObjectType,
-                     cir::StructType BaseSubobjectType,
+  CIRGenRecordLayout(cir::RecordType CompleteObjectType,
+                     cir::RecordType BaseSubobjectType,
                      bool IsZeroInitializable, bool IsZeroInitializableAsBase)
       : CompleteObjectType(CompleteObjectType),
         BaseSubobjectType(BaseSubobjectType),
@@ -175,20 +175,20 @@ public:
 
   /// Return the "complete object" LLVM type associated with
   /// this record.
-  cir::StructType getCIRType() const { return CompleteObjectType; }
+  cir::RecordType getCIRType() const { return CompleteObjectType; }
 
   /// Return the "base subobject" LLVM type associated with
   /// this record.
-  cir::StructType getBaseSubobjectCIRType() const { return BaseSubobjectType; }
+  cir::RecordType getBaseSubobjectCIRType() const { return BaseSubobjectType; }
 
-  /// Return cir::StructType element number that corresponds to the field FD.
+  /// Return cir::RecordType element number that corresponds to the field FD.
   unsigned getCIRFieldNo(const clang::FieldDecl *FD) const {
     FD = FD->getCanonicalDecl();
     assert(FieldInfo.count(FD) && "Invalid field for record!");
     return FieldInfo.lookup(FD);
   }
 
-  /// Check whether this struct can be C++ zero-initialized with a
+  /// Check whether this record can be C++ zero-initialized with a
   /// zeroinitializer.
   bool isZeroInitializable() const { return IsZeroInitializable; }
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.h
@@ -35,7 +35,7 @@ class FunctionType;
 class DataLayout;
 class Type;
 class LLVMContext;
-class StructType;
+class RecordType;
 } // namespace llvm
 
 namespace clang {
@@ -65,7 +65,7 @@ class Type;
 } // namespace mlir
 
 namespace cir {
-class StructType;
+class RecordType;
 } // namespace cir
 
 namespace clang::CIRGen {
@@ -93,7 +93,7 @@ class CIRGenTypes {
       CIRGenRecordLayouts;
 
   /// Contains the CIR type for any converted RecordDecl
-  llvm::DenseMap<const clang::Type *, cir::StructType> recordDeclTypes;
+  llvm::DenseMap<const clang::Type *, cir::RecordType> recordDeclTypes;
 
   /// Hold memoized CIRGenFunctionInfo results
   llvm::FoldingSet<CIRGenFunctionInfo> FunctionInfos;
@@ -106,7 +106,7 @@ class CIRGenTypes {
 
   llvm::SmallPtrSet<const CIRGenFunctionInfo *, 4> FunctionsBeingProcessed;
 
-  /// True if we didn't layout a function due to being inside a recursive struct
+  /// True if we didn't layout a function due to being inside a recursive record
   /// conversion, set this to true.
   bool SkippedLayout;
 
@@ -170,7 +170,7 @@ public:
   mlir::Type convertRecordDeclType(const clang::RecordDecl *recordDecl);
 
   std::unique_ptr<CIRGenRecordLayout>
-  computeRecordLayout(const clang::RecordDecl *D, cir::StructType *Ty);
+  computeRecordLayout(const clang::RecordDecl *D, cir::RecordType *Ty);
 
   std::string getRecordTypeName(const clang::RecordDecl *,
                                 llvm::StringRef suffix);

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -63,7 +63,7 @@ mlir::Type CIRGenVTables::getVTableType(const VTableLayout &layout) {
 
   // FIXME(cir): should VTableLayout be encoded like we do for some
   // AST nodes?
-  return CGM.getBuilder().getAnonStructTy(tys, /*incomplete=*/false);
+  return CGM.getBuilder().getAnonRecordTy(tys, /*incomplete=*/false);
 }
 
 /// At this point in the translation unit, does it appear that can we
@@ -304,7 +304,7 @@ void CIRGenVTables::addVTableComponent(ConstantArrayBuilder &builder,
   llvm_unreachable("Unexpected vtable component kind");
 }
 
-void CIRGenVTables::createVTableInitializer(ConstantStructBuilder &builder,
+void CIRGenVTables::createVTableInitializer(ConstantRecordBuilder &builder,
                                             const VTableLayout &layout,
                                             mlir::Attribute rtti,
                                             bool vtableHasLocalLinkage) {
@@ -377,7 +377,7 @@ cir::GlobalOp CIRGenVTables::generateConstructionVTable(
 
   // Create and set the initializer.
   ConstantInitBuilder builder(CGM);
-  auto components = builder.beginStruct();
+  auto components = builder.beginRecord();
   createVTableInitializer(components, *VTLayout, RTTI,
                           cir::isLocalLinkage(VTable.getLinkage()));
   components.finishAndSetAsInitializer(VTable);

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.h
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.h
@@ -69,7 +69,7 @@ class CIRGenVTables {
 public:
   /// Add vtable components for the given vtable layout to the given
   /// global initializer.
-  void createVTableInitializer(ConstantStructBuilder &builder,
+  void createVTableInitializer(ConstantRecordBuilder &builder,
                                const VTableLayout &layout, mlir::Attribute rtti,
                                bool vtableHasLocalLinkage);
 

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
@@ -300,8 +300,8 @@ mlir::Attribute ConstantAggregateBuilderBase::finishArray(mlir::Type eltTy) {
 }
 
 mlir::Attribute
-ConstantAggregateBuilderBase::finishStruct(mlir::MLIRContext *mlirContext,
-                                           cir::StructType ty) {
+ConstantAggregateBuilderBase::finishRecord(mlir::MLIRContext *mlirContext,
+                                           cir::RecordType ty) {
   markFinished();
 
   auto &buffer = getBuffer();
@@ -318,7 +318,7 @@ ConstantAggregateBuilderBase::finishStruct(mlir::MLIRContext *mlirContext,
     // constant = llvm::ConstantStruct::get(ty, elts);
   } else {
     const auto members = mlir::ArrayAttr::get(mlirContext, elts);
-    constant = Builder.CGM.getBuilder().getAnonConstStruct(members, Packed);
+    constant = Builder.CGM.getBuilder().getAnonConstRecord(members, Packed);
   }
 
   buffer.erase(buffer.begin() + Begin, buffer.end());

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -60,10 +60,10 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
 
   AliasResult getAlias(Type type, raw_ostream &os) const final {
-    if (auto structType = dyn_cast<cir::StructType>(type)) {
-      StringAttr nameAttr = structType.getName();
+    if (auto recordType = dyn_cast<cir::RecordType>(type)) {
+      StringAttr nameAttr = recordType.getName();
       if (!nameAttr)
-        os << "ty_anon_" << structType.getKindAsStr();
+        os << "ty_anon_" << recordType.getKindAsStr();
       else
         os << "ty_" << nameAttr.getValue();
       return AliasResult::OverridableAlias;
@@ -392,10 +392,10 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
   }
 
   if (isa<cir::ZeroAttr>(attrType)) {
-    if (::mlir::isa<cir::StructType, cir::ArrayType, cir::ComplexType,
+    if (::mlir::isa<cir::RecordType, cir::ArrayType, cir::ComplexType,
                     cir::VectorType>(opType))
       return success();
-    return op->emitOpError("zero expects struct or array type");
+    return op->emitOpError("zero expects record or array type");
   }
 
   if (isa<cir::UndefAttr>(attrType)) {
@@ -437,7 +437,7 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
       mlir::isa<cir::TypeInfoAttr>(attrType) ||
       mlir::isa<cir::ConstArrayAttr>(attrType) ||
       mlir::isa<cir::ConstVectorAttr>(attrType) ||
-      mlir::isa<cir::ConstStructAttr>(attrType) ||
+      mlir::isa<cir::ConstRecordAttr>(attrType) ||
       mlir::isa<cir::VTableAttr>(attrType))
     return success();
   if (mlir::isa<cir::IntAttr>(attrType))
@@ -551,8 +551,8 @@ LogicalResult cir::CastOp::verify() {
     return success();
   }
   case cir::CastKind::bitcast: {
-    // Allow bitcast of structs for calling conventions.
-    if (isa<StructType>(srcType) || isa<StructType>(resType))
+    // Allow bitcast of records for calling conventions.
+    if (isa<RecordType>(srcType) || isa<RecordType>(resType))
       return success();
 
     // Handle the pointer types first.
@@ -854,9 +854,9 @@ OpFoldResult cir::UnaryOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult cir::DynamicCastOp::verify() {
   auto resultPointeeTy = mlir::cast<cir::PointerType>(getType()).getPointee();
-  if (!mlir::isa<cir::VoidType, cir::StructType>(resultPointeeTy))
+  if (!mlir::isa<cir::VoidType, cir::RecordType>(resultPointeeTy))
     return emitOpError()
-           << "cir.dyn_cast must produce a void ptr or struct ptr";
+           << "cir.dyn_cast must produce a void ptr or record ptr";
 
   return mlir::success();
 }
@@ -3526,7 +3526,7 @@ LogicalResult cir::TypeInfoAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     ::mlir::Type type, ::mlir::ArrayAttr typeinfoData) {
 
-  if (cir::ConstStructAttr::verify(emitError, type, typeinfoData).failed())
+  if (cir::ConstRecordAttr::verify(emitError, type, typeinfoData).failed())
     return failure();
 
   for (auto &member : typeinfoData) {
@@ -3542,13 +3542,13 @@ LogicalResult cir::TypeInfoAttr::verify(
 LogicalResult cir::VTableAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     ::mlir::Type type, ::mlir::ArrayAttr vtableData) {
-  auto sTy = mlir::dyn_cast_if_present<cir::StructType>(type);
+  auto sTy = mlir::dyn_cast_if_present<cir::RecordType>(type);
   if (!sTy) {
-    emitError() << "expected !cir.struct type result";
+    emitError() << "expected !cir.record type result";
     return failure();
   }
   if (sTy.getMembers().empty() || vtableData.empty()) {
-    emitError() << "expected struct type with one or more subtype";
+    emitError() << "expected record type with one or more subtype";
     return failure();
   }
 
@@ -3557,11 +3557,11 @@ LogicalResult cir::VTableAttr::verify(
     auto arrayTy = mlir::dyn_cast<cir::ArrayType>(sTy.getMembers()[i]);
     auto constArrayAttr = mlir::dyn_cast<cir::ConstArrayAttr>(vtableData[i]);
     if (!arrayTy || !constArrayAttr) {
-      emitError() << "expected struct type with one array element";
+      emitError() << "expected record type with one array element";
       return failure();
     }
 
-    if (cir::ConstStructAttr::verify(emitError, type, vtableData).failed())
+    if (cir::ConstRecordAttr::verify(emitError, type, vtableData).failed())
       return failure();
 
     LogicalResult eltTypeCheck = success();
@@ -3606,7 +3606,7 @@ LogicalResult cir::CopyOp::verify() {
 
 LogicalResult cir::GetMemberOp::verify() {
 
-  const auto recordTy = dyn_cast<StructType>(getAddrTy().getPointee());
+  const auto recordTy = dyn_cast<RecordType>(getAddrTy().getPointee());
   if (!recordTy)
     return emitError() << "expected pointer to a record type";
 
@@ -3627,8 +3627,8 @@ LogicalResult cir::GetMemberOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult cir::ExtractMemberOp::verify() {
-  auto recordTy = mlir::cast<cir::StructType>(getRecord().getType());
-  if (recordTy.getKind() == cir::StructType::Union)
+  auto recordTy = mlir::cast<cir::RecordType>(getRecord().getType());
+  if (recordTy.getKind() == cir::RecordType::Union)
     return emitError()
            << "cir.extract_member currently does not work on unions";
   if (recordTy.getMembers().size() <= getIndex())
@@ -3643,8 +3643,8 @@ LogicalResult cir::ExtractMemberOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult cir::InsertMemberOp::verify() {
-  auto recordTy = mlir::cast<cir::StructType>(getRecord().getType());
-  if (recordTy.getKind() == cir::StructType::Union)
+  auto recordTy = mlir::cast<cir::RecordType>(getRecord().getType());
+  if (recordTy.getKind() == cir::RecordType::Union)
     return emitError() << "cir.update_member currently does not work on unions";
   if (recordTy.getMembers().size() <= getIndex())
     return emitError() << "member index out of range";
@@ -3660,7 +3660,7 @@ LogicalResult cir::InsertMemberOp::verify() {
 
 LogicalResult cir::GetRuntimeMemberOp::verify() {
   auto recordTy =
-      cast<StructType>(cast<PointerType>(getAddr().getType()).getPointee());
+      cast<RecordType>(cast<PointerType>(getAddr().getType()).getPointee());
   auto memberPtrTy = getMember().getType();
 
   if (recordTy != memberPtrTy.getClsTy()) {

--- a/clang/lib/CIR/Dialect/Transforms/DropAST.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/DropAST.cpp
@@ -33,7 +33,7 @@ void DropASTPass::runOnOperation() {
   op->walk([&](Operation *op) {
     if (auto alloca = dyn_cast<AllocaOp>(op)) {
       alloca.removeAstAttr();
-      auto ty = mlir::dyn_cast<cir::StructType>(alloca.getAllocaType());
+      auto ty = mlir::dyn_cast<cir::RecordType>(alloca.getAllocaType());
       if (!ty)
         return;
       ty.dropAst();

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -91,7 +91,7 @@ static bool isSequentialContainer(mlir::Type t) {
   return isStdArrayType(t);
 }
 
-static bool getIntegralNTTPAt(StructType t, size_t pos, unsigned &size) {
+static bool getIntegralNTTPAt(RecordType t, size_t pos, unsigned &size) {
   auto *d =
       dyn_cast<clang::ClassTemplateSpecializationDecl>(t.getAst().getRawDecl());
   if (!d)
@@ -109,7 +109,7 @@ static bool getIntegralNTTPAt(StructType t, size_t pos, unsigned &size) {
   return true;
 }
 
-static bool containerHasStaticSize(StructType t, unsigned &size) {
+static bool containerHasStaticSize(RecordType t, unsigned &size) {
   // TODO: add others.
   if (!isStdArrayType(t))
     return false;
@@ -179,7 +179,7 @@ void LibOptPass::xformStdFindIntoMemchr(StdFindOp findOp) {
       // Look at this pointer to retrieve container information.
       auto thisPtr =
           cast<PointerType>(iterBegin.getOperand().getType()).getPointee();
-      auto containerTy = dyn_cast<StructType>(thisPtr);
+      auto containerTy = dyn_cast<RecordType>(thisPtr);
 
       unsigned staticSize = 0;
       if (containerTy && isSequentialContainer(containerTy) &&

--- a/clang/lib/CIR/Dialect/Transforms/StdHelpers.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/StdHelpers.cpp
@@ -11,7 +11,7 @@
 namespace cir {
 
 bool isStdArrayType(mlir::Type t) {
-  auto sTy = mlir::dyn_cast<StructType>(t);
+  auto sTy = mlir::dyn_cast<RecordType>(t);
   if (!sTy)
     return false;
   auto recordDecl = sTy.getAst();

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -24,7 +24,7 @@ bool classifyReturnType(const CIRCXXABI &CXXABI, LowerFunctionInfo &FI,
                         const ABIInfo &Info) {
   mlir::Type Ty = FI.getReturnType();
 
-  if (const auto RT = mlir::dyn_cast<StructType>(Ty)) {
+  if (const auto RT = mlir::dyn_cast<RecordType>(Ty)) {
     cir_cconv_assert(!cir::MissingFeatures::isCXXRecordDecl());
   }
 
@@ -49,7 +49,7 @@ mlir::Value emitRoundPointerUpToAlignment(cir::CIRBaseBuilderTy &builder,
 }
 
 mlir::Type useFirstFieldIfTransparentUnion(mlir::Type Ty) {
-  if (auto RT = mlir::dyn_cast<StructType>(Ty)) {
+  if (auto RT = mlir::dyn_cast<RecordType>(Ty)) {
     if (RT.isUnion())
       cir_cconv_assert_or_abort(
           !cir::MissingFeatures::ABITransparentUnionHandling(), "NYI");
@@ -57,7 +57,7 @@ mlir::Type useFirstFieldIfTransparentUnion(mlir::Type Ty) {
   return Ty;
 }
 
-CIRCXXABI::RecordArgABI getRecordArgABI(const StructType RT,
+CIRCXXABI::RecordArgABI getRecordArgABI(const RecordType RT,
                                         CIRCXXABI &CXXABI) {
   if (cir::MissingFeatures::typeIsCXXRecordDecl()) {
     cir_cconv_unreachable("NYI");
@@ -66,7 +66,7 @@ CIRCXXABI::RecordArgABI getRecordArgABI(const StructType RT,
 }
 
 CIRCXXABI::RecordArgABI getRecordArgABI(mlir::Type ty, CIRCXXABI &CXXABI) {
-  auto st = mlir::dyn_cast<StructType>(ty);
+  auto st = mlir::dyn_cast<RecordType>(ty);
   if (!st)
     return CIRCXXABI::RAA_Default;
   return getRecordArgABI(st, CXXABI);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.h
@@ -32,7 +32,7 @@ mlir::Value emitRoundPointerUpToAlignment(cir::CIRBaseBuilderTy &builder,
 /// should ensure that all elements of the union have the same "machine type".
 mlir::Type useFirstFieldIfTransparentUnion(mlir::Type Ty);
 
-CIRCXXABI::RecordArgABI getRecordArgABI(const StructType RT, CIRCXXABI &CXXABI);
+CIRCXXABI::RecordArgABI getRecordArgABI(const RecordType RT, CIRCXXABI &CXXABI);
 CIRCXXABI::RecordArgABI getRecordArgABI(mlir::Type ty, CIRCXXABI &CXXABI);
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -64,7 +64,7 @@ public:
 
   /// Returns how an argument of the given record type should be passed.
   /// FIXME(cir): This expects a CXXRecordDecl! Not any record type.
-  virtual RecordArgABI getRecordArgABI(const StructType RD) const = 0;
+  virtual RecordArgABI getRecordArgABI(const RecordType RD) const = 0;
 
   /// Lower the given data member pointer type to its ABI type. The returned
   /// type is also a CIR type.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRLowerContext.cpp
@@ -54,7 +54,7 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const mlir::Type T) const {
   auto typeKind = clang::Type::Builtin;
   if (mlir::isa<IntType, SingleType, DoubleType, BoolType>(T)) {
     typeKind = clang::Type::Builtin;
-  } else if (mlir::isa<StructType>(T)) {
+  } else if (mlir::isa<RecordType>(T)) {
     typeKind = clang::Type::Record;
   } else {
     cir_cconv_assert_or_abort(!cir::MissingFeatures::ABIClangTypeKind(),
@@ -105,7 +105,7 @@ clang::TypeInfo CIRLowerContext::getTypeInfoImpl(const mlir::Type T) const {
     break;
   }
   case clang::Type::Record: {
-    const auto RT = mlir::dyn_cast<StructType>(T);
+    const auto RT = mlir::dyn_cast<RecordType>(T);
     cir_cconv_assert(!cir::MissingFeatures::tagTypeClassAbstraction());
 
     // Only handle TagTypes (names types) for now.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRToCIRArgMapping.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRToCIRArgMapping.h
@@ -94,7 +94,7 @@ public:
       case cir::ABIArgInfo::Direct: {
         // FIXME(cir): handle sseregparm someday...
         cir_cconv_assert(AI.getCoerceToType() && "Missing coerced type!!");
-        StructType STy = mlir::dyn_cast<StructType>(AI.getCoerceToType());
+        RecordType STy = mlir::dyn_cast<RecordType>(AI.getCoerceToType());
         if (AI.isDirect() && AI.getCanBeFlattened() && STy) {
           IRArgs.NumberOfArgs = STy.getNumElements();
         } else {

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunctionInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerFunctionInfo.h
@@ -93,9 +93,9 @@ class LowerFunctionInfo final
 
   RequiredArgs Required;
 
-  /// The struct representing all arguments passed in memory.  Only used when
+  /// The record representing all arguments passed in memory.  Only used when
   /// passing non-trivial types with inalloca.  Not part of the profile.
-  StructType ArgStruct;
+  RecordType ArgRecord;
 
   unsigned NumArgs;
 
@@ -121,7 +121,7 @@ public:
     FI->ChainCall = chainCall;
     FI->DelegateCall = delegateCall;
     FI->Required = required;
-    FI->ArgStruct = nullptr;
+    FI->ArgRecord = nullptr;
     FI->NumArgs = argTypes.size();
     FI->getArgsBuffer()[0].type = resultType;
     for (unsigned i = 0, e = argTypes.size(); i != e; ++i)
@@ -167,8 +167,8 @@ public:
   /// into an LLVM CC.
   unsigned getCallingConvention() const { return CallingConvention; }
 
-  /// Get the struct type used to represent all the arguments in memory.
-  StructType getArgStruct() const { return ArgStruct; }
+  /// Get the record type used to represent all the arguments in memory.
+  RecordType getArgRecord() const { return ArgRecord; }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerTypes.cpp
@@ -88,7 +88,7 @@ FuncType LowerTypes::getFunctionType(const LowerFunctionInfo &FI) {
       // Fast-isel and the optimizer generally like scalar values better than
       // FCAs, so we flatten them if this is safe to do for this argument.
       mlir::Type argType = ArgInfo.getCoerceToType();
-      StructType st = mlir::dyn_cast<StructType>(argType);
+      RecordType st = mlir::dyn_cast<RecordType>(argType);
       if (st && ArgInfo.isDirect() && ArgInfo.getCanBeFlattened()) {
         cir_cconv_assert(NumIRArgs == st.getNumElements());
         for (unsigned i = 0, e = st.getNumElements(); i != e; ++i)

--- a/clang/test/CIR/CallConvLowering/AArch64/struct.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/struct.c
@@ -70,7 +70,7 @@ void foo1() {
 // CIR: %[[#V2:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["__retval"] {alignment = 4 : i64}
 // CIR: %[[#V3:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["s2"]
 // CIR: %[[#V4:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["tmp"] {alignment = 4 : i64}
-// CIR: %[[#V5:]] = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !ty_S
+// CIR: %[[#V5:]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !ty_S
 // CIR: cir.store %[[#V5]], %[[#V3]] : !ty_S, !cir.ptr<!ty_S>
 // CIR: %[[#V6:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S>), !cir.ptr<!u64i>
 // CIR: %[[#V7:]] = cir.load %[[#V6]] : !cir.ptr<!u64i>, !u64i

--- a/clang/test/CIR/CallConvLowering/AArch64/union.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/union.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -triple aarch64-unknown-linux-gnu  -fclangir -emit-llvm %s -o %t.ll -fclangir-call-conv-lowering
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
-// CIR: !ty_U = !cir.struct<union "U" {!s32i, !s32i, !s32i}>
+// CIR: !ty_U = !cir.record<union "U" {!s32i, !s32i, !s32i}>
 // LLVM: %union.U = type { i32 }
 typedef union {
   int a, b, c;

--- a/clang/test/CIR/CallConvLowering/x86_64/int128.cpp
+++ b/clang/test/CIR/CallConvLowering/x86_64/int128.cpp
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fclangir-call-conv-lowering -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
-// CHECK: ![[I128_STRUCT:.+]] = !cir.struct<struct  {!s64i, !s64i}>
+// CHECK: ![[I128_STRUCT:.+]] = !cir.record<struct  {!s64i, !s64i}>
 
 // CHECK: @_Z5test1nn(%[[ARG0:.+]]: !s64i loc({{.+}}), %[[ARG1:.+]]: !s64i loc({{.+}}), %[[ARG2:.+]]: !s64i loc({{.+}}), %[[ARG3:.+]]: !s64i loc({{.+}})) -> ![[I128_STRUCT]]
 // LLVM: define dso_local { i64, i64 } @_Z5test1nn(i64 %[[#A_LO:]], i64 %[[#A_HI:]], i64 %[[#B_LO:]], i64 %[[#B_HI:]])

--- a/clang/test/CIR/CodeGen/CUDA/registration.cu
+++ b/clang/test/CIR/CodeGen/CUDA/registration.cu
@@ -84,7 +84,7 @@ __global__ void fn() {}
 
 // The first value is CUDA file head magic number.
 // CIR-HOST: cir.global "private" constant internal @__cuda_fatbin_wrapper
-// CIR-HOST: = #cir.const_struct<{
+// CIR-HOST: = #cir.const_record<{
 // CIR-HOST:   #cir.int<1180844977> : !s32i,
 // CIR-HOST:   #cir.int<1> : !s32i,
 // CIR-HOST:   #cir.global_view<@__cuda_fatbin_str> : !cir.ptr<!void>,

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-// CHECK: !ty_yep_ = !cir.struct<struct "yep_" {!u32i, !u32i}>
+// CHECK: !ty_yep_ = !cir.record<struct "yep_" {!u32i, !u32i}>
 
 typedef enum xxy_ {
   xxy_Low = 0,
@@ -49,7 +49,7 @@ void yo() {
 // CHECK: cir.func @_Z2yov()
 // CHECK:   %0 = cir.alloca !ty_Yo, !cir.ptr<!ty_Yo>, ["ext"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.alloca !ty_Yo, !cir.ptr<!ty_Yo>, ["ext2", init] {alignment = 8 : i64}
-// CHECK:   %2 = cir.const #cir.const_struct<{#cir.int<1000070000> : !u32i, #cir.ptr<null> : !cir.ptr<!void>, #cir.int<0> : !u64i}> : !ty_Yo
+// CHECK:   %2 = cir.const #cir.const_record<{#cir.int<1000070000> : !u32i, #cir.ptr<null> : !cir.ptr<!void>, #cir.int<0> : !u64i}> : !ty_Yo
 // CHECK:   cir.store %2, %0 : !ty_Yo, !cir.ptr<!ty_Yo>
 // CHECK:   %3 = cir.get_member %1[0] {name = "type"} : !cir.ptr<!ty_Yo> -> !cir.ptr<!u32i>
 // CHECK:   %4 = cir.const #cir.int<1000066001> : !u32i

--- a/clang/test/CIR/CodeGen/agg-init2.cpp
+++ b/clang/test/CIR/CodeGen/agg-init2.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-// CHECK: !ty_Zero = !cir.struct<struct "Zero" padded {!u8i}>
+// CHECK: !ty_Zero = !cir.record<struct "Zero" padded {!u8i}>
 
 struct Zero {
   void yolo();

--- a/clang/test/CIR/CodeGen/array.c
+++ b/clang/test/CIR/CodeGen/array.c
@@ -5,7 +5,7 @@
 struct S {
   int i;
 } arr[3] = {{1}};
-// CHECK: cir.global external @arr = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S, #cir.zero : !ty_S, #cir.zero : !ty_S]> : !cir.array<!ty_S x 3>
+// CHECK: cir.global external @arr = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S, #cir.zero : !ty_S, #cir.zero : !ty_S]> : !cir.array<!ty_S x 3>
 
 int a[4];
 // CHECK: cir.global external @a = #cir.zero : !cir.array<!s32i x 4> 

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -70,7 +70,7 @@ int globalNullArr[] = {0, 0};
 struct S {
   int i;
 } arr[3] = {{1}};
-// CHECK: cir.global external @arr = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S, #cir.zero : !ty_S, #cir.zero : !ty_S]> : !cir.array<!ty_S x 3>
+// CHECK: cir.global external @arr = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S, #cir.zero : !ty_S, #cir.zero : !ty_S]> : !cir.array<!ty_S x 3>
 
 void testPointerDecaySubscriptAccess(int arr[]) {
 // CHECK: cir.func @{{.+}}testPointerDecaySubscriptAccess

--- a/clang/test/CIR/CodeGen/atomic-xchg-field.c
+++ b/clang/test/CIR/CodeGen/atomic-xchg-field.c
@@ -22,7 +22,7 @@ void field_access(wPtr item) {
   __atomic_exchange_n((&item->ref), (((void*)0)), 5);
 }
 
-// CHECK: ![[W:.*]] = !cir.struct<struct "w"
+// CHECK: ![[W:.*]] = !cir.record<struct "w"
 // CHECK-LABEL: @field_access
 // CHECK-NEXT: %[[WADDR:.*]] = cir.alloca !cir.ptr<![[W]]>, {{.*}} {alignment = 8 : i64}
 // CHECK: %[[FIELD:.*]] = cir.load %[[WADDR]]

--- a/clang/test/CIR/CodeGen/atomic.cpp
+++ b/clang/test/CIR/CodeGen/atomic.cpp
@@ -21,7 +21,7 @@ unsigned int ui;
 signed long long sll;
 unsigned long long ull;
 
-// CHECK: ![[A:.*]] = !cir.struct<struct "_a" {!s32i}>
+// CHECK: ![[A:.*]] = !cir.record<struct "_a" {!s32i}>
 
 int basic_binop_fetch(int *i) {
   return __atomic_add_fetch(i, 1, memory_order_seq_cst);

--- a/clang/test/CIR/CodeGen/bitfield-union.c
+++ b/clang/test/CIR/CodeGen/bitfield-union.c
@@ -13,7 +13,7 @@ void main() {
     d.z = 0;
 }
 
-// CHECK: !ty_demo = !cir.struct<union "demo" {!s32i, !u8i, !u8i}>
+// CHECK: !ty_demo = !cir.record<union "demo" {!s32i, !u8i, !u8i}>
 // CHECK: #bfi_y = #cir.bitfield_info<name = "y", storage_type = !u8i, size = 4, offset = 0, is_signed = true>
 // CHECK: #bfi_z = #cir.bitfield_info<name = "z", storage_type = !u8i, size = 8, offset = 0, is_signed = true>
 

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -55,16 +55,16 @@ typedef struct {
                // because (tail - startOffset) is 65 after 'l' field
 } U;
 
-// CHECK: !ty_D = !cir.struct<struct "D" {!u16i, !s32i}>
-// CHECK: !ty_G = !cir.struct<struct "G" {!u16i, !s32i} #cir.record.decl.ast>
-// CHECK: !ty_T = !cir.struct<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK: !ty_anon2E0 = !cir.struct<struct "anon.0" {!u32i} #cir.record.decl.ast>
+// CHECK: !ty_D = !cir.record<struct "D" {!u16i, !s32i}>
+// CHECK: !ty_G = !cir.record<struct "G" {!u16i, !s32i} #cir.record.decl.ast>
+// CHECK: !ty_T = !cir.record<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
+// CHECK: !ty_anon2E0 = !cir.record<struct "anon.0" {!u32i} #cir.record.decl.ast>
 // CHECK: #bfi_a = #cir.bitfield_info<name = "a", storage_type = !u8i, size = 3, offset = 0, is_signed = true>
 // CHECK: #bfi_e = #cir.bitfield_info<name = "e", storage_type = !u16i, size = 15, offset = 0, is_signed = true>
-// CHECK: !ty_S = !cir.struct<struct "S" {!u32i, !cir.array<!u8i x 3>, !u16i, !u32i}>
-// CHECK: !ty_U = !cir.struct<struct "U" {!s8i, !s8i, !s8i, !cir.array<!u8i x 9>}>
-// CHECK: !ty___long = !cir.struct<struct "__long" {!ty_anon2E0, !u32i, !cir.ptr<!u32i>}>
-// CHECK: !ty_anon_struct = !cir.struct<struct  {!u8i, !u8i, !cir.array<!u8i x 2>, !s32i}>
+// CHECK: !ty_S = !cir.record<struct "S" {!u32i, !cir.array<!u8i x 3>, !u16i, !u32i}>
+// CHECK: !ty_U = !cir.record<struct "U" {!s8i, !s8i, !s8i, !cir.array<!u8i x 9>}>
+// CHECK: !ty___long = !cir.record<struct "__long" {!ty_anon2E0, !u32i, !cir.ptr<!u32i>}>
+// CHECK: !ty_anon_struct = !cir.record<struct  {!u8i, !u8i, !cir.array<!u8i x 2>, !s32i}>
 // CHECK: #bfi_d = #cir.bitfield_info<name = "d", storage_type = !cir.array<!u8i x 3>, size = 2, offset = 17, is_signed = true>
 
 // CHECK: cir.func {{.*@store_field}}
@@ -127,7 +127,7 @@ void createU() {
 // CHECK: cir.func {{.*@createD}}
 // CHECK:   %0 = cir.alloca !ty_D, !cir.ptr<!ty_D>, ["d"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.cast(bitcast, %0 : !cir.ptr<!ty_D>), !cir.ptr<!ty_anon_struct>
-// CHECK:   %2 = cir.const #cir.const_struct<{#cir.int<33> : !u8i, #cir.int<0> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>, #cir.int<3> : !s32i}> : !ty_anon_struct
+// CHECK:   %2 = cir.const #cir.const_record<{#cir.int<33> : !u8i, #cir.int<0> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>, #cir.int<3> : !s32i}> : !ty_anon_struct
 // CHECK:   cir.store %2, %1 : !ty_anon_struct, !cir.ptr<!ty_anon_struct>
 void createD() {
   D d = {1,2,3};
@@ -148,7 +148,7 @@ typedef struct {
   int y ;
 } G;
 
-// CHECK: cir.global external @g = #cir.const_struct<{#cir.int<133> : !u8i, #cir.int<127> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>, #cir.int<254> : !s32i}> : !ty_anon_struct
+// CHECK: cir.global external @g = #cir.const_record<{#cir.int<133> : !u8i, #cir.int<127> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>, #cir.int<254> : !s32i}> : !ty_anon_struct
 G g = { -123, 254UL};
 
 // CHECK: cir.func {{.*@get_y}}

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -27,10 +27,10 @@ typedef struct {
   int a : 3;  // one bitfield with size < 8
   unsigned b;
 } T;
-// CHECK: !ty_T = !cir.struct<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK: !ty_anon2E0 = !cir.struct<struct "anon.0" {!u32i} #cir.record.decl.ast>
-// CHECK: !ty_S = !cir.struct<struct "S" {!u32i, !cir.array<!u8i x 3>, !u16i, !u32i}>
-// CHECK: !ty___long = !cir.struct<struct "__long" {!ty_anon2E0, !u32i, !cir.ptr<!u32i>}>
+// CHECK: !ty_T = !cir.record<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
+// CHECK: !ty_anon2E0 = !cir.record<struct "anon.0" {!u32i} #cir.record.decl.ast>
+// CHECK: !ty_S = !cir.record<struct "S" {!u32i, !cir.array<!u8i x 3>, !u16i, !u32i}>
+// CHECK: !ty___long = !cir.record<struct "__long" {!ty_anon2E0, !u32i, !cir.ptr<!u32i>}>
 
 // CHECK: cir.func @_Z11store_field
 // CHECK:   [[TMP0:%.*]] = cir.alloca !ty_S, !cir.ptr<!ty_S>

--- a/clang/test/CIR/CodeGen/builtin-arm-exclusive.c
+++ b/clang/test/CIR/CodeGen/builtin-arm-exclusive.c
@@ -4,7 +4,7 @@
 struct twoFldT {
   char a, b;
 };
-// CIR: !ty_twoFldT = !cir.struct<struct "twoFldT" {!s8i, !s8i}
+// CIR: !ty_twoFldT = !cir.record<struct "twoFldT" {!s8i, !s8i}
 
 int test_ldrex(char *addr, long long *addr64, float *addrfloat) {
 // CIR-LABEL: @test_ldrex

--- a/clang/test/CIR/CodeGen/c11atomic.c
+++ b/clang/test/CIR/CodeGen/c11atomic.c
@@ -3,9 +3,9 @@
 // RUN: %clang_cc1 %s -triple aarch64-none-linux-android21 -fclangir -emit-llvm -std=c11 -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// CIR-DAG: ![[PS:.*]] = !cir.struct<struct "PS" {!s16i, !s16i, !s16i}
-// CIR-DAG: ![[ANON:.*]] = !cir.struct<struct  {![[PS]], !cir.array<!u8i x 2>}>
-// CIR-DAG: cir.global external @testPromotedStructGlobal = #cir.const_struct<{#cir.const_struct<{#cir.int<1> : !s16i, #cir.int<2> : !s16i, #cir.int<3> : !s16i}> : ![[PS]], #cir.zero : !cir.array<!u8i x 2>}> : ![[ANON]]
+// CIR-DAG: ![[PS:.*]] = !cir.record<struct "PS" {!s16i, !s16i, !s16i}
+// CIR-DAG: ![[ANON:.*]] = !cir.record<struct  {![[PS]], !cir.array<!u8i x 2>}>
+// CIR-DAG: cir.global external @testPromotedStructGlobal = #cir.const_record<{#cir.const_record<{#cir.int<1> : !s16i, #cir.int<2> : !s16i, #cir.int<3> : !s16i}> : ![[PS]], #cir.zero : !cir.array<!u8i x 2>}> : ![[ANON]]
 
 // LLVM-DAG: %[[PS:.*]] = type { i16, i16, i16 }
 // LLVM-DAG: @testPromotedStructGlobal = global { %[[PS]], [2 x i8] } { %[[PS]] { i16 1, i16 2, i16 3 }, [2 x i8] zeroinitializer }

--- a/clang/test/CIR/CodeGen/call-via-class-member-funcptr.cpp
+++ b/clang/test/CIR/CodeGen/call-via-class-member-funcptr.cpp
@@ -16,8 +16,8 @@ public:
 const char *f::b() { return g.b(h); }
 void fn1() { f f1; }
 
-// CIR: ty_a = !cir.struct<class "a" padded {!u8i} #cir.record.decl.ast>
-// CIR: ty_f = !cir.struct<class "f" {!ty_a}>
+// CIR: ty_a = !cir.record<class "a" padded {!u8i} #cir.record.decl.ast>
+// CIR: ty_f = !cir.record<class "f" {!ty_a}>
 
 // CIR: cir.global external @h = #cir.int<0>
 // CIR: cir.func private @_ZN1a1bEi(!s32i) -> !cir.ptr<!s8i>

--- a/clang/test/CIR/CodeGen/compound-literal.c
+++ b/clang/test/CIR/CodeGen/compound-literal.c
@@ -13,7 +13,7 @@ S a = {
 };
 
 // CIR: cir.global "private" internal @".compoundLiteral.0" = #cir.zero : !cir.array<!s32i x 0> {alignment = 4 : i64}
-// CIR: cir.global external @a = #cir.const_struct<{#cir.global_view<@".compoundLiteral.0"> : !cir.ptr<!s32i>}> : !ty_S
+// CIR: cir.global external @a = #cir.const_record<{#cir.global_view<@".compoundLiteral.0"> : !cir.ptr<!s32i>}> : !ty_S
 
 // LLVM: @.compoundLiteral.0 = internal global [0 x i32] zeroinitializer
 // LLVM: @a = global %struct.S { ptr @.compoundLiteral.0 }
@@ -23,7 +23,7 @@ S b = {
 };
 
 // CIR: cir.global "private" internal @".compoundLiteral.1" = #cir.const_array<[#cir.int<1> : !s32i]> : !cir.array<!s32i x 1> {alignment = 4 : i64}
-// CIR: cir.global external @b = #cir.const_struct<{#cir.global_view<@".compoundLiteral.1"> : !cir.ptr<!s32i>}> : !ty_S
+// CIR: cir.global external @b = #cir.const_record<{#cir.global_view<@".compoundLiteral.1"> : !cir.ptr<!s32i>}> : !ty_S
 
 // LLVM: @.compoundLiteral.1 = internal global [1 x i32] [i32 1]
 // LLVM: @b = global %struct.S { ptr @.compoundLiteral.1 }

--- a/clang/test/CIR/CodeGen/conditional-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/conditional-cleanup.cpp
@@ -23,11 +23,11 @@ namespace test7 {
   }
 }
 
-// CIR-DAG: ![[A:.*]] = !cir.struct<struct "test7::A" padded {!u8i}
-// CIR-DAG: ![[B:.*]] = !cir.struct<struct "test7::B" padded {!u8i}
+// CIR-DAG: ![[A:.*]] = !cir.record<struct "test7::A" padded {!u8i}
+// CIR-DAG: ![[B:.*]] = !cir.record<struct "test7::B" padded {!u8i}
 
-// CIR_EH-DAG: ![[A:.*]] = !cir.struct<struct "test7::A" padded {!u8i}
-// CIR_EH-DAG: ![[B:.*]] = !cir.struct<struct "test7::B" padded {!u8i}
+// CIR_EH-DAG: ![[A:.*]] = !cir.record<struct "test7::A" padded {!u8i}
+// CIR_EH-DAG: ![[B:.*]] = !cir.record<struct "test7::B" padded {!u8i}
 
 // CIR-LABEL: _ZN5test74testEv
 // CIR:   %[[RET_VAL:.*]] = cir.alloca !cir.ptr<![[B]]>, !cir.ptr<!cir.ptr<![[B]]>>, ["__retval"] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/const-bitfields.c
+++ b/clang/test/CIR/CodeGen/const-bitfields.c
@@ -14,17 +14,17 @@ struct Inner {
   unsigned d : 30;
 };
 
-// CHECK: !ty_anon_struct = !cir.struct<struct  {!u8i, !u8i, !u8i, !u8i, !s32i}>
-// CHECK: !ty_T = !cir.struct<struct "T" {!cir.array<!u8i x 3>, !s32i} #cir.record.decl.ast>
-// CHECK: !ty_anon_struct1 = !cir.struct<struct  {!u8i, !cir.array<!u8i x 3>, !u8i, !u8i, !u8i, !u8i}>
+// CHECK: !ty_anon_struct = !cir.record<struct  {!u8i, !u8i, !u8i, !u8i, !s32i}>
+// CHECK: !ty_T = !cir.record<struct "T" {!cir.array<!u8i x 3>, !s32i} #cir.record.decl.ast>
+// CHECK: !ty_anon_struct1 = !cir.record<struct  {!u8i, !cir.array<!u8i x 3>, !u8i, !u8i, !u8i, !u8i}>
 // CHECK: #bfi_Z = #cir.bitfield_info<name = "Z", storage_type = !cir.array<!u8i x 3>, size = 9, offset = 11, is_signed = true>
 
 struct T GV = { 1, 5, 26, 42 };
-// CHECK: cir.global external @GV = #cir.const_struct<{#cir.int<161> : !u8i, #cir.int<208> : !u8i, #cir.int<0> : !u8i,  #cir.zero : !u8i, #cir.int<42> : !s32i}> : !ty_anon_struct
+// CHECK: cir.global external @GV = #cir.const_record<{#cir.int<161> : !u8i, #cir.int<208> : !u8i, #cir.int<0> : !u8i,  #cir.zero : !u8i, #cir.int<42> : !s32i}> : !ty_anon_struct
 
 // check padding is used (const array of zeros)
 struct Inner var = { 1, 0, 1, 21};
-// CHECK: cir.global external @var = #cir.const_struct<{#cir.int<5> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>, #cir.int<21> : !u8i, #cir.int<0> : !u8i, #cir.int<0> : !u8i, #cir.int<0> : !u8i}> : !ty_anon_struct1
+// CHECK: cir.global external @var = #cir.const_record<{#cir.int<5> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>, #cir.int<21> : !u8i, #cir.int<0> : !u8i, #cir.int<0> : !u8i, #cir.int<0> : !u8i}> : !ty_anon_struct1
 
 
 // CHECK: cir.func {{.*@getZ()}}

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -126,13 +126,13 @@ co_invoke_fn co_invoke;
 
 }} // namespace folly::coro
 
-// CHECK-DAG: ![[IntTask:.*]] = !cir.struct<struct "folly::coro::Task<int>" padded {!u8i}>
-// CHECK-DAG: ![[VoidTask:.*]] = !cir.struct<struct "folly::coro::Task<void>" padded {!u8i}>
-// CHECK-DAG: ![[VoidPromisse:.*]] = !cir.struct<struct "folly::coro::Task<void>::promise_type" padded {!u8i}>
-// CHECK-DAG: ![[CoroHandleVoid:.*]] = !cir.struct<struct "std::coroutine_handle<void>" padded {!u8i}>
-// CHECK-DAG: ![[CoroHandlePromise:ty_.*]]  = !cir.struct<struct "std::coroutine_handle<folly::coro::Task<void>::promise_type>" padded {!u8i}>
-// CHECK-DAG: ![[StdString:.*]] = !cir.struct<struct "std::string" padded {!u8i}>
-// CHECK-DAG: ![[SuspendAlways:.*]] = !cir.struct<struct "std::suspend_always" padded {!u8i}>
+// CHECK-DAG: ![[IntTask:.*]] = !cir.record<struct "folly::coro::Task<int>" padded {!u8i}>
+// CHECK-DAG: ![[VoidTask:.*]] = !cir.record<struct "folly::coro::Task<void>" padded {!u8i}>
+// CHECK-DAG: ![[VoidPromisse:.*]] = !cir.record<struct "folly::coro::Task<void>::promise_type" padded {!u8i}>
+// CHECK-DAG: ![[CoroHandleVoid:.*]] = !cir.record<struct "std::coroutine_handle<void>" padded {!u8i}>
+// CHECK-DAG: ![[CoroHandlePromise:ty_.*]]  = !cir.record<struct "std::coroutine_handle<folly::coro::Task<void>::promise_type>" padded {!u8i}>
+// CHECK-DAG: ![[StdString:.*]] = !cir.record<struct "std::string" padded {!u8i}>
+// CHECK-DAG: ![[SuspendAlways:.*]] = !cir.record<struct "std::suspend_always" padded {!u8i}>
 
 // CHECK: module {{.*}} {
 // CHECK-NEXT: cir.global external @_ZN5folly4coro9co_invokeE = #cir.zero : !ty_folly3A3Acoro3A3Aco_invoke_fn

--- a/clang/test/CIR/CodeGen/ctor.cpp
+++ b/clang/test/CIR/CodeGen/ctor.cpp
@@ -11,7 +11,7 @@ void baz() {
   Struk s;
 }
 
-// CHECK: !ty_Struk = !cir.struct<struct "Struk" {!s32i}>
+// CHECK: !ty_Struk = !cir.record<struct "Struk" {!s32i}>
 
 // CHECK:   cir.func linkonce_odr @_ZN5StrukC2Ev(%arg0: !cir.ptr<!ty_Struk>
 // CHECK-NEXT:     %0 = cir.alloca !cir.ptr<!ty_Struk>, !cir.ptr<!cir.ptr<!ty_Struk>>, ["this", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -75,11 +75,11 @@ void C3::Layer::Initialize() {
   }
 }
 
-// CHECK-DAG: !ty_C23A3ALayer = !cir.struct<class "C2::Layer"
-// CHECK-DAG: !ty_C33A3ALayer = !cir.struct<struct "C3::Layer"
-// CHECK-DAG: !ty_A = !cir.struct<class "A"
-// CHECK-DAG: !ty_A2Ebase = !cir.struct<class "A.base"
-// CHECK-DAG: !ty_B = !cir.struct<class "B" {!ty_A2Ebase
+// CHECK-DAG: !ty_C23A3ALayer = !cir.record<class "C2::Layer"
+// CHECK-DAG: !ty_C33A3ALayer = !cir.record<struct "C3::Layer"
+// CHECK-DAG: !ty_A = !cir.record<class "A"
+// CHECK-DAG: !ty_A2Ebase = !cir.record<class "A.base"
+// CHECK-DAG: !ty_B = !cir.record<class "B" {!ty_A2Ebase
 
 // CHECK: cir.func @_ZN2C35Layer10InitializeEv
 

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -36,10 +36,10 @@ public:
 };
 
 // Class A
-// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
+// CHECK: ![[ClassA:ty_.*]] = !cir.record<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
 
 // Class B
-// CHECK: ![[ClassB:ty_.*]] = !cir.struct<class "B" {![[ClassA]]}>
+// CHECK: ![[ClassB:ty_.*]] = !cir.record<class "B" {![[ClassA]]}>
 
 // CHECK: cir.func @_Z4bluev()
 // CHECK:   %0 = cir.alloca !ty_PSEvent, !cir.ptr<!ty_PSEvent>, ["p", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/dynamic-cast-relative-layout.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast-relative-layout.cpp
@@ -5,7 +5,7 @@ struct Base {
   virtual ~Base();
 };
 
-// BEFORE: !ty_Base = !cir.struct<struct "Base"
+// BEFORE: !ty_Base = !cir.record<struct "Base"
 
 void *ptr_cast_to_complete(Base *ptr) {
   return dynamic_cast<void *>(ptr);

--- a/clang/test/CIR/CodeGen/dynamic-cast.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast.cpp
@@ -8,8 +8,8 @@ struct Base {
 struct Derived : Base {};
 
 // BEFORE: #dyn_cast_info__ZTI4Base__ZTI7Derived = #cir.dyn_cast_info<#cir.global_view<@_ZTI4Base> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI7Derived> : !cir.ptr<!u8i>, @__dynamic_cast, @__cxa_bad_cast, #cir.int<0> : !s64i>
-// BEFORE: !ty_Base = !cir.struct
-// BEFORE: !ty_Derived = !cir.struct
+// BEFORE: !ty_Base = !cir.record
+// BEFORE: !ty_Derived = !cir.record
 
 Derived *ptr_cast(Base *b) {
   return dynamic_cast<Derived *>(b);

--- a/clang/test/CIR/CodeGen/fun-ptr.c
+++ b/clang/test/CIR/CodeGen/fun-ptr.c
@@ -17,7 +17,7 @@ typedef struct A {
   fun_typ fun;
 } A;
 
-// CIR: !ty_A = !cir.struct<struct "A" {!cir.ptr<!cir.func<(!cir.ptr<!cir.struct<struct "A">>) -> !s32i>>} #cir.record.decl.ast>
+// CIR: !ty_A = !cir.record<struct "A" {!cir.ptr<!cir.func<(!cir.ptr<!cir.record<struct "A">>) -> !s32i>>} #cir.record.decl.ast>
 A a = {(fun_typ)0};
 
 int extract_a(Data* d) {

--- a/clang/test/CIR/CodeGen/global-new.cpp
+++ b/clang/test/CIR/CodeGen/global-new.cpp
@@ -12,7 +12,7 @@
 struct e { e(int); };
 e *g = new e(0);
 
-// CIR_BEFORE: ![[ty:.*]] = !cir.struct<struct "e" padded {!u8i}
+// CIR_BEFORE: ![[ty:.*]] = !cir.record<struct "e" padded {!u8i}
 
 // CIR_BEFORE: cir.global external @g = ctor : !cir.ptr<![[ty]]> {
 // CIR_BEFORE:     %[[GlobalAddr:.*]] = cir.get_global @g : !cir.ptr<!cir.ptr<![[ty]]>>

--- a/clang/test/CIR/CodeGen/globals-ref-globals.c
+++ b/clang/test/CIR/CodeGen/globals-ref-globals.c
@@ -20,17 +20,17 @@ static S g6[2] = {{2799, 9, 123}, {2799, 9, 123}};
 static int *g7[2] = {&g6[0].f2, &g6[1].f2};
 static int **g8 = &g7[1];
 
-// CHECK-DAG: !ty_anon_struct = !cir.struct<struct  {!u8i, !u8i, !u8i, !u8i, !s32i, !s32i}>
-// CHECK-DAG: !ty_anon_struct1 = !cir.struct<struct  {!s8i, !cir.array<!u8i x 3>, !s32i}>
-// CHECK-DAG: !ty_anon_struct2 = !cir.struct<struct  {!u8i, !u8i, !u8i, !u8i, !u8i, !u8i, !u8i, !u8i, !ty_S4_}>
-// CHECK-DAG: !ty_anon_struct3 = !cir.struct<struct  {!s16i, !cir.array<!u8i x 2>, !s32i, !s8i, !cir.array<!u8i x 3>}>
+// CHECK-DAG: !ty_anon_struct = !cir.record<struct  {!u8i, !u8i, !u8i, !u8i, !s32i, !s32i}>
+// CHECK-DAG: !ty_anon_struct1 = !cir.record<struct  {!s8i, !cir.array<!u8i x 3>, !s32i}>
+// CHECK-DAG: !ty_anon_struct2 = !cir.record<struct  {!u8i, !u8i, !u8i, !u8i, !u8i, !u8i, !u8i, !u8i, !ty_S4_}>
+// CHECK-DAG: !ty_anon_struct3 = !cir.record<struct  {!s16i, !cir.array<!u8i x 2>, !s32i, !s8i, !cir.array<!u8i x 3>}>
 
-// CHECK-DAG: g1 = #cir.const_struct<{#cir.int<239> : !u8i, #cir.int<10> : !u8i, #cir.int<0> : !u8i, #cir.zero : !u8i, #cir.int<9> : !s32i, #cir.int<123> : !s32i}> : !ty_anon_struct
+// CHECK-DAG: g1 = #cir.const_record<{#cir.int<239> : !u8i, #cir.int<10> : !u8i, #cir.int<0> : !u8i, #cir.zero : !u8i, #cir.int<9> : !s32i, #cir.int<123> : !s32i}> : !ty_anon_struct
 // CHECK-DAG: g2 = #cir.const_array<[#cir.global_view<@g1, [4]> : !cir.ptr<!ty_anon_struct>, #cir.global_view<@g1, [4]> : !cir.ptr<!ty_anon_struct>, #cir.global_view<@g1, [4]> : !cir.ptr<!ty_anon_struct>, #cir.global_view<@g1, [4]> : !cir.ptr<!ty_anon_struct>]> : !cir.array<!cir.ptr<!s32i> x 4>
 // CHECK-DAG: g3 = #cir.global_view<@g2, [1 : i32]> : !cir.ptr<!cir.ptr<!s32i>>
 // CHECK-DAG: g4 = #cir.global_view<@g3> : !cir.ptr<!cir.ptr<!cir.ptr<!s32i>>>
 // CHECK-DAG: g5 = #cir.global_view<@g4> : !cir.ptr<!cir.ptr<!cir.ptr<!cir.ptr<!s32i>>>>
-// CHECK-DAG: g6 = #cir.const_array<[#cir.const_struct<{#cir.int<239> : !u8i, #cir.int<10> : !u8i, #cir.int<0> : !u8i, #cir.zero : !u8i, #cir.int<9> : !s32i, #cir.int<123> : !s32i}> : !ty_anon_struct, #cir.const_struct<{#cir.int<239> : !u8i, #cir.int<10> : !u8i, #cir.int<0> : !u8i, #cir.zero : !u8i, #cir.int<9> : !s32i, #cir.int<123> : !s32i}> : !ty_anon_struct]> : !cir.array<!ty_anon_struct x 2> 
+// CHECK-DAG: g6 = #cir.const_array<[#cir.const_record<{#cir.int<239> : !u8i, #cir.int<10> : !u8i, #cir.int<0> : !u8i, #cir.zero : !u8i, #cir.int<9> : !s32i, #cir.int<123> : !s32i}> : !ty_anon_struct, #cir.const_record<{#cir.int<239> : !u8i, #cir.int<10> : !u8i, #cir.int<0> : !u8i, #cir.zero : !u8i, #cir.int<9> : !s32i, #cir.int<123> : !s32i}> : !ty_anon_struct]> : !cir.array<!ty_anon_struct x 2> 
 // CHECK-DAG: g7 = #cir.const_array<[#cir.global_view<@g6, [0, 5]> : !cir.ptr<!s32i>, #cir.global_view<@g6, [1, 5]> : !cir.ptr<!s32i>]> : !cir.array<!cir.ptr<!s32i> x 2> 
 // CHECK-DAG: g8 = #cir.global_view<@g7, [1 : i32]> : !cir.ptr<!cir.ptr<!s32i>> 
 
@@ -67,9 +67,9 @@ typedef struct {
 S2 g11 = {1, 42};
 int* g12 = &g11.f6;
 
-// CHECK-DAG: g9 = #cir.const_struct<{#cir.int<1> : !s8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>, #cir.int<42> : !s32i}> : !ty_anon_struct1 {alignment = 4 : i64}
+// CHECK-DAG: g9 = #cir.const_record<{#cir.int<1> : !s8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>, #cir.int<42> : !s32i}> : !ty_anon_struct1 {alignment = 4 : i64}
 // CHECK-DAG: g10 = #cir.global_view<@g9, [2 : i32]> : !cir.ptr<!s32i> {alignment = 8 : i64}
-// CHECK-DAG: g11 = #cir.const_struct<{#cir.int<1> : !s8i, #cir.int<42> : !s32i}> : !ty_S2_ {alignment = 1 : i64}
+// CHECK-DAG: g11 = #cir.const_record<{#cir.int<1> : !s8i, #cir.int<42> : !s32i}> : !ty_S2_ {alignment = 1 : i64}
 // CHECK-DAG: g12 = #cir.global_view<@g11, [1 : i32]> : !cir.ptr<!s32i> {alignment = 8 : i64} 
 
 // LLVM-DAG: @g9 = global { i8, [3 x i8], i32 } { i8 1, [3 x i8] zeroinitializer, i32 42 }, align 4
@@ -90,7 +90,7 @@ typedef struct {
 static S3 g13 = {-1L,0L,1L};
 static S3* g14[2][2] = {{0, &g13}, {&g13, &g13}};
 
-// CHECK-DAG: g13 = #cir.const_struct<{#cir.int<-1> : !s16i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>, #cir.int<0> : !s32i, #cir.int<1> : !s8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>}> : !ty_anon_struct3
+// CHECK-DAG: g13 = #cir.const_record<{#cir.int<-1> : !s16i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>, #cir.int<0> : !s32i, #cir.int<1> : !s8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>}> : !ty_anon_struct3
 // CHECK-DAG: g14 = #cir.const_array<[#cir.const_array<[#cir.ptr<null> : !cir.ptr<!ty_S3_>, #cir.global_view<@g13> : !cir.ptr<!ty_S3_>]> : !cir.array<!cir.ptr<!ty_S3_> x 2>, #cir.const_array<[#cir.global_view<@g13> : !cir.ptr<!ty_S3_>, #cir.global_view<@g13> : !cir.ptr<!ty_S3_>]> : !cir.array<!cir.ptr<!ty_S3_> x 2>]> : !cir.array<!cir.array<!cir.ptr<!ty_S3_> x 2> x 2>
 
 typedef struct {
@@ -109,7 +109,7 @@ static S5 g15 = {187,1,442,{123,321}};
 
 int* g16 = &g15.f3.f1;
 
-// CHECK-DAG: g15 = #cir.const_struct<{#cir.int<187> : !u8i, #cir.int<0> : !u8i, #cir.int<2> : !u8i, #cir.zero : !u8i, #cir.int<186> : !u8i, #cir.int<1> : !u8i, #cir.int<0> : !u8i, #cir.zero : !u8i, #cir.const_struct<{#cir.int<123> : !s32i, #cir.int<321> : !s32i}> : !ty_S4_}> : !ty_anon_struct2 {alignment = 4 : i64}
+// CHECK-DAG: g15 = #cir.const_record<{#cir.int<187> : !u8i, #cir.int<0> : !u8i, #cir.int<2> : !u8i, #cir.zero : !u8i, #cir.int<186> : !u8i, #cir.int<1> : !u8i, #cir.int<0> : !u8i, #cir.zero : !u8i, #cir.const_record<{#cir.int<123> : !s32i, #cir.int<321> : !s32i}> : !ty_S4_}> : !ty_anon_struct2 {alignment = 4 : i64}
 // CHECK-DAG: g16 = #cir.global_view<@g15, [8, 1]> : !cir.ptr<!ty_anon_struct2> {alignment = 8 : i64}
 
 // LLVM-DAG: @g15 = internal global { i8, i8, i8, i8, i8, i8, i8, i8, %struct.S4 } { i8 -69, i8 0, i8 2, i8 0, i8 -70, i8 1, i8 0, i8 0, %struct.S4 { i32 123, i32 321 } }, align 4

--- a/clang/test/CIR/CodeGen/globals.c
+++ b/clang/test/CIR/CodeGen/globals.c
@@ -36,19 +36,19 @@ struct {
   int x;
   int y[2][2];
 } nestedTwoDim = {1, {{2, 3}, {4, 5}}};
-// CHECK: cir.global external @nestedTwoDim = #cir.const_struct<{#cir.int<1> : !s32i, #cir.const_array<[#cir.const_array<[#cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>}>
+// CHECK: cir.global external @nestedTwoDim = #cir.const_record<{#cir.int<1> : !s32i, #cir.const_array<[#cir.const_array<[#cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>}>
 
 struct {
   char x[3];
   char y[3];
   char z[3];
 } nestedString = {"1", "", "\0"};
-// CHECK: cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1" : !cir.array<!s8i x 1>, trailing_zeros> : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>}>
+// CHECK: cir.global external @nestedString = #cir.const_record<{#cir.const_array<"1" : !cir.array<!s8i x 1>, trailing_zeros> : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>, #cir.zero : !cir.array<!s8i x 3>}>
 
 struct {
   char *name;
 } nestedStringPtr = {"1"};
-// CHECK: cir.global external @nestedStringPtr = #cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>}>
+// CHECK: cir.global external @nestedStringPtr = #cir.const_record<{#cir.global_view<@".str"> : !cir.ptr<!s8i>}>
 
 int *globalPtr = &nestedString.y[1];
 // CHECK: cir.global external @globalPtr = #cir.global_view<@nestedString, [1 : i32, 1 : i32]> : !cir.ptr<!s32i>
@@ -57,25 +57,25 @@ const int i = 12;
 int i2 = i;
 struct { int i; } i3 = {i};
 // CHECK: cir.global external @i2 = #cir.int<12> : !s32i
-// CHECK: cir.global external @i3 = #cir.const_struct<{#cir.int<12> : !s32i}> : !ty_anon2E3
+// CHECK: cir.global external @i3 = #cir.const_record<{#cir.int<12> : !s32i}> : !ty_anon2E3
 
 int a[10][10][10];
 int *a2 = &a[3][0][8];
 struct { int *p; } a3 = {&a[3][0][8]};
 // CHECK: cir.global external @a2 = #cir.global_view<@a, [3 : i32, 0 : i32, 8 : i32]> : !cir.ptr<!s32i>
-// CHECK: cir.global external @a3 = #cir.const_struct<{#cir.global_view<@a, [3 : i32, 0 : i32, 8 : i32]> : !cir.ptr<!s32i>}> : !ty_anon2E4
+// CHECK: cir.global external @a3 = #cir.const_record<{#cir.global_view<@a, [3 : i32, 0 : i32, 8 : i32]> : !cir.ptr<!s32i>}> : !ty_anon2E4
 
 int p[10];
 int *p1 = &p[0];
 struct { int *x; } p2 = {&p[0]};
 // CHECK: cir.global external @p1 = #cir.global_view<@p> : !cir.ptr<!s32i>
-// CHECK: cir.global external @p2 = #cir.const_struct<{#cir.global_view<@p> : !cir.ptr<!s32i>}> : !ty_anon2E5
+// CHECK: cir.global external @p2 = #cir.const_record<{#cir.global_view<@p> : !cir.ptr<!s32i>}> : !ty_anon2E5
 
 int q[10];
 int *q1 = q;
 struct { int *x; } q2 = {q};
 // CHECK: cir.global external @q1 = #cir.global_view<@q> : !cir.ptr<!s32i>
-// CHECK: cir.global external @q2 = #cir.const_struct<{#cir.global_view<@q> : !cir.ptr<!s32i>}> : !ty_anon2E6
+// CHECK: cir.global external @q2 = #cir.const_record<{#cir.global_view<@q> : !cir.ptr<!s32i>}> : !ty_anon2E6
 
 int foo() {
     extern int optind;

--- a/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
+++ b/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
@@ -15,7 +15,7 @@ void test() {
 }
 } // namespace std
 
-// CIR: [[INITLIST_TYPE:!.*]] = !cir.struct<class "std::initializer_list<const char *>" {!cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>}>
+// CIR: [[INITLIST_TYPE:!.*]] = !cir.record<class "std::initializer_list<const char *>" {!cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>}>
 // CIR: cir.func linkonce_odr @_ZSt1fIPKcEvSt16initializer_listIT_E(%arg0: [[INITLIST_TYPE]]
 // CIR: [[LOCAL:%.*]] = cir.alloca [[INITLIST_TYPE]], !cir.ptr<[[INITLIST_TYPE]]>,
 // CIR: cir.store %arg0, [[LOCAL]] : [[INITLIST_TYPE]], !cir.ptr<[[INITLIST_TYPE]]>

--- a/clang/test/CIR/CodeGen/initlist-ptr-unsigned.cpp
+++ b/clang/test/CIR/CodeGen/initlist-ptr-unsigned.cpp
@@ -15,7 +15,7 @@ void test() {
 }
 } // namespace std
 
-// CIR: [[INITLIST_TYPE:!.*]] = !cir.struct<class "std::initializer_list<int>" {!cir.ptr<!s32i>, !u64i}>
+// CIR: [[INITLIST_TYPE:!.*]] = !cir.record<class "std::initializer_list<int>" {!cir.ptr<!s32i>, !u64i}>
 
 // CIR: cir.func linkonce_odr @_ZSt1fIiEvSt16initializer_listIT_E(%arg0: [[INITLIST_TYPE]]
 // CIR: [[REG0:%.*]] = cir.alloca [[INITLIST_TYPE]], !cir.ptr<[[INITLIST_TYPE]]>,

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -9,10 +9,10 @@ void fn() {
   a();
 }
 
-//      CHECK-DAG: !ty_A = !cir.struct<struct "A" {!s32i}>
-//      CHECK: !ty_anon2E0 = !cir.struct<class "anon.0" padded {!u8i}>
-//      CHECK-DAG: !ty_anon2E7 = !cir.struct<class "anon.7" {!ty_A}>
-//      CHECK-DAG: !ty_anon2E8 = !cir.struct<class "anon.8" {!cir.ptr<!ty_A>}>
+//      CHECK-DAG: !ty_A = !cir.record<struct "A" {!s32i}>
+//      CHECK: !ty_anon2E0 = !cir.record<class "anon.0" padded {!u8i}>
+//      CHECK-DAG: !ty_anon2E7 = !cir.record<class "anon.7" {!ty_A}>
+//      CHECK-DAG: !ty_anon2E8 = !cir.record<class "anon.8" {!cir.ptr<!ty_A>}>
 //  CHECK-DAG: module
 
 //      CHECK: cir.func lambda internal private @_ZZ2fnvENK3$_0clEv{{.*}}) extra

--- a/clang/test/CIR/CodeGen/move.cpp
+++ b/clang/test/CIR/CodeGen/move.cpp
@@ -16,7 +16,7 @@ struct string {
 
 } // std namespace
 
-// CHECK: ![[StdString:ty_.*]] = !cir.struct<struct "std::string" padded {!u8i}>
+// CHECK: ![[StdString:ty_.*]] = !cir.record<struct "std::string" padded {!u8i}>
 
 std::string getstr();
 void emplace(std::string &&s);

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -30,14 +30,14 @@ int main() {
     return 0;
 }
 
-// CIR: ![[VTypeInfoA:ty_.*]] = !cir.struct<struct  {!cir.ptr<!u8i>, !cir.ptr<!u8i>}>
-// CIR: ![[VTypeInfoB:ty_.*]] = !cir.struct<struct  {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !u32i, !u32i, !cir.ptr<!u8i>, !s64i, !cir.ptr<!u8i>, !s64i}>
-// CIR: ![[VTableTypeMother:ty_.*]] = !cir.struct<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
-// CIR: ![[VTableTypeFather:ty_.*]] = !cir.struct<struct  {!cir.array<!cir.ptr<!u8i> x 3>}>
-// CIR: ![[VTableTypeChild:ty_.*]] = !cir.struct<struct  {!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 3>}>
-// CIR: !ty_Father = !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
-// CIR: !ty_Mother = !cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
-// CIR: !ty_Child = !cir.struct<class "Child" {!ty_Mother, !ty_Father} #cir.record.decl.ast>
+// CIR: ![[VTypeInfoA:ty_.*]] = !cir.record<struct  {!cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+// CIR: ![[VTypeInfoB:ty_.*]] = !cir.record<struct  {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !u32i, !u32i, !cir.ptr<!u8i>, !s64i, !cir.ptr<!u8i>, !s64i}>
+// CIR: ![[VTableTypeMother:ty_.*]] = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
+// CIR: ![[VTableTypeFather:ty_.*]] = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 3>}>
+// CIR: ![[VTableTypeChild:ty_.*]] = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 3>}>
+// CIR: !ty_Father = !cir.record<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
+// CIR: !ty_Mother = !cir.record<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
+// CIR: !ty_Child = !cir.record<class "Child" {!ty_Mother, !ty_Father} #cir.record.decl.ast>
 
 // CIR: cir.func linkonce_odr @_ZN6MotherC2Ev(%arg0: !cir.ptr<!ty_Mother>
 // CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV6Mother, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>

--- a/clang/test/CIR/CodeGen/new-null.cpp
+++ b/clang/test/CIR/CodeGen/new-null.cpp
@@ -39,7 +39,7 @@ void *operator new[](size_t, void*, bool) throw();
 
 namespace test15 {
   struct A { A(); ~A(); };
-  // CIR-DAG:   ![[TEST15A:.*]] = !cir.struct<struct "test15::A" padded {!u8i}
+  // CIR-DAG:   ![[TEST15A:.*]] = !cir.record<struct "test15::A" padded {!u8i}
 
   void test0a(void *p) {
     new (p) A();

--- a/clang/test/CIR/CodeGen/nrvo.cpp
+++ b/clang/test/CIR/CodeGen/nrvo.cpp
@@ -9,7 +9,7 @@ std::vector<const char*> test_nrvo() {
   return result;
 }
 
-// CHECK: ![[VEC:.*]] = !cir.struct<class "std::vector<const char *>" {!cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>}>
+// CHECK: ![[VEC:.*]] = !cir.record<class "std::vector<const char *>" {!cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!cir.ptr<!s8i>>}>
 
 // CHECK: cir.func @_Z9test_nrvov() -> ![[VEC]]
 // CHECK:   %0 = cir.alloca ![[VEC]], !cir.ptr<![[VEC]]>, ["__retval", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/packed-structs.c
+++ b/clang/test/CIR/CodeGen/packed-structs.c
@@ -22,16 +22,16 @@ typedef struct {
 } __attribute__((aligned(2))) C;
 
 
-// CIR: !ty_A = !cir.struct<struct "A" packed {!s32i, !s8i}>
-// CIR: !ty_C = !cir.struct<struct "C" packed padded {!s32i, !s8i, !u8i}>
-// CIR: !ty_D = !cir.struct<struct "D" packed padded {!s8i, !u8i, !s32i}
-// CIR: !ty_F = !cir.struct<struct "F" packed {!s64i, !s8i}
-// CIR: !ty_E = !cir.struct<struct "E" packed {!ty_D
-// CIR: !ty_G = !cir.struct<struct "G" {!ty_F
-// CIR: !ty_H = !cir.struct<struct "H" {!s32i, !ty_anon2E0
-// CIR: !ty_B = !cir.struct<struct "B" packed {!s32i, !s8i, !cir.array<!ty_A x 6>}>
-// CIR: !ty_I = !cir.struct<struct "I" packed {!s8i, !ty_H
-// CIR: !ty_J = !cir.struct<struct "J" packed {!s8i, !s8i, !s8i, !s8i, !ty_I
+// CIR: !ty_A = !cir.record<struct "A" packed {!s32i, !s8i}>
+// CIR: !ty_C = !cir.record<struct "C" packed padded {!s32i, !s8i, !u8i}>
+// CIR: !ty_D = !cir.record<struct "D" packed padded {!s8i, !u8i, !s32i}
+// CIR: !ty_F = !cir.record<struct "F" packed {!s64i, !s8i}
+// CIR: !ty_E = !cir.record<struct "E" packed {!ty_D
+// CIR: !ty_G = !cir.record<struct "G" {!ty_F
+// CIR: !ty_H = !cir.record<struct "H" {!s32i, !ty_anon2E0
+// CIR: !ty_B = !cir.record<struct "B" packed {!s32i, !s8i, !cir.array<!ty_A x 6>}>
+// CIR: !ty_I = !cir.record<struct "I" packed {!s8i, !ty_H
+// CIR: !ty_J = !cir.record<struct "J" packed {!s8i, !s8i, !s8i, !s8i, !ty_I
 
 // LLVM: %struct.A = type <{ i32, i8 }>
 // LLVM: %struct.B = type <{ i32, i8, [6 x %struct.A] }>

--- a/clang/test/CIR/CodeGen/paren-list-init.cpp
+++ b/clang/test/CIR/CodeGen/paren-list-init.cpp
@@ -13,11 +13,11 @@ struct S1 {
   Vec v;
 };
 
-// CIR-DAG: ![[VecType:.*]] = !cir.struct<struct "Vec" padded {!u8i}>
-// CIR-DAG: ![[S1:.*]] = !cir.struct<struct "S1" {![[VecType]]}>
+// CIR-DAG: ![[VecType:.*]] = !cir.record<struct "Vec" padded {!u8i}>
+// CIR-DAG: ![[S1:.*]] = !cir.record<struct "S1" {![[VecType]]}>
 
-// CIR_EH-DAG: ![[VecType:.*]] = !cir.struct<struct "Vec" padded {!u8i}>
-// CIR_EH-DAG: ![[S1:.*]] = !cir.struct<struct "S1" {![[VecType]]}>
+// CIR_EH-DAG: ![[VecType:.*]] = !cir.record<struct "Vec" padded {!u8i}>
+// CIR_EH-DAG: ![[S1:.*]] = !cir.record<struct "S1" {![[VecType]]}>
 
 template <int I>
 void make1() {

--- a/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
@@ -6,10 +6,10 @@ struct Point {
   int y;
   int z;
 };
-// CHECK-DAG: !ty_Point = !cir.struct<struct "Point" {!s32i, !s32i, !s32i}
+// CHECK-DAG: !ty_Point = !cir.record<struct "Point" {!s32i, !s32i, !s32i}
 
 struct Incomplete;
-// CHECK-DAG: !ty_Incomplete = !cir.struct<struct "Incomplete" incomplete>
+// CHECK-DAG: !ty_Incomplete = !cir.record<struct "Incomplete" incomplete>
 
 int Point::*pt_member = &Point::x;
 // CHECK: cir.global external @pt_member = #cir.data_member<0> : !cir.data_member<!s32i in !ty_Point>

--- a/clang/test/CIR/CodeGen/rangefor.cpp
+++ b/clang/test/CIR/CodeGen/rangefor.cpp
@@ -21,9 +21,9 @@ void init(unsigned numImages) {
   }
 }
 
-// CHECK-DAG: !ty_triple = !cir.struct<struct "triple" {!u32i, !cir.ptr<!void>, !u32i}>
-// CHECK-DAG: ![[VEC:.*]] = !cir.struct<class "std::vector<triple>" {!cir.ptr<!ty_triple>, !cir.ptr<!ty_triple>, !cir.ptr<!ty_triple>}>
-// CHECK-DAG: ![[VEC_IT:.*]] = !cir.struct<struct "__vector_iterator<triple, triple *, triple &>" {!cir.ptr<!ty_triple>}>
+// CHECK-DAG: !ty_triple = !cir.record<struct "triple" {!u32i, !cir.ptr<!void>, !u32i}>
+// CHECK-DAG: ![[VEC:.*]] = !cir.record<class "std::vector<triple>" {!cir.ptr<!ty_triple>, !cir.ptr<!ty_triple>, !cir.ptr<!ty_triple>}>
+// CHECK-DAG: ![[VEC_IT:.*]] = !cir.record<struct "__vector_iterator<triple, triple *, triple &>" {!cir.ptr<!ty_triple>}>
 
 // CHECK: cir.func @_Z4initj(%arg0: !u32i
 // CHECK:   %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["numImages", init] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/std-array.cpp
+++ b/clang/test/CIR/CodeGen/std-array.cpp
@@ -8,7 +8,7 @@ void t() {
   (void)v.end();
 }
 
-// CHECK: ![[array:.*]] = !cir.struct<struct "std::array<unsigned char, 9U>"
+// CHECK: ![[array:.*]] = !cir.record<struct "std::array<unsigned char, 9U>"
 
 // CHECK: {{.*}} = cir.get_member
 // CHECK: {{.*}} = cir.cast(array_to_ptrdecay

--- a/clang/test/CIR/CodeGen/std-find.cpp
+++ b/clang/test/CIR/CodeGen/std-find.cpp
@@ -3,7 +3,7 @@
 
 #include "std-cxx.h"
 
-// CHECK: ![[array:.*]] = !cir.struct<struct "std::array<unsigned char, 9U>"
+// CHECK: ![[array:.*]] = !cir.record<struct "std::array<unsigned char, 9U>"
 
 int test_find(unsigned char n = 3)
 {

--- a/clang/test/CIR/CodeGen/stmtexpr-init.c
+++ b/clang/test/CIR/CodeGen/stmtexpr-init.c
@@ -3,8 +3,8 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// CIR: ![[annon_struct:.*]] = !cir.struct<struct  {!s32i, !cir.array<!s32i x 2>}>
-// CIR: ![[sized_array:.*]] = !cir.struct<struct "sized_array" {!s32i, !cir.array<!s32i x 0>}
+// CIR: ![[annon_struct:.*]] = !cir.record<struct  {!s32i, !cir.array<!s32i x 2>}>
+// CIR: ![[sized_array:.*]] = !cir.record<struct "sized_array" {!s32i, !cir.array<!s32i x 0>}
 
 void escape(const void *);
 
@@ -33,11 +33,11 @@ struct outer {
 };
 
 void T2(void) {
-  // CIR-DAG: cir.global "private" constant internal dsolocal @T2._a = #cir.const_struct<{#cir.int<2> : !s32i, #cir.const_array<[#cir.int<50> : !s32i, #cir.int<60> : !s32i]> : !cir.array<!s32i x 2>}>
+  // CIR-DAG: cir.global "private" constant internal dsolocal @T2._a = #cir.const_record<{#cir.int<2> : !s32i, #cir.const_array<[#cir.int<50> : !s32i, #cir.int<60> : !s32i]> : !cir.array<!s32i x 2>}>
   // LLVM-DAG: internal constant { i32, [2 x i32] } { i32 2, [2 x i32] [i32 50, i32 60] }
   const struct sized_array *A = ARRAY_PTR(50, 60);
 
-  // CIR-DAG: cir.global "private" constant internal dsolocal @T2._a.1 = #cir.const_struct<{#cir.int<3> : !s32i, #cir.const_array<[#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.int<30> : !s32i]> : !cir.array<!s32i x 3>}>
+  // CIR-DAG: cir.global "private" constant internal dsolocal @T2._a.1 = #cir.const_record<{#cir.int<3> : !s32i, #cir.const_array<[#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.int<30> : !s32i]> : !cir.array<!s32i x 3>}>
   // LLVM-DAG: internal constant { i32, [3 x i32] } { i32 3, [3 x i32] [i32 10, i32 20, i32 30] }
   struct outer X = {ARRAY_PTR(10, 20, 30)};
 

--- a/clang/test/CIR/CodeGen/string-literals.c
+++ b/clang/test/CIR/CodeGen/string-literals.c
@@ -10,7 +10,7 @@ struct {
 } literals = {"1", "", "\00"};
 
 // CIR-LABEL: @literals
-// CIR:  #cir.const_struct<{
+// CIR:  #cir.const_record<{
 // CIR:     #cir.const_array<"1" : !cir.array<!s8i x 1>, trailing_zeros> : !cir.array<!s8i x 10>,
 // CIR:     #cir.zero : !cir.array<!s8i x 10>,
 // CIR:     #cir.zero : !cir.array<!s8i x 10>

--- a/clang/test/CIR/CodeGen/struct-empty.c
+++ b/clang/test/CIR/CodeGen/struct-empty.c
@@ -3,8 +3,8 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
-// CIR: ![[lock:.*]] = !cir.struct<struct "rwlock_t" {}>
-// CIR: ![[fs_struct:.*]] = !cir.struct<struct "fs_struct" {![[lock]], !s32i}
+// CIR: ![[lock:.*]] = !cir.record<struct "rwlock_t" {}>
+// CIR: ![[fs_struct:.*]] = !cir.record<struct "fs_struct" {![[lock]], !s32i}
 
 typedef struct { } rwlock_t;
 struct fs_struct { rwlock_t lock; int umask; };

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -22,11 +22,11 @@ void baz(void) {
   struct Foo f;
 }
 
-// CHECK-DAG: !ty_Node = !cir.struct<struct "Node" {!cir.ptr<!cir.struct<struct "Node">>} #cir.record.decl.ast>
-// CHECK-DAG: !ty_Bar = !cir.struct<struct "Bar" {!s32i, !s8i}>
-// CHECK-DAG: !ty_Foo = !cir.struct<struct "Foo" {!s32i, !s8i, !ty_Bar}>
-// CHECK-DAG: !ty_SLocal = !cir.struct<struct "SLocal" {!s32i}>
-// CHECK-DAG: !ty_SLocal2E0 = !cir.struct<struct "SLocal.0" {!cir.float}>
+// CHECK-DAG: !ty_Node = !cir.record<struct "Node" {!cir.ptr<!cir.record<struct "Node">>} #cir.record.decl.ast>
+// CHECK-DAG: !ty_Bar = !cir.record<struct "Bar" {!s32i, !s8i}>
+// CHECK-DAG: !ty_Foo = !cir.record<struct "Foo" {!s32i, !s8i, !ty_Bar}>
+// CHECK-DAG: !ty_SLocal = !cir.record<struct "SLocal" {!s32i}>
+// CHECK-DAG: !ty_SLocal2E0 = !cir.record<struct "SLocal.0" {!cir.float}>
 //  CHECK-DAG: module {{.*}} {
      // CHECK:   cir.func @baz()
 // CHECK-NEXT:     %0 = cir.alloca !ty_Bar, !cir.ptr<!ty_Bar>, ["b"] {alignment = 4 : i64}
@@ -39,9 +39,9 @@ void shouldConstInitStructs(void) {
   struct Foo f = {1, 2, {3, 4}};
   // CHECK: %[[#V0:]] = cir.alloca !ty_Foo, !cir.ptr<!ty_Foo>, ["f"] {alignment = 4 : i64}
   // CHECK: %[[#V1:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_Foo>), !cir.ptr<!ty_anon_struct1>
-  // CHECK: %[[#V2:]] = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s8i,
+  // CHECK: %[[#V2:]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s8i,
   // CHECK-SAME:        #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>,
-  // CHECK-SAME:        #cir.const_struct<{#cir.int<3> : !s32i, #cir.int<4> : !s8i,
+  // CHECK-SAME:        #cir.const_record<{#cir.int<3> : !s32i, #cir.int<4> : !s8i,
   // CHECK-SAME:        #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>}>
   // CHECK-SAME:        : !ty_anon_struct}> : !ty_anon_struct1
   // CHECK: cir.store %[[#V2]], %[[#V1]] : !ty_anon_struct1, !cir.ptr<!ty_anon_struct1>
@@ -59,7 +59,7 @@ struct S1 {
   float f;
   int *p;
 } s1 = {1, .1, 0};
-// CHECK-DAG: cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, #cir.fp<1.000000e-01> : !cir.float, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_S1
+// CHECK-DAG: cir.global external @s1 = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<1.000000e-01> : !cir.float, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_S1
 
 // Should initialize global nested structs.
 struct S2 {
@@ -67,13 +67,13 @@ struct S2 {
     int a;
   } s2a;
 } s2 = {{1}};
-// CHECK-DAG: cir.global external @s2 = #cir.const_struct<{#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S2A}> : !ty_S2
+// CHECK-DAG: cir.global external @s2 = #cir.const_record<{#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S2A}> : !ty_S2
 
 // Should initialize global arrays of structs.
 struct S3 {
   int a;
 } s3[3] = {{1}, {2}, {3}};
-// CHECK-DAG: cir.global external @s3 = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S3, #cir.const_struct<{#cir.int<2> : !s32i}> : !ty_S3, #cir.const_struct<{#cir.int<3> : !s32i}> : !ty_S3]> : !cir.array<!ty_S3 x 3>
+// CHECK-DAG: cir.global external @s3 = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S3, #cir.const_record<{#cir.int<2> : !s32i}> : !ty_S3, #cir.const_record<{#cir.int<3> : !s32i}> : !ty_S3]> : !cir.array<!ty_S3 x 3>
 
 void shouldCopyStructAsCallArg(struct S1 s) {
 // CHECK-DAG: cir.func @shouldCopyStructAsCallArg

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -26,13 +26,13 @@ void baz() {
 struct incomplete;
 void yoyo(incomplete *i) {}
 
-//  CHECK-DAG: !ty_incomplete = !cir.struct<struct "incomplete" incomplete
-//  CHECK-DAG: !ty_Bar = !cir.struct<struct "Bar" {!s32i, !s8i}>
+//  CHECK-DAG: !ty_incomplete = !cir.record<struct "incomplete" incomplete
+//  CHECK-DAG: !ty_Bar = !cir.record<struct "Bar" {!s32i, !s8i}>
 
-//  CHECK-DAG: !ty_Foo = !cir.struct<struct "Foo" {!s32i, !s8i, !ty_Bar}>
-//  CHECK-DAG: !ty_Mandalore = !cir.struct<struct "Mandalore" {!u32i, !cir.ptr<!void>, !s32i} #cir.record.decl.ast>
-//  CHECK-DAG: !ty_Adv = !cir.struct<class "Adv" {!ty_Mandalore}>
-//  CHECK-DAG: !ty_Entry = !cir.struct<struct "Entry" {!cir.ptr<!cir.func<(!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>) -> !u32i>>}>
+//  CHECK-DAG: !ty_Foo = !cir.record<struct "Foo" {!s32i, !s8i, !ty_Bar}>
+//  CHECK-DAG: !ty_Mandalore = !cir.record<struct "Mandalore" {!u32i, !cir.ptr<!void>, !s32i} #cir.record.decl.ast>
+//  CHECK-DAG: !ty_Adv = !cir.record<class "Adv" {!ty_Mandalore}>
+//  CHECK-DAG: !ty_Entry = !cir.record<struct "Entry" {!cir.ptr<!cir.func<(!s32i, !cir.ptr<!s8i>, !cir.ptr<!void>) -> !u32i>>}>
 
 //      CHECK: cir.func linkonce_odr @_ZN3Bar6methodEv(%arg0: !cir.ptr<!ty_Bar>
 // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!ty_Bar>, !cir.ptr<!cir.ptr<!ty_Bar>>, ["this", init] {alignment = 8 : i64}
@@ -117,11 +117,11 @@ struct A {
 
 // Should globally const-initialize struct members.
 struct A simpleConstInit = {1};
-// CHECK: cir.global external @simpleConstInit = #cir.const_struct<{#cir.int<1> : !s32i}> : !ty_A
+// CHECK: cir.global external @simpleConstInit = #cir.const_record<{#cir.int<1> : !s32i}> : !ty_A
 
 // Should globally const-initialize arrays with struct members.
 struct A arrConstInit[1] = {{1}};
-// CHECK: cir.global external @arrConstInit = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_A]> : !cir.array<!ty_A x 1>
+// CHECK: cir.global external @arrConstInit = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s32i}> : !ty_A]> : !cir.array<!ty_A x 1>
 
 // Should globally const-initialize empty structs with a non-trivial constexpr
 // constructor (as undef, to match existing clang CodeGen behavior).

--- a/clang/test/CIR/CodeGen/three-way-comparison.cpp
+++ b/clang/test/CIR/CodeGen/three-way-comparison.cpp
@@ -7,8 +7,8 @@
 
 // BEFORE: #cmp3way_info_partial_ltn1eq0gt1unn127 = #cir.cmp3way_info<partial, lt = -1, eq = 0, gt = 1, unordered = -127>
 // BEFORE: #cmp3way_info_strong_ltn1eq0gt1 = #cir.cmp3way_info<strong, lt = -1, eq = 0, gt = 1>
-// BEFORE: !ty_std3A3A__13A3Apartial_ordering = !cir.struct<class "std::__1::partial_ordering" {!s8i}
-// BEFORE: !ty_std3A3A__13A3Astrong_ordering = !cir.struct<class "std::__1::strong_ordering" {!s8i}
+// BEFORE: !ty_std3A3A__13A3Apartial_ordering = !cir.record<class "std::__1::partial_ordering" {!s8i}
+// BEFORE: !ty_std3A3A__13A3Astrong_ordering = !cir.record<class "std::__1::strong_ordering" {!s8i}
 
 auto three_way_strong(int x, int y) {
   return x <=> y;

--- a/clang/test/CIR/CodeGen/try-catch-dtors.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-dtors.cpp
@@ -20,11 +20,11 @@ void yo() {
   }
 }
 
-// CIR-DAG: ![[VecTy:.*]] = !cir.struct<struct "Vec" padded {!u8i}>
-// CIR-DAG: ![[S1:.*]] = !cir.struct<struct "S1" {![[VecTy]]}>
+// CIR-DAG: ![[VecTy:.*]] = !cir.record<struct "Vec" padded {!u8i}>
+// CIR-DAG: ![[S1:.*]] = !cir.record<struct "S1" {![[VecTy]]}>
 
-// CIR_FLAT-DAG: ![[VecTy:.*]] = !cir.struct<struct "Vec" padded {!u8i}>
-// CIR_FLAT-DAG: ![[S1:.*]] = !cir.struct<struct "S1" {![[VecTy]]}>
+// CIR_FLAT-DAG: ![[VecTy:.*]] = !cir.record<struct "Vec" padded {!u8i}>
+// CIR_FLAT-DAG: ![[S1:.*]] = !cir.record<struct "S1" {![[VecTy]]}>
 
 // CIR: cir.scope {
 // CIR:   %[[VADDR:.*]] = cir.alloca ![[VecTy]], !cir.ptr<![[VecTy]]>, ["v", init]

--- a/clang/test/CIR/CodeGen/union-array.c
+++ b/clang/test/CIR/CodeGen/union-array.c
@@ -18,5 +18,5 @@ typedef union {
 
 void foo() { U arr[2] = {{.b = {1, 2}}, {.a = {1}}}; }
 
-// CIR: cir.const #cir.const_struct<{#cir.const_struct<{#cir.const_struct<{#cir.int<1> : !s64i, #cir.int<2> : !s64i}> : {{.*}}}> : {{.*}}, #cir.const_struct<{#cir.const_struct<{#cir.int<1> : !s8i}> : {{.*}}, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 15>}>
+// CIR: cir.const #cir.const_record<{#cir.const_record<{#cir.const_record<{#cir.int<1> : !s64i, #cir.int<2> : !s64i}> : {{.*}}}> : {{.*}}, #cir.const_record<{#cir.const_record<{#cir.int<1> : !s8i}> : {{.*}}, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 15>}>
 // LLVM: store { { %struct.S_2 }, { %struct.S_1, [15 x i8] } } { { %struct.S_2 } { %struct.S_2 { i64 1, i64 2 } }, { %struct.S_1, [15 x i8] } { %struct.S_1 { i8 1 }, [15 x i8] zeroinitializer } }

--- a/clang/test/CIR/CodeGen/union-init.c
+++ b/clang/test/CIR/CodeGen/union-init.c
@@ -12,11 +12,11 @@ void foo(int x) {
   A a = {.x = x};
 }
 
-// CHECK-DAG: ![[anon0:.*]] = !cir.struct<struct  {!u32i}>
-// CHECK-DAG: ![[anon:.*]] = !cir.struct<struct  {!s32i}>
+// CHECK-DAG: ![[anon0:.*]] = !cir.record<struct  {!u32i}>
+// CHECK-DAG: ![[anon:.*]] = !cir.record<struct  {!s32i}>
 // CHECK-DAG: #[[bfi_x:.*]] = #cir.bitfield_info<name = "x", storage_type = !u32i, size = 16, offset = 0, is_signed = true>
 // CHECK-DAG: #[[bfi_y:.*]] = #cir.bitfield_info<name = "y", storage_type = !u32i, size = 16, offset = 16, is_signed = true>
-// CHECK-DAG: ![[anon1:.*]] = !cir.struct<union "{{.*}}" {!u32i, !cir.array<!u8i x 4>}
+// CHECK-DAG: ![[anon1:.*]] = !cir.record<union "{{.*}}" {!u32i, !cir.array<!u8i x 4>}
 
 // CHECK-LABEL:   cir.func @foo(
 // CHECK:  %[[VAL_1:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/union-padding.c
+++ b/clang/test/CIR/CodeGen/union-padding.c
@@ -15,17 +15,17 @@ short use() {
   U u;
   return **g3;
 }
-// CHECK:       !ty_U = !cir.struct<union "U" padded {!s16i, !u16i, !u8i, !u8i, !cir.array<!u8i x 2>}>
-// CHECK:       !ty_anon_struct = !cir.struct<struct  {!s16i, !cir.array<!u8i x 2>}>
+// CHECK:       !ty_U = !cir.record<union "U" padded {!s16i, !u16i, !u8i, !u8i, !cir.array<!u8i x 2>}>
+// CHECK:       !ty_anon_struct = !cir.record<struct  {!s16i, !cir.array<!u8i x 2>}>
 
 // CHECK:       @g3 = #cir.global_view<@g2> : !cir.ptr<!cir.ptr<!s16i>>
 // CHECK:       @g2 = #cir.const_array<[#cir.global_view<@g1, [1]> : !cir.ptr<!s16i>]> : !cir.array<!cir.ptr<!s16i> x 1>
 
 // CHECK:       @g1 = 
 // CHECK-SAME:    #cir.const_array<[
-// CHECK-SAME:      #cir.const_struct<{#cir.int<-2> : !s16i, 
+// CHECK-SAME:      #cir.const_record<{#cir.int<-2> : !s16i, 
 // CHECK-SAME:      #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>}> : !ty_anon_struct, 
-// CHECK-SAME:      #cir.const_struct<{#cir.int<-2> : !s16i,
+// CHECK-SAME:      #cir.const_record<{#cir.int<-2> : !s16i,
 // CHECK-SAME:      #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>}> : !ty_anon_struct
 // CHECK-SAME:    ]> : !cir.array<!ty_anon_struct x 2>
 

--- a/clang/test/CIR/CodeGen/union.cpp
+++ b/clang/test/CIR/CodeGen/union.cpp
@@ -6,15 +6,15 @@ typedef union { yolo y; struct { int lifecnt; }; } yolm;
 typedef union { yolo y; struct { int *lifecnt; int genpad; }; } yolm2;
 typedef union { yolo y; struct { bool life; int genpad; }; } yolm3;
 
-// CHECK-DAG: !ty_U23A3ADummy = !cir.struct<struct "U2::Dummy" {!s16i, !cir.float} #cir.record.decl.ast>
-// CHECK-DAG: !ty_anon2E0 = !cir.struct<struct "anon.0" {!s32i} #cir.record.decl.ast>
-// CHECK-DAG: !ty_anon2E2 = !cir.struct<struct "anon.2" {!cir.bool, !s32i} #cir.record.decl.ast>
-// CHECK-DAG: !ty_yolo = !cir.struct<struct "yolo" {!s32i} #cir.record.decl.ast>
-// CHECK-DAG: !ty_anon2E1 = !cir.struct<struct "anon.1" {!cir.ptr<!s32i>, !s32i} #cir.record.decl.ast>
+// CHECK-DAG: !ty_U23A3ADummy = !cir.record<struct "U2::Dummy" {!s16i, !cir.float} #cir.record.decl.ast>
+// CHECK-DAG: !ty_anon2E0 = !cir.record<struct "anon.0" {!s32i} #cir.record.decl.ast>
+// CHECK-DAG: !ty_anon2E2 = !cir.record<struct "anon.2" {!cir.bool, !s32i} #cir.record.decl.ast>
+// CHECK-DAG: !ty_yolo = !cir.record<struct "yolo" {!s32i} #cir.record.decl.ast>
+// CHECK-DAG: !ty_anon2E1 = !cir.record<struct "anon.1" {!cir.ptr<!s32i>, !s32i} #cir.record.decl.ast>
 
-// CHECK-DAG: !ty_yolm = !cir.struct<union "yolm" {!ty_yolo, !ty_anon2E0}>
-// CHECK-DAG: !ty_yolm3 = !cir.struct<union "yolm3" {!ty_yolo, !ty_anon2E2}>
-// CHECK-DAG: !ty_yolm2 = !cir.struct<union "yolm2" {!ty_yolo, !ty_anon2E1}>
+// CHECK-DAG: !ty_yolm = !cir.record<union "yolm" {!ty_yolo, !ty_anon2E0}>
+// CHECK-DAG: !ty_yolm3 = !cir.record<union "yolm3" {!ty_yolo, !ty_anon2E2}>
+// CHECK-DAG: !ty_yolm2 = !cir.record<union "yolm2" {!ty_yolo, !ty_anon2E1}>
 
 // Should generate a union type with all members preserved.
 union U {
@@ -24,7 +24,7 @@ union U {
   float f;
   double d;
 };
-// CHECK-DAG: !ty_U = !cir.struct<union "U" {!cir.bool, !s16i, !s32i, !cir.float, !cir.double}>
+// CHECK-DAG: !ty_U = !cir.record<union "U" {!cir.bool, !s16i, !s32i, !cir.float, !cir.double}>
 
 // Should generate unions with complex members.
 union U2 {
@@ -34,14 +34,14 @@ union U2 {
     float f;
   } s;
 } u2;
-// CHECK-DAG: !cir.struct<union "U2" {!cir.bool, !ty_U23A3ADummy} #cir.record.decl.ast>
+// CHECK-DAG: !cir.record<union "U2" {!cir.bool, !ty_U23A3ADummy} #cir.record.decl.ast>
 
 // Should genereate unions without padding.
 union U3 {
   short b;
   U u;
 } u3;
-// CHECK-DAG: !ty_U3 = !cir.struct<union "U3" {!s16i, !ty_U} #cir.record.decl.ast>
+// CHECK-DAG: !ty_U3 = !cir.record<union "U3" {!s16i, !ty_U} #cir.record.decl.ast>
 
 void m() {
   yolm q;

--- a/clang/test/CIR/CodeGen/var-arg-float.c
+++ b/clang/test/CIR/CodeGen/var-arg-float.c
@@ -13,7 +13,7 @@ double f1(int n, ...) {
   return res;
 }
 
-// BEFORE: !ty___va_list = !cir.struct<struct "__va_list" {!cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>, !s32i, !s32i}
+// BEFORE: !ty___va_list = !cir.record<struct "__va_list" {!cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>, !s32i, !s32i}
 // BEFORE:  cir.func @f1(%arg0: !s32i, ...) -> !cir.double
 // BEFORE:  [[RETP:%.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["__retval"]
 // BEFORE:  [[RESP:%.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["res", init]
@@ -27,7 +27,7 @@ double f1(int n, ...) {
 // BEFORE:   cir.return [[RETV]] : !cir.double
 
 // beginning block cir code
-// AFTER: !ty___va_list = !cir.struct<struct "__va_list" {!cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>, !s32i, !s32i}
+// AFTER: !ty___va_list = !cir.record<struct "__va_list" {!cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>, !s32i, !s32i}
 // AFTER:  cir.func @f1(%arg0: !s32i, ...) -> !cir.double
 // AFTER:  [[RETP:%.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["__retval"]
 // AFTER:  [[RESP:%.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["res", init]

--- a/clang/test/CIR/CodeGen/var-arg.c
+++ b/clang/test/CIR/CodeGen/var-arg.c
@@ -13,7 +13,7 @@ int f1(int n, ...) {
   return res;
 }
 
-// BEFORE: !ty___va_list = !cir.struct<struct "__va_list" {!cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>, !s32i, !s32i}
+// BEFORE: !ty___va_list = !cir.record<struct "__va_list" {!cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>, !s32i, !s32i}
 // BEFORE:  cir.func @f1(%arg0: !s32i, ...) -> !s32i
 // BEFORE:  [[RETP:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
 // BEFORE:  [[RESP:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["res", init]
@@ -26,7 +26,7 @@ int f1(int n, ...) {
 // BEFORE:  [[RETV:%.*]] = cir.load [[RETP]] : !cir.ptr<!s32i>, !s32i
 // BEFORE:   cir.return [[RETV]] : !s32i
 
-// AFTER: !ty___va_list = !cir.struct<struct "__va_list" {!cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>, !s32i, !s32i}
+// AFTER: !ty___va_list = !cir.record<struct "__va_list" {!cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>, !s32i, !s32i}
 // AFTER:  cir.func @f1(%arg0: !s32i, ...) -> !s32i
 // AFTER:  [[RETP:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
 // AFTER:  [[RESP:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["res", init]

--- a/clang/test/CIR/CodeGen/variadics.c
+++ b/clang/test/CIR/CodeGen/variadics.c
@@ -8,7 +8,7 @@ typedef __builtin_va_list va_list;
 #define va_arg(ap, type)    __builtin_va_arg(ap, type)
 #define va_copy(dst, src)   __builtin_va_copy(dst, src)
 
-// CHECK: [[VALISTTYPE:!.+va_list.*]] = !cir.struct<struct "{{.*}}__va_list
+// CHECK: [[VALISTTYPE:!.+va_list.*]] = !cir.record<struct "{{.*}}__va_list
 
 int average(int count, ...) {
 // CHECK: cir.func @{{.*}}average{{.*}}(%arg0: !s32i, ...) -> !s32i

--- a/clang/test/CIR/CodeGen/vtable-emission.cpp
+++ b/clang/test/CIR/CodeGen/vtable-emission.cpp
@@ -12,15 +12,15 @@ struct S {
 
 void S::key() {}
 
-// CHECK-DAG: !ty_anon_struct1 = !cir.struct<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
-// CHECK-DAG: !ty_anon_struct2 = !cir.struct<struct  {!cir.ptr<!ty_anon_struct1>}>
+// CHECK-DAG: !ty_anon_struct1 = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
+// CHECK-DAG: !ty_anon_struct2 = !cir.record<struct  {!cir.ptr<!ty_anon_struct1>}>
 
 // The definition of the key function should result in the vtable being emitted.
 // CHECK: cir.global external @_ZTV1S = #cir.vtable
 // LLVM: @_ZTV1S = global { [4 x ptr] } { [4 x ptr]
 // LLVM-SAME: [ptr null, ptr @_ZTI1S, ptr @_ZN1S3keyEv, ptr @_ZN1S6nonKeyEv] }, align 8
 
-// CHECK: cir.global external @sobj = #cir.const_struct
+// CHECK: cir.global external @sobj = #cir.const_record
 // CHECK-SAME: <{#cir.global_view<@_ZTV1S, [0 : i32, 2 : i32]> :
 // CHECK-SAME: !cir.ptr<!ty_anon_struct1>}> : !ty_anon_struct2 {alignment = 8 : i64}
 // LLVM: @sobj = global { ptr } { ptr getelementptr inbounds

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -20,19 +20,19 @@ public:
 };
 
 // Type info B.
-// CHECK: ![[TypeInfoB:ty_.*]] = !cir.struct<struct {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+// CHECK: ![[TypeInfoB:ty_.*]] = !cir.record<struct {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
 
 // vtable for A type
-// CHECK: ![[VTableTypeA:ty_.*]] = !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
-// RTTI_DISABLED: ![[VTableTypeA:ty_.*]] = !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
+// CHECK: ![[VTableTypeA:ty_.*]] = !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
+// RTTI_DISABLED: ![[VTableTypeA:ty_.*]] = !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
 
 // Class A
-// CHECK: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
-// RTTI_DISABLED: ![[ClassA:ty_.*]] = !cir.struct<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
+// CHECK: ![[ClassA:ty_.*]] = !cir.record<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
+// RTTI_DISABLED: ![[ClassA:ty_.*]] = !cir.record<class "A" {!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>} #cir.record.decl.ast>
 
 // Class B
-// CHECK: ![[ClassB:ty_.*]] = !cir.struct<class "B" {![[ClassA]]}>
-// RTTI_DISABLED: ![[ClassB:ty_.*]] = !cir.struct<class "B" {![[ClassA]]}>
+// CHECK: ![[ClassB:ty_.*]] = !cir.record<class "B" {![[ClassA]]}>
+// RTTI_DISABLED: ![[ClassB:ty_.*]] = !cir.record<class "B" {![[ClassA]]}>
 
 // B ctor => @B::B()
 // Calls @A::A() and initialize __vptr with address of B's vtable.

--- a/clang/test/CIR/IR/aliases.cir
+++ b/clang/test/CIR/IR/aliases.cir
@@ -5,11 +5,11 @@ module {
   // CHECK: @testAnonRecordsAlias
   cir.func @testAnonRecordsAlias() {
     // CHECK: cir.alloca !ty_anon_struct, !cir.ptr<!ty_anon_struct>
-    %0 = cir.alloca !cir.struct<struct {!cir.int<s, 32>}>, !cir.ptr<!cir.struct<struct {!cir.int<s, 32>}>>, ["A"]
+    %0 = cir.alloca !cir.record<struct {!cir.int<s, 32>}>, !cir.ptr<!cir.record<struct {!cir.int<s, 32>}>>, ["A"]
     // CHECK: cir.alloca !ty_anon_struct1, !cir.ptr<!ty_anon_struct1>
-    %1 = cir.alloca !cir.struct<struct {!cir.int<u, 8>}>, !cir.ptr<!cir.struct<struct {!cir.int<u, 8>}>>, ["B"]
+    %1 = cir.alloca !cir.record<struct {!cir.int<u, 8>}>, !cir.ptr<!cir.record<struct {!cir.int<u, 8>}>>, ["B"]
     // CHECK: cir.alloca !ty_anon_union, !cir.ptr<!ty_anon_union>
-    %2 = cir.alloca !cir.struct<union {!cir.int<s, 32>}>, !cir.ptr<!cir.struct<union {!cir.int<s, 32>}>>, ["C"]
+    %2 = cir.alloca !cir.record<union {!cir.int<s, 32>}>, !cir.ptr<!cir.record<union {!cir.int<s, 32>}>>, ["C"]
     cir.return
   }
 }

--- a/clang/test/CIR/IR/data-member-ptr.cir
+++ b/clang/test/CIR/IR/data-member-ptr.cir
@@ -1,7 +1,7 @@
 // RUN: cir-opt %s | cir-opt | FileCheck %s
 
 !s32i = !cir.int<s, 32>
-!ty_Foo = !cir.struct<struct "Foo" {!s32i}>
+!ty_Foo = !cir.record<struct "Foo" {!s32i}>
 
 module {
   cir.func @null_member() {

--- a/clang/test/CIR/IR/getmember.cir
+++ b/clang/test/CIR/IR/getmember.cir
@@ -4,9 +4,9 @@
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
 
-!ty_Class = !cir.struct<class "Class" {!u16i, !u32i}>
-!ty_Incomplete = !cir.struct<struct "Incomplete" incomplete>
-!ty_Struct = !cir.struct<struct "Struct" {!u16i, !u32i}>
+!ty_Class = !cir.record<class "Class" {!u16i, !u32i}>
+!ty_Incomplete = !cir.record<struct "Incomplete" incomplete>
+!ty_Struct = !cir.record<struct "Struct" {!u16i, !u32i}>
 
 module  {
   cir.func @shouldGetStructMember(%arg0 : !cir.ptr<!ty_Struct>) {

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -3,12 +3,12 @@
 !s8i = !cir.int<s, 8>
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
-!ty_Init = !cir.struct<class "Init" {!s8i} #cir.record.decl.ast>
+!ty_Init = !cir.record<class "Init" {!s8i} #cir.record.decl.ast>
 module {
   cir.global external @a = #cir.int<3> : !s32i
   cir.global external @rgb = #cir.const_array<[#cir.int<0> : !s8i, #cir.int<-23> : !s8i, #cir.int<33> : !s8i] : !cir.array<!s8i x 3>>
   cir.global external @b = #cir.const_array<"example\00" : !cir.array<!s8i x 8>>
-  cir.global external @rgb2 = #cir.const_struct<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.ptr<null> : !cir.ptr<!s8i>}> : !cir.struct<struct {!s8i, !s64i, !cir.ptr<!s8i>}>
+  cir.global external @rgb2 = #cir.const_record<{#cir.int<0> : !s8i, #cir.int<5> : !s64i, #cir.ptr<null> : !cir.ptr<!s8i>}> : !cir.record<struct {!s8i, !s64i, !cir.ptr<!s8i>}>
   cir.global "private" constant internal @".str" : !cir.array<!s8i x 8> {alignment = 1 : i64}
   cir.global "private" internal @c : !s32i
   cir.global "private" constant internal @".str.2" = #cir.const_array<"example\00" : !cir.array<!s8i x 8>> : !cir.array<!s8i x 8> {alignment = 1 : i64}
@@ -31,7 +31,7 @@ module {
     #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!s8i>,
     #cir.global_view<@type_info_name_B> : !cir.ptr<!s8i>,
     #cir.global_view<@type_info_A> : !cir.ptr<!s8i>}>
-  : !cir.struct<struct {!cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>}>
+  : !cir.record<struct {!cir.ptr<!s8i>, !cir.ptr<!s8i>, !cir.ptr<!s8i>}>
   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_Init>, !s8i)
   cir.func private @_ZN4InitD1Ev(!cir.ptr<!ty_Init>)
   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_Init {

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -382,7 +382,7 @@ module {
 
 !u32i = !cir.int<u, 32>
 module {
-  cir.global external @v = #cir.zero : !u32i // expected-error {{zero expects struct or array type}}
+  cir.global external @v = #cir.zero : !u32i // expected-error {{zero expects record or array type}}
 }
 
 // -----
@@ -579,7 +579,7 @@ module {
   // expected-error@+1 {{element at index 0 has type '!cir.ptr<!cir.int<u, 8>>' but return type for this element is '!cir.ptr<!cir.int<u, 32>>'}}
   cir.global external @type_info_B = #cir.typeinfo<{
     #cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2]> : !cir.ptr<!u8i>}>
-    : !cir.struct<struct {!cir.ptr<!u32i>}>
+    : !cir.record<struct {!cir.ptr<!u32i>}>
 }
 
 // -----
@@ -755,7 +755,7 @@ module {
 
 // -----
 !s8i = !cir.int<s, 8>
-!ty_Init = !cir.struct<class "Init" {!s8i} #cir.record.decl.ast>
+!ty_Init = !cir.record<class "Init" {!s8i} #cir.record.decl.ast>
 module {
   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_Init {
   }
@@ -765,7 +765,7 @@ module {
 // -----
 !s8i = !cir.int<s, 8>
 #true = #cir.bool<true> : !cir.bool
-!ty_Init = !cir.struct<class "Init" {!s8i} #cir.record.decl.ast>
+!ty_Init = !cir.record<class "Init" {!s8i} #cir.record.decl.ast>
 module {
   cir.func private @_ZN4InitC1Eb(!cir.ptr<!ty_Init>)
   cir.global "private" internal @_ZL8__ioinit = ctor : !ty_Init {
@@ -794,7 +794,7 @@ module {
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct = !cir.struct<struct "Struct" {!u16i, !u32i}>
+!struct = !cir.record<struct "Struct" {!u16i, !u32i}>
 module {
   cir.func @memeber_index_out_of_bounds(%arg0 : !cir.ptr<!struct>) {
     // expected-error@+1 {{member index out of bounds}}
@@ -807,7 +807,7 @@ module {
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct = !cir.struct<struct "Struct" {!u16i, !u32i}>
+!struct = !cir.record<struct "Struct" {!u16i, !u32i}>
 module {
   cir.func @memeber_type_mismatch(%arg0 : !cir.ptr<!struct>) {
     // expected-error@+1 {{member type mismatch}}
@@ -819,24 +819,24 @@ module {
 // -----
 
 !u16i = !cir.int<u, 16>
-// expected-error@+1 {{anonymous structs must be complete}}
-!struct = !cir.struct<struct incomplete>
+// expected-error@+1 {{anonymous records must be complete}}
+!struct = !cir.record<struct incomplete>
 
 // -----
 
 !u16i = !cir.int<u, 16>
-// expected-error@+1 {{identified structs cannot have an empty name}}
-!struct = !cir.struct<struct "" incomplete>
+// expected-error@+1 {{identified records cannot have an empty name}}
+!struct = !cir.record<struct "" incomplete>
 
 // -----
 
 // expected-error@+1 {{invalid self-reference within record}}
-!struct = !cir.struct<struct {!cir.struct<struct "SelfReference">}>
+!struct = !cir.record<struct {!cir.record<struct "SelfReference">}>
 
 // -----
 
 // expected-error@+1 {{record already defined}}
-!struct = !cir.struct<struct "SelfReference" {!cir.struct<struct "SelfReference" {}>}>
+!struct = !cir.record<struct "SelfReference" {!cir.record<struct "SelfReference" {}>}>
 
 // -----
 !s32i = !cir.int<s, 32>
@@ -880,7 +880,7 @@ module {
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
+!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
 
 // expected-error@+1 {{member type of a #cir.data_member attribute must match the attribute type}}
 #invalid_member_ty = #cir.data_member<0> : !cir.data_member<!u32i in !struct1>
@@ -889,12 +889,12 @@ module {
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
+!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
 
 module {
   cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {
     %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["tmp"] {alignment = 4 : i64}
-    // expected-error@+1 {{'cir.get_runtime_member' op operand #0 must be !cir.struct*}}
+    // expected-error@+1 {{'cir.get_runtime_member' op operand #0 must be !cir.record*}}
     %1 = cir.get_runtime_member %0[%arg0 : !cir.data_member<!u32i in !struct1>] : !cir.ptr<!u32i> -> !cir.ptr<!u32i>
     cir.return
   }
@@ -904,8 +904,8 @@ module {
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
-!struct2 = !cir.struct<struct "Struct2" {!u16i, !u32i}>
+!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
+!struct2 = !cir.record<struct "Struct2" {!u16i, !u32i}>
 
 module {
   cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {
@@ -920,7 +920,7 @@ module {
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.struct<struct "Struct1" {!u16i, !u32i}>
+!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
 
 module {
   cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {
@@ -934,9 +934,9 @@ module {
 // -----
 
 !u16i = !cir.int<u, 16>
-!incomplete_struct = !cir.struct<struct "Incomplete" incomplete>
+!incomplete_struct = !cir.record<struct "Incomplete" incomplete>
 
-// expected-error@+1 {{incomplete 'cir.struct' cannot be used to build a non-null data member pointer}}
+// expected-error@+1 {{incomplete 'cir.record' cannot be used to build a non-null data member pointer}}
 #incomplete_cls_member = #cir.data_member<0> : !cir.data_member<!u16i in !incomplete_struct>
 
 
@@ -1176,8 +1176,8 @@ cir.func @bad_long_double(%arg0 : !cir.long_double<!cir.float>) -> () {
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!Base = !cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
-!Derived = !cir.struct<struct "Derived" {!cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
+!Base = !cir.record<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
+!Derived = !cir.record<struct "Derived" {!cir.record<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
 
 module {
   cir.global "private" constant external @_ZTI4Base : !cir.ptr<!u32i>
@@ -1198,8 +1198,8 @@ module {
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!Base = !cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
-!Derived = !cir.struct<struct "Derived" {!cir.struct<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
+!Base = !cir.record<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
+!Derived = !cir.record<struct "Derived" {!cir.record<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
 
 module {
   cir.global "private" constant external @_ZTI4Base : !cir.ptr<!u8i>

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -6,16 +6,16 @@
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-!ty_2222 = !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
-!ty_22221 = !cir.struct<struct {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
-!ty_A = !cir.struct<class "A" incomplete #cir.record.decl.ast>
-!ty_i = !cir.struct<union "i" incomplete>
-!ty_S = !cir.struct<struct "S" {!u8i, !u16i, !u32i}>
-!ty_S1 = !cir.struct<struct "S1" {!s32i, !s32i}>
+!ty_2222 = !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
+!ty_22221 = !cir.record<struct {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+!ty_A = !cir.record<class "A" incomplete #cir.record.decl.ast>
+!ty_i = !cir.record<union "i" incomplete>
+!ty_S = !cir.record<struct "S" {!u8i, !u16i, !u32i}>
+!ty_S1 = !cir.record<struct "S1" {!s32i, !s32i}>
 
 // Test recursive struct parsing/printing.
-!ty_Node = !cir.struct<struct "Node" {!cir.ptr<!cir.struct<struct "Node">>} #cir.record.decl.ast>
-// CHECK-DAG: !cir.struct<struct "Node" {!cir.ptr<!cir.struct<struct "Node">>} #cir.record.decl.ast>
+!ty_Node = !cir.record<struct "Node" {!cir.ptr<!cir.record<struct "Node">>} #cir.record.decl.ast>
+// CHECK-DAG: !cir.record<struct "Node" {!cir.ptr<!cir.record<struct "Node">>} #cir.record.decl.ast>
 
 module  {
   // Dummy function to use types and force them to be printed.
@@ -24,8 +24,8 @@ module  {
   }
 
   cir.func @structs() {
-    %0 = cir.alloca !cir.ptr<!cir.struct<struct "S" {!u8i, !u16i, !u32i}>>, !cir.ptr<!cir.ptr<!cir.struct<struct "S" {!u8i, !u16i, !u32i}>>>, ["s", init]
-    %1 = cir.alloca !cir.ptr<!cir.struct<union "i" incomplete>>, !cir.ptr<!cir.ptr<!cir.struct<union "i" incomplete>>>, ["i", init]
+    %0 = cir.alloca !cir.ptr<!cir.record<struct "S" {!u8i, !u16i, !u32i}>>, !cir.ptr<!cir.ptr<!cir.record<struct "S" {!u8i, !u16i, !u32i}>>>, ["s", init]
+    %1 = cir.alloca !cir.ptr<!cir.record<union "i" incomplete>>, !cir.ptr<!cir.ptr<!cir.record<union "i" incomplete>>>, ["i", init]
     cir.return
   }
 
@@ -34,8 +34,8 @@ module  {
 // CHECK:     %1 = cir.alloca !cir.ptr<!ty_i>, !cir.ptr<!cir.ptr<!ty_i>>, ["i", init]
 
   cir.func @shouldSuccessfullyParseConstStructAttrs() {
-    %0 = cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !ty_S1
-    // CHECK: cir.const #cir.const_struct<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !ty_S1
+    %0 = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !ty_S1
+    // CHECK: cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !ty_S1
     cir.return
   }
 }

--- a/clang/test/CIR/IR/vtableAttr.cir
+++ b/clang/test/CIR/IR/vtableAttr.cir
@@ -3,6 +3,6 @@
 !u8i = !cir.int<u, 8>
 module {
     // Should parse VTable attribute.
-    cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
+    cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
     // CHECK: cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !ty_anon_struct
 }

--- a/clang/test/CIR/Lowering/ThroughMLIR/vtable.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/vtable.cir
@@ -8,14 +8,14 @@
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!ty_anon_struct = !cir.struct<struct  {!cir.ptr<!cir.int<u, 8>>, !cir.ptr<!cir.int<u, 8>>}>
-!ty_anon_struct1 = !cir.struct<struct  {!cir.ptr<!cir.int<u, 8>>, !cir.ptr<!cir.int<u, 8>>, !cir.int<u, 32>, !cir.int<u, 32>, !cir.ptr<!cir.int<u, 8>>, !cir.int<s, 64>, !cir.ptr<!cir.int<u, 8>>, !cir.int<s, 64>}>
-!ty_anon_struct2 = !cir.struct<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 4>}>
-!ty_anon_struct3 = !cir.struct<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 3>}>
-!ty_anon_struct4 = !cir.struct<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 4>, !cir.array<!cir.ptr<!cir.int<u, 8>> x 3>}>
-!ty_Father = !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>
-!ty_Mother = !cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>
-!ty_Child = !cir.struct<class "Child" {!cir.struct<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>, !cir.struct<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>} #cir.record.decl.ast>
+!ty_anon_struct = !cir.record<struct  {!cir.ptr<!cir.int<u, 8>>, !cir.ptr<!cir.int<u, 8>>}>
+!ty_anon_struct1 = !cir.record<struct  {!cir.ptr<!cir.int<u, 8>>, !cir.ptr<!cir.int<u, 8>>, !cir.int<u, 32>, !cir.int<u, 32>, !cir.ptr<!cir.int<u, 8>>, !cir.int<s, 64>, !cir.ptr<!cir.int<u, 8>>, !cir.int<s, 64>}>
+!ty_anon_struct2 = !cir.record<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 4>}>
+!ty_anon_struct3 = !cir.record<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 3>}>
+!ty_anon_struct4 = !cir.record<struct  {!cir.array<!cir.ptr<!cir.int<u, 8>> x 4>, !cir.array<!cir.ptr<!cir.int<u, 8>> x 3>}>
+!ty_Father = !cir.record<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>
+!ty_Mother = !cir.record<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>
+!ty_Child = !cir.record<class "Child" {!cir.record<class "Mother" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>, !cir.record<class "Father" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>} #cir.record.decl.ast>} #cir.record.decl.ast>
 
 module {
   cir.func linkonce_odr @_ZN6Mother6simpleEv(%arg0: !cir.ptr<!ty_Mother>) { 

--- a/clang/test/CIR/Lowering/array.cir
+++ b/clang/test/CIR/Lowering/array.cir
@@ -2,7 +2,7 @@
 // RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering -o -  | FileCheck %s -check-prefix=LLVM
 
 !s32i = !cir.int<s, 32>
-!ty_S = !cir.struct<struct "S" {!s32i} #cir.record.decl.ast>
+!ty_S = !cir.record<struct "S" {!s32i} #cir.record.decl.ast>
 
 module {
   cir.func @foo() {
@@ -21,7 +21,7 @@ module {
 //      LLVM: %1 = alloca [10 x i32], i64 1, align 16
 // LLVM-NEXT: ret void
 
-  cir.global external @arr = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S, #cir.zero : !ty_S]> : !cir.array<!ty_S x 2>
+  cir.global external @arr = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S, #cir.zero : !ty_S]> : !cir.array<!ty_S x 2>
   // CHECK: llvm.mlir.global external @arr() {addr_space = 0 : i32} : !llvm.array<2 x struct<"struct.S", (i32)>> {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.array<2 x struct<"struct.S", (i32)>>
   // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"struct.S", (i32)>

--- a/clang/test/CIR/Lowering/attribute-lowering.cir
+++ b/clang/test/CIR/Lowering/attribute-lowering.cir
@@ -8,7 +8,7 @@ module {
   cir.global "private" internal @const_array = #cir.const_array<[#cir.int<1> : !s32i]> : !cir.array<!s32i x 1> {section = ".abc"}
   // LLVM: @const_array = internal global [1 x i32] [i32 1], section ".abc"
 
-  cir.global "private" internal @const_struct = #cir.const_struct<{#cir.int<1> : !s32i}> : !cir.struct<struct {!s32i}> {section = ".abc"}
+  cir.global "private" internal @const_struct = #cir.const_record<{#cir.int<1> : !s32i}> : !cir.record<struct {!s32i}> {section = ".abc"}
   // LLVM: @const_struct = internal global { i32 } { i32 1 }, section ".abc"
 
   cir.func @func_zeroext(%arg0: !u8i {cir.zeroext}) -> (!u8i {cir.zeroext}) {

--- a/clang/test/CIR/Lowering/class.cir
+++ b/clang/test/CIR/Lowering/class.cir
@@ -4,11 +4,11 @@
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
-!ty_S = !cir.struct<class "S" {!u8i, !s32i}>
-!ty_S2A = !cir.struct<class "S2A" {!s32i} #cir.record.decl.ast>
-!ty_S1_ = !cir.struct<class "S1" {!s32i, !cir.float, !cir.ptr<!s32i>} #cir.record.decl.ast>
-!ty_S2_ = !cir.struct<class "S2" {!ty_S2A} #cir.record.decl.ast>
-!ty_S3_ = !cir.struct<class "S3" {!s32i} #cir.record.decl.ast>
+!ty_S = !cir.record<class "S" {!u8i, !s32i}>
+!ty_S2A = !cir.record<class "S2A" {!s32i} #cir.record.decl.ast>
+!ty_S1_ = !cir.record<class "S1" {!s32i, !cir.float, !cir.ptr<!s32i>} #cir.record.decl.ast>
+!ty_S2_ = !cir.record<class "S2" {!ty_S2A} #cir.record.decl.ast>
+!ty_S3_ = !cir.record<class "S3" {!s32i} #cir.record.decl.ast>
 
 module {
   cir.func @test() {
@@ -24,7 +24,7 @@ module {
 
   cir.func @shouldConstInitLocalClassesWithConstStructAttr() {
     %0 = cir.alloca !ty_S2A, !cir.ptr<!ty_S2A>, ["s"] {alignment = 4 : i64}
-    %1 = cir.const #cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S2A
+    %1 = cir.const #cir.const_record<{#cir.int<1> : !s32i}> : !ty_S2A
     cir.store %1, %0 : !ty_S2A, !cir.ptr<!ty_S2A>
     cir.return
   }
@@ -38,8 +38,8 @@ module {
   // CHECK:   llvm.return
   // CHECK: }
 
-  // Should lower basic #cir.const_struct initializer.
-  cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, #cir.fp<1.000000e-01> : !cir.float, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_S1_
+  // Should lower basic #cir.const_record initializer.
+  cir.global external @s1 = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<1.000000e-01> : !cir.float, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_S1_
   // CHECK: llvm.mlir.global external @s1() {addr_space = 0 : i32} : !llvm.struct<"class.S1", (i32, f32, ptr)> {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"class.S1", (i32, f32, ptr)>
   // CHECK:   %1 = llvm.mlir.constant(1 : i32) : i32
@@ -51,8 +51,8 @@ module {
   // CHECK:   llvm.return %6 : !llvm.struct<"class.S1", (i32, f32, ptr)>
   // CHECK: }
 
-  // Should lower nested #cir.const_struct initializer.
-  cir.global external @s2 = #cir.const_struct<{#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S2A}> : !ty_S2_
+  // Should lower nested #cir.const_record initializer.
+  cir.global external @s2 = #cir.const_record<{#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S2A}> : !ty_S2_
   // CHECK: llvm.mlir.global external @s2() {addr_space = 0 : i32} : !llvm.struct<"class.S2", (struct<"class.S2A", (i32)>)> {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"class.S2", (struct<"class.S2A", (i32)>)>
   // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"class.S2A", (i32)>
@@ -62,7 +62,7 @@ module {
   // CHECK:   llvm.return %4 : !llvm.struct<"class.S2", (struct<"class.S2A", (i32)>)>
   // CHECK: }
 
-  cir.global external @s3 = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S3_, #cir.const_struct<{#cir.int<2> : !s32i}> : !ty_S3_, #cir.const_struct<{#cir.int<3> : !s32i}> : !ty_S3_]> : !cir.array<!ty_S3_ x 3>
+  cir.global external @s3 = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S3_, #cir.const_record<{#cir.int<2> : !s32i}> : !ty_S3_, #cir.const_record<{#cir.int<3> : !s32i}> : !ty_S3_]> : !cir.array<!ty_S3_ x 3>
   // CHECK: llvm.mlir.global external @s3() {addr_space = 0 : i32} : !llvm.array<3 x struct<"class.S3", (i32)>> {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.array<3 x struct<"class.S3", (i32)>>
   // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"class.S3", (i32)>

--- a/clang/test/CIR/Lowering/const.cir
+++ b/clang/test/CIR/Lowering/const.cir
@@ -4,7 +4,7 @@
 !s8i = !cir.int<s, 8>
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
-!ty_anon2E1_ = !cir.struct<struct "anon.1" {!cir.int<s, 32>, !cir.int<s, 32>} #cir.record.decl.ast>
+!ty_anon2E1_ = !cir.record<struct "anon.1" {!cir.int<s, 32>, !cir.int<s, 32>} #cir.record.decl.ast>
 module {
   cir.func @testConstArrInit() {
     %0 = cir.const #cir.const_array<"string\00" : !cir.array<!s8i x 7>> : !cir.array<!s8i x 7>
@@ -41,7 +41,7 @@ module {
 
   cir.func @testConstArrayOfStructs() {
     %0 = cir.alloca !cir.array<!ty_anon2E1_ x 1>, !cir.ptr<!cir.array<!ty_anon2E1_ x 1>>, ["a"] {alignment = 4 : i64}
-    %1 = cir.const #cir.const_array<[#cir.const_struct<{#cir.int<0> : !s32i, #cir.int<1> : !s32i}> : !ty_anon2E1_]> : !cir.array<!ty_anon2E1_ x 1>
+    %1 = cir.const #cir.const_array<[#cir.const_record<{#cir.int<0> : !s32i, #cir.int<1> : !s32i}> : !ty_anon2E1_]> : !cir.array<!ty_anon2E1_ x 1>
     cir.store %1, %0 : !cir.array<!ty_anon2E1_ x 1>, !cir.ptr<!cir.array<!ty_anon2E1_ x 1>>
     cir.return
   }

--- a/clang/test/CIR/Lowering/data-member.cir
+++ b/clang/test/CIR/Lowering/data-member.cir
@@ -3,7 +3,7 @@
 
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
-!structT = !cir.struct<struct "Point" {!cir.int<s, 32>, !cir.int<s, 32>, !cir.int<s, 32>}>
+!structT = !cir.record<struct "Point" {!cir.int<s, 32>, !cir.int<s, 32>, !cir.int<s, 32>}>
 
 module @test attributes {
   cir.triple = "x86_64-unknown-linux-gnu",

--- a/clang/test/CIR/Lowering/globals.cir
+++ b/clang/test/CIR/Lowering/globals.cir
@@ -11,11 +11,11 @@
 !u32i = !cir.int<u, 32>
 !u64i = !cir.int<u, 64>
 !u8i = !cir.int<u, 8>
-!ty_A = !cir.struct<struct "A" {!s32i, !cir.array<!cir.array<!s32i x 2> x 2>} #cir.record.decl.ast>
-!ty_Bar = !cir.struct<struct "Bar" {!s32i, !s8i} #cir.record.decl.ast>
-!ty_StringStruct = !cir.struct<struct "StringStruct" {!cir.array<!s8i x 3>, !cir.array<!s8i x 3>, !cir.array<!s8i x 3>} #cir.record.decl.ast>
-!ty_StringStructPtr = !cir.struct<struct "StringStructPtr" {!cir.ptr<!s8i>} #cir.record.decl.ast>
-!ty_anon2E1_ = !cir.struct<struct "anon.1" {!cir.ptr<!cir.func<(!cir.int<s, 32>)>>} #cir.record.decl.ast>
+!ty_A = !cir.record<struct "A" {!s32i, !cir.array<!cir.array<!s32i x 2> x 2>} #cir.record.decl.ast>
+!ty_Bar = !cir.record<struct "Bar" {!s32i, !s8i} #cir.record.decl.ast>
+!ty_StringStruct = !cir.record<struct "StringStruct" {!cir.array<!s8i x 3>, !cir.array<!s8i x 3>, !cir.array<!s8i x 3>} #cir.record.decl.ast>
+!ty_StringStructPtr = !cir.record<struct "StringStructPtr" {!cir.ptr<!s8i>} #cir.record.decl.ast>
+!ty_anon2E1_ = !cir.record<struct "anon.1" {!cir.ptr<!cir.func<(!cir.int<s, 32>)>>} #cir.record.decl.ast>
 
 module {
   cir.global external @a = #cir.int<3> : !s32i
@@ -98,11 +98,11 @@ module {
 
   // The following tests check direclty the resulting LLVM IR because the MLIR
   // version is two long. Always prefer the MLIR prefix when possible.
-  cir.global external @nestedTwoDim = #cir.const_struct<{#cir.int<1> : !s32i, #cir.const_array<[#cir.const_array<[#cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>}> : !ty_A
+  cir.global external @nestedTwoDim = #cir.const_record<{#cir.int<1> : !s32i, #cir.const_array<[#cir.const_array<[#cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 2>}> : !ty_A
   // LLVM: @nestedTwoDim = global %struct.A { i32 1, [2 x [2 x i32{{\]\] \[\[}}2 x i32] [i32 2, i32 3], [2 x i32] [i32 4, i32 5{{\]\]}} }
-  cir.global external @nestedString = #cir.const_struct<{#cir.const_array<"1\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>}> : !ty_StringStruct
+  cir.global external @nestedString = #cir.const_record<{#cir.const_array<"1\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>, #cir.const_array<"\00\00\00" : !cir.array<!s8i x 3>> : !cir.array<!s8i x 3>}> : !ty_StringStruct
   // LLVM: @nestedString = global %struct.StringStruct { [3 x i8] c"1\00\00", [3 x i8] zeroinitializer, [3 x i8] zeroinitializer }
-  cir.global external @nestedStringPtr = #cir.const_struct<{#cir.global_view<@".str"> : !cir.ptr<!s8i>}> : !ty_StringStructPtr
+  cir.global external @nestedStringPtr = #cir.const_record<{#cir.global_view<@".str"> : !cir.ptr<!s8i>}> : !ty_StringStructPtr
   // LLVM: @nestedStringPtr = global %struct.StringStructPtr { ptr @.str }
 
   cir.func @_Z11get_globalsv() {
@@ -164,7 +164,7 @@ module {
   // MLIR: }
   // LLVM: @undefStruct = global %struct.Bar undef
 
-  cir.global "private" internal @Handlers = #cir.const_array<[#cir.const_struct<{#cir.global_view<@myfun> : !cir.ptr<!cir.func<(!s32i)>>}> : !ty_anon2E1_]> : !cir.array<!ty_anon2E1_ x 1>
+  cir.global "private" internal @Handlers = #cir.const_array<[#cir.const_record<{#cir.global_view<@myfun> : !cir.ptr<!cir.func<(!s32i)>>}> : !ty_anon2E1_]> : !cir.array<!ty_anon2E1_ x 1>
   cir.func internal private @myfun(%arg0: !s32i) {
     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
     cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -4,13 +4,13 @@
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
-!ty_S = !cir.struct<struct "S" {!u8i, !s32i}>
-!ty_S2A = !cir.struct<struct "S2A" {!s32i} #cir.record.decl.ast>
-!ty_S1_ = !cir.struct<struct "S1" {!s32i, !cir.float, !cir.ptr<!s32i>} #cir.record.decl.ast>
-!ty_S2_ = !cir.struct<struct "S2" {!ty_S2A} #cir.record.decl.ast>
-!ty_S3_ = !cir.struct<struct "S3" {!s32i} #cir.record.decl.ast>
+!ty_S = !cir.record<struct "S" {!u8i, !s32i}>
+!ty_S2A = !cir.record<struct "S2A" {!s32i} #cir.record.decl.ast>
+!ty_S1_ = !cir.record<struct "S1" {!s32i, !cir.float, !cir.ptr<!s32i>} #cir.record.decl.ast>
+!ty_S2_ = !cir.record<struct "S2" {!ty_S2A} #cir.record.decl.ast>
+!ty_S3_ = !cir.record<struct "S3" {!s32i} #cir.record.decl.ast>
 
-!struct_with_bool = !cir.struct<struct "struct_with_bool" {!u32i, !cir.bool}>
+!struct_with_bool = !cir.record<struct "struct_with_bool" {!u32i, !cir.bool}>
 
 module {
   cir.func @test() {
@@ -26,7 +26,7 @@ module {
 
   // CHECK-LABEL: @test_value
   cir.func @test_value() {
-    %0 = cir.const #cir.const_struct<{#cir.int<1> : !u8i, #cir.int<2> : !s32i}> : !ty_S
+    %0 = cir.const #cir.const_record<{#cir.int<1> : !u8i, #cir.int<2> : !s32i}> : !ty_S
     //      CHECK: %[[#v0:]] = llvm.mlir.undef : !llvm.struct<"struct.S", (i8, i32)>
     // CHECK-NEXT: %[[#v1:]] = llvm.mlir.constant(1 : i8) : i8
     // CHECK-NEXT: %[[#v2:]] = llvm.insertvalue %[[#v1]], %[[#v0]][0] : !llvm.struct<"struct.S", (i8, i32)>
@@ -41,7 +41,7 @@ module {
 
   cir.func @shouldConstInitLocalStructsWithConstStructAttr() {
     %0 = cir.alloca !ty_S2A, !cir.ptr<!ty_S2A>, ["s"] {alignment = 4 : i64}
-    %1 = cir.const #cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S2A
+    %1 = cir.const #cir.const_record<{#cir.int<1> : !s32i}> : !ty_S2A
     cir.store %1, %0 : !ty_S2A, !cir.ptr<!ty_S2A>
     cir.return
   }
@@ -55,8 +55,8 @@ module {
   // CHECK:   llvm.return
   // CHECK: }
 
-  // Should lower basic #cir.const_struct initializer.
-  cir.global external @s1 = #cir.const_struct<{#cir.int<1> : !s32i, #cir.fp<1.000000e-01> : !cir.float, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_S1_
+  // Should lower basic #cir.const_record initializer.
+  cir.global external @s1 = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<1.000000e-01> : !cir.float, #cir.ptr<null> : !cir.ptr<!s32i>}> : !ty_S1_
   // CHECK: llvm.mlir.global external @s1() {addr_space = 0 : i32} : !llvm.struct<"struct.S1", (i32, f32, ptr)> {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"struct.S1", (i32, f32, ptr)>
   // CHECK:   %1 = llvm.mlir.constant(1 : i32) : i32
@@ -68,8 +68,8 @@ module {
   // CHECK:   llvm.return %6 : !llvm.struct<"struct.S1", (i32, f32, ptr)>
   // CHECK: }
 
-  // Should lower nested #cir.const_struct initializer.
-  cir.global external @s2 = #cir.const_struct<{#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S2A}> : !ty_S2_
+  // Should lower nested #cir.const_record initializer.
+  cir.global external @s2 = #cir.const_record<{#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S2A}> : !ty_S2_
   // CHECK: llvm.mlir.global external @s2() {addr_space = 0 : i32} : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)> {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)>
   // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"struct.S2A", (i32)>
@@ -79,7 +79,7 @@ module {
   // CHECK:   llvm.return %4 : !llvm.struct<"struct.S2", (struct<"struct.S2A", (i32)>)>
   // CHECK: }
 
-  cir.global external @s3 = #cir.const_array<[#cir.const_struct<{#cir.int<1> : !s32i}> : !ty_S3_, #cir.const_struct<{#cir.int<2> : !s32i}> : !ty_S3_, #cir.const_struct<{#cir.int<3> : !s32i}> : !ty_S3_]> : !cir.array<!ty_S3_ x 3>
+  cir.global external @s3 = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s32i}> : !ty_S3_, #cir.const_record<{#cir.int<2> : !s32i}> : !ty_S3_, #cir.const_record<{#cir.int<3> : !s32i}> : !ty_S3_]> : !cir.array<!ty_S3_ x 3>
   // CHECK: llvm.mlir.global external @s3() {addr_space = 0 : i32} : !llvm.array<3 x struct<"struct.S3", (i32)>> {
   // CHECK:   %0 = llvm.mlir.undef : !llvm.array<3 x struct<"struct.S3", (i32)>>
   // CHECK:   %1 = llvm.mlir.undef : !llvm.struct<"struct.S3", (i32)>
@@ -112,7 +112,7 @@ module {
   }
 
   // Verify that boolean fields are lowered to i8 and that the correct type is inserted during initialization.
-  cir.global external @struct_with_bool = #cir.const_struct<{#cir.int<1> : !u32i, #cir.bool<false> : !cir.bool}> : !struct_with_bool
+  cir.global external @struct_with_bool = #cir.const_record<{#cir.int<1> : !u32i, #cir.bool<false> : !cir.bool}> : !struct_with_bool
   // CHECK: llvm.mlir.global external @struct_with_bool() {addr_space = 0 : i32} : !llvm.struct<"struct.struct_with_bool", (i32, i8)> {
   // CHECK:  %[[FALSE:.+]] = llvm.mlir.constant(false) : i1
   // CHECK-NEXT:  %[[FALSE_MEM:.+]] = llvm.zext %[[FALSE]] : i1 to i8

--- a/clang/test/CIR/Lowering/types.cir
+++ b/clang/test/CIR/Lowering/types.cir
@@ -4,7 +4,7 @@
 !void = !cir.void
 !u8i = !cir.int<u, 8>
 module {
-  cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<-8> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.struct<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
+  cir.global external @testVTable = #cir.vtable<{#cir.const_array<[#cir.ptr<-8> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 1>}> : !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 1>}>
   // CHECK: llvm.mlir.constant(-8 : i64) : i64
   // CHECK:  llvm.inttoptr %{{[0-9]+}} : i64 to !llvm.ptr
   cir.func @testTypeLowering() {

--- a/clang/test/CIR/Lowering/unions.cir
+++ b/clang/test/CIR/Lowering/unions.cir
@@ -4,9 +4,9 @@
 !s16i = !cir.int<s, 16>
 !s32i = !cir.int<s, 32>
 #true = #cir.bool<true> : !cir.bool
-!ty_U1_ = !cir.struct<union "U1" {!cir.bool, !s16i, !s32i} #cir.record.decl.ast>
-!ty_U2_ = !cir.struct<union "U2" {f64, !ty_U1_} #cir.record.decl.ast>
-!ty_U3_ = !cir.struct<union "U3" {!s16i, !ty_U1_} #cir.record.decl.ast>
+!ty_U1_ = !cir.record<union "U1" {!cir.bool, !s16i, !s32i} #cir.record.decl.ast>
+!ty_U2_ = !cir.record<union "U2" {f64, !ty_U1_} #cir.record.decl.ast>
+!ty_U3_ = !cir.record<union "U3" {!s16i, !ty_U1_} #cir.record.decl.ast>
 module {
   // Should lower union to struct with only the largest member.
   cir.global external @u1 = #cir.zero : !ty_U1_

--- a/clang/test/CIR/Lowering/variadics.cir
+++ b/clang/test/CIR/Lowering/variadics.cir
@@ -5,7 +5,7 @@
 !u32i = !cir.int<u, 32>
 !u8i = !cir.int<u, 8>
 
-!ty___va_list_tag = !cir.struct<struct "__va_list_tag" {!u32i, !u32i, !cir.ptr<!u8i>, !cir.ptr<!u8i>} #cir.record.decl.ast>
+!ty___va_list_tag = !cir.record<struct "__va_list_tag" {!u32i, !u32i, !cir.ptr<!u8i>, !cir.ptr<!u8i>} #cir.record.decl.ast>
 
 module {
   cir.func @average(%arg0: !s32i, ...) -> !s32i {


### PR DESCRIPTION
During the initial upstreaming of `cir.struct` support, a request was made to rename `cir.struct` to `cir.record` for consistency with its multiple uses. This change makes the modification along with renaming various other related classes. I've attempted to also update variable names and comments to keep everything consistent.

This creates an unfortunate name collision between cir::RecordType and clang::RecordType, but the impact of that overlaps was relatively small.

The only intended behavioral change is in the names used in the emitted CIR files and diagnostics.