### PR TITLE
[CIR][CodeGen] Supports const array user in the globals replacement

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1009,7 +1009,7 @@ void CIRGenModule::replaceGlobal(cir::GlobalOp oldSym, cir::GlobalOp newSym) {
     if (oldSymUses.has_value()) {
       for (auto use : *oldSymUses) {
         auto *userOp = use.getUser();
-        assert((isa<cir::GetGlobalOp>(userOp) || isa<cir::GlobalOp>(userOp)) &&
+        assert((isa<cir::GetGlobalOp, cir::GlobalOp, cir::ConstantOp>(userOp)) &&
                "GlobalOp symbol user is neither a GetGlobalOp nor a GlobalOp");
 
         if (auto ggo = dyn_cast<cir::GetGlobalOp>(use.getUser())) {
@@ -1028,6 +1028,13 @@ void CIRGenModule::replaceGlobal(cir::GlobalOp oldSym, cir::GlobalOp newSym) {
             auto nw = getNewInitValue(*this, newSym, oldTy, glob, init.value());
             glob.setInitialValueAttr(nw);
           }
+        } else if (auto c = dyn_cast<cir::ConstantOp>(userOp)) {
+          auto init = getNewInitValue(*this,  newSym, oldTy, glob, c.getValue());
+          auto ar = cast<ConstArrayAttr>(init);
+          mlir::OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPointAfter(c);
+          auto newUser = builder.create<cir::ConstantOp>(c.getLoc(), ar.getType(), ar);
+          c.replaceAllUsesWith(newUser.getOperation());
         }
       }
     }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1030,7 +1030,7 @@ void CIRGenModule::replaceGlobal(cir::GlobalOp oldSym, cir::GlobalOp newSym) {
             glob.setInitialValueAttr(nw);
           }
         } else if (auto c = dyn_cast<cir::ConstantOp>(userOp)) {
-          auto init = getNewInitValue(*this, newSym, oldTy, glob, c.getValue());
+          mlir::Attribute init = getNewInitValue(*this, newSym, oldTy, glob, c.getValue());
           auto ar = cast<ConstArrayAttr>(init);
           mlir::OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPointAfter(c);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1009,8 +1009,9 @@ void CIRGenModule::replaceGlobal(cir::GlobalOp oldSym, cir::GlobalOp newSym) {
     if (oldSymUses.has_value()) {
       for (auto use : *oldSymUses) {
         auto *userOp = use.getUser();
-        assert((isa<cir::GetGlobalOp, cir::GlobalOp, cir::ConstantOp>(userOp)) &&
-               "GlobalOp symbol user is neither a GetGlobalOp nor a GlobalOp");
+        assert(
+            (isa<cir::GetGlobalOp, cir::GlobalOp, cir::ConstantOp>(userOp)) &&
+            "GlobalOp symbol user is neither a GetGlobalOp nor a GlobalOp");
 
         if (auto ggo = dyn_cast<cir::GetGlobalOp>(use.getUser())) {
           auto useOpResultValue = ggo.getAddr();
@@ -1029,11 +1030,12 @@ void CIRGenModule::replaceGlobal(cir::GlobalOp oldSym, cir::GlobalOp newSym) {
             glob.setInitialValueAttr(nw);
           }
         } else if (auto c = dyn_cast<cir::ConstantOp>(userOp)) {
-          auto init = getNewInitValue(*this,  newSym, oldTy, glob, c.getValue());
+          auto init = getNewInitValue(*this, newSym, oldTy, glob, c.getValue());
           auto ar = cast<ConstArrayAttr>(init);
           mlir::OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPointAfter(c);
-          auto newUser = builder.create<cir::ConstantOp>(c.getLoc(), ar.getType(), ar);
+          auto newUser =
+              builder.create<cir::ConstantOp>(c.getLoc(), ar.getType(), ar);
           c.replaceAllUsesWith(newUser.getOperation());
         }
       }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1030,7 +1030,8 @@ void CIRGenModule::replaceGlobal(cir::GlobalOp oldSym, cir::GlobalOp newSym) {
             glob.setInitialValueAttr(nw);
           }
         } else if (auto c = dyn_cast<cir::ConstantOp>(userOp)) {
-          mlir::Attribute init = getNewInitValue(*this, newSym, oldTy, glob, c.getValue());
+          mlir::Attribute init =
+              getNewInitValue(*this, newSym, oldTy, glob, c.getValue());
           auto ar = cast<ConstArrayAttr>(init);
           mlir::OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPointAfter(c);

--- a/clang/test/CIR/CodeGen/union-array.c
+++ b/clang/test/CIR/CodeGen/union-array.c
@@ -32,9 +32,8 @@ void foo() { U arr[2] = {{.b = {1, 2}}, {.a = {1}}}; }
 // CIR: cir.const #cir.const_record<{#cir.const_record<{#cir.const_record<{#cir.int<1> : !s64i, #cir.int<2> : !s64i}> : {{.*}}}> : {{.*}}, #cir.const_record<{#cir.const_record<{#cir.int<1> : !s8i}> : {{.*}}, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 15>}>
 // LLVM: store { { %struct.S_2 }, { %struct.S_1, [15 x i8] } } { { %struct.S_2 } { %struct.S_2 { i64 1, i64 2 } }, { %struct.S_1, [15 x i8] } { %struct.S_1 { i8 1 }, [15 x i8] zeroinitializer } }
 
-
 void bar(void) {
   int *x[2] = { &g.f0, &g.f0 };
 }
-// CIR: cir.global "private" internal dsolocal @g = #cir.const_struct<{#cir.int<5> : !s32i}> : !ty_anon_struct
+// CIR: cir.global "private" internal dsolocal @g = #cir.const_record<{#cir.int<5> : !s32i}> : !ty_anon_struct
 // CIR: cir.const #cir.const_array<[#cir.global_view<@g> : !cir.ptr<!s32i>, #cir.global_view<@g> : !cir.ptr<!s32i>]> : !cir.array<!cir.ptr<!s32i> x 2>

--- a/clang/test/CIR/CodeGen/union-array.c
+++ b/clang/test/CIR/CodeGen/union-array.c
@@ -16,7 +16,25 @@ typedef union {
   S_2 b;
 } U;
 
+typedef union {
+   int f0;
+   int f1;
+} U1;
+
+static U1 g = {5};
+// LLVM: @__const.bar.x = private constant [2 x ptr] [ptr @g, ptr @g]
+// LLVM: @g = internal global { i32 } { i32 5 }
+// FIXME: LLVM output should be: @g = internal global %union.U { i32 5 }
+
+
 void foo() { U arr[2] = {{.b = {1, 2}}, {.a = {1}}}; }
 
 // CIR: cir.const #cir.const_record<{#cir.const_record<{#cir.const_record<{#cir.int<1> : !s64i, #cir.int<2> : !s64i}> : {{.*}}}> : {{.*}}, #cir.const_record<{#cir.const_record<{#cir.int<1> : !s8i}> : {{.*}}, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 15>}>
 // LLVM: store { { %struct.S_2 }, { %struct.S_1, [15 x i8] } } { { %struct.S_2 } { %struct.S_2 { i64 1, i64 2 } }, { %struct.S_1, [15 x i8] } { %struct.S_1 { i8 1 }, [15 x i8] zeroinitializer } }
+
+
+void bar(void) {
+  int *x[2] = { &g.f0, &g.f0 };
+}
+// CIR: cir.global "private" internal dsolocal @g = #cir.const_struct<{#cir.int<5> : !s32i}> : !ty_anon_struct
+// CIR: cir.const #cir.const_array<[#cir.global_view<@g> : !cir.ptr<!s32i>, #cir.global_view<@g> : !cir.ptr<!s32i>]> : !cir.array<!cir.ptr<!s32i> x 2>


### PR DESCRIPTION
This is a just small fix that cover the case when the global union is declared with `static` keyword and one of the its users is an array 