### PR TITLE
[CIR][ThroughMLIR] Fix ForOp handling

### DIFF
--- a/clang/test/CIR/Lowering/ThroughMLIR/for-reject-1.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/for-reject-1.cpp
@@ -1,0 +1,9 @@
+// RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o - 2>&1 | FileCheck %s
+
+void f();
+
+void reject() {
+  for (int i = 0; i < 100; i++, f());
+  // CHECK: cannot handle non-constant step for induction variable
+  // CHECK: cannot handle non-canonicalized loop
+}

--- a/clang/test/CIR/Lowering/ThroughMLIR/for-reject-2.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/for-reject-2.cpp
@@ -1,0 +1,7 @@
+// RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -fno-clangir-direct-lowering -emit-mlir=core %s -o - 2>&1 | FileCheck %s
+
+void reject() {
+  for (int i = 0; i < 100; i++, i++);
+  // CHECK: cannot handle non-constant step for induction variable
+  // CHECK: cannot handle non-canonicalized loop
+}


### PR DESCRIPTION
Currently the ForOp handling ignores everything except load, store and arithmetic in the step region. It does not detect whether the step and induction variable has already been assigned, either.

That might result to wrong behaviour:

```cpp
// Ignores printf
for (int i = 0; i < n; i++, printf("\n"));

// Only increments once
for (int i = 0; i < n; i++, i++);
```

I choose to rewrite the detection and do an exact match of the instruction sequence for `i++` and `i += n`. It doesn't seem easy to detect a more general pattern without phi nodes.

The new test case is xfailed, because ForOp hits an unreachable when it meets a non-canonicalized loop. We can implement that functionality later.