### PR TITLE
[CIR] Refactor constraints for integers, floats, and complex pointees

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1455,8 +1455,8 @@ def ComplexRealPtrOp : CIR_Op<"complex.real_ptr", [Pure]> {
     ```
   }];
 
-  let results = (outs PrimitiveIntOrFPPtr:$result);
-  let arguments = (ins ComplexPtr:$operand);
+  let results = (outs CIR_PtrToIntOrFloatType:$result);
+  let arguments = (ins CIR_PtrToComplexType:$operand);
 
   let assemblyFormat = [{
     $operand `:`
@@ -1480,8 +1480,8 @@ def ComplexImagPtrOp : CIR_Op<"complex.imag_ptr", [Pure]> {
     ```
   }];
 
-  let results = (outs PrimitiveIntOrFPPtr:$result);
-  let arguments = (ins ComplexPtr:$operand);
+  let results = (outs CIR_PtrToIntOrFloatType:$result);
+  let arguments = (ins CIR_PtrToComplexType:$operand);
 
   let assemblyFormat = [{
     $operand `:`
@@ -5515,17 +5515,19 @@ def AtomicFetch : CIR_Op<"atomic.fetch",
                             %val : !s32i, seq_cst) : !s32i
   }];
   let results = (outs CIR_AnyIntOrFloatType:$result);
-  let arguments = (ins Arg<PrimitiveIntOrFPPtr, "", [MemRead, MemWrite]>:$ptr,
-                       CIR_AnyIntOrFloatType:$val,
-                       AtomicFetchKind:$binop,
-                       Arg<MemOrder, "memory order">:$mem_order,
-                       UnitAttr:$is_volatile,
-                       UnitAttr:$fetch_first);
+  let arguments = (ins
+    Arg<CIR_PtrToIntOrFloatType, "", [MemRead, MemWrite]>:$ptr,
+    CIR_AnyIntOrFloatType:$val,
+    AtomicFetchKind:$binop,
+    Arg<MemOrder, "memory order">:$mem_order,
+    UnitAttr:$is_volatile,
+    UnitAttr:$fetch_first
+  );
 
   let assemblyFormat = [{
     `(`
     $binop `,`
-    $ptr `:` type($ptr) `,`
+    $ptr `:` qualified(type($ptr)) `,`
     $val `:` type($val) `,`
     $mem_order `)`
     (`volatile` $is_volatile^)?

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
@@ -135,6 +135,10 @@ def CIR_AnyFloatType : AnyTypeOf<[
     let cppFunctionName = "isAnyFloatingPointType";
 }
 
+//===----------------------------------------------------------------------===//
+// Integer or Float Type predicates
+//===----------------------------------------------------------------------===//
+
 def CIR_AnyIntOrFloatType : AnyTypeOf<[CIR_AnyFloatType, CIR_AnyIntType],
     "integer or floating point type"
 > {
@@ -168,6 +172,14 @@ class CIR_PtrToPtrTo<code type, string summary>
     : CIR_ConfinedType<CIR_AnyPtrType, [CIR_IsPtrToPtrToPred<type>],
         "pointer to pointer to " # summary>;
 
+// Pointee type constraint bases
+class CIR_PointeePred<Pred pred> : SubstLeaves<"$_self",
+    "::mlir::cast<::cir::PointerType>($_self).getPointee()", pred>;
+
+class CIR_PtrToType<Type type>
+    : CIR_ConfinedType<CIR_AnyPtrType, [CIR_PointeePred<type.predicate>],
+        "pointer to " # type.summary>;
+
 // Void pointer type constraints
 def CIR_VoidPtrType
     : CIR_PtrTo<"::cir::VoidType", "void type">,
@@ -179,5 +191,10 @@ def CIR_PtrToVoidPtrType
       BuildableType<"$_builder.getType<" # cppType # ">("
         "$_builder.getType<" # cppType # ">("
         "cir::VoidType::get($_builder.getContext())))">;
+
+// Pointer to type constraints
+def CIR_PtrToIntOrFloatType : CIR_PtrToType<CIR_AnyIntOrFloatType>;
+
+def CIR_PtrToComplexType : CIR_PtrToType<CIR_AnyComplexType>;
 
 #endif // CLANG_CIR_DIALECT_IR_CIRTYPECONSTRAINTS_TD

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -505,24 +505,6 @@ def CIR_VoidType : CIR_Type<"Void", "void"> {
 
 // Constraints
 
-// Pointer to a primitive int, float or double
-def PrimitiveIntOrFPPtr : Type<
-    And<[
-      CPred<"::mlir::isa<::cir::PointerType>($_self)">,
-      CPred<"::mlir::isa<::cir::IntType, ::cir::SingleType,"
-            "::cir::DoubleType>("
-            "::mlir::cast<::cir::PointerType>($_self).getPointee())">,
-    ]>, "{int,void}*"> {
-}
-
-def ComplexPtr : Type<
-    And<[
-      CPred<"::mlir::isa<::cir::PointerType>($_self)">,
-      CPred<"::mlir::isa<::cir::ComplexType>("
-        "::mlir::cast<::cir::PointerType>($_self).getPointee())">,
-    ]>, "!cir.complex*"> {
-}
-
 // Pointer to record
 def RecordPtr : Type<
     And<[


### PR DESCRIPTION
- Rename `PrimitiveIntOrFPPtr` to `CIR_PtrToIntOrFloatType` and broaden it to accept any floating-point type.
- Fix incorrect constraint name from `PrimitiveInt` to any `Int`; prior constraint already allowed arbitrary bitwidths, so the name was misleading.
- Rename `ComplexPtr` to `CIR_PtrToComplexType` for clarity.