### PR TITLE
[CIR] Backport Extending VecShuffleOp verifier to catch invalid index

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1081,6 +1081,15 @@ LogicalResult cir::VecShuffleOp::verify() {
           [](mlir::Attribute attr) { return mlir::isa<cir::IntAttr>(attr); })) {
     return emitOpError() << "all index values must be integers";
   }
+
+  const uint64_t maxValidIndex =
+      getVec1().getType().getSize() + getVec2().getType().getSize() - 1;
+  for (const auto &idxAttr : getIndices().getAsRange<cir::IntAttr>()) {
+    if (idxAttr.getUInt() > maxValidIndex)
+      return emitOpError() << ": index for __builtin_shufflevector must be "
+                              "less than the total number of vector elements";
+  }
+
   return success();
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1085,7 +1085,7 @@ LogicalResult cir::VecShuffleOp::verify() {
   const uint64_t maxValidIndex =
       getVec1().getType().getSize() + getVec2().getType().getSize() - 1;
   for (const auto &idxAttr : getIndices().getAsRange<cir::IntAttr>()) {
-    if (idxAttr.getUInt() > maxValidIndex)
+    if (idxAttr.getSInt() != -1 && idxAttr.getUInt() > maxValidIndex)
       return emitOpError() << ": index for __builtin_shufflevector must be "
                               "less than the total number of vector elements";
   }

--- a/clang/test/CIR/IR/invalid-vector-shuffle-wrong-index.cir
+++ b/clang/test/CIR/IR/invalid-vector-shuffle-wrong-index.cir
@@ -1,0 +1,16 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+module  {
+  cir.func @fold_shuffle_vector_op_test() -> !cir.vector<!s32i x 4> {
+    %vec_1 = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<3> : !s32i, #cir.int<5> : !s32i, #cir.int<7> : !s32i]> : !cir.vector<!s32i x 4>
+    %vec_2 = cir.const #cir.const_vector<[#cir.int<2> : !s32i, #cir.int<4> : !s32i, #cir.int<6> : !s32i, #cir.int<8> : !s32i]> : !cir.vector<!s32i x 4>
+
+    // expected-error @below {{index for __builtin_shufflevector must be less than the total number of vector elements}}
+    %new_vec = cir.vec.shuffle(%vec_1, %vec_2 : !cir.vector<!s32i x 4>) [#cir.int<9> : !s64i, #cir.int<4> : !s64i,
+      #cir.int<1> : !s64i, #cir.int<5> : !s64i] : !cir.vector<!s32i x 4>
+    cir.return %new_vec : !cir.vector<!s32i x 4>
+  }
+}


### PR DESCRIPTION
Backport the VecShuffleOp verifier to catch invalid index

Implemented in https://github.com/llvm/llvm-project/pull/143262