### PR TITLE
[CIR][CodeGen] Support for _mm_prefetch 

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5304,6 +5304,8 @@ def PrefetchOp : CIR_Op<"prefetch"> {
           IntMaxValue<3>]>:$locality,
         UnitAttr:$isWrite);
 
+  let results = (outs VoidPtr:$result);
+
   let assemblyFormat = [{
     `(` $addr `:` qualified(type($addr)) `)`
         `locality``(` $locality `)`

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -95,7 +95,21 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned BuiltinID,
   default:
     return nullptr;
   case X86::BI_mm_prefetch: {
-    llvm_unreachable("_mm_prefetch NYI");
+    mlir::Location loc = getLoc(E->getExprLoc());
+    auto C = dyn_cast<cir::IntAttr>(
+        cast<cir::ConstantOp>(Ops[1].getDefiningOp()).getValue());
+    auto Locality = mlir::IntegerAttr::get(
+        mlir::IntegerType::get(builder.getContext(), 32), C.getUInt() & 0x3);
+    bool ReadWrite = ((C.getUInt() >> 2) & 0x1) == 1;
+    mlir::UnitAttr isWrite =
+        ReadWrite ? mlir::UnitAttr::get(&getMLIRContext()) : nullptr;
+    mlir::Type voidPtrType =
+        cir::PointerType::get(cir::VoidType::get(&getMLIRContext()));
+    auto CastToVoid = builder.create<cir::CastOp>(
+        loc, voidPtrType, cir::CastKind::bitcast, Ops[0]);
+    auto res =
+        builder.create<cir::PrefetchOp>(loc, CastToVoid, Locality, isWrite);
+    return res->getResult(0);
   }
   case X86::BI_mm_clflush: {
     mlir::Type voidTy = cir::VoidType::get(&getMLIRContext());

--- a/clang/test/CIR/CodeGen/X86/builtins-x86.c
+++ b/clang/test/CIR/CodeGen/X86/builtins-x86.c
@@ -6,6 +6,14 @@
 // This test mimics clang/test/CodeGen/builtins-x86.c, which eventually
 // CIR shall be able to support fully.
 
+void test_mm_prefetch(char const* p) {
+  // CIR-LABEL: test_mm_prefetch
+  // LLVM-LABEL: test_mm_prefetch
+  _mm_prefetch(p,0);
+  //CIR: {{%.*}}= cir.prefetch({{%.*}} : !cir.ptr<!void>) locality(0) read
+  // LLVM: call void @llvm.prefetch.p0(ptr {{.*}}, i32 0, i32 0, i32 1)
+}
+
 void test_mm_clflush(const void* tmp_vCp) {
   // CIR-LABEL: test_mm_clflush
   // LLVM-LABEL: test_mm_clflush


### PR DESCRIPTION
After the new rebase had some difficulties to hard rebase locally , my apologies for that . 
this is how I think i can avoid the fall over to the `clflush` case in  `clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp ` .

The generated CIR is 
```
!s32i = !cir.int<s, 32>
!s8i = !cir.int<s, 8>
!void = !cir.void
#fn_attr = #cir<extra({inline = #cir.inline<no>, optnone = #cir.optnone, uwtable = #cir.uwtable<async>})>
module @"/home/shrikardongre/clangir/clang/test/CIR/CodeGen/X86/new.cc" attributes {cir.lang = #cir.lang<cxx>, cir.sob = #cir.signed_overflow_behavior<undefined>, cir.triple = "x86_64-unknown-linux-gnu", cir.type_size_info = #cir.type_size_info<char = 8, int = 32, size_t = 64>, cir.uwtable = #cir.uwtable<async>, dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, f80 = dense<128> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, "dlti.stack_alignment" = 128 : i64, "dlti.endianness" = "little", "dlti.mangling_mode" = "e">} {
  cir.func @main() -> !s32i extra(#fn_attr) {
    %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64} loc(#loc2)
    %1 = cir.alloca !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>, ["p"] {alignment = 8 : i64} loc(#loc9)
    %2 = cir.load %1 : !cir.ptr<!cir.ptr<!s8i>>, !cir.ptr<!s8i> loc(#loc5)
    %3 = cir.const #cir.int<0> : !s32i loc(#loc6)
    %4 = cir.cast(bitcast, %2 : !cir.ptr<!s8i>), !cir.ptr<!void> loc(#loc7)
    %5 = cir.prefetch(%4 : !cir.ptr<!void>) locality(0) read loc(#loc7)
    %6 = cir.load %0 : !cir.ptr<!s32i>, !s32i loc(#loc2)
    cir.return %6 : !s32i loc(#loc2)
  } loc(#loc8)
} loc(#loc)
#loc = loc("/home/shrikardongre/clangir/clang/test/CIR/CodeGen/X86/new.cc":0:0)
#loc1 = loc("new.cc":1:1)
#loc2 = loc("new.cc":4:1)
#loc3 = loc("new.cc":2:5)
#loc4 = loc("new.cc":2:17)clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
#loc5 = loc("new.cc":3:18)
#loc6 = loc("new.cc":3:20)
#loc7 = loc("new.cc":3:5)
#loc8 = loc(fused[#loc1, #loc2])
#loc9 = loc(fused[#loc3, #loc4])

```
for the file , 
```
int main(){
    char const *p;
    _mm_prefetch(p,0);
}
```

however I had a doubt on wether 
`//CIR: {{%.*}}= cir.prefetch({{%.*}} : !cir.ptr<!void>) locality(0) read `
in the test file is correct as if nothing is provided initially it should be write if I am not wrong, please giude 
Thanks :) .
