### PR TITLE
[CIR] Remove ABI handling from CIRGen call handling

### DIFF
--- a/clang/lib/CIR/CodeGen/ABIInfo.h
+++ b/clang/lib/CIR/CodeGen/ABIInfo.h
@@ -34,8 +34,6 @@ public:
   CIRGenCXXABI &getCXXABI() const;
   clang::ASTContext &getContext() const;
 
-  virtual void computeInfo(CIRGenFunctionInfo &FI) const = 0;
-
   virtual bool allowBFloatArgsAndRet() const { return false; }
 
   // Implement the Type::IsPromotableIntegerType for ABI specific needs. The

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -524,15 +524,12 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
   // If this is a Microsoft-style asm blob, store the return registers (EAX:EDX)
   // to the return value slot. Only do this when returning in registers.
   if (isa<MSAsmStmt>(&S)) {
-    const cir::ABIArgInfo &RetAI = CurFnInfo->getReturnInfo();
-    if (RetAI.isDirect() || RetAI.isExtend()) {
-      // Make a fake lvalue for the return value slot.
-      LValue ReturnSlot = makeAddrLValue(ReturnValue, FnRetTy);
-      CGM.getTargetCIRGenInfo().addReturnRegisterOutputs(
-          *this, ReturnSlot, Constraints, ResultRegTypes, ResultTruncRegTypes,
-          ResultRegDests, AsmString, S.getNumOutputs());
-      SawAsmBlock = true;
-    }
+    // Make a fake lvalue for the return value slot.
+    LValue ReturnSlot = makeAddrLValue(ReturnValue, FnRetTy);
+    CGM.getTargetCIRGenInfo().addReturnRegisterOutputs(
+        *this, ReturnSlot, Constraints, ResultRegTypes, ResultTruncRegTypes,
+        ResultRegDests, AsmString, S.getNumOutputs());
+    SawAsmBlock = true;
   }
 
   for (unsigned i = 0, e = S.getNumInputs(); i != e; i++) {

--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -521,17 +521,6 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
     }
   } // iterate over output operands
 
