### PR TITLE
[CIR] Replace RecordType data layout calculations

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -839,45 +839,6 @@ def VTableAttr : CIR_Attr<"VTable", "vtable", [TypedAttrInterface]> {
 }
 
 //===----------------------------------------------------------------------===//
-// RecordLayoutAttr
-//===----------------------------------------------------------------------===//
-
-// Used to decouple layout information from the record type. RecordType's
-// uses this attribute to cache that information.
-
-def RecordLayoutAttr : CIR_Attr<"RecordLayout", "record_layout"> {
-  let summary = "ABI specific information about a record layout";
-  let description = [{
-    Holds layout information often queried by !cir.record users
-    during lowering passes and optimizations.
-  }];
-
-  let parameters = (ins "unsigned":$size,
-                        "unsigned":$alignment,
-                        "bool":$padded,
-                        "mlir::Type":$largest_member,
-                        "mlir::ArrayAttr":$offsets);
-
-  let builders = [
-    AttrBuilderWithInferredContext<(ins "unsigned":$size,
-                                        "unsigned":$alignment,
-                                        "bool":$padded,
-                                        "mlir::Type":$largest_member,
-                                        "mlir::ArrayAttr":$offsets), [{
-      return $_get(largest_member.getContext(), size, alignment, padded,
-                   largest_member, offsets);
-    }]>,
-  ];
-
-  let genVerifyDecl = 1;
-  let assemblyFormat = [{
-    `<`
-      struct($size, $alignment, $padded, $largest_member, $offsets)
-    `>`
-  }];
-}
-
-//===----------------------------------------------------------------------===//
 // DynamicCastInfoAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -743,13 +743,12 @@ def CIR_RecordType : CIR_Type<"Record", "record",
 
     bool isLayoutIdentical(const RecordType &other);
 
-  // Utilities for lazily computing and cacheing data layout info.
-  // FIXME: currently opaque because there's a cycle if CIRTypes.types include
-  // from CIRAttrs.h. The implementation operates in terms of RecordLayoutAttr
-  // instead.
+  // Utilities for computing data layout info
   private:
-    mutable mlir::Attribute layoutInfo;
-    void computeSizeAndAlignment(const mlir::DataLayout &dataLayout) const;
+    unsigned computeStructSize(const mlir::DataLayout &dataLayout) const;
+    unsigned computeUnionSize(const mlir::DataLayout &dataLayout) const;
+    uint64_t computeStructAlignment(const mlir::DataLayout &dataLayout) const;
+    uint64_t computeUnionAlignment(const mlir::DataLayout &dataLayout) const;
   public:
   }];
 

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -170,18 +170,6 @@ LogicalResult ConstRecordAttr::verify(
   return success();
 }
 
-LogicalResult RecordLayoutAttr::verify(
-    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, unsigned size,
-    unsigned alignment, bool padded, mlir::Type largest_member,
-    mlir::ArrayAttr offsets) {
-  if (not std::all_of(offsets.begin(), offsets.end(), [](mlir::Attribute attr) {
-        return mlir::isa<mlir::IntegerAttr>(attr);
-      })) {
-    return emitError() << "all index values must be integers";
-  }
-  return success();
-}
-
 //===----------------------------------------------------------------------===//
 // LangAttr definitions
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
We have been using RecordLayoutAttr to "cache" data layout information calculated for records. Unfortunately, it wasn't actually caching the information, and because each call was calculating more information than it needed, it was doing extra work.

This replaces the previous implementation with a set of functions that compute only the information needed. Ideally, we would like to have a mechanism to properly cache this information, but until such a mechanism is implemented, these new functions should be a small step forward.