### PR TITLE
[CIR] Simlipify string literal global creation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1888,10 +1888,10 @@ LValue CIRGenFunction::emitStringLiteralLValue(const StringLiteral *e) {
   auto g = CGM.getGlobalForStringLiteral(e);
   assert(g.getAlignment() && "expected alignment for string literal");
   auto align = *g.getAlignment();
-  auto addr = builder.createGetGlobal(getLoc(E->getSourceRange()), g);
+  auto addr = builder.createGetGlobal(getLoc(e->getSourceRange()), g);
   return makeAddrLValue(
       Address(addr, g.getSymType(), CharUnits::fromQuantity(align)),
-      E->getType(), AlignmentSource::Decl);
+      e->getType(), AlignmentSource::Decl);
 }
 
 /// Casts are never lvalues unless that cast is to a reference type. If the cast

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1885,14 +1885,7 @@ LValue CIRGenFunction::emitArraySubscriptExpr(const ArraySubscriptExpr *E,
 }
 
 LValue CIRGenFunction::emitStringLiteralLValue(const StringLiteral *E) {
-  auto sym = CGM.getAddrOfConstantStringFromLiteral(E).getSymbol();
-
-  auto cstGlobal = mlir::SymbolTable::lookupSymbolIn(CGM.getModule(), sym);
-  assert(cstGlobal && "Expected global");
-
-  auto g = dyn_cast<cir::GlobalOp>(cstGlobal);
-  assert(g && "unaware of other symbol providers");
-
+  auto g = CGM.getGlobalForStringLiteral(E);
   assert(g.getAlignment() && "expected alignment for string literal");
   auto align = *g.getAlignment();
   auto addr = builder.createGetGlobal(getLoc(E->getSourceRange()), g);

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1884,8 +1884,8 @@ LValue CIRGenFunction::emitArraySubscriptExpr(const ArraySubscriptExpr *E,
   return LV;
 }
 
-LValue CIRGenFunction::emitStringLiteralLValue(const StringLiteral *E) {
-  auto g = CGM.getGlobalForStringLiteral(E);
+LValue CIRGenFunction::emitStringLiteralLValue(const StringLiteral *e) {
+  auto g = CGM.getGlobalForStringLiteral(e);
   assert(g.getAlignment() && "expected alignment for string literal");
   auto align = *g.getAlignment();
   auto addr = builder.createGetGlobal(getLoc(E->getSourceRange()), g);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -448,8 +448,8 @@ public:
   mlir::Attribute getConstantArrayFromStringLiteral(const StringLiteral *E);
 
   /// Return a global op for the given string literal.
-  cir::GlobalOp getGlobalForStringLiteral(const StringLiteral *S,
-                                          llvm::StringRef Name = ".str");
+  cir::GlobalOp getGlobalForStringLiteral(const StringLiteral *s,
+                                          llvm::StringRef name = ".str");
 
   /// Return a global symbol reference to a constant array for the given string
   /// literal.

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -338,6 +338,9 @@ public:
     return !getLangOpts().CPlusPlus;
   }
 
+  llvm::StringMap<unsigned> cgGlobalNames;
+  std::string getUniqueGlobalName(const std::string &baseName);
+
   /// Return the mlir::Value for the address of the given global variable.
   /// If Ty is non-null and if the global doesn't exist, then it will be created
   /// with the specified type instead of whatever the normal requested type
@@ -444,12 +447,15 @@ public:
   /// Return a constant array for the given string.
   mlir::Attribute getConstantArrayFromStringLiteral(const StringLiteral *E);
 
+  /// Return a global op for the given string literal.
+  cir::GlobalOp getGlobalForStringLiteral(const StringLiteral *S,
+                                          llvm::StringRef Name = ".str");
+
   /// Return a global symbol reference to a constant array for the given string
   /// literal.
   cir::GlobalViewAttr
   getAddrOfConstantStringFromLiteral(const StringLiteral *S,
                                      llvm::StringRef Name = ".str");
-  unsigned StringLiteralCnt = 0;
 
   unsigned CompoundLitaralCnt = 0;
   /// Return the unique name for global compound literal


### PR DESCRIPTION
Previously, when emitting a global for a string literal, we were creating a GlobalOp, building a GlobalView attr for it, and looking up the global from the symbol associated with the attr. This change splits out the function that creates the global so that the global is returned directly and the GlobalView attribute is only created in the case where it is needed.

This also updates the mechanism used for uniquing the global name used for the strings so that if different base names are used the uniquing numbers each base name separately. The mangling of the global used for strings is not implemented, but the uniquing was happening prior to the mangling. This change drops the uniquing below the placeholder for mangling.