### PR TITLE
[CIR][LowerMLIR] Add support for `almabench` and `fbench` from SingleSource test suite.

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4794,6 +4794,7 @@ class BinaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
   let llvmOp = llvmOpName;
 }
 
+def ATan2Op: BinaryFPToFPBuiltinOp<"atan2", "ATan2Op">;
 def CopysignOp : BinaryFPToFPBuiltinOp<"copysign", "CopySignOp">;
 def FMaxNumOp : BinaryFPToFPBuiltinOp<"fmaxnum", "MaxNumOp">;
 def FMinNumOp : BinaryFPToFPBuiltinOp<"fminnum", "MinNumOp">;
@@ -4801,6 +4802,7 @@ def FMaximumOp : BinaryFPToFPBuiltinOp<"fmaximum", "MaximumOp">;
 def FMinimumOp : BinaryFPToFPBuiltinOp<"fminimum", "MinimumOp">;
 def FModOp : BinaryFPToFPBuiltinOp<"fmod", "FRemOp">;
 def PowOp : BinaryFPToFPBuiltinOp<"pow", "PowOp">;
+
 
 def IsFPClassOp : CIR_Op<"is_fp_class"> {
   let summary = "Corresponding to the `__builtin_fpclassify` builtin function in clang";

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -661,7 +661,8 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BI__builtin_asinf16:
     case Builtin::BI__builtin_asinl:
     case Builtin::BI__builtin_asinf128:
-      llvm_unreachable("Builtin::BIasin like NYI");
+      assert(!cir::MissingFeatures::fastMathFlags());
+      return emitUnaryMaybeConstrainedFPBuiltin<cir::ASinOp>(*this, *E);
 
     case Builtin::BIatan:
     case Builtin::BIatanf:
@@ -671,7 +672,8 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BI__builtin_atanf16:
     case Builtin::BI__builtin_atanl:
     case Builtin::BI__builtin_atanf128:
-      llvm_unreachable("Builtin::BIatan like NYI");
+      assert(!cir::MissingFeatures::fastMathFlags());
+      return emitUnaryMaybeConstrainedFPBuiltin<cir::ATanOp>(*this, *E);
 
     case Builtin::BIatan2:
     case Builtin::BIatan2f:
@@ -681,7 +683,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BI__builtin_atan2f16:
     case Builtin::BI__builtin_atan2l:
     case Builtin::BI__builtin_atan2f128:
-      llvm_unreachable("Builtin::BIatan2 like NYI");
+      return emitBinaryFPBuiltin<cir::ATan2Op>(*this, *E);
 
     case Builtin::BIceil:
     case Builtin::BIceilf:

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -293,6 +293,22 @@ public:
   }
 };
 
+class CIRATan2OpLowering : public mlir::OpConversionPattern<cir::ATan2Op> {
+public:
+  using mlir::OpConversionPattern<cir::ATan2Op>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::ATan2Op op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    mlir::Location loc = op.getLoc();
+    auto resultType = op.getResult().getType();
+
+    rewriter.replaceOpWithNewOp<mlir::math::Atan2Op>(
+        op, resultType, adaptor.getLhs(), adaptor.getRhs());
+    return mlir::success();
+  }
+};
+
 using CIRASinOpLowering =
     CIRUnaryMathOpLowering<cir::ASinOp, mlir::math::AsinOp>;
 using CIRSinOpLowering = CIRUnaryMathOpLowering<cir::SinOp, mlir::math::SinOp>;
@@ -1258,24 +1274,24 @@ void populateCIRToMLIRConversionPatterns(mlir::RewritePatternSet &patterns,
                                          mlir::TypeConverter &converter) {
   patterns.add<CIRReturnLowering, CIRBrOpLowering>(patterns.getContext());
 
-  patterns
-      .add<CIRATanOpLowering, CIRCmpOpLowering, CIRCallOpLowering,
-           CIRUnaryOpLowering, CIRBinOpLowering, CIRLoadOpLowering,
-           CIRConstantOpLowering, CIRStoreOpLowering, CIRAllocaOpLowering,
-           CIRFuncOpLowering, CIRScopeOpLowering, CIRBrCondOpLowering,
-           CIRTernaryOpLowering, CIRYieldOpLowering, CIRCosOpLowering,
-           CIRGlobalOpLowering, CIRGetGlobalOpLowering, CIRCastOpLowering,
-           CIRPtrStrideOpLowering, CIRSqrtOpLowering, CIRCeilOpLowering,
-           CIRExp2OpLowering, CIRExpOpLowering, CIRFAbsOpLowering,
-           CIRAbsOpLowering, CIRFloorOpLowering, CIRLog10OpLowering,
-           CIRLog2OpLowering, CIRLogOpLowering, CIRRoundOpLowering,
-           CIRPtrStrideOpLowering, CIRSinOpLowering, CIRShiftOpLowering,
-           CIRBitClzOpLowering, CIRBitCtzOpLowering, CIRBitPopcountOpLowering,
-           CIRBitClrsbOpLowering, CIRBitFfsOpLowering, CIRBitParityOpLowering,
-           CIRIfOpLowering, CIRVectorCreateLowering, CIRVectorInsertLowering,
-           CIRVectorExtractLowering, CIRVectorCmpOpLowering, CIRACosOpLowering,
-           CIRASinOpLowering, CIRUnreachableOpLowering, CIRTanOpLowering>(
-          converter, patterns.getContext());
+  patterns.add<
+      CIRATanOpLowering, CIRATan2OpLowering, CIRCmpOpLowering,
+      CIRCallOpLowering, CIRUnaryOpLowering, CIRBinOpLowering,
+      CIRLoadOpLowering, CIRConstantOpLowering, CIRStoreOpLowering,
+      CIRAllocaOpLowering, CIRFuncOpLowering, CIRScopeOpLowering,
+      CIRBrCondOpLowering, CIRTernaryOpLowering, CIRYieldOpLowering,
+      CIRCosOpLowering, CIRGlobalOpLowering, CIRGetGlobalOpLowering,
+      CIRCastOpLowering, CIRPtrStrideOpLowering, CIRSqrtOpLowering,
+      CIRCeilOpLowering, CIRExp2OpLowering, CIRExpOpLowering, CIRFAbsOpLowering,
+      CIRAbsOpLowering, CIRFloorOpLowering, CIRLog10OpLowering,
+      CIRLog2OpLowering, CIRLogOpLowering, CIRRoundOpLowering,
+      CIRPtrStrideOpLowering, CIRSinOpLowering, CIRShiftOpLowering,
+      CIRBitClzOpLowering, CIRBitCtzOpLowering, CIRBitPopcountOpLowering,
+      CIRBitClrsbOpLowering, CIRBitFfsOpLowering, CIRBitParityOpLowering,
+      CIRIfOpLowering, CIRVectorCreateLowering, CIRVectorInsertLowering,
+      CIRVectorExtractLowering, CIRVectorCmpOpLowering, CIRACosOpLowering,
+      CIRASinOpLowering, CIRUnreachableOpLowering, CIRTanOpLowering>(
+      converter, patterns.getContext());
 }
 
 static mlir::TypeConverter prepareTypeConverter() {


### PR DESCRIPTION
From the SingleSource test suite, `almabench` had a missing `ATan2` implemention, whereas `fbench` had missing `asin` support. This PR adds support for both.