### PR TITLE
[CIR] Add support for DumpRecordLayouts

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
@@ -201,6 +201,7 @@ public:
     assert(it != BitFields.end() && "Unable to find bitfield info");
     return it->second;
   }
+  void print(raw_ostream &os) const;
 };
 
 } // namespace clang::CIRGen


### PR DESCRIPTION
This PR adds support for the `-fdump-record-layouts` flag. It enables printing both the `CIRGenRecordLayout` and the `ASTRecordLayout`, similar to what is done in CodeGen.