### PR TITLE
[CIR] Infer MLIR context in type builders when possible

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -302,7 +302,7 @@ public:
 
   mlir::Value createComplexCreate(mlir::Location loc, mlir::Value real,
                                   mlir::Value imag) {
-    auto resultComplexTy = cir::ComplexType::get(getContext(), real.getType());
+    auto resultComplexTy = cir::ComplexType::get(real.getType());
     return create<cir::ComplexCreateOp>(loc, resultComplexTy, real, imag);
   }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -228,6 +228,12 @@ def CIR_ComplexType : CIR_Type<"Complex", "complex",
 
   let parameters = (ins "mlir::Type":$elementTy);
 
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "mlir::Type":$elementTy), [{
+      return $_get(elementTy.getContext(), elementTy);
+    }]>,
+  ];
+
   let assemblyFormat = [{
     `<` $elementTy `>`
   }];
@@ -301,6 +307,14 @@ def CIR_DataMemberType : CIR_Type<"DataMember", "data_member",
   let parameters = (ins "mlir::Type":$memberTy,
                         "cir::RecordType":$clsTy);
 
+  let builders = [
+    TypeBuilderWithInferredContext<(ins
+      "mlir::Type":$memberTy, "cir::RecordType":$clsTy
+    ), [{
+      return $_get(memberTy.getContext(), memberTy, clsTy);
+    }]>,
+  ];
+
   let assemblyFormat = [{
     `<` $memberTy `in` $clsTy `>`
   }];
@@ -338,6 +352,14 @@ def CIR_ArrayType : CIR_Type<"Array", "array",
 
   let parameters = (ins "mlir::Type":$eltType, "uint64_t":$size);
 
+  let builders = [
+    TypeBuilderWithInferredContext<(ins
+      "mlir::Type":$eltType, "uint64_t":$size
+    ), [{
+        return $_get(eltType.getContext(), eltType, size);
+    }]>,
+  ];
+
   let assemblyFormat = [{
     `<` $eltType `x` $size `>`
   }];
