### PR TITLE
[CIR][NFC] Add helper functions for CIR visibility

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
@@ -18,6 +18,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -90,6 +91,7 @@ public:
 
 namespace cir {
 void buildTerminatedBody(mlir::OpBuilder &builder, mlir::Location loc);
+
 } // namespace cir
 
 #define GET_OP_CLASSES

--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.h
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.h
@@ -17,6 +17,7 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Mangle.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 
 namespace cir {} // namespace cir

--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
@@ -46,120 +46,132 @@ let cppNamespace = "::cir" in {
   def CIRGlobalValueInterface
       : OpInterface<"CIRGlobalValueInterface", [Symbol]> {
 
-    let methods = [
-      InterfaceMethod<"",
-      "bool", "hasExternalLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+    let methods =
+        [InterfaceMethod<"", "bool", "hasExternalLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isExternalLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasAvailableExternallyLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasAvailableExternallyLinkage", (ins),
+                         [{}],
+                         /*defaultImplementation=*/[{
         return cir::isAvailableExternallyLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasLinkOnceLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasLinkOnceLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isLinkOnceLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasLinkOnceAnyLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasLinkOnceAnyLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isLinkOnceAnyLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasLinkOnceODRLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasLinkOnceODRLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isLinkOnceODRLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasWeakLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasWeakLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isWeakLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasWeakAnyLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasWeakAnyLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isWeakAnyLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasWeakODRLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasWeakODRLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isWeakODRLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasInternalLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasInternalLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isInternalLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasPrivateLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasPrivateLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isPrivateLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasLocalLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasLocalLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isLocalLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasExternalWeakLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasExternalWeakLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isExternalWeakLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasCommonLinkage", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasCommonLinkage", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isCommonLinkage($_op.getLinkage());
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "isDeclarationForLinker", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "isDeclarationForLinker", (ins), [{}],
+                         /*defaultImplementation=*/[{
         if ($_op.hasAvailableExternallyLinkage())
           return true;
         return $_op.isDeclaration();
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "hasComdat", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "hasComdat", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return $_op.getComdat();
-      }]
-      >,
-      InterfaceMethod<"",
-      "void", "setDSOLocal", (ins "bool":$val), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "void", "setDSOLocal", (ins "bool":$val), [{}],
+                         /*defaultImplementation=*/[{
         $_op.setDsolocal(val);
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "isDSOLocal", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "isDSOLocal", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return $_op.getDsolocal();
-      }]
-      >,
-      InterfaceMethod<"",
-      "bool", "isWeakForLinker", (ins), [{}],
-      /*defaultImplementation=*/[{
+      }]>,
+         InterfaceMethod<"", "bool", "isWeakForLinker", (ins), [{}],
+                         /*defaultImplementation=*/[{
         return cir::isWeakForLinker($_op.getLinkage());
-      }]
-      >
+      }]>,
+         InterfaceMethod<"Gets the CIR visibility of this global variable.",
+                         "::cir::VisibilityKind", "getCIRVisibility", (ins),
+                         [{}],
+                         /*defaultImplementation=*/[{
+          return $_op.getGlobalVisibility().getValue();
+        }]>,
+         InterfaceMethod<
+             "Returns true if this global variable has default CIR visibility.",
+             "bool", "hasDefaultVisibility", (ins), [{}],
+             /*defaultImplementation=*/[{
+          return $_op.getGlobalVisibility().isDefault();
+        }]>,
+         InterfaceMethod<
+             "Returns true if this global variable has hidden CIR visibility.",
+             "bool", "hasHiddenVisibility", (ins), [{}],
+             /*defaultImplementation=*/[{
+          return $_op.getGlobalVisibility().isHidden();
+        }]>,
+         InterfaceMethod<"Returns true if this global variable has protected "
+                         "CIR visibility.",
+                         "bool", "hasProtectedVisibility", (ins), [{}],
+                         /*defaultImplementation=*/[{
+          return $_op.getGlobalVisibility().isProtected();
+        }]>,
+         InterfaceMethod<"Sets the CIR visibility of this global variable.",
+                         "void", "setGlobalVisibility",
+                         (ins "::cir::VisibilityKind":$vis), [{}],
+                         /*defaultImplementation=*/[{
+          $_op.setGlobalVisibilityAttr(::cir::VisibilityAttr::get($_op.getContext(), vis));
+        }]>,
+         InterfaceMethod<
+             "Sets the CIR visibility of this global variable to be default.",
+             "void", "setDefaultCIRVisibility", (ins), [{}],
+             /*defaultImplementation=*/[{
+          setGlobalVisibility(::cir::VisibilityKind::Default);
+        }]>,
+         InterfaceMethod<
+             "Sets the CIR visibility of this global variable to be hidden.",
+             "void", "setHiddenCIRVisibility", (ins), [{}],
+             /*defaultImplementation=*/[{
+          setGlobalVisibility(::cir::VisibilityKind::Hidden);
+        }]>,
+         InterfaceMethod<
+             "Sets the CIR visibility of this global variable to be protected.",
+             "void", "setProtectedCIRVisibility", (ins), [{}],
+             /*defaultImplementation=*/[{
+          setGlobalVisibility(::cir::VisibilityKind::Protected);
+        }]>,
     ];
     let extraClassDeclaration = [{
-      bool hasDefaultVisibility();
       bool canBenefitFromLocalAlias();
     }];
   }

--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
@@ -170,6 +170,16 @@ let cppNamespace = "::cir" in {
              /*defaultImplementation=*/[{
           setGlobalVisibility(::cir::VisibilityKind::Protected);
         }]>,
+         InterfaceMethod<"Updates the MLIR visibility of this global variable "
+                         "based on the CIR visiblity and linkage.",
+                         "void", "updateMLIRVisibility", (ins), [{}],
+                         /*defaultImplementation=*/[{
+            mlir::SymbolTable::setSymbolVisibility(
+                $_op, ::cir::deduceMLIRVisibility(
+                          $_op.getLinkage(),
+                          $_op.getGlobalVisibility().getValue())
+            );
+          }]>,
     ];
     let extraClassDeclaration = [{
       bool canBenefitFromLocalAlias();

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -23,6 +23,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/MissingFeatures.h"
@@ -485,7 +486,8 @@ CIRGenModule::getOrCreateStaticVarDecl(const VarDecl &D,
   cir::GlobalOp GV = builder.createVersionedGlobal(
       getModule(), getLoc(D.getLocation()), Name, LTy, false, Linkage, AS);
   // TODO(cir): infer visibility from linkage in global op builder.
-  GV.setVisibility(getMLIRVisibilityFromCIRLinkage(Linkage));
+  GV.setVisibility(
+      cir::deduceMLIRVisibility(Linkage, cir::VisibilityKind::Default));
   GV.setInitialValueAttr(Init);
   GV.setAlignment(getASTContext().getDeclAlign(&D).getAsAlign().value());
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -827,9 +827,9 @@ public:
                                                     bool IsConstantVariable);
   void setFunctionLinkage(GlobalDecl GD, cir::FuncOp f) {
     auto L = getFunctionLinkage(GD);
+    auto V = f.getGlobalVisibility().getValue();
     f.setLinkageAttr(cir::GlobalLinkageKindAttr::get(&getMLIRContext(), L));
-    mlir::SymbolTable::setSymbolVisibility(f,
-                                           getMLIRVisibilityFromCIRLinkage(L));
+    mlir::SymbolTable::setSymbolVisibility(f, cir::deduceMLIRVisibility(L, V));
   }
 
   cir::GlobalLinkageKind getCIRLinkageVarDefinition(const VarDecl *VD,

--- a/clang/lib/CIR/Interfaces/CIROpInterfaces.cpp
+++ b/clang/lib/CIR/Interfaces/CIROpInterfaces.cpp
@@ -17,12 +17,6 @@ using namespace cir;
 
 #include "clang/CIR/MissingFeatures.h"
 
-bool CIRGlobalValueInterface::hasDefaultVisibility() {
-  assert(!cir::MissingFeatures::hiddenVisibility());
-  assert(!cir::MissingFeatures::protectedVisibility());
-  return isPublic() || isPrivate();
-}
-
 bool CIRGlobalValueInterface::canBenefitFromLocalAlias() {
   assert(!cir::MissingFeatures::supportIFuncAttr());
   // hasComdat here should be isDeduplicateComdat, but as far as clang codegen


### PR DESCRIPTION
This PR contains 2 changes:
- Add getters/setters for CIR visibility in `CIRGlobalValueInterface`, which is implemented by `GlobalOp` and `FuncOp` with linkage and CIR visibility. The getters/setters are analogous to existing getters/setters for linkage and symbol visibility.
- Add a helper function for deducing MLIR visibility using both linkage and CIR visibility (previously only linkage was used).

more notes in  https://github.com/llvm/clangir/issues/1029#issuecomment-2920372269