### PR TITLE
[CIR][ThroughMLIR] Lower TrapOp

### DIFF
--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -1248,8 +1248,24 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::UnreachableOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    // match and rewrite.
     rewriter.replaceOpWithNewOp<mlir::LLVM::UnreachableOp>(op);
+    return mlir::success();
+  }
+};
+
+class CIRTrapOpLowering : public mlir::OpConversionPattern<cir::TrapOp> {
+public:
+  using OpConversionPattern<cir::TrapOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::TrapOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.setInsertionPointAfter(op);
+    auto trapIntrinsicName = rewriter.getStringAttr("llvm.trap");
+    rewriter.create<mlir::LLVM::CallIntrinsicOp>(op.getLoc(), trapIntrinsicName,
+                                                 /*args=*/mlir::ValueRange());
+    rewriter.create<mlir::LLVM::UnreachableOp>(op.getLoc());
+    rewriter.eraseOp(op);
     return mlir::success();
   }
 };
@@ -1274,8 +1290,8 @@ void populateCIRToMLIRConversionPatterns(mlir::RewritePatternSet &patterns,
            CIRBitClrsbOpLowering, CIRBitFfsOpLowering, CIRBitParityOpLowering,
            CIRIfOpLowering, CIRVectorCreateLowering, CIRVectorInsertLowering,
            CIRVectorExtractLowering, CIRVectorCmpOpLowering, CIRACosOpLowering,
-           CIRASinOpLowering, CIRUnreachableOpLowering, CIRTanOpLowering>(
-          converter, patterns.getContext());
+           CIRASinOpLowering, CIRUnreachableOpLowering, CIRTanOpLowering,
+           CIRTrapOpLowering>(converter, patterns.getContext());
 }
 
 static mlir::TypeConverter prepareTypeConverter() {

--- a/clang/test/CIR/Lowering/ThroughMLIR/unreachable.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/unreachable.cir
@@ -7,4 +7,13 @@ module {
 
   //      MLIR: func.func @test_unreachable()
   // MLIR-NEXT:   llvm.unreachable
+
+  cir.func @test_trap() {
+    cir.trap
+  }
+
+  //      MLIR: func.func @test_trap() {
+  // MLIR-NEXT:   llvm.call_intrinsic "llvm.trap"() : () -> ()
+  // MLIR-NEXT:   llvm.unreachable
+  // MLIR-NEXT: }
 }


### PR DESCRIPTION
`cir.trap` corresponds to two operations, `call @llvm.trap` and `unreachable`. See the test case `Lowering/intrinsics.cir`.