### PR TITLE
[CIR][Lowering] Lower CIR ptrmask to LLVM ptrmask

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4933,6 +4933,8 @@ def PtrMaskOp : CIR_Op<"ptr_mask", [AllTypesMatch<["ptr", "result"]>]> {
   let assemblyFormat = [{
     `(` $ptr `,` $mask `:` type($mask) `)` `:` qualified(type($result)) attr-dict
   }];
+
+  let llvmOp = "PtrMaskOp";
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -43,9 +43,11 @@ mlir::Value emitRoundPointerUpToAlignment(cir::CIRBaseBuilderTy &builder,
   mlir::Value roundUp = builder.createPtrStride(
       loc, builder.createPtrBitcast(ptr, builder.getUIntNTy(8)),
       builder.getUnsignedInt(loc, alignment - 1, /*width=*/32));
+  auto dataLayout = mlir::DataLayout::closest(roundUp.getDefiningOp());
   return builder.create<cir::PtrMaskOp>(
       loc, roundUp.getType(), roundUp,
-      builder.getSignedInt(loc, -(signed)alignment, /*width=*/32));
+      builder.getSignedInt(loc, -(signed)alignment,
+                           dataLayout.getTypeSizeInBits(roundUp.getType())));
 }
 
 mlir::Type useFirstFieldIfTransparentUnion(mlir::Type Ty) {

--- a/clang/test/CIR/Lowering/var-arg-x86_64.c
+++ b/clang/test/CIR/Lowering/var-arg-x86_64.c
@@ -95,10 +95,7 @@ long double f2(int n, ...) {
 // CHECK: [[OVERFLOW_AREA:%.+]] = load ptr, ptr [[OVERFLOW_AREA_P]]
 // Ptr Mask Operations
 // CHECK: [[OVERFLOW_AREA_OFFSET_ALIGNED:%.+]] = getelementptr i8, ptr [[OVERFLOW_AREA]], i64 15
-// CHECK: [[OVERFLOW_AREA_OFFSET_ALIGNED_P:%.+]] = ptrtoint ptr [[OVERFLOW_AREA_OFFSET_ALIGNED]] to i32
-// CHECK: [[MASKED:%.+]] = and i32 [[OVERFLOW_AREA_OFFSET_ALIGNED_P]], -16
-// CHECK: [[DIFF:%.+]] = sub i32 [[OVERFLOW_AREA_OFFSET_ALIGNED_P]], [[MASKED]]
-// CHECK: [[PTR_MASKED:%.+]] = getelementptr i8, ptr [[OVERFLOW_AREA_OFFSET_ALIGNED]], i32 [[DIFF]]
+// CHECK: [[PTR_MASKED:%.+]] = call ptr @llvm.ptrmask.{{.*}}.[[PTR_SIZE_INT:.*]](ptr [[OVERFLOW_AREA_OFFSET_ALIGNED]], [[PTR_SIZE_INT]] -16)
 // CHECK: [[OVERFLOW_AREA_NEXT:%.+]] = getelementptr i8, ptr [[PTR_MASKED]], i64 16
 // CHECK: store ptr [[OVERFLOW_AREA_NEXT]], ptr [[OVERFLOW_AREA_P]]
 // CHECK: [[VALUE:%.+]] = load x86_fp80, ptr [[PTR_MASKED]]


### PR DESCRIPTION
LLVM dialect now has ptrmask intrinsic, use it instead of the manual computation

Fix bitwidth of the generated mask in ABIInfoImpl