### PR TITLE
[CIR][CodeGen] Fix crash during exception cleanup

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -613,6 +613,10 @@ void CIRGenFunction::PopCleanupBlock(bool FallthroughIsBranchThrough) {
   // Emit the EH cleanup if required.
   if (RequiresEHCleanup) {
     cir::TryOp tryOp = ehEntry->getParentOp()->getParentOfType<cir::TryOp>();
+
+    if (EHParent == EHStack.stable_end() && !tryOp)
+      return;
+
     auto *nextAction = getEHDispatchBlock(EHParent, tryOp);
     (void)nextAction;
 

--- a/clang/test/CIR/CodeGen/try-catch-dtors.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-dtors.cpp
@@ -339,3 +339,37 @@ void bar() {
 // CIR:  cir.store %[[V3]], %[[V1]] : !s32i, !cir.ptr<!s32i>
 // CIR:  cir.call @_ZN1AD2Ev(%[[V0]]) : (!cir.ptr<!ty_A>) -> () extra(#fn_attr)
 // CIR:  cir.return
+
+class C {
+public:
+  ~C();
+  void operator=(C);
+};
+
+void d() {
+  C a, b;
+  a = b;
+}
+
+// CIR: %[[V0:.*]] = cir.alloca !ty_C, !cir.ptr<!ty_C>, ["a"] {alignment = 1 : i64}
+// CIR: %[[V1:.*]] = cir.alloca !ty_C, !cir.ptr<!ty_C>, ["b"] {alignment = 1 : i64}
+// CIR: cir.scope {
+// CIR:   %[[V2:.*]] = cir.alloca !ty_C, !cir.ptr<!ty_C>, ["agg.tmp0"] {alignment = 1 : i64}
+// CIR:   cir.call @_ZN1CC2ERKS_(%[[V2]], %[[V1]]) : (!cir.ptr<!ty_C>, !cir.ptr<!ty_C>) -> () extra(#fn_attr)
+// CIR:   %[[V3:.*]] = cir.load %[[V2]] : !cir.ptr<!ty_C>, !ty_C
+// CIR:   cir.try synthetic cleanup {
+// CIR:     cir.call exception @_ZN1CaSES_(%[[V0]], %[[V3]]) : (!cir.ptr<!ty_C>, !ty_C) -> () cleanup {
+// CIR:       cir.call @_ZN1CD1Ev(%[[V2]]) : (!cir.ptr<!ty_C>) -> () extra(#fn_attr)
+// CIR:       cir.call @_ZN1CD1Ev(%[[V1]]) : (!cir.ptr<!ty_C>) -> () extra(#fn_attr)
+// CIR:       cir.yield
+// CIR:     }
+// CIR:     cir.yield
+// CIR:   } catch [#cir.unwind {
+// CIR:     cir.resume
+// CIR:   }]
+// CIR:   cir.call @_ZN1CD1Ev(%[[V2]]) : (!cir.ptr<!ty_C>) -> () extra(#fn_attr)
+// CIR:   cir.call @_ZN1CD1Ev(%[[V1]]) : (!cir.ptr<!ty_C>) -> () extra(#fn_attr)
+// CIR: }
+// CIR: cir.call @_ZN1CD1Ev(%[[V1]]) : (!cir.ptr<!ty_C>) -> () extra(#fn_attr)
+// CIR: cir.call @_ZN1CD1Ev(%[[V0]]) : (!cir.ptr<!ty_C>) -> () extra(#fn_attr)
+// CIR: cir.return


### PR DESCRIPTION
Currently, the following code snippet fails with a crash during CodeGen
```
class C {
public:
  ~C();
  void operator=(C);
};

void d() {
  C a, b;
  a = b;
}
```
with error: 
```
mlir::Block* clang::CIRGen::CIRGenFunction::getEHResumeBlock(bool, cir::TryOp): Assertion `tryOp && "expected available cir.try"' failed.
```
in CIRGenCleanup [these lines](https://github.com/llvm/clangir/blob/204c03efbe898c9f64e477937d869767fdfb1310/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp#L615C1-L617C6) don't check if there is a TryOp when at the end of the scope chain before [getEHResumeBlock](https://github.com/llvm/clangir/blob/204c03efbe898c9f64e477937d869767fdfb1310/clang/lib/CIR/CodeGen/CIRGenException.cpp#L764) is called causing the crash, because it contains an assertion. 

This PR fixes this and adds a simple test for a case like this.