### PR TITLE
[CIR][CodeGen] Emit dtor properly for objects in TernaryOp

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -803,6 +803,8 @@ CIRGenFunction::getEHDispatchBlock(EHScopeStack::stable_iterator si,
                "one per call: expected empty region at this point");
         dispatchBlock = builder.createBlock(&callWithExceptionCtx.getCleanup());
         builder.createYield(callWithExceptionCtx.getLoc());
+      } else if (currLexScope && currLexScope->isTernary()) {
+        break;
       } else {
         // Usually coming from general cir.scope cleanups that aren't
         // tried to a specific throwing call.

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2678,6 +2678,7 @@ mlir::Value ScalarExprEmitter::VisitBinLAnd(const clang::BinaryOperator *E) {
               auto res = b.create<cir::ConstantOp>(Loc, Builder.getFalseAttr());
               b.create<cir::YieldOp>(Loc, res.getRes());
             });
+        LexScope.ForceCleanup();
         B.create<cir::YieldOp>(Loc, res.getResult());
       },
       /*falseBuilder*/
@@ -2773,6 +2774,7 @@ mlir::Value ScalarExprEmitter::VisitBinLOr(const clang::BinaryOperator *E) {
               auto res = b.create<cir::ConstantOp>(Loc, Builder.getFalseAttr());
               b.create<cir::YieldOp>(Loc, res.getRes());
             });
+        LexScope.ForceCleanup();
         B.create<cir::YieldOp>(Loc, res.getResult());
       });
 


### PR DESCRIPTION
Currently, the following code snippet fails with a crash: 
```
#include <stdio.h>

struct X {
  int a;
  X(int a) : a(a) {}
  ~X() {}
};

bool foo(const X &) { return false; }
bool bar() { return foo(1) || foo(2); }
```
it fails with 
```
error: 'cir.yield' op must be the last operation in the parent block
```
The crash can be traced to the [construction of the TernaryOp](https://github.com/llvm/clangir/blob/5df50096be1a783c26b48ea437523347df8a3110/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp#L2728). A [yield](https://github.com/llvm/clangir/blob/5df50096be1a783c26b48ea437523347df8a3110/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp#L2776) is created and when the LexicalScope is destroyed the destructors for the object follow. 

So, the CIR looks something like:
```
%11 = "cir.ternary"(%10) ({
    %13 = "cir.const"() <{value = #cir.bool<true> : !cir.bool}> : () -> !cir.bool
    "cir.yield"(%13) : (!cir.bool) -> ()
}, {
    %12 = "cir.const"() <{value = #cir.bool<false> : !cir.bool}> : () -> !cir.bool
    "cir.yield"(%12) : (!cir.bool) -> ()
}) : (!cir.bool) -> !cir.bool
"cir.yield"(%11) : (!cir.bool) -> ()
"cir.call"(%7) <{callee = @_ZN1XD2Ev, calling_conv = 1 : i32, extra_attrs = #cir<extra({nothrow = #cir.nothrow})>, side_effect = 1 : i32}> ({
}) 
```
which is wrong, since the yield should come last. 

The fix here is forcing a cleanup and then the yield follows. A similar rule also applies [here](https://github.com/llvm/clangir/blob/5df50096be1a783c26b48ea437523347df8a3110/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp#L2657) for the "&&" case, e.g., foo(1) && foo(2) instead in the code snippet. 

One more modification I made is adding a check for when the current lexScope is ternary, when creating dispatch blocks for cleanups. I believe in this case, we do not want to create a dispatch block, please correct me if I am wrong.

Finally, I add two tests to verify that everything works as intended.