### PR TITLE
[CIR] Refactor floating point type constraints

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4724,7 +4724,7 @@ def FrameAddrOp : FuncAddrBuiltinOp<"frame_address"> {
 
 class UnaryFPToIntBuiltinOp<string mnemonic, string llvmOpName>
     : CIR_Op<mnemonic, [Pure]> {
-  let arguments = (ins CIR_AnyFloat:$src);
+  let arguments = (ins CIR_AnyFloatType:$src);
   let results = (outs CIR_IntType:$result);
 
   let summary = [{
@@ -4847,7 +4847,7 @@ def IsFPClassOp : CIR_Op<"is_fp_class"> {
     | 9 | Positive infinity  |
   }];
 
-  let arguments = (ins CIR_AnyFloat:$src,
+  let arguments = (ins CIR_AnyFloatType:$src,
                        I32Attr:$flags);
   let results = (outs CIR_BoolType:$result);
   let assemblyFormat = [{
@@ -5708,7 +5708,7 @@ def SignBitOp : CIR_Op<"signbit", [Pure]> {
     It returns whether the sign bit (i.e. the highest bit) of the input operand
     is set.
   }];
-  let arguments = (ins CIR_AnyFloat:$input);
+  let arguments = (ins CIR_AnyFloatType:$input);
   let results = (outs CIR_BoolType:$res);
   let assemblyFormat = [{
       $input attr-dict `:` type($input) `->` qualified(type($res))

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
@@ -110,4 +110,31 @@ def CIR_AnyFundamentalSIntType
     let cppFunctionName = "isFundamentalSIntType";
 }
 
+//===----------------------------------------------------------------------===//
+// Float Type predicates
+//===----------------------------------------------------------------------===//
+
+def CIR_AnySingleType : CIR_TypeBase<"::cir::SingleType", "single float type">;
+def CIR_AnyFP32Type : TypeAlias<CIR_AnySingleType>;
+
+def CIR_AnyDoubleType : CIR_TypeBase<"::cir::DoubleType", "double float type">;
+def CIR_AnyFP64Type : TypeAlias<CIR_AnyDoubleType>;
+
+def CIR_AnyFP16Type : CIR_TypeBase<"::cir::FP16Type", "f16 type">;
+def CIR_AnyBFloat16Type : CIR_TypeBase<"::cir::BF16Type", "bf16 type">;
+def CIR_AnyFP80Type : CIR_TypeBase<"::cir::FP80Type", "f80 type">;
+def CIR_AnyFP128Type : CIR_TypeBase<"::cir::FP128Type", "f128 type">;
+def CIR_AnyLongDoubleType : CIR_TypeBase<"::cir::LongDoubleType",
+    "long double type">;
+
+def CIR_AnyFloatType : AnyTypeOf<[
+    CIR_AnySingleType, CIR_AnyDoubleType, CIR_AnyFP16Type,
+    CIR_AnyBFloat16Type, CIR_AnyFP80Type, CIR_AnyFP128Type,
+    CIR_AnyLongDoubleType
+]> {
+    let cppFunctionName = "isAnyFloatingPointType";
+}
+
+def CIR_AnyIntOrFloat : AnyTypeOf<[CIR_AnyFloatType, CIR_AnyIntType]>;
+
 #endif // CLANG_CIR_DIALECT_IR_CIRTYPECONSTRAINTS_TD

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -27,7 +27,6 @@ struct RecordTypeStorage;
 
 bool isValidFundamentalIntWidth(unsigned width);
 
-bool isAnyFloatingPointType(mlir::Type t);
 bool isScalarType(mlir::Type t);
 bool isFPOrFPVectorTy(mlir::Type);
 bool isIntOrIntVectorTy(mlir::Type);

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -80,12 +80,10 @@ def CIR_IntType : CIR_Type<"Int", "int",
 // FloatType
 //===----------------------------------------------------------------------===//
 
-class CIR_FloatType<string name, string mnemonic>
-    : CIR_Type<name, mnemonic,
-          [
-            DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-            DeclareTypeInterfaceMethods<CIRFPTypeInterface>,
-          ]> {}
+class CIR_FloatType<string name, string mnemonic> : CIR_Type<name, mnemonic, [
+  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+  DeclareTypeInterfaceMethods<CIRFPTypeInterface>
+]>;
 
 def CIR_Single : CIR_FloatType<"Single", "float"> {
   let summary = "CIR single-precision float type";
@@ -99,7 +97,7 @@ def CIR_Double : CIR_FloatType<"Double", "double"> {
   let summary = "CIR double-precision float type";
   let description = [{
     Floating-point type that represents the `double` type in C/C++. Its
-    underlying floating-point format is the IEEE-754 binar64 format.
+    underlying floating-point format is the IEEE-754 binary64 format.
   }];
 }
 
@@ -138,24 +136,16 @@ def CIR_LongDouble : CIR_FloatType<"LongDouble", "long_double"> {
 
     The underlying floating-point format of a long double value depends on the
     implementation. The `underlying` parameter specifies the CIR floating-point
-    type that corresponds to this format. For now, it can only be either
-    `!cir.double` or `!cir.fp80`.
+    type that corresponds to this format.
   }];
 
-  let parameters = (ins "mlir::Type":$underlying);
+  let parameters = (ins AnyTypeOf<[CIR_Double, CIR_FP80, CIR_FP128],
+    "expects !cir.double, !cir.fp80 or !cir.fp128">:$underlying);
 
   let assemblyFormat = [{
     `<` $underlying `>`
   }];
-
-  let genVerifyDecl = 1;
 }
-
-// Constraints
-
-def CIR_AnyFloat: AnyTypeOf<[CIR_Single, CIR_Double, CIR_FP80, CIR_FP128, CIR_LongDouble,
-    CIR_FP16, CIR_BFloat16]>;
-def CIR_AnyIntOrFloat: AnyTypeOf<[CIR_AnyFloat, CIR_IntType]>;
 
 //===----------------------------------------------------------------------===//
 // ComplexType
@@ -568,11 +558,12 @@ def FPVector : Type<
 
 // Constraints
 def CIR_AnyIntOrVecOfInt: AnyTypeOf<[CIR_IntType, IntegerVector]>;
+
 def CIR_AnySignedIntOrVecOfSignedInt: AnyTypeOf<[
   CIR_AnyFundamentalSIntType, SignedIntegerVector
 ]>;
 
-def CIR_AnyFloatOrVecOfFloat: AnyTypeOf<[CIR_AnyFloat, FPVector]>;
+def CIR_AnyFloatOrVecOfFloat: AnyTypeOf<[CIR_AnyFloatType, FPVector]>;
 
 // Pointer to Arrays
 def ArrayPtr : Type<
@@ -669,7 +660,7 @@ def CIR_RecordType : CIR_Type<"Record", "record",
       CArg<"ASTRecordDeclInterface", "{}">:$ast
     ), [{
       return $_get($_ctxt, members, name, /*complete=*/true, packed, padded,
-                       kind, ast);    
+                       kind, ast);
     }]>,
 
     // Create an identified and incomplete record type.
@@ -680,7 +671,7 @@ def CIR_RecordType : CIR_Type<"Record", "record",
       return $_get($_ctxt, /*members=*/llvm::ArrayRef<Type>{}, name,
                          /*complete=*/false, /*packed=*/false,
                          /*padded=*/false, kind,
-                         /*ast=*/ASTRecordDeclInterface{});    
+                         /*ast=*/ASTRecordDeclInterface{});
     }]>,
 
     // Create an anonymous record type (always complete).