@@ -357,6 +379,14 @@ def CIR_VectorType : CIR_Type<"Vector", "vector",
   }];
 
   let parameters = (ins "mlir::Type":$eltType, "uint64_t":$size);
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins
+      "mlir::Type":$eltType, "uint64_t":$size
+    ), [{
+        return $_get(eltType.getContext(), eltType, size);
+    }]>,
+  ];
 
   let assemblyFormat = [{
     `<` $eltType `x` $size `>`
@@ -451,6 +481,14 @@ def CIR_MethodType : CIR_Type<"Method", "method",
 
   let parameters = (ins "cir::FuncType":$memberFuncTy,
                         "cir::RecordType":$clsTy);
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins
+      "cir::FuncType":$memberFuncTy, "cir::RecordType":$clsTy
+    ), [{
+      return $_get(memberFuncTy.getContext(), memberFuncTy, clsTy);
+    }]>,
+  ];
 
   let assemblyFormat = [{
     `<` qualified($memberFuncTy) `in` $clsTy `>`

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -168,7 +168,7 @@ public:
     // If the string is full of null bytes, emit a #cir.zero rather than
     // a #cir.const_array.
     if (lastNonZeroPos == llvm::StringRef::npos) {
-      auto arrayTy = cir::ArrayType::get(getContext(), eltTy, finalSize);
+      auto arrayTy = cir::ArrayType::get(eltTy, finalSize);
       return getZeroAttr(arrayTy);
     }
     // We will use trailing zeros only if there are more than one zero
@@ -176,8 +176,8 @@ public:
     int trailingZerosNum =
         finalSize > lastNonZeroPos + 2 ? finalSize - lastNonZeroPos - 1 : 0;
     auto truncatedArrayTy =
-        cir::ArrayType::get(getContext(), eltTy, finalSize - trailingZerosNum);
-    auto fullArrayTy = cir::ArrayType::get(getContext(), eltTy, finalSize);
+        cir::ArrayType::get(eltTy, finalSize - trailingZerosNum);
+    auto fullArrayTy = cir::ArrayType::get(eltTy, finalSize);
     return cir::ConstArrayAttr::get(
         getContext(), fullArrayTy,
         mlir::StringAttr::get(str.drop_back(trailingZerosNum),
@@ -407,8 +407,7 @@ public:
                                           bool isSigned = false) {
     auto elementTy = mlir::dyn_cast_or_null<cir::IntType>(vt.getEltType());
     assert(elementTy && "expected int vector");
-    return cir::VectorType::get(getContext(),
-                                isExtended
+    return cir::VectorType::get(isExtended
                                     ? getExtendedIntTy(elementTy, isSigned)
                                     : getTruncatedIntTy(elementTy, isSigned),
                                 vt.getSize());
@@ -528,10 +527,6 @@ public:
       return getAnonRecordTy(members, packed, padded, ast);
     else
       return getCompleteRecordTy(members, name, packed, padded, ast);
-  }
-
-  cir::ArrayType getArrayType(mlir::Type eltType, unsigned size) {
-    return cir::ArrayType::get(getContext(), eltType, size);
   }
 
   bool isSized(mlir::Type ty) {

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -1863,14 +1863,12 @@ static cir::VectorType GetNeonType(CIRGenFunction *CGF, NeonTypeFlags TypeFlags,
   switch (TypeFlags.getEltType()) {
   case NeonTypeFlags::Int8:
   case NeonTypeFlags::Poly8:
-    return cir::VectorType::get(CGF->getBuilder().getContext(),
-                                TypeFlags.isUnsigned() ? CGF->UInt8Ty
+    return cir::VectorType::get(TypeFlags.isUnsigned() ? CGF->UInt8Ty
                                                        : CGF->SInt8Ty,
                                 V1Ty ? 1 : (8 << IsQuad));
   case NeonTypeFlags::Int16:
   case NeonTypeFlags::Poly16:
-    return cir::VectorType::get(CGF->getBuilder().getContext(),
-                                TypeFlags.isUnsigned() ? CGF->UInt16Ty
+    return cir::VectorType::get(TypeFlags.isUnsigned() ? CGF->UInt16Ty
                                                        : CGF->SInt16Ty,
                                 V1Ty ? 1 : (4 << IsQuad));
   case NeonTypeFlags::BFloat16:
@@ -1884,14 +1882,12 @@ static cir::VectorType GetNeonType(CIRGenFunction *CGF, NeonTypeFlags TypeFlags,
     else
       llvm_unreachable("NeonTypeFlags::Float16 NYI");
   case NeonTypeFlags::Int32:
-    return cir::VectorType::get(CGF->getBuilder().getContext(),
-                                TypeFlags.isUnsigned() ? CGF->UInt32Ty
+    return cir::VectorType::get(TypeFlags.isUnsigned() ? CGF->UInt32Ty
                                                        : CGF->SInt32Ty,
                                 V1Ty ? 1 : (2 << IsQuad));
   case NeonTypeFlags::Int64:
   case NeonTypeFlags::Poly64:
-    return cir::VectorType::get(CGF->getBuilder().getContext(),
-                                TypeFlags.isUnsigned() ? CGF->UInt64Ty
+    return cir::VectorType::get(TypeFlags.isUnsigned() ? CGF->UInt64Ty
                                                        : CGF->SInt64Ty,
                                 V1Ty ? 1 : (1 << IsQuad));
   case NeonTypeFlags::Poly128:
@@ -1900,12 +1896,10 @@ static cir::VectorType GetNeonType(CIRGenFunction *CGF, NeonTypeFlags TypeFlags,
     // so we use v16i8 to represent poly128 and get pattern matched.
     llvm_unreachable("NeonTypeFlags::Poly128 NYI");
   case NeonTypeFlags::Float32:
-    return cir::VectorType::get(CGF->getBuilder().getContext(),
-                                CGF->getCIRGenModule().FloatTy,
+    return cir::VectorType::get(CGF->getCIRGenModule().FloatTy,
                                 V1Ty ? 1 : (2 << IsQuad));
   case NeonTypeFlags::Float64:
-    return cir::VectorType::get(CGF->getBuilder().getContext(),
-                                CGF->getCIRGenModule().DoubleTy,
+    return cir::VectorType::get(CGF->getCIRGenModule().DoubleTy,
                                 V1Ty ? 1 : (1 << IsQuad));
   }
   llvm_unreachable("Unknown vector element type!");
@@ -2102,7 +2096,7 @@ static cir::VectorType getSignChangedVectorType(CIRGenBuilderTy &builder,
   auto elemTy = mlir::cast<cir::IntType>(vecTy.getEltType());
   elemTy = elemTy.isSigned() ? builder.getUIntNTy(elemTy.getWidth())
                              : builder.getSIntNTy(elemTy.getWidth());
-  return cir::VectorType::get(builder.getContext(), elemTy, vecTy.getSize());
+  return cir::VectorType::get(elemTy, vecTy.getSize());
 }
 
 static cir::VectorType
@@ -2111,19 +2105,16 @@ getHalfEltSizeTwiceNumElemsVecType(CIRGenBuilderTy &builder,
   auto elemTy = mlir::cast<cir::IntType>(vecTy.getEltType());
   elemTy = elemTy.isSigned() ? builder.getSIntNTy(elemTy.getWidth() / 2)
                              : builder.getUIntNTy(elemTy.getWidth() / 2);
-  return cir::VectorType::get(builder.getContext(), elemTy,
-                              vecTy.getSize() * 2);
+  return cir::VectorType::get(elemTy, vecTy.getSize() * 2);
 }
 
 static cir::VectorType
 castVecOfFPTypeToVecOfIntWithSameWidth(CIRGenBuilderTy &builder,
                                        cir::VectorType vecTy) {
   if (mlir::isa<cir::SingleType>(vecTy.getEltType()))
-    return cir::VectorType::get(builder.getContext(), builder.getSInt32Ty(),
-                                vecTy.getSize());
+    return cir::VectorType::get(builder.getSInt32Ty(), vecTy.getSize());
   if (mlir::isa<cir::DoubleType>(vecTy.getEltType()))
-    return cir::VectorType::get(builder.getContext(), builder.getSInt64Ty(),
-                                vecTy.getSize());
+    return cir::VectorType::get(builder.getSInt64Ty(), vecTy.getSize());
   llvm_unreachable(
       "Unsupported element type in getVecOfIntTypeWithSameEltWidth");
 }
@@ -2315,8 +2306,7 @@ static mlir::Value emitCommonNeonVecAcrossCall(CIRGenFunction &cgf,
                                                const clang::CallExpr *e) {
   CIRGenBuilderTy &builder = cgf.getBuilder();
   mlir::Value op = cgf.emitScalarExpr(e->getArg(0));
-  cir::VectorType vTy =
-      cir::VectorType::get(&cgf.getMLIRContext(), eltTy, vecLen);
+  cir::VectorType vTy = cir::VectorType::get(eltTy, vecLen);
   llvm::SmallVector<mlir::Value, 1> args{op};
   return emitNeonCall(builder, {vTy}, args, intrincsName, eltTy,
                       cgf.getLoc(e->getExprLoc()));
@@ -2447,8 +2437,7 @@ mlir::Value CIRGenFunction::emitCommonNeonBuiltinExpr(
     cir::VectorType resTy =
         (builtinID == NEON::BI__builtin_neon_vqdmulhq_lane_v ||
          builtinID == NEON::BI__builtin_neon_vqrdmulhq_lane_v)
-            ? cir::VectorType::get(&getMLIRContext(), vTy.getEltType(),
-                                   vTy.getSize() * 2)
+            ? cir::VectorType::get(vTy.getEltType(), vTy.getSize() * 2)
             : vTy;
     cir::VectorType mulVecT =
         GetNeonType(this, NeonTypeFlags(neonType.getEltType(), false,
@@ -2888,10 +2877,8 @@ static mlir::Value emitCommonNeonSISDBuiltinExpr(
     llvm_unreachable(" neon_vqmovnh_u16 NYI ");
   case NEON::BI__builtin_neon_vqmovns_s32: {
     mlir::Location loc = cgf.getLoc(expr->getExprLoc());
-    cir::VectorType argVecTy =
-        cir::VectorType::get(&(cgf.getMLIRContext()), cgf.SInt32Ty, 4);
-    cir::VectorType resVecTy =
-        cir::VectorType::get(&(cgf.getMLIRContext()), cgf.SInt16Ty, 4);
+    cir::VectorType argVecTy = cir::VectorType::get(cgf.SInt32Ty, 4);
+    cir::VectorType resVecTy = cir::VectorType::get(cgf.SInt16Ty, 4);
     vecExtendIntValue(cgf, argVecTy, ops[0], loc);
     mlir::Value result = emitNeonCall(builder, {argVecTy}, ops,
                                       "aarch64.neon.sqxtn", resVecTy, loc);
@@ -3706,88 +3693,74 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
 
   case NEON::BI__builtin_neon_vset_lane_f64: {
     Ops.push_back(emitScalarExpr(E->getArg(2)));
-    Ops[1] = builder.createBitcast(
-        Ops[1], cir::VectorType::get(&getMLIRContext(), DoubleTy, 1));
+    Ops[1] = builder.createBitcast(Ops[1], cir::VectorType::get(DoubleTy, 1));
     return builder.create<cir::VecInsertOp>(getLoc(E->getExprLoc()), Ops[1],
                                             Ops[0], Ops[2]);
   }
   case NEON::BI__builtin_neon_vsetq_lane_f64: {
     Ops.push_back(emitScalarExpr(E->getArg(2)));
-    Ops[1] = builder.createBitcast(
-        Ops[1], cir::VectorType::get(&getMLIRContext(), DoubleTy, 2));
+    Ops[1] = builder.createBitcast(Ops[1], cir::VectorType::get(DoubleTy, 2));
     return builder.create<cir::VecInsertOp>(getLoc(E->getExprLoc()), Ops[1],
                                             Ops[0], Ops[2]);
   }
   case NEON::BI__builtin_neon_vget_lane_i8:
   case NEON::BI__builtin_neon_vdupb_lane_i8:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), UInt8Ty, 8));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(UInt8Ty, 8));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vgetq_lane_i8:
   case NEON::BI__builtin_neon_vdupb_laneq_i8:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), UInt8Ty, 16));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(UInt8Ty, 16));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vget_lane_i16:
   case NEON::BI__builtin_neon_vduph_lane_i16:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), UInt16Ty, 4));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(UInt16Ty, 4));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vgetq_lane_i16:
   case NEON::BI__builtin_neon_vduph_laneq_i16:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), UInt16Ty, 8));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(UInt16Ty, 8));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vget_lane_i32:
   case NEON::BI__builtin_neon_vdups_lane_i32:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), UInt32Ty, 2));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(UInt32Ty, 2));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vget_lane_f32:
   case NEON::BI__builtin_neon_vdups_lane_f32:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), FloatTy, 2));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(FloatTy, 2));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vgetq_lane_i32:
   case NEON::BI__builtin_neon_vdups_laneq_i32:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), UInt32Ty, 4));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(UInt32Ty, 4));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vget_lane_i64:
   case NEON::BI__builtin_neon_vdupd_lane_i64:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), UInt64Ty, 1));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(UInt64Ty, 1));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vdupd_lane_f64:
   case NEON::BI__builtin_neon_vget_lane_f64:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), DoubleTy, 1));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(DoubleTy, 1));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vgetq_lane_i64:
   case NEON::BI__builtin_neon_vdupd_laneq_i64:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), UInt64Ty, 2));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(UInt64Ty, 2));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vgetq_lane_f32:
   case NEON::BI__builtin_neon_vdups_laneq_f32:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), FloatTy, 4));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(FloatTy, 4));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vgetq_lane_f64:
   case NEON::BI__builtin_neon_vdupd_laneq_f64:
