### PR TITLE
[CIR] Mark `addInt` as NYI due to incorrect implementation

### DIFF
--- a/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
+++ b/clang/lib/CIR/CodeGen/ConstantInitBuilder.h
@@ -187,8 +187,7 @@ public:
 
   /// Add an integer value of a specific type.
   void addInt(cir::IntType intTy, uint64_t value, bool isSigned = false) {
-    add(mlir::IntegerAttr::get(intTy,
-                               llvm::APInt{intTy.getWidth(), value, isSigned}));
+    llvm_unreachable("NYI");
   }
 
   /// Add a pointer of a specific type.


### PR DESCRIPTION
The current implementation incorrectly uses `mlir::IntegerAttr::get` with the unsupported type `cir::IntType`, which is not compatible and was never tested. As discussed in PR #1645, this is to be marked as NYI until a proper implementation is provided.