### PR TITLE
[CIR] Un-xfail some tests affected by GEP changes

### DIFF
--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -407,6 +407,7 @@ void qux(void) {
 // CHECK: %[[#V8:]] = cir.const #cir.int<6> : !u64i
 // CHECK: cir.libc.memcpy %[[#V8]] bytes from %[[#V7]] 
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // LLVM: void @qux
 // LLVM: %[[#V1:]] = alloca ptr, i64 1, align 8
 // LLVM: %[[#V2:]] = alloca i64, i64 1, align 8

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple aarch64-unknown-linux-gnu -fclangir -emit-cir-flat -fclangir-call-conv-lowering %s -o - | FileCheck %s
 // RUN: %clang_cc1 -triple aarch64-unknown-linux-gnu -fclangir -emit-llvm -fclangir-call-conv-lowering %s -o -| FileCheck %s -check-prefix=LLVM
-// XFAIL: *
 
 #include <stdint.h>
 
@@ -411,7 +410,7 @@ void qux(void) {
 // LLVM: void @qux
 // LLVM: %[[#V1:]] = alloca ptr, i64 1, align 8
 // LLVM: %[[#V2:]] = alloca i64, i64 1, align 8
-// LLVM: store ptr getelementptr (%struct.PackedS2, ptr @g, i64 1), ptr %[[#V1]], align 8
+// LLVM: store ptr getelementptr inbounds nuw (i8, ptr @g, i64 6), ptr %[[#V1]], align 8
 // LLVM: %[[#V3:]] = load ptr, ptr %[[#V1]], align 8
 // LLVM: %[[#V4:]] = load %struct.PackedS2, ptr %[[#V3]], align 1
 // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr %[[#V2]], ptr %[[#V3]], i64 6, i1 false)

--- a/clang/test/CIR/CodeGen/clear_cache.c
+++ b/clang/test/CIR/CodeGen/clear_cache.c
@@ -2,7 +2,6 @@
 // RUN: FileCheck --input-file=%t.cir -check-prefix=CIR %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu %s -fclangir -emit-llvm -o %t.ll
 // RUN: FileCheck --input-file=%t.ll -check-prefix=LLVM %s
-// XFAIL: *
 
 char buffer[32] = "This is a largely unused buffer";
 
@@ -21,7 +20,7 @@ char buffer[32] = "This is a largely unused buffer";
 // CIR:  cir.clear_cache %[[VAL_3]] : !cir.ptr<!void>, %[[VAL_8]],
 
 // LLVM-LABEL: main
-// LLVM:  call void @llvm.clear_cache(ptr @buffer, ptr getelementptr (i8, ptr @buffer, i64 32))
+// LLVM:  call void @llvm.clear_cache(ptr @buffer, ptr getelementptr inbounds nuw (i8, ptr @buffer, i64 32))
 
 int main(void) {
   __builtin___clear_cache(buffer, buffer+32);

--- a/clang/test/CIR/CodeGen/complex.c
+++ b/clang/test/CIR/CodeGen/complex.c
@@ -301,6 +301,7 @@ void imag_ptr() {
 // CHECK-AFTER-NEXT:   %{{.+}} = cir.complex.imag_ptr %[[#CI_PTR]] : !cir.ptr<!cir.complex<!s32i>> -> !cir.ptr<!s32i>
 //      CHECK-AFTER: }
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // LLVM: define dso_local void @imag_ptr()
 // LLVM:   store ptr getelementptr inbounds nuw (i8, ptr @c, i64 8), ptr %{{.+}}, align 8
 // LLVM:   store ptr getelementptr inbounds nuw (i8, ptr @ci, i64 4), ptr %{{.+}}, align 8
@@ -329,6 +330,7 @@ void extract_imag() {
 // CHECK-AFTER-NEXT:   %{{.+}} = cir.load %[[#IMAG_PTR]] : !cir.ptr<!s32i>, !s32i
 //      CHECK-AFTER: }
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // LLVM: define dso_local void @extract_imag()
 // LLVM:   %{{.+}} = load double, ptr getelementptr inbounds nuw (i8, ptr @c, i64 8), align 8
 // LLVM:   %{{.+}} = load i32, ptr getelementptr inbounds nuw (i8, ptr @ci, i64 4), align 4

--- a/clang/test/CIR/CodeGen/complex.c
+++ b/clang/test/CIR/CodeGen/complex.c
@@ -4,7 +4,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -fclangir -emit-cir -mmlir --mlir-print-ir-after=cir-canonicalize -o %t.cir %s 2>&1 | FileCheck --check-prefix=CHECK-AFTER %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -o %t.ll %s
 // RUN: FileCheck --input-file=%t.ll --check-prefixes=LLVM %s
-// XFAIL: *
 
 double _Complex c, c2;
 int _Complex ci, ci2;
@@ -303,8 +302,8 @@ void imag_ptr() {
 //      CHECK-AFTER: }
 
 // LLVM: define dso_local void @imag_ptr()
-// LLVM:   store ptr getelementptr inbounds ({ double, double }, ptr @c, i32 0, i32 1), ptr %{{.+}}, align 8
-// LLVM:   store ptr getelementptr inbounds ({ i32, i32 }, ptr @ci, i32 0, i32 1), ptr %{{.+}}, align 8
+// LLVM:   store ptr getelementptr inbounds nuw (i8, ptr @c, i64 8), ptr %{{.+}}, align 8
+// LLVM:   store ptr getelementptr inbounds nuw (i8, ptr @ci, i64 4), ptr %{{.+}}, align 8
 // LLVM: }
 
 void extract_imag() {
@@ -331,6 +330,6 @@ void extract_imag() {
 //      CHECK-AFTER: }
 
 // LLVM: define dso_local void @extract_imag()
-// LLVM:   %{{.+}} = load double, ptr getelementptr inbounds ({ double, double }, ptr @c, i32 0, i32 1), align 8
-// LLVM:   %{{.+}} = load i32, ptr getelementptr inbounds ({ i32, i32 }, ptr @ci, i32 0, i32 1), align 4
+// LLVM:   %{{.+}} = load double, ptr getelementptr inbounds nuw (i8, ptr @c, i64 8), align 8
+// LLVM:   %{{.+}} = load i32, ptr getelementptr inbounds nuw (i8, ptr @ci, i64 4), align 4
 // LLVM: }

--- a/clang/test/CIR/CodeGen/globals-neg-index-array.c
+++ b/clang/test/CIR/CodeGen/globals-neg-index-array.c
@@ -6,7 +6,6 @@
 // RUN: FileCheck --input-file=%t.cir %s
 // RUN: %clang_cc1 -x c++ -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// XFAIL: *
 
 struct __attribute__((packed)) PackedStruct {
     char a1;
@@ -18,4 +17,4 @@ char *packed_element = &(packed[-2].a3);
 // CHECK: cir.global external @packed = #cir.zero : !cir.array<!rec_PackedStruct x 10> {alignment = 16 : i64} loc(#loc5)
 // CHECK: cir.global external @packed_element = #cir.global_view<@packed, [-2 : i32, 2 : i32]>
 // LLVM: @packed = global [10 x %struct.PackedStruct] zeroinitializer
-// LLVM: @packed_element = global ptr getelementptr inbounds ([10 x %struct.PackedStruct], ptr @packed, i32 0, i32 -2, i32 2)
+// LLVM: @packed_element = global ptr getelementptr inbounds (i8, ptr @packed, i64 -4)

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -45,6 +45,7 @@ int main() {
 // CIR:   cir.return
 // CIR: }
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // LLVM-DAG: define linkonce_odr void @_ZN6MotherC2Ev(ptr %0)
 // LLVM-DAG:   store ptr getelementptr inbounds nuw (i8, ptr @_ZTV6Mother, i64 16), ptr %{{[0-9]+}}, align 8
 // LLVM-DAG:   ret void
@@ -65,6 +66,7 @@ int main() {
 // LLVM-DAG: $_ZTS5Child = comdat any
 // LLVM-DAG: $_ZTS6Father = comdat any
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // LLVM-DAG: define linkonce_odr void @_ZN5ChildC2Ev(ptr %0)
 // LLVM-DAG:  store ptr getelementptr inbounds nuw (i8, ptr @_ZTV5Child, i64 16), ptr %{{[0-9]+}}, align 8
 // LLVM-DAG:  %{{[0-9]+}} = getelementptr i8, ptr {{.*}}, i32 8
@@ -93,6 +95,7 @@ int main() {
 // LLVM-DAG: @_ZTS6Mother = linkonce_odr global [7 x i8] c"6Mother", comdat
 
 //   typeinfo for Mother
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // CIR: cir.global constant external @_ZTI6Mother = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Mother> : !cir.ptr<!u8i>}> : ![[VTypeInfoA]] {alignment = 8 : i64}
 // LLVM-DAG: @_ZTI6Mother = constant { ptr, ptr } { ptr getelementptr inbounds nuw (i8, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i64 16), ptr @_ZTS6Mother }
 
@@ -117,9 +120,11 @@ int main() {
 // LLVM-DAG: @_ZTS6Father = linkonce_odr global [7 x i8] c"6Father", comdat
 
 //   typeinfo for Father
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // CIR: cir.global constant external @_ZTI6Father = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Father> : !cir.ptr<!u8i>}> : !rec_anon_struct {alignment = 8 : i64}
 // LLVM-DAG: @_ZTI6Father = constant { ptr, ptr } { ptr getelementptr inbounds nuw (i8, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i64 16), ptr @_ZTS6Father }
 
 //   typeinfo for Child
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // CIR: cir.global constant external @_ZTI5Child = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv121__vmi_class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS5Child> : !cir.ptr<!u8i>, #cir.int<0> : !u32i, #cir.int<2> : !u32i, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.int<2> : !s64i, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.int<2050> : !s64i}> : ![[VTypeInfoB]] {alignment = 8 : i64}
 // LLVM-DAG: @_ZTI5Child = constant { ptr, ptr, i32, i32, ptr, i64, ptr, i64 } { ptr getelementptr inbounds nuw (i8, ptr @_ZTVN10__cxxabiv121__vmi_class_type_infoE, i64 16), ptr @_ZTS5Child, i32 0, i32 2, ptr @_ZTI6Mother, i64 2, ptr @_ZTI6Father, i64 2050 }

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -2,7 +2,6 @@
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// XFAIL: *
 
 class Mother {
 public:
@@ -40,22 +39,22 @@ int main() {
 // CIR: !rec_Child = !cir.record<class "Child" {!rec_Mother, !rec_Father} #cir.record.decl.ast>
 
 // CIR: cir.func linkonce_odr @_ZN6MotherC2Ev(%arg0: !cir.ptr<!rec_Mother>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV6Mother, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV6Mother, address_point = <index = 0, offset = 2>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 // CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_Mother>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.store %2, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.return
 // CIR: }
 
 // LLVM-DAG: define linkonce_odr void @_ZN6MotherC2Ev(ptr %0)
-// LLVM-DAG:   store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV6Mother, i32 0, i32 0, i32 2), ptr %{{[0-9]+}}, align 8
+// LLVM-DAG:   store ptr getelementptr inbounds nuw (i8, ptr @_ZTV6Mother, i64 16), ptr %{{[0-9]+}}, align 8
 // LLVM-DAG:   ret void
 // LLVM-DAG: }
 
 // CIR: cir.func linkonce_odr @_ZN5ChildC2Ev(%arg0: !cir.ptr<!rec_Child>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, address_point = <index = 0, offset = 2>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 // CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_Child>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, vtable_index = 1, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, address_point = <index = 1, offset = 2>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 // CIR:   %7 = cir.base_class_addr(%1 : !cir.ptr<!rec_Child> nonnull) [8] -> !cir.ptr<!rec_Father>
 // CIR:   %8 = cir.cast(bitcast, %7 : !cir.ptr<!rec_Father>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>> loc(#loc8)
 // CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
@@ -67,17 +66,17 @@ int main() {
 // LLVM-DAG: $_ZTS6Father = comdat any
 
 // LLVM-DAG: define linkonce_odr void @_ZN5ChildC2Ev(ptr %0)
-// LLVM-DAG:  store ptr getelementptr inbounds ({ [4 x ptr], [3 x ptr] }, ptr @_ZTV5Child, i32 0, i32 0, i32 2), ptr %{{[0-9]+}}, align 8
+// LLVM-DAG:  store ptr getelementptr inbounds nuw (i8, ptr @_ZTV5Child, i64 16), ptr %{{[0-9]+}}, align 8
 // LLVM-DAG:  %{{[0-9]+}} = getelementptr i8, ptr {{.*}}, i32 8
-// LLVM-DAG:  store ptr getelementptr inbounds ({ [4 x ptr], [3 x ptr] }, ptr @_ZTV5Child, i32 0, i32 1, i32 2), ptr %{{[0-9]+}}, align 8
+// LLVM-DAG:  store ptr getelementptr inbounds nuw (i8, ptr @_ZTV5Child, i64 48), ptr %{{[0-9]+}}, align 8
 // LLVM-DAG:  ret void
 // }
 
 // CIR: cir.func @main() -> !s32i extra(#fn_attr) {
 
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point( %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_Mother>)>>>, vtable_index = 0, address_point_index = 0) : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_Mother>)>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point( %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_Mother>)>>>, address_point = <index = 0, offset = 0>) : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_Mother>)>>>
 
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point( %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_Child>)>>>, vtable_index = 0, address_point_index = 0) : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_Child>)>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point( %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_Child>)>>>, address_point = <index = 0, offset = 0>) : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!rec_Child>)>>>
 
 // CIR: }
 
@@ -95,7 +94,7 @@ int main() {
 
 //   typeinfo for Mother
 // CIR: cir.global constant external @_ZTI6Mother = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Mother> : !cir.ptr<!u8i>}> : ![[VTypeInfoA]] {alignment = 8 : i64}
-// LLVM-DAG: @_ZTI6Mother = constant { ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i32 2), ptr @_ZTS6Mother }
+// LLVM-DAG: @_ZTI6Mother = constant { ptr, ptr } { ptr getelementptr inbounds nuw (i8, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i64 16), ptr @_ZTS6Mother }
 
 //   vtable for Father
 // CIR: cir.global linkonce_odr @_ZTV6Father = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.global_view<@_ZN6Father9FatherFooEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 3>}> : ![[VTableTypeFather]] {alignment = 8 : i64}
@@ -119,8 +118,8 @@ int main() {
 
 //   typeinfo for Father
 // CIR: cir.global constant external @_ZTI6Father = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS6Father> : !cir.ptr<!u8i>}> : !rec_anon_struct {alignment = 8 : i64}
-// LLVM-DAG: @_ZTI6Father = constant { ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i32 2), ptr @_ZTS6Father }
+// LLVM-DAG: @_ZTI6Father = constant { ptr, ptr } { ptr getelementptr inbounds nuw (i8, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i64 16), ptr @_ZTS6Father }
 
 //   typeinfo for Child
 // CIR: cir.global constant external @_ZTI5Child = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv121__vmi_class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS5Child> : !cir.ptr<!u8i>, #cir.int<0> : !u32i, #cir.int<2> : !u32i, #cir.global_view<@_ZTI6Mother> : !cir.ptr<!u8i>, #cir.int<2> : !s64i, #cir.global_view<@_ZTI6Father> : !cir.ptr<!u8i>, #cir.int<2050> : !s64i}> : ![[VTypeInfoB]] {alignment = 8 : i64}
-// LLVM-DAG: @_ZTI5Child = constant { ptr, ptr, i32, i32, ptr, i64, ptr, i64 } { ptr getelementptr inbounds (ptr, ptr @_ZTVN10__cxxabiv121__vmi_class_type_infoE, i32 2), ptr @_ZTS5Child, i32 0, i32 2, ptr @_ZTI6Mother, i64 2, ptr @_ZTI6Father, i64 2050 }
+// LLVM-DAG: @_ZTI5Child = constant { ptr, ptr, i32, i32, ptr, i64, ptr, i64 } { ptr getelementptr inbounds nuw (i8, ptr @_ZTVN10__cxxabiv121__vmi_class_type_infoE, i64 16), ptr @_ZTS5Child, i32 0, i32 2, ptr @_ZTI6Mother, i64 2, ptr @_ZTI6Father, i64 2050 }

--- a/clang/test/CIR/CodeGen/vbase.cpp
+++ b/clang/test/CIR/CodeGen/vbase.cpp
@@ -39,6 +39,7 @@ void ppp() { B b; }
 // LLVM: $_ZTS1B = comdat any
 // LLVM: $_ZTS1A = comdat any
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // LLVM: @_ZTV1B = linkonce_odr global { [3 x ptr] } { [3 x ptr] [ptr inttoptr (i64 12 to ptr), ptr null, ptr @_ZTI1B] }
 // LLVM: @_ZTT1B = linkonce_odr global [1 x ptr] [ptr getelementptr inbounds nuw (i8, ptr @_ZTV1B, i64 24)]
 // LLVM: @_ZTVN10__cxxabiv121__vmi_class_type_infoE = external global ptr

--- a/clang/test/CIR/CodeGen/vbase.cpp
+++ b/clang/test/CIR/CodeGen/vbase.cpp
@@ -2,7 +2,6 @@
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
-// XFAIL: *
 
 struct A {
   int a;
@@ -41,10 +40,10 @@ void ppp() { B b; }
 // LLVM: $_ZTS1A = comdat any
 
 // LLVM: @_ZTV1B = linkonce_odr global { [3 x ptr] } { [3 x ptr] [ptr inttoptr (i64 12 to ptr), ptr null, ptr @_ZTI1B] }
-// LLVM: @_ZTT1B = linkonce_odr global [1 x ptr] [ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 3)]
+// LLVM: @_ZTT1B = linkonce_odr global [1 x ptr] [ptr getelementptr inbounds nuw (i8, ptr @_ZTV1B, i64 24)]
 // LLVM: @_ZTVN10__cxxabiv121__vmi_class_type_infoE = external global ptr
 // LLVM: @_ZTS1B = linkonce_odr global [2 x i8] c"1B", comdat
 // LLVM: @_ZTVN10__cxxabiv117__class_type_infoE = external global ptr
 // LLVM: @_ZTS1A = linkonce_odr global [2 x i8] c"1A", comdat
-// LLVM: @_ZTI1A = constant { ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i32 2), ptr @_ZTS1A }
-// LLVM: @_ZTI1B = constant { ptr, ptr, i32, i32, ptr, i64 } { ptr getelementptr inbounds (ptr, ptr @_ZTVN10__cxxabiv121__vmi_class_type_infoE, i32 2), ptr @_ZTS1B, i32 0, i32 1, ptr @_ZTI1A, i64 -6141 }
+// LLVM: @_ZTI1A = constant { ptr, ptr } { ptr getelementptr inbounds nuw (i8, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i64 16), ptr @_ZTS1A }
+// LLVM: @_ZTI1B = constant { ptr, ptr, i32, i32, ptr, i64 } { ptr getelementptr inbounds nuw (i8, ptr @_ZTVN10__cxxabiv121__vmi_class_type_infoE, i64 16), ptr @_ZTS1B, i32 0, i32 1, ptr @_ZTI1A, i64 -6141 }

--- a/clang/test/CIR/CodeGen/vtable-emission.cpp
+++ b/clang/test/CIR/CodeGen/vtable-emission.cpp
@@ -3,7 +3,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir  -emit-llvm -o - %s \
 // RUN: | opt -S -passes=instcombine,mem2reg,simplifycfg -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// XFAIL: *
 
 struct S {
   virtual void key();
@@ -23,8 +22,8 @@ void S::key() {}
 // CHECK: cir.global external @sobj = #cir.const_record
 // CHECK-SAME: <{#cir.global_view<@_ZTV1S, [0 : i32, 2 : i32]> :
 // CHECK-SAME: !cir.ptr<!rec_anon_struct1>}> : !rec_anon_struct2 {alignment = 8 : i64}
-// LLVM: @sobj = global { ptr } { ptr getelementptr inbounds
-// LLVM-SAME: ({ [4 x ptr] }, ptr @_ZTV1S, i32 0, i32 0, i32 2) }, align 8
+// LLVM: @sobj = global { ptr } { ptr getelementptr inbounds nuw
+// LLVM-SAME: (i8, ptr @_ZTV1S, i64 16) }, align 8
 
 // The reference from the vtable should result in nonKey being emitted.
 // CHECK: cir.func linkonce_odr @_ZN1S6nonKeyEv({{.*}} {

--- a/clang/test/CIR/CodeGen/vtable-emission.cpp
+++ b/clang/test/CIR/CodeGen/vtable-emission.cpp
@@ -19,6 +19,7 @@ void S::key() {}
 // LLVM: @_ZTV1S = global { [4 x ptr] } { [4 x ptr]
 // LLVM-SAME: [ptr null, ptr @_ZTI1S, ptr @_ZN1S3keyEv, ptr @_ZN1S6nonKeyEv] }, align 8
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // CHECK: cir.global external @sobj = #cir.const_record
 // CHECK-SAME: <{#cir.global_view<@_ZTV1S, [0 : i32, 2 : i32]> :
 // CHECK-SAME: !cir.ptr<!rec_anon_struct1>}> : !rec_anon_struct2 {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/vtt.cpp
+++ b/clang/test/CIR/CodeGen/vtt.cpp
@@ -131,6 +131,7 @@ int f() {
 // CIR:   cir.return
 // CIR: }
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // LLVM-LABEL: @_ZN1DC1Ev
 // LLVM:   %2 = alloca ptr, i64 1, align 8
 // LLVM:   store ptr %0, ptr %2, align 8

--- a/clang/test/CIR/CodeGen/vtt.cpp
+++ b/clang/test/CIR/CodeGen/vtt.cpp
@@ -2,7 +2,6 @@
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll  %s
-// XFAIL: *
 
 class A {
 public:
@@ -39,7 +38,7 @@ int f() {
 
 // Class A constructor
 // CIR: cir.func linkonce_odr @_ZN1AC2Ev(%arg0: !cir.ptr<!rec_A>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1A, vtable_index = 0, address_point_index = 2) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1A, address_point = <index = 0, offset = 2>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 // CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_A>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR: }
@@ -116,15 +115,15 @@ int f() {
 // CIR:   %[[VTT_D_TO_C:.*]] = cir.vtt.address_point @_ZTT1D, offset = 3 -> !cir.ptr<!cir.ptr<!void>>
 // CIR:   cir.call @_ZN1CC2Ev(%[[C_PTR]], %[[VTT_D_TO_C]]) : (!cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!void>>) -> ()
 
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 0, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, address_point = <index = 0, offset = 3>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 // CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_D>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 2, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, address_point = <index = 2, offset = 3>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 
 // CIR:   %{{[0-9]+}} = cir.base_class_addr(%{{[0-9]+}} : !cir.ptr<!rec_D> nonnull) [40] -> !cir.ptr<!rec_A>
 // CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_A>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.store %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
-// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, vtable_index = 1, address_point_index = 3) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
+// CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, address_point = <index = 1, offset = 3>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 
 // CIR:   cir.base_class_addr(%{{[0-9]+}} : !cir.ptr<!rec_D> nonnull) [16] -> !cir.ptr<!rec_C>
 // CIR:   cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_C>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
@@ -138,9 +137,9 @@ int f() {
 // LLVM:   %[[THIS:.*]] = load ptr, ptr %2, align 8
 // LLVM:   %[[BASE_A:.*]] = getelementptr i8, ptr %[[THIS]], i32 40
 // LLVM:   call void @_ZN1AC2Ev(ptr %[[BASE_A]])
-// LLVM:   call void @_ZN1BC2Ev(ptr %[[THIS]], ptr getelementptr inbounds ([7 x ptr], ptr @_ZTT1D, i32 0, i32 1))
+// LLVM:   call void @_ZN1BC2Ev(ptr %[[THIS]], ptr getelementptr inbounds nuw (i8, ptr @_ZTT1D, i64 8))
 // LLVM:   %[[BASE_C:.*]] = getelementptr i8, ptr %[[THIS]], i32 16
-// LLVM:   call void @_ZN1CC2Ev(ptr %[[BASE_C]], ptr getelementptr inbounds ([7 x ptr], ptr @_ZTT1D, i32 0, i32 3))
+// LLVM:   call void @_ZN1CC2Ev(ptr %[[BASE_C]], ptr getelementptr inbounds nuw (i8, ptr @_ZTT1D, i64 24))
 // LLVM:   ret void
 // LLVM: }
 

--- a/clang/test/CIR/Lowering/ThroughMLIR/ptrstride.cir
+++ b/clang/test/CIR/Lowering/ThroughMLIR/ptrstride.cir
@@ -1,6 +1,5 @@
 // RUN: cir-opt %s -cir-to-mlir | FileCheck %s -check-prefix=MLIR
 // RUN: cir-opt %s -cir-to-mlir -cir-mlir-to-llvm | mlir-translate -mlir-to-llvmir | FileCheck %s -check-prefix=LLVM
-// XFAIL: *
 
 !s32i = !cir.int<s, 32>
 module {
@@ -16,7 +15,7 @@ module {
     // MLIR-NEXT: %[[INDEX:.*]] = arith.index_cast %[[ONE]] : i32 to index
     // MLIR-NEXT: %[[VALUE:.*]] = memref.load %[[BASE]][%[[INDEX]]] : memref<100xi32>
 
-    // LLVM-NEXT: load i32, ptr getelementptr (i32, ptr @a, i64 1)
+    // LLVM-NEXT: load i32, ptr getelementptr inbounds nuw (i8, ptr @a, i64 4)
 
     %1 = cir.get_global @a : !cir.ptr<!cir.array<!s32i x 100>>
     %2 = cir.const #cir.int<1> : !s32i
@@ -37,7 +36,7 @@ module {
     // MLIR-NEXT: %[[INDEX2:.*]] = arith.index_cast %[[TWO]] : i32 to index
     // MLIR-NEXT: %[[VALUE:.*]] = memref.load %[[BASE]][%[[INDEX1]], %[[INDEX2]]] : memref<100x100xi32>
 
-    // LLVM-NEXT: load i32, ptr getelementptr (i32, ptr @aa, i64 102)
+    // LLVM-NEXT: load i32, ptr getelementptr inbounds nuw (i8, ptr @aa, i64 408)
 
     %1 = cir.get_global @aa : !cir.ptr<!cir.array<!cir.array<!s32i x 100> x 100>>
     %2 = cir.const #cir.int<1> : !s32i
@@ -62,9 +61,9 @@ module {
     // MLIR-NEXT: %[[VALUE_INC:.*]] = arith.addi %[[VALUE]], %[[TWO]] : i32
     // MLIR-NEXT: memref.store %[[VALUE_INC]], %[[BASE]][%[[INDEX]]] : memref<100xi32>
 
-    // LLVM-NEXT: %[[VALUE:.*]] = load i32, ptr getelementptr (i32, ptr @a, i64 1)
+    // LLVM-NEXT: %[[VALUE:.*]] = load i32, ptr getelementptr inbounds nuw (i8, ptr @a, i64 4)
     // LLVM-NEXT: %[[VALUE_INC:.*]] = add i32 %[[VALUE]], 2
-    // LLVM-NEXT: store i32 %[[VALUE_INC]], ptr getelementptr (i32, ptr @a, i64 1)
+    // LLVM-NEXT: store i32 %[[VALUE_INC]], ptr getelementptr inbounds nuw (i8, ptr @a, i64 4)
 
     %0 = cir.const #cir.int<2> : !s32i
     %1 = cir.get_global @a : !cir.ptr<!cir.array<!s32i x 100>>

--- a/clang/test/CIR/Lowering/global-ptr.c
+++ b/clang/test/CIR/Lowering/global-ptr.c
@@ -7,6 +7,7 @@
 // LLVM: %struct.S4 = type { i32, i32, i32 }
 // LLVM: %union.U1 = type { [2000 x i32] }
 
+// Note: GEP emitted by cir might not be the same as LLVM, due to constant folding.
 // LLVM: @s1 = global %struct.S1 zeroinitializer, align 8
 // LLVM: @b1 = global ptr getelementptr inbounds nuw (i8, ptr @s1, i64 25600), align 8
 // LLVM: @s2 = global %struct.S2 zeroinitializer, align 8

--- a/clang/test/CIR/Lowering/global-ptr.c
+++ b/clang/test/CIR/Lowering/global-ptr.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
-// XFAIL: *
 
 // LLVM: %struct.S1 = type { [3200 x double], [3200 x double] }
 // LLVM: %struct.S2 = type { [10 x ptr] }
@@ -9,13 +8,13 @@
 // LLVM: %union.U1 = type { [2000 x i32] }
 
 // LLVM: @s1 = global %struct.S1 zeroinitializer, align 8
-// LLVM: @b1 = global ptr getelementptr inbounds (%struct.S1, ptr @s1, i32 0, i32 1), align 8
+// LLVM: @b1 = global ptr getelementptr inbounds nuw (i8, ptr @s1, i64 25600), align 8
 // LLVM: @s2 = global %struct.S2 zeroinitializer, align 8
 // LLVM: @b2 = global ptr @s2, align 8
 // LLVM: @s3 = global %struct.S3 zeroinitializer, align 4
-// LLVM: @b3 = global ptr getelementptr inbounds (%struct.S3, ptr @s3, i32 0, i32 2), align 8
+// LLVM: @b3 = global ptr getelementptr inbounds nuw (i8, ptr @s3, i64 16000), align 8
 // LLVM: @s4 = global %struct.S4 zeroinitializer, align 4
-// LLVM: @b4 = global ptr getelementptr inbounds (%struct.S4, ptr @s4, i32 0, i32 2), align 8
+// LLVM: @b4 = global ptr getelementptr inbounds nuw (i8, ptr @s4, i64 8), align 8
 // LLVM: @u1 = global %union.U1 zeroinitializer, align 4
 // LLVM: @b5 = global ptr @u1, align 8
 


### PR DESCRIPTION
This commit un-xfails some tests that were affected by upstream GEP changes. #1497 

The changes are likely introduced by inference of `inbounds` and `nuw` flags https://github.com/llvm/llvm-project/commit/10f315dc9c96ec2413881ab55a285e35d80def88. It seems to allow LLVM to enable some constant foldings, whose effects include re-calculating the address using i8 and a single offset. (This change seems to arise from https://discourse.llvm.org/t/rfc-replacing-getelementptr-with-ptradd/68699/39)