### PR TITLE
[CIR] Always zero-extend shift amounts

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2967,10 +2967,11 @@ mlir::LogicalResult CIRToLLVMShiftOpLowering::matchAndRewrite(
   // behavior might occur in the casts below as per [C99 6.5.7.3].
   // Vector type shift amount needs no cast as type consistency is expected to
   // be already be enforced at CIRGen.
+  // Negative shift amounts are undefined behavior so we can always zero extend
+  // the integer here.
   if (cirAmtTy)
     amt = getLLVMIntCast(rewriter, amt, mlir::cast<mlir::IntegerType>(llvmTy),
-                         !cirAmtTy.isSigned(), cirAmtTy.getWidth(),
-                         cirValTy.getWidth());
+                         true, cirAmtTy.getWidth(), cirValTy.getWidth());
 
   // Lower to the proper LLVM shift operation.
   if (op.getIsShiftleft())

--- a/clang/test/CIR/Lowering/shift.cir
+++ b/clang/test/CIR/Lowering/shift.cir
@@ -16,7 +16,7 @@ module {
 
     // Should allow shift with signed smaller amount type.
     %2 = cir.shift(left, %arg1 : !s32i, %arg0 : !s16i) -> !s32i
-    // CHECK: %[[#CAST:]] = llvm.sext %{{.+}} : i16 to i32
+    // CHECK: %[[#CAST:]] = llvm.zext %{{.+}} : i16 to i32
     // CHECK: llvm.shl %{{.+}}, %[[#CAST]]  : i32
 
     // Should allow shift with unsigned smaller amount type.


### PR DESCRIPTION
Negative shift amounts are undefined behavior in C and C++. Because of that we can always zero-extend the shift amount which is slightly faster on certain architectures (e. g. x86). This also matches the behavior of the original clang Codegen.

Backported from https://github.com/llvm/llvm-project/pull/133405