-    Ops[0] = builder.createBitcast(
-        Ops[0], cir::VectorType::get(&getMLIRContext(), DoubleTy, 2));
+    Ops[0] = builder.createBitcast(Ops[0], cir::VectorType::get(DoubleTy, 2));
     return builder.create<cir::VecExtractOp>(getLoc(E->getExprLoc()), Ops[0],
                                              emitScalarExpr(E->getArg(1)));
   case NEON::BI__builtin_neon_vaddh_f16: {
@@ -4318,7 +4291,7 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
     [[fallthrough]];
   case NEON::BI__builtin_neon_vaddv_s16: {
     cir::IntType eltTy = usgn ? UInt16Ty : SInt16Ty;
-    cir::VectorType vTy = cir::VectorType::get(builder.getContext(), eltTy, 4);
+    cir::VectorType vTy = cir::VectorType::get(eltTy, 4);
     Ops.push_back(emitScalarExpr(E->getArg(0)));
     // This is to add across the vector elements, so wider result type needed.
     Ops[0] = emitNeonCall(builder, {vTy}, Ops,
@@ -4427,8 +4400,7 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
     usgn = true;
     [[fallthrough]];
   case NEON::BI__builtin_neon_vaddlvq_s16: {
-    mlir::Type argTy = cir::VectorType::get(builder.getContext(),
-                                            usgn ? UInt16Ty : SInt16Ty, 8);
+    mlir::Type argTy = cir::VectorType::get(usgn ? UInt16Ty : SInt16Ty, 8);
     llvm::SmallVector<mlir::Value, 1> argOps = {emitScalarExpr(E->getArg(0))};
     return emitNeonCall(builder, {argTy}, argOps,
                         usgn ? "aarch64.neon.uaddlv" : "aarch64.neon.saddlv",
@@ -4441,8 +4413,7 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned BuiltinID, const CallExpr *E,
     usgn = true;
     [[fallthrough]];
   case NEON::BI__builtin_neon_vaddlv_s16: {
-    mlir::Type argTy = cir::VectorType::get(builder.getContext(),
-                                            usgn ? UInt16Ty : SInt16Ty, 4);
+    mlir::Type argTy = cir::VectorType::get(usgn ? UInt16Ty : SInt16Ty, 4);
     llvm::SmallVector<mlir::Value, 1> argOps = {emitScalarExpr(E->getArg(0))};
     return emitNeonCall(builder, {argTy}, argOps,
                         usgn ? "aarch64.neon.uaddlv" : "aarch64.neon.saddlv",

--- a/clang/lib/CIR/CodeGen/CIRGenCUDANV.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCUDANV.cpp
@@ -129,8 +129,7 @@ void CIRGenNVCUDARuntime::emitDeviceStubBodyNew(CIRGenFunction &cgf,
   // we need to pass it as `void *args[2] = { &a, &b }`.
 
   auto loc = fn.getLoc();
-  auto voidPtrArrayTy =
-      cir::ArrayType::get(&cgm.getMLIRContext(), cgm.VoidPtrTy, args.size());
+  auto voidPtrArrayTy = cir::ArrayType::get(cgm.VoidPtrTy, args.size());
   mlir::Value kernelArgs = builder.createAlloca(
       loc, cir::PointerType::get(voidPtrArrayTy), voidPtrArrayTy, "kernel_args",
       CharUnits::fromQuantity(16));

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -50,7 +50,7 @@ static mlir::TypedAttr computePadding(CIRGenModule &CGM, CharUnits size) {
   if (size > CharUnits::One()) {
     SmallVector<mlir::Attribute, 4> elts(arSize, bld.getZeroAttr(eltTy));
     return bld.getConstArray(mlir::ArrayAttr::get(bld.getContext(), elts),
-                             bld.getArrayType(eltTy, arSize));
+                             cir::ArrayType::get(eltTy, arSize));
   } else {
     return cir::ZeroAttr::get(bld.getContext(), eltTy);
   }
@@ -1303,8 +1303,7 @@ emitArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
 
     return builder.getConstArray(
         mlir::ArrayAttr::get(builder.getContext(), Eles),
-        cir::ArrayType::get(builder.getContext(), CommonElementType,
-                            ArrayBound));
+        cir::ArrayType::get(CommonElementType, ArrayBound));
     // TODO(cir): If all the elements had the same type up to the trailing
     // zeroes, emit a record of two arrays (the nonzero data and the
     // zeroinitializer). Use DesiredType to get the element type.
@@ -1324,8 +1323,7 @@ emitArrayConstant(CIRGenModule &CGM, mlir::Type DesiredType,
 
     return builder.getConstArray(
         mlir::ArrayAttr::get(builder.getContext(), Eles),
-        cir::ArrayType::get(builder.getContext(), CommonElementType,
-                            ArrayBound));
+        cir::ArrayType::get(CommonElementType, ArrayBound));
   }
 
   SmallVector<mlir::Attribute, 4> Eles;
@@ -1831,8 +1829,7 @@ mlir::Attribute ConstantEmitter::emitForMemory(CIRGenModule &CGM,
     assert(innerSize < outerSize && "emitted over-large constant for atomic");
     auto &builder = CGM.getBuilder();
     auto zeroArray = builder.getZeroInitAttr(
-        cir::ArrayType::get(builder.getContext(), builder.getUInt8Ty(),
-                            (outerSize - innerSize) / 8));
+        cir::ArrayType::get(builder.getUInt8Ty(), (outerSize - innerSize) / 8));
     SmallVector<mlir::Attribute, 4> anonElts = {C, zeroArray};
     auto arrAttr = mlir::ArrayAttr::get(builder.getContext(), anonElts);
     return builder.getAnonConstRecord(arrAttr, false);

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -602,7 +602,7 @@ mlir::Type CIRGenTypes::convertType(QualType T) {
   case Type::Complex: {
     const ComplexType *CT = cast<ComplexType>(Ty);
     auto ElementTy = convertType(CT->getElementType());
-    ResultType = cir::ComplexType::get(Builder.getContext(), ElementTy);
+    ResultType = cir::ComplexType::get(ElementTy);
     break;
   }
   case Type::LValueReference:
@@ -650,7 +650,7 @@ mlir::Type CIRGenTypes::convertType(QualType T) {
       SkippedLayout = true;
       ResultType = Builder.getUInt8Ty();
     }
-    ResultType = Builder.getArrayType(ResultType, 0);
+    ResultType = cir::ArrayType::get(ResultType, 0);
     break;
   }
   case Type::ConstantArray: {
@@ -660,16 +660,14 @@ mlir::Type CIRGenTypes::convertType(QualType T) {
     // FIXME: In LLVM, "lower arrays of undefined struct type to arrays of
     // i8 just to have a concrete type". Not sure this makes sense in CIR yet.
     assert(Builder.isSized(EltTy) && "not implemented");
-    ResultType = cir::ArrayType::get(Builder.getContext(), EltTy,
-                                     A->getSize().getZExtValue());
+    ResultType = cir::ArrayType::get(EltTy, A->getSize().getZExtValue());
     break;
   }
   case Type::ExtVector:
   case Type::Vector: {
     const VectorType *V = cast<VectorType>(Ty);
     auto ElementType = convertTypeForMem(V->getElementType());
-    ResultType = cir::VectorType::get(Builder.getContext(), ElementType,
-                                      V->getNumElements());
+    ResultType = cir::VectorType::get(ElementType, V->getNumElements());
     break;
   }
   case Type::ConstantMatrix: {
@@ -717,12 +715,10 @@ mlir::Type CIRGenTypes::convertType(QualType T) {
     auto clsTy =
         mlir::cast<cir::RecordType>(convertType(QualType(MPT->getClass(), 0)));
     if (MPT->isMemberDataPointer())
-      ResultType =
-          cir::DataMemberType::get(Builder.getContext(), memberTy, clsTy);
+      ResultType = cir::DataMemberType::get(memberTy, clsTy);
     else {
       auto memberFuncTy = mlir::cast<cir::FuncType>(memberTy);
-      ResultType =
-          cir::MethodType::get(Builder.getContext(), memberFuncTy, clsTy);
+      ResultType = cir::MethodType::get(memberFuncTy, clsTy);
     }
     break;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -58,8 +58,7 @@ mlir::Type CIRGenVTables::getVTableType(const VTableLayout &layout) {
   mlir::MLIRContext *mlirContext = CGM.getBuilder().getContext();
   auto componentType = getVTableComponentType();
   for (unsigned i = 0, e = layout.getNumVTables(); i != e; ++i)
-    tys.push_back(cir::ArrayType::get(mlirContext, componentType,
-                                      layout.getVTableSize(i)));
+    tys.push_back(cir::ArrayType::get(componentType, layout.getVTableSize(i)));
 
   // FIXME(cir): should VTableLayout be encoded like we do for some
   // AST nodes?
@@ -519,8 +518,7 @@ cir::GlobalOp CIRGenVTables::getAddrOfVTT(const CXXRecordDecl *RD) {
 
   VTTBuilder Builder(CGM.getASTContext(), RD, /*GenerateDefinition=*/false);
 
-  auto ArrayType = cir::ArrayType::get(CGM.getBuilder().getContext(),
-                                       CGM.getBuilder().getUInt8PtrTy(),
+  auto ArrayType = cir::ArrayType::get(CGM.getBuilder().getUInt8PtrTy(),
                                        Builder.getVTTComponents().size());
   auto Align =
       CGM.getDataLayout().getABITypeAlign(CGM.getBuilder().getUInt8PtrTy());
@@ -590,8 +588,7 @@ void CIRGenVTables::emitVTTDefinition(cir::GlobalOp VTT,
                                       const CXXRecordDecl *RD) {
   VTTBuilder Builder(CGM.getASTContext(), RD, /*GenerateDefinition=*/true);
 
-  auto ArrayType = cir::ArrayType::get(CGM.getBuilder().getContext(),
-                                       CGM.getBuilder().getUInt8PtrTy(),
+  auto ArrayType = cir::ArrayType::get(CGM.getBuilder().getUInt8PtrTy(),
                                        Builder.getVTTComponents().size());
 
   SmallVector<cir::GlobalOp, 8> VTables;

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -152,8 +152,7 @@ struct CIRRecordLowering final {
     mlir::Type type = getCharType();
     return numberOfChars == CharUnits::One()
                ? type
-               : cir::ArrayType::get(type.getContext(), type,
-                                     numberOfChars.getQuantity());
+               : cir::ArrayType::get(type, numberOfChars.getQuantity());
   }
 
   // This is different from LLVM traditional codegen because CIRGen uses arrays
@@ -165,8 +164,7 @@ struct CIRRecordLowering final {
       return builder.getUIntNTy(alignedBits);
     } else {
       mlir::Type type = getCharType();
-      return cir::ArrayType::get(type.getContext(), type,
-                                 alignedBits / astContext.getCharWidth());
+      return cir::ArrayType::get(type, alignedBits / astContext.getCharWidth());
     }
   }
 

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.cpp
@@ -292,9 +292,8 @@ mlir::Attribute ConstantAggregateBuilderBase::finishArray(mlir::Type eltTy) {
     // eltTy = tAttr.getType();
   }
 
-  auto constant = getConstArray(
-      mlir::ArrayAttr::get(eltTy.getContext(), elts),
-      cir::ArrayType::get(eltTy.getContext(), eltTy, elts.size()));
+  auto constant = getConstArray(mlir::ArrayAttr::get(eltTy.getContext(), elts),
+                                cir::ArrayType::get(eltTy, elts.size()));
   buffer.erase(buffer.begin() + Begin, buffer.end());
   return constant;
 }

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -440,7 +440,7 @@ cir::VectorType
 ABIInfo::getOptimalVectorMemoryType(cir::VectorType T,
                                     const clang::LangOptions &Opt) const {
   if (T.getSize() == 3 && !Opt.PreserveVec3Type) {
-    return cir::VectorType::get(&CGT.getMLIRContext(), T.getEltType(), 4);
+    return cir::VectorType::get(T.getEltType(), 4);
   }
   return T;
 }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -936,7 +936,7 @@ OpFoldResult cir::ComplexCreateOp::fold(FoldAdaptor adaptor) {
   assert(realAttr.getType() == imagAttr.getType() &&
          "real part and imag part should be of the same type");
 
-  auto complexTy = cir::ComplexType::get(getContext(), realAttr.getType());
+  auto complexTy = cir::ComplexType::get(realAttr.getType());
   return cir::ComplexAttr::get(complexTy, realAttr, imagAttr);
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/AArch64.cpp
@@ -128,8 +128,7 @@ ABIArgInfo AArch64ABIInfo::classifyReturnType(mlir::Type RetTy,
     // For aggregates with 16-byte alignment, we use i128.
     if (Alignment < 128 && Size == 128) {
       mlir::Type baseTy = cir::IntType::get(LT.getMLIRContext(), 64, false);
-      return ABIArgInfo::getDirect(
-          cir::ArrayType::get(LT.getMLIRContext(), baseTy, Size / 64));
+      return ABIArgInfo::getDirect(cir::ArrayType::get(baseTy, Size / 64));
     }
 
     return ABIArgInfo::getDirect(
@@ -180,8 +179,7 @@ AArch64ABIInfo::classifyArgumentType(mlir::Type Ty, bool IsVariadic,
         cir::IntType::get(LT.getMLIRContext(), Alignment, false);
     auto argTy = Size == Alignment
                      ? baseTy
-                     : cir::ArrayType::get(LT.getMLIRContext(), baseTy,
-                                           Size / Alignment);
+                     : cir::ArrayType::get(baseTy, Size / Alignment);
     return ABIArgInfo::getDirect(argTy);
   }
 


### PR DESCRIPTION
Add `TypeBuilderWithInferredContext` to each CIR type that supports MLIR context inference from its parameters.