### PR TITLE
[CIR] Streamline creation of `mlir::IntegerAttr`s using mlir::Builder

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -151,9 +151,7 @@ public:
                                         llvm::ArrayRef<int64_t> indices) {
     llvm::SmallVector<mlir::Attribute> attrs;
     for (auto ind : indices) {
-      auto a =
-          mlir::IntegerAttr::get(mlir::IntegerType::get(getContext(), 64), ind);
-      attrs.push_back(a);
+      attrs.push_back(getI64IntegerAttr(ind));
     }
 
     mlir::ArrayAttr arAttr = mlir::ArrayAttr::get(getContext(), attrs);
@@ -938,13 +936,7 @@ public:
                      clang::CharUnits align = clang::CharUnits::One(),
                      bool isVolatile = false, bool isNontemporal = false,
                      cir::MemOrderAttr order = {}) {
-    llvm::MaybeAlign mayAlign = align.getAsAlign();
-    mlir::IntegerAttr alignAttr;
-    if (mayAlign) {
-      uint64_t alignment = mayAlign ? mayAlign->value() : 0;
-      alignAttr = mlir::IntegerAttr::get(
-          mlir::IntegerType::get(dst.getContext(), 64), alignment);
-    }
+    mlir::IntegerAttr alignAttr = getAlignmentAttr(align);
     return CIRBaseBuilderTy::createStore(loc, val, dst, isVolatile,
                                          isNontemporal, alignAttr, order);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1706,10 +1706,9 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
                         E->getArg(1)->getExprLoc(), FD, 1);
     uint64_t size =
         E->getArg(2)->EvaluateKnownConstInt(getContext()).getZExtValue();
-    builder.create<cir::MemCpyInlineOp>(
-        getLoc(E->getSourceRange()), dest.getPointer(), src.getPointer(),
-        mlir::IntegerAttr::get(mlir::IntegerType::get(builder.getContext(), 64),
-                               size));
+    builder.create<cir::MemCpyInlineOp>(getLoc(E->getSourceRange()),
+                                        dest.getPointer(), src.getPointer(),
+                                        builder.getI64IntegerAttr(size));
     // __builtin_memcpy_inline has no return value
     return RValue::get(nullptr);
   }
@@ -1788,10 +1787,8 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
         E->getArg(2)->EvaluateKnownConstInt(getContext()).getZExtValue();
     emitNonNullArgCheck(RValue::get(Dest.getPointer()), E->getArg(0)->getType(),
                         E->getArg(0)->getExprLoc(), FD, 0);
-    builder.createMemSetInline(
-        getLoc(E->getSourceRange()), Dest.getPointer(), ByteVal,
-        mlir::IntegerAttr::get(mlir::IntegerType::get(builder.getContext(), 64),
-                               size));
+    builder.createMemSetInline(getLoc(E->getSourceRange()), Dest.getPointer(),
+                               ByteVal, builder.getI64IntegerAttr(size));
     // __builtin_memset_inline has no return value
     return RValue::get(nullptr);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1269,12 +1269,11 @@ public:
     {
       mlir::OpBuilder::InsertionGuard guard(builder);
       builder.restoreInsertionPoint(OutermostConditional->getInsertPoint());
-      builder.createStore(
-          value.getLoc(), value, addr,
-          /*isVolatile=*/false, /*isNontemporal=*/false,
-          mlir::IntegerAttr::get(
-              mlir::IntegerType::get(value.getContext(), 64),
-              (uint64_t)addr.getAlignment().getAsAlign().value()));
+      mlir::IntegerAttr alignmentAttr =
+          builder.getAlignmentAttr(addr.getAlignment());
+      builder.createStore(value.getLoc(), value, addr,
+                          /*isVolatile=*/false, /*isNontemporal=*/false,
+                          alignmentAttr);
     }
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3342,7 +3342,7 @@ void CIRGenModule::emitDeferred(unsigned recursionLimit) {
 }
 
 mlir::IntegerAttr CIRGenModule::getSize(CharUnits size) {
-  return builder.getSizeFromCharUnits(&getMLIRContext(), size);
+  return builder.getSizeFromCharUnits(size);
 }
 
 mlir::Operation *