-  // If this is a Microsoft-style asm blob, store the return registers (EAX:EDX)
-  // to the return value slot. Only do this when returning in registers.
-  if (isa<MSAsmStmt>(&S)) {
-    // Make a fake lvalue for the return value slot.
-    LValue ReturnSlot = makeAddrLValue(ReturnValue, FnRetTy);
-    CGM.getTargetCIRGenInfo().addReturnRegisterOutputs(
-        *this, ReturnSlot, Constraints, ResultRegTypes, ResultTruncRegTypes,
-        ResultRegDests, AsmString, S.getNumOutputs());
-    SawAsmBlock = true;
-  }
-
   for (unsigned i = 0, e = S.getNumInputs(); i != e; i++) {
     const Expr *InputExpr = S.getInputExpr(i);
 

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -77,117 +77,6 @@ CIRGenFunctionInfo *CIRGenFunctionInfo::create(
   return FI;
 }
 
-namespace {
-
-/// Encapsulates information about the way function arguments from
-/// CIRGenFunctionInfo should be passed to actual CIR function.
-class ClangToCIRArgMapping {
-  static const unsigned InvalidIndex = ~0U;
-  unsigned InallocaArgNo;
-  unsigned SRetArgNo;
-  unsigned TotalCIRArgs;
-
-  /// Arguments of CIR function corresponding to single Clang argument.
-  struct CIRArgs {
-    unsigned PaddingArgIndex = 0;
-    // Argument is expanded to CIR arguments at positions
-    // [FirstArgIndex, FirstArgIndex + NumberOfArgs).
-    unsigned FirstArgIndex = 0;
-    unsigned NumberOfArgs = 0;
-
-    CIRArgs()
-        : PaddingArgIndex(InvalidIndex), FirstArgIndex(InvalidIndex),
-          NumberOfArgs(0) {}
-  };
-
-  SmallVector<CIRArgs, 8> ArgInfo;
-
-public:
-  ClangToCIRArgMapping(const ASTContext &astContext,
-                       const CIRGenFunctionInfo &FI,
-                       bool OnlyRequiredArgs = false)
-      : InallocaArgNo(InvalidIndex), SRetArgNo(InvalidIndex), TotalCIRArgs(0),
-        ArgInfo(OnlyRequiredArgs ? FI.getNumRequiredArgs() : FI.arg_size()) {
-    construct(astContext, FI, OnlyRequiredArgs);
-  }
-
-  bool hasSRetArg() const { return SRetArgNo != InvalidIndex; }
-
-  bool hasInallocaArg() const { return InallocaArgNo != InvalidIndex; }
-
-  unsigned totalCIRArgs() const { return TotalCIRArgs; }
-
-  bool hasPaddingArg(unsigned ArgNo) const {
-    assert(ArgNo < ArgInfo.size());
-    return ArgInfo[ArgNo].PaddingArgIndex != InvalidIndex;
-  }
-
-  /// Returns index of first CIR argument corresponding to ArgNo, and their
-  /// quantity.
-  std::pair<unsigned, unsigned> getCIRArgs(unsigned ArgNo) const {
-    assert(ArgNo < ArgInfo.size());
-    return std::make_pair(ArgInfo[ArgNo].FirstArgIndex,
-                          ArgInfo[ArgNo].NumberOfArgs);
-  }
-
-private:
-  void construct(const ASTContext &astContext, const CIRGenFunctionInfo &FI,
-                 bool OnlyRequiredArgs);
-};
-
-void ClangToCIRArgMapping::construct(const ASTContext &astContext,
-                                     const CIRGenFunctionInfo &FI,
-                                     bool OnlyRequiredArgs) {
-  unsigned CIRArgNo = 0;
-  bool SwapThisWithSRet = false;
-  const cir::ABIArgInfo &RetAI = FI.getReturnInfo();
-
-  assert(RetAI.getKind() != cir::ABIArgInfo::Indirect && "NYI");
-
-  unsigned ArgNo = 0;
-  unsigned NumArgs = OnlyRequiredArgs ? FI.getNumRequiredArgs() : FI.arg_size();
-  for (CIRGenFunctionInfo::const_arg_iterator I = FI.arg_begin();
-       ArgNo < NumArgs; ++I, ++ArgNo) {
-    assert(I != FI.arg_end());
-    const cir::ABIArgInfo &AI = I->info;
-    // Collect data about CIR arguments corresponding to Clang argument ArgNo.
-    auto &CIRArgs = ArgInfo[ArgNo];
-
-    assert(!AI.getPaddingType() && "NYI");
-
-    switch (AI.getKind()) {
-    default:
-      llvm_unreachable("NYI");
-    case cir::ABIArgInfo::Extend:
-    case cir::ABIArgInfo::Direct: {
-      // Postpone splitting structs into elements since this makes it way
-      // more complicated for analysis to obtain information on the original
-      // arguments.
-      //
-      // TODO(cir): a LLVM lowering prepare pass should break this down into
-      // the appropriated pieces.
-      assert(!cir::MissingFeatures::constructABIArgDirectExtend());
-      CIRArgs.NumberOfArgs = 1;
-      break;
-    }
-    }
-
-    if (CIRArgs.NumberOfArgs > 0) {
-      CIRArgs.FirstArgIndex = CIRArgNo;
-      CIRArgNo += CIRArgs.NumberOfArgs;
-    }
-
-    assert(!SwapThisWithSRet && "NYI");
-  }
-  assert(ArgNo == ArgInfo.size());
-
-  assert(!FI.usesInAlloca() && "NYI");
-
-  TotalCIRArgs = CIRArgNo;
-}
-
-} // namespace
-
 static bool hasInAllocaArgs(CIRGenModule &CGM, CallingConv ExplicitCC,
                             ArrayRef<QualType> ArgTypes) {
   assert(ExplicitCC != CC_Swift && ExplicitCC != CC_SwiftAsync && "Swift NYI");
@@ -206,56 +95,13 @@ cir::FuncType CIRGenTypes::GetFunctionType(const CIRGenFunctionInfo &FI) {
   (void)Inserted;
   assert(Inserted && "Recursively being processed?");
 
-  mlir::Type resultType = nullptr;
-  const cir::ABIArgInfo &retAI = FI.getReturnInfo();
-  switch (retAI.getKind()) {
-  case cir::ABIArgInfo::Ignore:
-    // TODO(CIR): This should probably be the None type from the builtin
-    // dialect.
-    resultType = nullptr;
-    break;
-
-  case cir::ABIArgInfo::Extend:
-  case cir::ABIArgInfo::Direct:
-    resultType = retAI.getCoerceToType();
-    break;
-
-  default:
-    assert(false && "NYI");
-  }
-
-  ClangToCIRArgMapping CIRFunctionArgs(getContext(), FI, true);
-  SmallVector<mlir::Type, 8> ArgTypes(CIRFunctionArgs.totalCIRArgs());
-
-  assert(!CIRFunctionArgs.hasSRetArg() && "NYI");
-  assert(!CIRFunctionArgs.hasInallocaArg() && "NYI");
+  mlir::Type resultType = convertType(FI.getReturnType());
+  SmallVector<mlir::Type, 8> ArgTypes;
+  ArgTypes.reserve(FI.getNumRequiredArgs());
 
   // Add in all of the required arguments.
-  unsigned ArgNo = 0;
-  CIRGenFunctionInfo::const_arg_iterator it = FI.arg_begin(),
-                                         ie = it + FI.getNumRequiredArgs();
-
-  for (; it != ie; ++it, ++ArgNo) {
-    const auto &ArgInfo = it->info;
-
-    assert(!CIRFunctionArgs.hasPaddingArg(ArgNo) && "NYI");
-
-    unsigned FirstCIRArg, NumCIRArgs;
-    std::tie(FirstCIRArg, NumCIRArgs) = CIRFunctionArgs.getCIRArgs(ArgNo);
-
-    switch (ArgInfo.getKind()) {
-    default:
-      llvm_unreachable("NYI");
-    case cir::ABIArgInfo::Extend:
-    case cir::ABIArgInfo::Direct: {
-      mlir::Type argType = ArgInfo.getCoerceToType();
-      // TODO: handle the test against llvm::RecordType from codegen
-      assert(NumCIRArgs == 1);
-      ArgTypes[FirstCIRArg] = argType;
-      break;
-    }
-    }
-  }
+  for (const CIRGenFunctionInfoArgInfo &argInfo : FI.requiredArguments())
+    ArgTypes.push_back(convertType(argInfo.type));
 
   bool Erased = FunctionsBeingProcessed.erase(&FI);
   (void)Erased;
@@ -304,14 +150,6 @@ void CIRGenFunction::emitAggregateStore(mlir::Value Val, Address Dest,
   mlir::OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointAfter(Val.getDefiningOp());
   builder.createStore(*currSrcLoc, Val, Dest);
-}
-
-static Address emitAddressAtOffset(CIRGenFunction &CGF, Address addr,
-                                   const cir::ABIArgInfo &info) {
-  if ([[maybe_unused]] unsigned offset = info.getDirectOffset()) {
-    llvm_unreachable("NYI");
-  }
-  return addr;
 }
 
 static void AddAttributesFromFunctionProtoType(CIRGenBuilderTy &builder,
@@ -593,8 +431,6 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &CallInfo,
   // Handle struct-return functions by passing a pointer to the location that we
   // would like to return info.
   QualType RetTy = CallInfo.getReturnType();
-  const auto &RetAI = CallInfo.getReturnInfo();
-
   cir::FuncType CIRFuncTy = getTypes().GetFunctionType(CallInfo);
 
   const Decl *TargetDecl = Callee.getAbstractInfo().getCalleeDecl().getDecl();
@@ -629,63 +465,32 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &CallInfo,
   Address ArgMemory = Address::invalid();
   assert(!CallInfo.getArgRecord() && "NYI");
 
-  ClangToCIRArgMapping CIRFunctionArgs(CGM.getASTContext(), CallInfo);
-  SmallVector<mlir::Value, 16> CIRCallArgs(CIRFunctionArgs.totalCIRArgs());
+  SmallVector<mlir::Value, 16> CIRCallArgs;
+  CIRCallArgs.reserve(CallArgs.size());
 
-  // If the call returns a temporary with struct return, create a temporary
-  // alloca to hold the result, unless one is given to us.
-  assert(!RetAI.isIndirect() && !RetAI.isInAlloca() &&
-         !RetAI.isCoerceAndExpand() && "NYI");
-
-  // When passing arguments using temporary allocas, we need to add the
-  // appropriate lifetime markers. This vector keeps track of all the lifetime
-  // markers that need to be ended right after the call.
-  assert(!cir::MissingFeatures::shouldEmitLifetimeMarkers() && "NYI");
-
-  // Translate all of the arguments as necessary to match the CIR lowering.
-  assert(CallInfo.arg_size() == CallArgs.size() &&
-         "Mismatch between function signature & arguments.");
   unsigned ArgNo = 0;
   CIRGenFunctionInfo::const_arg_iterator info_it = CallInfo.arg_begin();
   for (CallArgList::const_iterator I = CallArgs.begin(), E = CallArgs.end();
        I != E; ++I, ++info_it, ++ArgNo) {
-    const cir::ABIArgInfo &ArgInfo = info_it->info;
 
-    // Insert a padding argument to ensure proper alignment.
-    assert(!CIRFunctionArgs.hasPaddingArg(ArgNo) && "Padding args NYI");
+    mlir::Type argType = convertType(info_it->type);
+    if (!mlir::isa<cir::RecordType>(argType)) {
+      mlir::Value V;
+      assert(!I->isAggregate() && "Aggregate NYI");
+      V = I->getKnownRValue().getScalarVal();
 
-    unsigned FirstCIRArg, NumCIRArgs;
-    std::tie(FirstCIRArg, NumCIRArgs) = CIRFunctionArgs.getCIRArgs(ArgNo);
+      // We might have to widen integers, but we should never truncate.
+      if (argType != V.getType() && mlir::isa<cir::IntType>(V.getType()))
+        llvm_unreachable("NYI");
 
-    switch (ArgInfo.getKind()) {
-    case cir::ABIArgInfo::Direct: {
-      if (!mlir::isa<cir::RecordType>(ArgInfo.getCoerceToType()) &&
-          ArgInfo.getCoerceToType() == convertType(info_it->type) &&
-          ArgInfo.getDirectOffset() == 0) {
-        assert(NumCIRArgs == 1);
-        mlir::Value V;
-        assert(!I->isAggregate() && "Aggregate NYI");
-        V = I->getKnownRValue().getScalarVal();
+      // If the argument doesn't match, perform a bitcast to coerce it. This
+      // can happen due to trivial type mismatches.
+      if (ArgNo < CIRFuncTy.getNumInputs() &&
+          V.getType() != CIRFuncTy.getInput(ArgNo))
+        V = builder.createBitcast(V, CIRFuncTy.getInput(ArgNo));
 
-        assert(CallInfo.getExtParameterInfo(ArgNo).getABI() !=
-                   ParameterABI::SwiftErrorResult &&
-               "swift NYI");
-
-        // We might have to widen integers, but we should never truncate.
-        if (ArgInfo.getCoerceToType() != V.getType() &&
-            mlir::isa<cir::IntType>(V.getType()))
-          llvm_unreachable("NYI");
-
-        // If the argument doesn't match, perform a bitcast to coerce it. This
-        // can happen due to trivial type mismatches.
-        if (FirstCIRArg < CIRFuncTy.getNumInputs() &&
-            V.getType() != CIRFuncTy.getInput(FirstCIRArg))
-          V = builder.createBitcast(V, CIRFuncTy.getInput(FirstCIRArg));
-
-        CIRCallArgs[FirstCIRArg] = V;
-        break;
-      }
-
+      CIRCallArgs.push_back(V);
+    } else {
       // FIXME: Avoid the conversion through memory if possible.
       Address Src = Address::invalid();
       if (!I->isAggregate()) {
@@ -695,53 +500,40 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &CallInfo,
                              : I->getKnownRValue().getAggregateAddress();
       }
 
-      // If the value is offset in memory, apply the offset now.
-      Src = emitAddressAtOffset(*this, Src, ArgInfo);
-
       // Fast-isel and the optimizer generally like scalar values better than
       // FCAs, so we flatten them if this is safe to do for this argument.
-      auto STy = dyn_cast<cir::RecordType>(ArgInfo.getCoerceToType());
-      if (STy && ArgInfo.isDirect() && ArgInfo.getCanBeFlattened()) {
-        auto SrcTy = Src.getElementType();
-        // FIXME(cir): get proper location for each argument.
-        auto argLoc = loc;
+      auto STy = cast<cir::RecordType>(argType);
+      auto SrcTy = Src.getElementType();
+      // FIXME(cir): get proper location for each argument.
+      auto argLoc = loc;
 
-        // If the source type is smaller than the destination type of the
-        // coerce-to logic, copy the source value into a temp alloca the size
-        // of the destination type to allow loading all of it. The bits past
-        // the source value are left undef.
-        // FIXME(cir): add data layout info and compare sizes instead of
-        // matching the types.
-        //
-        // uint64_t SrcSize = CGM.getDataLayout().getTypeAllocSize(SrcTy);
-        // uint64_t DstSize = CGM.getDataLayout().getTypeAllocSize(STy);
-        // if (SrcSize < DstSize) {
-        if (SrcTy != STy)
-          llvm_unreachable("NYI");
-        else {
-          // FIXME(cir): this currently only runs when the types are different,
-          // but should be when alloc sizes are different, fix this as soon as
-          // datalayout gets introduced.
-          Src = builder.createElementBitCast(argLoc, Src, STy);
-        }
-
-        // assert(NumCIRArgs == STy.getMembers().size());
-        // In LLVMGen: Still only pass the struct without any gaps but mark it
-        // as such somehow.
-        //
-        // In CIRGen: Emit a load from the "whole" struct,
-        // which shall be broken later by some lowering step into multiple
-        // loads.
-        assert(NumCIRArgs == 1 && "dont break up arguments here!");
-        CIRCallArgs[FirstCIRArg] = builder.createLoad(argLoc, Src);
-      } else {
+      // If the source type is smaller than the destination type of the
+      // coerce-to logic, copy the source value into a temp alloca the size
+      // of the destination type to allow loading all of it. The bits past
+      // the source value are left undef.
+      // FIXME(cir): add data layout info and compare sizes instead of
+      // matching the types.
+      //
+      // uint64_t SrcSize = CGM.getDataLayout().getTypeAllocSize(SrcTy);
+      // uint64_t DstSize = CGM.getDataLayout().getTypeAllocSize(STy);
+      // if (SrcSize < DstSize) {
+      if (SrcTy != STy)
         llvm_unreachable("NYI");
+      else {
+        // FIXME(cir): this currently only runs when the types are different,
+        // but should be when alloc sizes are different, fix this as soon as
+        // datalayout gets introduced.
+        Src = builder.createElementBitCast(argLoc, Src, STy);
       }
 
-      break;
-    }
-    default:
-      assert(false && "Only Direct support so far");
+      // assert(NumCIRArgs == STy.getMembers().size());
+      // In LLVMGen: Still only pass the struct without any gaps but mark it
+      // as such somehow.
+      //
+      // In CIRGen: Emit a load from the "whole" struct,
+      // which shall be broken later by some lowering step into multiple
+      // loads.
+      CIRCallArgs.push_back(builder.createLoad(argLoc, Src));
     }
   }
 
@@ -890,66 +682,48 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &CallInfo,
 
   // Extract the return value.
   RValue ret = [&] {
-    switch (RetAI.getKind()) {
-    case cir::ABIArgInfo::Direct: {
-      mlir::Type RetCIRTy = convertType(RetTy);
-      if (RetAI.getCoerceToType() == RetCIRTy && RetAI.getDirectOffset() == 0) {
-        switch (getEvaluationKind(RetTy)) {
-        case cir::TEK_Aggregate: {
-          Address DestPtr = ReturnValue.getValue();
-          bool DestIsVolatile = ReturnValue.isVolatile();
-
-          if (!DestPtr.isValid()) {
-            DestPtr = CreateMemTemp(RetTy, callLoc, getCounterAggTmpAsString());
-            DestIsVolatile = false;
-          }
-
-          auto Results = theCall->getOpResults();
-          assert(Results.size() <= 1 && "multiple returns NYI");
-
-          SourceLocRAIIObject Loc{*this, callLoc};
-          emitAggregateStore(Results[0], DestPtr, DestIsVolatile);
-          return RValue::getAggregate(DestPtr);
-        }
-        case cir::TEK_Scalar: {
-          // If the argument doesn't match, perform a bitcast to coerce it. This
-          // can happen due to trivial type mismatches.
-          auto Results = theCall->getOpResults();
-          assert(Results.size() <= 1 && "multiple returns NYI");
-          assert(Results[0].getType() == RetCIRTy && "Bitcast support NYI");
-
-          mlir::Region *region = builder.getBlock()->getParent();
-          if (region != theCall->getParentRegion()) {
-            Address DestPtr = ReturnValue.getValue();
-
-            if (!DestPtr.isValid())
-              DestPtr = CreateMemTemp(RetTy, callLoc, "tmp.try.call.res");
-
-            return getRValueThroughMemory(callLoc, builder, Results[0],
-                                          DestPtr);
-          }
-
-          return RValue::get(Results[0]);
-        }
-        default:
-          llvm_unreachable("NYI");
-        }
-      } else {
-        llvm_unreachable("No other forms implemented yet.");
-      }
-    }
-
-    case cir::ABIArgInfo::Ignore:
-      // If we are ignoring an argument that had a result, make sure to
-      // construct the appropriate return value for our caller.
+    mlir::Type RetCIRTy = convertType(RetTy);
+    if (isa<cir::VoidType>(RetCIRTy))
       return GetUndefRValue(RetTy);
+    switch (getEvaluationKind(RetTy)) {
+    case cir::TEK_Aggregate: {
+      Address DestPtr = ReturnValue.getValue();
+      bool DestIsVolatile = ReturnValue.isVolatile();
 
+      if (!DestPtr.isValid()) {
+        DestPtr = CreateMemTemp(RetTy, callLoc, getCounterAggTmpAsString());
+        DestIsVolatile = false;
+      }
+
+      auto Results = theCall->getOpResults();
+      assert(Results.size() <= 1 && "multiple returns NYI");
+
+      SourceLocRAIIObject Loc{*this, callLoc};
+      emitAggregateStore(Results[0], DestPtr, DestIsVolatile);
+      return RValue::getAggregate(DestPtr);
+    }
+    case cir::TEK_Scalar: {
+      // If the argument doesn't match, perform a bitcast to coerce it. This
+      // can happen due to trivial type mismatches.
+      auto Results = theCall->getOpResults();
+      assert(Results.size() <= 1 && "multiple returns NYI");
+      assert(Results[0].getType() == RetCIRTy && "Bitcast support NYI");
+
+      mlir::Region *region = builder.getBlock()->getParent();
+      if (region != theCall->getParentRegion()) {
+        Address DestPtr = ReturnValue.getValue();
+
+        if (!DestPtr.isValid())
+          DestPtr = CreateMemTemp(RetTy, callLoc, "tmp.try.call.res");
+
+        return getRValueThroughMemory(callLoc, builder, Results[0], DestPtr);
+      }
+
+      return RValue::get(Results[0]);
+    }
     default:
       llvm_unreachable("NYI");
     }
-
-    llvm_unreachable("NYI");
-    return RValue{};
   }();
 
   // TODO: implement assumed_aligned

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -1015,11 +1015,6 @@ void CIRGenFunction::emitForwardingCallToLambda(
       callOperator->getType()->castAs<FunctionProtoType>();
   QualType resultType = FPT->getReturnType();
   ReturnValueSlot returnSlot;
-  if (!resultType->isVoidType() &&
-      calleeFnInfo.getReturnInfo().getKind() == cir::ABIArgInfo::Indirect &&
-      !hasScalarEvaluationKind(calleeFnInfo.getReturnType())) {
-    llvm_unreachable("NYI");
-  }
 
   // We don't need to separately arrange the call arguments because
   // the call can't be variadic anyway --- it's impossible to forward

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -271,14 +271,6 @@ void CIRGenFunction::emitAndUpdateRetAlloca(QualType ty, mlir::Location loc,
     // Count the implicit return.
     if (!endsWithReturn(CurFuncDecl))
       ++NumReturnExprs;
-  } else if (CurFnInfo->getReturnInfo().getKind() ==
-             cir::ABIArgInfo::Indirect) {
-    // TODO(CIR): Consider this implementation in CIRtoLLVM
-    llvm_unreachable("NYI");
-    // TODO(CIR): Consider this implementation in CIRtoLLVM
-  } else if (CurFnInfo->getReturnInfo().getKind() ==
-             cir::ABIArgInfo::InAlloca) {
-    llvm_unreachable("NYI");
   } else {
     auto addr = emitAlloca("__retval", ty, loc, alignment);
     FnRetAlloca = addr;

--- a/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
@@ -26,7 +26,6 @@ namespace clang::CIRGen {
 
 struct CIRGenFunctionInfoArgInfo {
   clang::CanQualType type;
-  cir::ABIArgInfo info;
 };
 
 /// A class for recording the number of arguments that a function signature
@@ -231,6 +230,13 @@ public:
     return llvm::ArrayRef<ArgInfo>(arg_begin(), NumArgs);
   }
 
+  llvm::MutableArrayRef<ArgInfo> requiredArguments() {
+    return llvm::MutableArrayRef<ArgInfo>(arg_begin(), getNumRequiredArgs());
+  }
+  llvm::ArrayRef<ArgInfo> requiredArguments() const {
+    return llvm::ArrayRef<ArgInfo>(arg_begin(), getNumRequiredArgs());
+  }
+
   const_arg_iterator arg_begin() const { return getArgsBuffer() + 1; }
   const_arg_iterator arg_end() const { return getArgsBuffer() + 1 + NumArgs; }
   arg_iterator arg_begin() { return getArgsBuffer() + 1; }
@@ -261,11 +267,6 @@ public:
   }
 
   clang::CanQualType getReturnType() const { return getArgsBuffer()[0].type; }
-
-  cir::ABIArgInfo &getReturnInfo() { return getArgsBuffer()[0].info; }
-  const cir::ABIArgInfo &getReturnInfo() const {
-    return getArgsBuffer()[0].info;
-  }
 
   bool isChainCall() const { return ChainCall; }
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -784,28 +784,6 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeCIRFunctionInfo(
   (void)inserted;
   assert(inserted && "Recursively being processed?");
 
-  // Compute ABI information.
-  if (CC == cir::CallingConv::SpirKernel) {
-    // Force target independent argument handling for the host visible
-    // kernel functions.
-    computeSPIRKernelABIInfo(CGM, *FI);
-  } else if (info.getCC() == CC_Swift || info.getCC() == CC_SwiftAsync) {
-    llvm_unreachable("Swift NYI");
-  } else {
-    getABIInfo().computeInfo(*FI);
-  }
-
-  // Loop over all of the computed argument and return value info. If any of
-  // them are direct or extend without a specified coerce type, specify the
-  // default now.
-  cir::ABIArgInfo &retInfo = FI->getReturnInfo();
-  if (retInfo.canHaveCoerceToType() && retInfo.getCoerceToType() == nullptr)
-    retInfo.setCoerceToType(convertType(FI->getReturnType()));
-
-  for (auto &I : FI->arguments())
-    if (I.info.canHaveCoerceToType() && I.info.getCoerceToType() == nullptr)
-      I.info.setCoerceToType(convertType(I.type));
-
   bool erased = FunctionsBeingProcessed.erase(FI);
   (void)erased;
   assert(erased && "Not in set?");

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -144,8 +144,6 @@ createAArch64TargetCIRGenInfo(CIRGenTypes &CGT, cir::AArch64ABIKind Kind);
 std::unique_ptr<TargetCIRGenInfo>
 createX86_64TargetCIRGenInfo(CIRGenTypes &CGT, cir::X86AVXABILevel AVXLevel);
 
-void computeSPIRKernelABIInfo(CIRGenModule &CGM, CIRGenFunctionInfo &FI);
-
 std::unique_ptr<TargetCIRGenInfo> createSPIRVTargetCIRGenInfo(CIRGenTypes &CGT);
 
 std::unique_ptr<TargetCIRGenInfo> createNVPTXTargetCIRGenInfo(CIRGenTypes &CGT);


### PR DESCRIPTION
Remove all the code the manages ABI info for arguments and return values in the initial CIR codegen. We prefer for the CIR to represent the types as they appear in the source code, with ABI handling being deferred until the lowering phase or calling convention transform.

The ABI handling being removed here was brought over from the classic codegen, but none of the effects being computed made it into the CIR so this change is effectively NFC.

This change leaves the `CIRGenFunctionInfoArgInfo` with just one member. That can be cleaned up in a later patch.