### PR TITLE
[CIR] Add code to detect non-zero-initializable records

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1729,10 +1729,14 @@ mlir::Attribute ConstantEmitter::tryEmitPrivateForVarInit(const VarDecl &D) {
           const auto *cxxrd =
               cast<CXXRecordDecl>(Ty->getAs<RecordType>()->getDecl());
           // Some cases, such as member pointer members, can't be zero
-          // initialized. The classic codegen goes through emitNullConstant
-          // for those cases but generates a non-zero constant. We can't
-          // quite do that here because we need an attribute and not a value,
-          // but something like that can be implemented.
+          // initialized. These are "zero-initialized" in the language standard
+          // sense, but the target ABI may require that a literal value other
+          // than zero be used in the initializer to make clear that a pointer
+          // with the value zero is not what is intended. The classic codegen
+          // goes through emitNullConstant for those cases but generates a
+          // non-zero constant. We can't quite do that here because we need an
+          // attribute and not a value, but something like that can be
+          // implemented.
           if (!CGM.getTypes().isZeroInitializable(cxxrd)) {
             llvm_unreachable("NYI");
           }

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1717,7 +1717,7 @@ mlir::Attribute ConstantEmitter::tryEmitPrivateForVarInit(const VarDecl &D) {
   // initialization of memory to all NULLs.
   if (!D.hasLocalStorage()) {
     QualType Ty = CGM.getASTContext().getBaseElementType(D.getType());
-    if (Ty->isRecordType())
+    if (Ty->isRecordType()) {
       if (const CXXConstructExpr *E =
               dyn_cast_or_null<CXXConstructExpr>(D.getInit())) {
         const CXXConstructorDecl *CD = E->getConstructor();
@@ -1725,9 +1725,21 @@ mlir::Attribute ConstantEmitter::tryEmitPrivateForVarInit(const VarDecl &D) {
         // just emitting a global with zero init (mimic what we do for trivial
         // assignments and whatnots). Since this is for globals shouldn't
         // be a problem for the near future.
-        if (CD->isTrivial() && CD->isDefaultConstructor())
+        if (CD->isTrivial() && CD->isDefaultConstructor()) {
+          const auto *cxxrd =
+              cast<CXXRecordDecl>(Ty->getAs<RecordType>()->getDecl());
+          // Some cases, such as member pointer members, can't be zero
+          // initialized. The classic codegen goes through emitNullConstant
+          // for those cases but generates a non-zero constant. We can't
+          // quite do that here because we need an attribute and not a value,
+          // but something like that can be implemented.
+          if (!CGM.getTypes().isZeroInitializable(cxxrd)) {
+            llvm_unreachable("NYI");
+          }
           return cir::ZeroAttr::get(CGM.convertType(D.getType()));
+        }
       }
+    }
   }
   InConstantContext = D.hasConstantInitialization();
 

--- a/clang/test/CIR/CodeGen/nonzeroinit-struct.cpp
+++ b/clang/test/CIR/CodeGen/nonzeroinit-struct.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// This case is not yet implemented.
+// XFAIL: *
+
+struct Other {
+    int x;
+};
+
+struct Trivial {
+    int x;
+    double y;
+    decltype(&Other::x) ptr;
+};
+
+// This case has a trivial default constructor, but can't be zero-initialized.
+Trivial t;
+
+// The type is wrong on the last member here. It needs to be initialized to -1,
+//   but I don't know what that will look like.
+// CHECK: cir.global {{.*}} @t = #cir.const_record<{#cir.int<0> : !s32i, #cir.fp<0.000000e+00> : !cir.double, #cir.int<-1> : !s64i}>


### PR DESCRIPTION
There are some cases where we're currently using the zero attribute to initialize global variables for records that aren't properly zero-initializable. We weren't checking for that, and we also weren't properly calculating zero-initializability for records. This patch addresses both of these issues.

This doesn't actually handle the case where the record isn't zero-initializable. It just reports it as NYI. It does add a comment about what needs to be done.