### PR TITLE
[CIR][Transforms] Fix flattening for TryOp with empty catch region

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -435,6 +435,10 @@ public:
     if (auto tryBodyYield = dyn_cast<cir::YieldOp>(afterBody->getTerminator()))
       rewriter.replaceOpWithNewOp<cir::BrOp>(tryBodyYield, afterTry);
 
+    mlir::ArrayAttr catches = tryOp.getCatchTypesAttr();
+    if (!catches || catches.empty())
+      return;
+
     // Start the landing pad by getting the inflight exception information.
     mlir::Block *nextDispatcher =
         buildLandingPads(tryOp, rewriter, beforeCatch, afterTry, callsToRewrite,


### PR DESCRIPTION
Currently, the following code snippet crashes during flattening, before lowering to llvm:
```
struct S {
  int a, b;
};

void foo() {
  try {
    S s{1, 2};
  } catch (...) {
  }
}
```
Command to reproduce:
```
clang tmp.cpp -Xclang -fclangir -Xclang -emit-cir-flat -S -o -
```
The crash happens when flattening a TryOp with an empty catch region and [building catchers](https://github.com/llvm/clangir/blob/791c327da623e4cb1c193422f4b7a555f572b70a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp#L423). Something like:
```
"cir.try"() ({
}, {
}) : () -> ()
```
the crash happens at [`tryOp.isCatchAllOnly()`](https://github.com/llvm/clangir/blob/791c327da623e4cb1c193422f4b7a555f572b70a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp#L441C39-L441C61) to be specific, because the catch types attribute list is empty. 

The fix is simple - adding a check for an empty/non-existent catch region before building the catch clauses. 

This PR adds this fix and one test.

**Side-note:** This enables `push_back` for `std::vector` to be lowered to llvm, for example: 
```
#include <vector>

void foo() {
  std::vector<int> v;
  v.push_back(1);
}
```