@@ -4214,10 +4214,7 @@ mlir::ArrayAttr CIRGenModule::emitAnnotationArgs(const AnnotateAttr *attr) {
       // Handle case which can be evaluated to some numbers, not only literals
       const auto &ap = ce.getAPValueResult();
       if (ap.isInt()) {
-        args.push_back(mlir::IntegerAttr::get(
-            mlir::IntegerType::get(&getMLIRContext(),
-                                   ap.getInt().getBitWidth()),
-            ap.getInt()));
+        args.push_back(builder.getIntegerAttr(ap.getInt()));
       } else {
         llvm_unreachable("NYI like float, fixed-point, array...");
       }

--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
@@ -193,8 +193,7 @@ public:
 
   /// Add a pointer of a specific type.
   void addPointer(cir::PointerType ptrTy, uint64_t value) {
-    auto val = mlir::IntegerAttr::get(
-        mlir::IntegerType::get(ptrTy.getContext(), 64), value);
+    mlir::IntegerAttr val = Builder.builder.getI64IntegerAttr(value);
     add(cir::ConstPtrAttr::get(ptrTy, val));
   }
 

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -186,8 +186,7 @@ LogicalResult OptInfoAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 static ParseResult parseConstPtr(AsmParser &parser, mlir::IntegerAttr &value) {
 
   if (parser.parseOptionalKeyword("null").succeeded()) {
-    value = mlir::IntegerAttr::get(
-        mlir::IntegerType::get(parser.getContext(), 64), 0);
+    value = parser.getBuilder().getI64IntegerAttr(0);
     return success();
   }
 

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRLoopToSCF.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRLoopToSCF.cpp
@@ -232,7 +232,7 @@ mlir::Value SCFLoop::plusConstant(mlir::Value V, mlir::Location loc,
                                   int addend) {
   auto type = V.getType();
   auto c1 = rewriter->create<mlir::arith::ConstantOp>(
-      loc, type, mlir::IntegerAttr::get(type, addend));
+      loc, mlir::IntegerAttr::get(type, addend));
   return rewriter->create<mlir::arith::AddIOp>(loc, V, c1);
 }
 
@@ -285,7 +285,7 @@ void SCFLoop::transferToSCFForOp() {
   auto loc = forOp.getLoc();
   auto type = lb.getType();
   auto step = rewriter->create<mlir::arith::ConstantOp>(
-      loc, type, mlir::IntegerAttr::get(type, getStep()));
+      loc, mlir::IntegerAttr::get(type, getStep()));
   auto scfForOp = rewriter->create<mlir::scf::ForOp>(loc, lb, ub, step);
   SmallVector<mlir::Value> bbArg;
   rewriter->eraseOp(&scfForOp.getBody()->back());

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -571,13 +571,13 @@ public:
     switch (op.getKind()) {
     case cir::UnaryOpKind::Inc: {
       auto One = rewriter.create<mlir::arith::ConstantOp>(
-          op.getLoc(), type, mlir::IntegerAttr::get(type, 1));
+          op.getLoc(), mlir::IntegerAttr::get(type, 1));
       rewriter.replaceOpWithNewOp<mlir::arith::AddIOp>(op, type, input, One);
       break;
     }
     case cir::UnaryOpKind::Dec: {
       auto One = rewriter.create<mlir::arith::ConstantOp>(
-          op.getLoc(), type, mlir::IntegerAttr::get(type, 1));
+          op.getLoc(), mlir::IntegerAttr::get(type, 1));
       rewriter.replaceOpWithNewOp<mlir::arith::SubIOp>(op, type, input, One);
       break;
     }
@@ -587,13 +587,13 @@ public:
     }
     case cir::UnaryOpKind::Minus: {
       auto Zero = rewriter.create<mlir::arith::ConstantOp>(
-          op.getLoc(), type, mlir::IntegerAttr::get(type, 0));
+          op.getLoc(), mlir::IntegerAttr::get(type, 0));
       rewriter.replaceOpWithNewOp<mlir::arith::SubIOp>(op, type, Zero, input);
       break;
     }
     case cir::UnaryOpKind::Not: {
       auto MinusOne = rewriter.create<mlir::arith::ConstantOp>(
-          op.getLoc(), type, mlir::IntegerAttr::get(type, -1));
+          op.getLoc(), mlir::IntegerAttr::get(type, -1));
       rewriter.replaceOpWithNewOp<mlir::arith::XOrIOp>(op, type, MinusOne,
                                                        input);
       break;


### PR DESCRIPTION
- Uses `getI<bitwidth>IntegerAttr` builder method instead of explicit attribute and its type creation.
- Adds few helper functions `getAlignmentAttr` to build  alignment representing `mlir::IntegerAttr`.
- Removes duplicit type parameters, that are inferred from `mlir::IntegerAttr`.