### PR TITLE
[CIR] Treat cir.record class and struct types equivalently.

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3613,8 +3613,6 @@ LogicalResult cir::GetMemberOp::verify() {
   if (recordTy.getMembers().size() <= getIndex())
     return emitError() << "member index out of bounds";
 
-  // FIXME(cir): member type check is disabled for classes as the codegen for
-  // these still need to be patched.
   if (recordTy.getMembers()[getIndex()] != getResultTy().getPointee())
     return emitError() << "member type mismatch";
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3615,8 +3615,7 @@ LogicalResult cir::GetMemberOp::verify() {
 
   // FIXME(cir): member type check is disabled for classes as the codegen for
   // these still need to be patched.
-  if (!recordTy.isClass() &&
-      recordTy.getMembers()[getIndex()] != getResultTy().getPointee())
+  if (recordTy.getMembers()[getIndex()] != getResultTy().getPointee())
     return emitError() << "member type mismatch";
 
   return mlir::success();

--- a/clang/test/CIR/IR/getmember.cir
+++ b/clang/test/CIR/IR/getmember.cir
@@ -4,21 +4,12 @@
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
 
-!ty_Class = !cir.record<class "Class" {!u16i, !u32i}>
-!ty_Incomplete = !cir.record<struct "Incomplete" incomplete>
 !ty_Struct = !cir.record<struct "Struct" {!u16i, !u32i}>
 
 module  {
   cir.func @shouldGetStructMember(%arg0 : !cir.ptr<!ty_Struct>) {
     // CHECK: cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_Struct> -> !cir.ptr<!u32i>
     %0 = cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_Struct> -> !cir.ptr<!u32i>
-    cir.return
-  }
-
-  // FIXME: remove bypass once codegen for CIR class records is patched.
-  cir.func @shouldBypassMemberTypeCheckForClassRecords(%arg0 : !cir.ptr<!ty_Class>) {
-    // CHECK: cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_Class> -> !cir.ptr<!cir.ptr<!u32i>> 
-    %0 = cir.get_member %arg0[1] {name = "test"} : !cir.ptr<!ty_Class> -> !cir.ptr<!cir.ptr<!u32i>>
     cir.return
   }
 }


### PR DESCRIPTION
When we create a `cir.record` type, we track the `RecordKind` according to whether the source code declared the type using `struct` or `class` even though these are semantically equivalent. The distinction is used in naming the type when we lower to the LLVM dialect.

This change updates the code to remove the last place where we were handling class and struct records differently.