@@ -757,8 +748,7 @@ def CIRRecordType : Type<
 def CIR_AnyType : AnyTypeOf<[
   CIR_IntType, CIR_PointerType, CIR_DataMemberType, CIR_MethodType,
   CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_FuncType, CIR_VoidType,
-  CIR_RecordType, CIR_ExceptionType, CIR_AnyFloat, CIR_FP16, CIR_BFloat16,
-  CIR_ComplexType
+  CIR_RecordType, CIR_ExceptionType, CIR_AnyFloatType, CIR_ComplexType
 ]>;
 
 #endif // MLIR_CIR_DIALECT_CIR_TYPES

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -758,25 +758,9 @@ LongDoubleType::getABIAlignment(const mlir::DataLayout &dataLayout,
       .getABIAlignment(dataLayout, params);
 }
 
-LogicalResult
-LongDoubleType::verify(function_ref<InFlightDiagnostic()> emitError,
-                       mlir::Type underlying) {
-  if (!mlir::isa<DoubleType, FP80Type, FP128Type>(underlying)) {
-    emitError() << "invalid underlying type for long double";
-    return failure();
-  }
-
-  return success();
-}
-
 //===----------------------------------------------------------------------===//
 // Floating-point type helpers
 //===----------------------------------------------------------------------===//
-
-bool cir::isAnyFloatingPointType(mlir::Type t) {
-  return isa<cir::SingleType, cir::DoubleType, cir::LongDoubleType,
-             cir::FP80Type, cir::BF16Type, cir::FP16Type, cir::FP128Type>(t);
-}
 
 bool cir::isScalarType(mlir::Type ty) {
   return isa<cir::IntType, cir::BoolType, cir::SingleType, cir::DoubleType,

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1163,7 +1163,7 @@ cir.func @no_reference_global() {
 
 // -----
 
-// expected-error@+1 {{invalid underlying type for long double}}
+// expected-error@+1 {{failed to verify 'underlying': expects !cir.double, !cir.fp80 or !cir.fp128}}
 cir.func @bad_long_double(%arg0 : !cir.long_double<!cir.float>) -> () {
   cir.return
 }


### PR DESCRIPTION
This refactors cir floating point type constraints, and fixes long double verifier to use constraints directly.