### PR TITLE
[CIR] Remove parens from C++ address-related ops' assembly format

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3362,7 +3362,7 @@ def BaseClassAddrOp : CIR_Op<"base_class_addr"> {
     ```
     will generate
     ```mlir
-    %3 = cir.base_class_addr (%1 : !cir.ptr<!rec_Derived> nonnull) [0] -> !cir.ptr<!rec_Base>
+    %3 = cir.base_class_addr %1 : !cir.ptr<!rec_Derived> nonnull [0] -> !cir.ptr<!rec_Base>
     ```
   }];
 
@@ -3375,10 +3375,9 @@ def BaseClassAddrOp : CIR_Op<"base_class_addr"> {
   let results = (outs Res<CIR_PointerType, "">:$base_addr);
 
   let assemblyFormat = [{
-    `(`
       $derived_addr `:` qualified(type($derived_addr))
       (`nonnull` $assume_not_null^)?
-    `)` `[` $offset `]` `->` qualified(type($base_addr)) attr-dict
+      ` ` `[` $offset `]` `->` qualified(type($base_addr)) attr-dict
   }];
 }
 
@@ -3411,8 +3410,8 @@ def DerivedClassAddrOp : CIR_Op<"derived_class_addr"> {
     leads to
     ```mlir
       %2 = cir.load %0 : !cir.ptr<!cir.ptr<!rec_B>>, !cir.ptr<!rec_B>
-      %3 = cir.derived_class_addr(%2 : !cir.ptr<!rec_B> nonnull) [4] -> !cir.ptr<!rec_X>
-      %4 = cir.base_class_addr(%3 : !cir.ptr<!rec_X>) [0] -> !cir.ptr<!rec_A>
+      %3 = cir.derived_class_addr %2 : !cir.ptr<!rec_B> nonnull [4] -> !cir.ptr<!rec_X>
+      %4 = cir.base_class_addr %3 : !cir.ptr<!rec_X> [0] -> !cir.ptr<!rec_A>
       cir.return %4
     ```
   }];
@@ -3426,10 +3425,9 @@ def DerivedClassAddrOp : CIR_Op<"derived_class_addr"> {
   let results = (outs Res<CIR_PointerType, "">:$derived_addr);
 
   let assemblyFormat = [{
-    `(`
       $base_addr `:` qualified(type($base_addr))
       (`nonnull` $assume_not_null^)?
-    `)` `[` $offset `]` `->` qualified(type($derived_addr)) attr-dict
+      ` ` `[` $offset `]` `->` qualified(type($derived_addr)) attr-dict
   }];
 }
 
@@ -3454,8 +3452,8 @@ def BaseDataMemberOp : CIR_Op<"base_data_member", [Pure]> {
   let results = (outs CIR_DataMemberType:$result);
 
   let assemblyFormat = [{
-    `(` $src `:` qualified(type($src)) `)`
-    `[` $offset `]` `->` qualified(type($result)) attr-dict
+    $src `:` qualified(type($src))
+    ` ` `[` $offset `]` `->` qualified(type($result)) attr-dict
   }];
 
   let hasVerifier = 1;
@@ -3478,8 +3476,8 @@ def DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
   let results = (outs CIR_DataMemberType:$result);
 
   let assemblyFormat = [{
-    `(` $src `:` qualified(type($src)) `)`
-    `[` $offset `]` `->` qualified(type($result)) attr-dict
+    $src `:` qualified(type($src))
+    ` ` `[` $offset `]` `->` qualified(type($result)) attr-dict
   }];
 
   let hasVerifier = 1;
@@ -3506,7 +3504,7 @@ def BaseMethodOp : CIR_Op<"base_method", [Pure]> {
     Example:
 
     ```mlir
-    %1 = cir.base_method(%0 : !cir.method<!cir.func<(!s32i)> in !rec_Derived>) [16] -> !cir.method<!cir.func<(!s32i)> in !rec_Base>
+    %1 = cir.base_method %0 : !cir.method<!cir.func<(!s32i)> in !rec_Derived> [16] -> !cir.method<!cir.func<(!s32i)> in !rec_Base>
     ```
   }];
 
@@ -3514,8 +3512,8 @@ def BaseMethodOp : CIR_Op<"base_method", [Pure]> {
   let results = (outs CIR_MethodType:$result);
 
   let assemblyFormat = [{
-    `(` $src `:` qualified(type($src)) `)`
-    `[` $offset `]` `->` qualified(type($result)) attr-dict
+    $src `:` qualified(type($src))
+    ` ` `[` $offset `]` `->` qualified(type($result)) attr-dict
   }];
 
   let hasVerifier = 1;
@@ -3538,7 +3536,7 @@ def DerivedMethodOp : CIR_Op<"derived_method", [Pure]> {
     Example:
 
     ```mlir
-    %1 = cir.derived_method(%0 : !cir.method<!cir.func<(!s32i)> in !rec_Base>) [16] -> !cir.method<!cir.func<(!s32i)> in !rec_Derived>
+    %1 = cir.derived_method %0 : !cir.method<!cir.func<(!s32i)> in !rec_Base> [16] -> !cir.method<!cir.func<(!s32i)> in !rec_Derived>
     ```
   }];
 
@@ -3546,8 +3544,8 @@ def DerivedMethodOp : CIR_Op<"derived_method", [Pure]> {
   let results = (outs CIR_MethodType:$result);
 
   let assemblyFormat = [{
-    `(` $src `:` qualified(type($src)) `)`
-    `[` $offset `]` `->` qualified(type($result)) attr-dict
+    $src `:` qualified(type($src))
+    ` ` `[` $offset `]` `->` qualified(type($result)) attr-dict
   }];
 
   let hasVerifier = 1;

--- a/clang/test/CIR/CodeGen/const-baseclass.cpp
+++ b/clang/test/CIR/CodeGen/const-baseclass.cpp
@@ -14,7 +14,7 @@ void f() {
 }
 
 // CHECK-LABEL: @_ZN1BC2Ev
-// CHECK: %[[A:.*]] = cir.base_class_addr({{.*}}) [0] -> !cir.ptr<!rec_A>
+// CHECK: %[[A:.*]] = cir.base_class_addr {{.*}} [0] -> !cir.ptr<!rec_A>
 // CHECK: cir.call @_ZN1AC2Ev(%[[A:.*]]) : (!cir.ptr<!rec_A>) -> ()
-// CHECK: %[[BASE:.*]] = cir.base_class_addr({{.*}}) [0] -> !cir.ptr<!rec_Empty>
+// CHECK: %[[BASE:.*]] = cir.base_class_addr {{.*}} [0] -> !cir.ptr<!rec_Empty>
 // CHECK: cir.call @_ZN5EmptyC2Ev(%[[BASE]]) : (!cir.ptr<!rec_Empty>) -> ()

--- a/clang/test/CIR/CodeGen/derived-cast.cpp
+++ b/clang/test/CIR/CodeGen/derived-cast.cpp
@@ -25,8 +25,8 @@ A *B::getAsA() {
 // CIR: %[[VAL_1:.*]] = cir.alloca !cir.ptr<!rec_B>, !cir.ptr<!cir.ptr<!rec_B>>, ["this", init] {alignment = 8 : i64}
 // CIR: %[[VAL_2:.*]] = cir.alloca !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>, ["__retval"] {alignment = 8 : i64}
 // CIR: %[[VAL_3:.*]] = cir.load %[[VAL_1]] : !cir.ptr<!cir.ptr<!rec_B>>, !cir.ptr<!rec_B>
-// CIR: %[[VAL_4:.*]] = cir.derived_class_addr(%[[VAL_3]] : !cir.ptr<!rec_B> nonnull) [4] -> !cir.ptr<!rec_X>
-// CIR: %[[VAL_5:.*]] = cir.base_class_addr(%[[VAL_4]] : !cir.ptr<!rec_X> nonnull) [0] -> !cir.ptr<!rec_A>
+// CIR: %[[VAL_4:.*]] = cir.derived_class_addr %[[VAL_3]] : !cir.ptr<!rec_B> nonnull [4] -> !cir.ptr<!rec_X>
+// CIR: %[[VAL_5:.*]] = cir.base_class_addr %[[VAL_4]] : !cir.ptr<!rec_X> nonnull [0] -> !cir.ptr<!rec_A>
 // CIR: cir.store %[[VAL_5]], %[[VAL_2]] : !cir.ptr<!rec_A>, !cir.ptr<!cir.ptr<!rec_A>>
 // CIR: %[[VAL_6:.*]] = cir.load %[[VAL_2]] : !cir.ptr<!cir.ptr<!rec_A>>, !cir.ptr<!rec_A>
 // CIR: cir.return %[[VAL_6]] : !cir.ptr<!rec_A>

--- a/clang/test/CIR/CodeGen/derived-to-base.cpp
+++ b/clang/test/CIR/CodeGen/derived-to-base.cpp
@@ -84,7 +84,7 @@ void C3::Layer::Initialize() {
 // CHECK: cir.func dso_local @_ZN2C35Layer10InitializeEv
 
 // CHECK:  cir.scope {
-// CHECK:    %2 = cir.base_class_addr(%1 : !cir.ptr<!rec_C33A3ALayer> nonnull) [0] -> !cir.ptr<!rec_C23A3ALayer>
+// CHECK:    %2 = cir.base_class_addr %1 : !cir.ptr<!rec_C33A3ALayer> nonnull [0] -> !cir.ptr<!rec_C23A3ALayer>
 // CHECK:    %3 = cir.get_member %2[1] {name = "m_C1"} : !cir.ptr<!rec_C23A3ALayer> -> !cir.ptr<!cir.ptr<!rec_C2>>
 // CHECK:    %4 = cir.load{{.*}} %3 : !cir.ptr<!cir.ptr<!rec_C2>>, !cir.ptr<!rec_C2>
 // CHECK:    %5 = cir.const #cir.ptr<null> : !cir.ptr<!rec_C2>
@@ -99,7 +99,7 @@ enumy C3::Initialize() {
 
 // CHECK:     cir.store %arg0, %0 : !cir.ptr<!rec_C3>, !cir.ptr<!cir.ptr<!rec_C3>>
 // CHECK:     %2 = cir.load{{.*}} %0 : !cir.ptr<!cir.ptr<!rec_C3>>, !cir.ptr<!rec_C3>
-// CHECK:     %3 = cir.base_class_addr(%2 : !cir.ptr<!rec_C3> nonnull) [0] -> !cir.ptr<!rec_C2>
+// CHECK:     %3 = cir.base_class_addr %2 : !cir.ptr<!rec_C3> nonnull [0] -> !cir.ptr<!rec_C2>
 // CHECK:     %4 = cir.call @_ZN2C210InitializeEv(%3) : (!cir.ptr<!rec_C2>) -> !s32i
 
 void vcall(C1 &c1) {
@@ -144,7 +144,7 @@ public:
 // CHECK:   %1 = cir.load{{.*}} deref %0 : !cir.ptr<!cir.ptr<!rec_B>>, !cir.ptr<!rec_B>
 // CHECK:   cir.scope {
 // CHECK:     %2 = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["ref.tmp0"] {alignment = 8 : i64}
-// CHECK:     %3 = cir.base_class_addr(%1 : !cir.ptr<!rec_B> nonnull) [0] -> !cir.ptr<!rec_A>
+// CHECK:     %3 = cir.base_class_addr %1 : !cir.ptr<!rec_B> nonnull [0] -> !cir.ptr<!rec_A>
 
 // Call @A::A(A const&)
 // CHECK:     cir.call @_ZN1AC2ERKS_(%2, %3) : (!cir.ptr<!rec_A>, !cir.ptr<!rec_A>) -> ()
@@ -181,17 +181,17 @@ void test_multi_base() {
   Derived d;
 
   Base2& bref = d; // no null check needed
-  // CHECK: %6 = cir.base_class_addr(%0 : !cir.ptr<!rec_Derived> nonnull) [4] -> !cir.ptr<!rec_Base2>
+  // CHECK: %6 = cir.base_class_addr %0 : !cir.ptr<!rec_Derived> nonnull [4] -> !cir.ptr<!rec_Base2>
 
   Base2* bptr = &d; // has null pointer check
-  // CHECK: %7 = cir.base_class_addr(%0 : !cir.ptr<!rec_Derived>) [4] -> !cir.ptr<!rec_Base2>
+  // CHECK: %7 = cir.base_class_addr %0 : !cir.ptr<!rec_Derived> [4] -> !cir.ptr<!rec_Base2>
 
   int a = d.a;
-  // CHECK: %8 = cir.base_class_addr(%0 : !cir.ptr<!rec_Derived> nonnull) [0] -> !cir.ptr<!rec_Base1>
+  // CHECK: %8 = cir.base_class_addr %0 : !cir.ptr<!rec_Derived> nonnull [0] -> !cir.ptr<!rec_Base1>
   // CHECK: %9 = cir.get_member %8[0] {name = "a"} : !cir.ptr<!rec_Base1> -> !cir.ptr<!s32i>
 
   int b = d.b;
-  // CHECK: %11 = cir.base_class_addr(%0 : !cir.ptr<!rec_Derived> nonnull) [4] -> !cir.ptr<!rec_Base2>
+  // CHECK: %11 = cir.base_class_addr %0 : !cir.ptr<!rec_Derived> nonnull [4] -> !cir.ptr<!rec_Base2>
   // CHECK: %12 = cir.get_member %11[0] {name = "b"} : !cir.ptr<!rec_Base2> -> !cir.ptr<!s32i>
 
   int c = d.c;

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -56,7 +56,7 @@ int main() {
 // CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_Child>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.store{{.*}} %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV5Child, address_point = <index = 1, offset = 2>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
-// CIR:   %7 = cir.base_class_addr(%1 : !cir.ptr<!rec_Child> nonnull) [8] -> !cir.ptr<!rec_Father>
+// CIR:   %7 = cir.base_class_addr %1 : !cir.ptr<!rec_Child> nonnull [8] -> !cir.ptr<!rec_Father>
 // CIR:   %8 = cir.cast(bitcast, %7 : !cir.ptr<!rec_Father>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>> loc(#loc8)
 // CIR:   cir.store{{.*}} %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.return

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
@@ -19,7 +19,7 @@ struct Derived : Base1, Base2 {
 // LLVM-LABEL: @_Z15base_to_derivedM5Base2i
 auto base_to_derived(int Base2::*ptr) -> int Derived::* {
   return ptr;
-  // CIR: %{{.+}} = cir.derived_data_member(%{{.+}} : !cir.data_member<!s32i in !rec_Base2>) [4] -> !cir.data_member<!s32i in !rec_Derived>
+  // CIR: %{{.+}} = cir.derived_data_member %{{.+}} : !cir.data_member<!s32i in !rec_Base2> [4] -> !cir.data_member<!s32i in !rec_Derived>
 
   //      LLVM: %[[#src:]] = load i64, ptr %{{.+}}
   // LLVM-NEXT: %[[#is_null:]] = icmp eq i64 %[[#src]], -1
@@ -31,7 +31,7 @@ auto base_to_derived(int Base2::*ptr) -> int Derived::* {
 // LLVM-LABEL: @_Z15derived_to_baseM7Derivedi
 auto derived_to_base(int Derived::*ptr) -> int Base2::* {
   return static_cast<int Base2::*>(ptr);
-  // CIR: %{{.+}} = cir.base_data_member(%{{.+}} : !cir.data_member<!s32i in !rec_Derived>) [4] -> !cir.data_member<!s32i in !rec_Base2>
+  // CIR: %{{.+}} = cir.base_data_member %{{.+}} : !cir.data_member<!s32i in !rec_Derived> [4] -> !cir.data_member<!s32i in !rec_Base2>
 
   //      LLVM: %[[#src:]] = load i64, ptr %{{.+}}
   // LLVM-NEXT: %[[#is_null:]] = icmp eq i64 %[[#src]], -1
@@ -43,7 +43,7 @@ auto derived_to_base(int Derived::*ptr) -> int Base2::* {
 // LLVM-LABEL: @_Z27base_to_derived_zero_offsetM5Base1i
 auto base_to_derived_zero_offset(int Base1::*ptr) -> int Derived::* {
   return ptr;
-  // CIR: %{{.+}} = cir.derived_data_member(%{{.+}} : !cir.data_member<!s32i in !rec_Base1>) [0] -> !cir.data_member<!s32i in !rec_Derived>
+  // CIR: %{{.+}} = cir.derived_data_member %{{.+}} : !cir.data_member<!s32i in !rec_Base1> [0] -> !cir.data_member<!s32i in !rec_Derived>
 
   // No LLVM instructions emitted for performing a zero-offset cast.
   // LLVM-NEXT: %[[#src_slot:]] = alloca i64, i64 1
@@ -59,7 +59,7 @@ auto base_to_derived_zero_offset(int Base1::*ptr) -> int Derived::* {
 // LLVM-LABEL: @_Z27derived_to_base_zero_offsetM7Derivedi
 auto derived_to_base_zero_offset(int Derived::*ptr) -> int Base1::* {
   return static_cast<int Base1::*>(ptr);
-  // CIR: %{{.+}} = cir.base_data_member(%{{.+}} : !cir.data_member<!s32i in !rec_Derived>) [0] -> !cir.data_member<!s32i in !rec_Base1>
+  // CIR: %{{.+}} = cir.base_data_member %{{.+}} : !cir.data_member<!s32i in !rec_Derived> [0] -> !cir.data_member<!s32i in !rec_Base1>
 
   // No LLVM instructions emitted for performing a zero-offset cast.
   // LLVM-NEXT: %[[#src_slot:]] = alloca i64, i64 1

--- a/clang/test/CIR/CodeGen/vtable-rtti.cpp
+++ b/clang/test/CIR/CodeGen/vtable-rtti.cpp
@@ -43,7 +43,7 @@ public:
 // CHECK:   %0 = cir.alloca !cir.ptr<![[ClassB]]>, !cir.ptr<!cir.ptr<![[ClassB]]>>, ["this", init] {alignment = 8 : i64}
 // CHECK:   cir.store{{.*}} %arg0, %0 : !cir.ptr<![[ClassB]]>, !cir.ptr<!cir.ptr<![[ClassB]]>>
 // CHECK:   %1 = cir.load %0 : !cir.ptr<!cir.ptr<![[ClassB]]>>, !cir.ptr<![[ClassB]]>
-// CHECK:   %2 = cir.base_class_addr(%1 : !cir.ptr<![[ClassB]]> nonnull) [0] -> !cir.ptr<![[ClassA]]>
+// CHECK:   %2 = cir.base_class_addr %1 : !cir.ptr<![[ClassB]]> nonnull [0] -> !cir.ptr<![[ClassA]]>
 // CHECK:   cir.call @_ZN1AC2Ev(%2) : (!cir.ptr<![[ClassA]]>) -> ()
 // CHECK:   %3 = cir.vtable.address_point(@_ZTV1B, address_point = <index = 0, offset = 2>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 // CHECK:   %4 = cir.cast(bitcast, %1 : !cir.ptr<![[ClassB]]>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>

--- a/clang/test/CIR/CodeGen/vtt.cpp
+++ b/clang/test/CIR/CodeGen/vtt.cpp
@@ -104,14 +104,14 @@ int f() {
 // CIR:   %{{[0-9]+}} = cir.alloca !cir.ptr<!rec_D>, !cir.ptr<!cir.ptr<!rec_D>>, ["this", init] {alignment = 8 : i64}
 // CIR:   cir.store{{.*}} %arg0, %{{[0-9]+}} : !cir.ptr<!rec_D>, !cir.ptr<!cir.ptr<!rec_D>>
 // CIR:   %[[D_PTR:.*]] = cir.load{{.*}} %0 : !cir.ptr<!cir.ptr<!rec_D>>, !cir.ptr<!rec_D>
-// CIR:   %[[A_PTR:.*]] = cir.base_class_addr(%[[D_PTR]] : !cir.ptr<!rec_D> nonnull) [40] -> !cir.ptr<!rec_A>
+// CIR:   %[[A_PTR:.*]] = cir.base_class_addr %[[D_PTR]] : !cir.ptr<!rec_D> nonnull [40] -> !cir.ptr<!rec_A>
 // CIR:   cir.call @_ZN1AC2Ev(%[[A_PTR]]) : (!cir.ptr<!rec_A>) -> ()
 
-// CIR:   %[[B_PTR:.*]] = cir.base_class_addr(%[[D_PTR]] : !cir.ptr<!rec_D> nonnull) [0] -> !cir.ptr<!rec_B>
+// CIR:   %[[B_PTR:.*]] = cir.base_class_addr %[[D_PTR]] : !cir.ptr<!rec_D> nonnull [0] -> !cir.ptr<!rec_B>
 // CIR:   %[[VTT_D_TO_B:.*]] = cir.vtt.address_point @_ZTT1D, offset = 1 -> !cir.ptr<!cir.ptr<!void>>
 // CIR:   cir.call @_ZN1BC2Ev(%[[B_PTR]], %[[VTT_D_TO_B]]) : (!cir.ptr<!rec_B>, !cir.ptr<!cir.ptr<!void>>) -> ()
 
-// CIR:   %[[C_PTR:.*]] = cir.base_class_addr(%1 : !cir.ptr<!rec_D> nonnull) [16] -> !cir.ptr<!rec_C>
+// CIR:   %[[C_PTR:.*]] = cir.base_class_addr %1 : !cir.ptr<!rec_D> nonnull [16] -> !cir.ptr<!rec_C>
 // CIR:   %[[VTT_D_TO_C:.*]] = cir.vtt.address_point @_ZTT1D, offset = 3 -> !cir.ptr<!cir.ptr<!void>>
 // CIR:   cir.call @_ZN1CC2Ev(%[[C_PTR]], %[[VTT_D_TO_C]]) : (!cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!void>>) -> ()
 
@@ -120,12 +120,12 @@ int f() {
 // CIR:   cir.store{{.*}} %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, address_point = <index = 2, offset = 3>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 
-// CIR:   %{{[0-9]+}} = cir.base_class_addr(%{{[0-9]+}} : !cir.ptr<!rec_D> nonnull) [40] -> !cir.ptr<!rec_A>
+// CIR:   %{{[0-9]+}} = cir.base_class_addr %{{[0-9]+}} : !cir.ptr<!rec_D> nonnull [40] -> !cir.ptr<!rec_A>
 // CIR:   %{{[0-9]+}} = cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_A>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.store{{.*}} %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   %{{[0-9]+}} = cir.vtable.address_point(@_ZTV1D, address_point = <index = 1, offset = 3>) : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>
 
-// CIR:   cir.base_class_addr(%{{[0-9]+}} : !cir.ptr<!rec_D> nonnull) [16] -> !cir.ptr<!rec_C>
+// CIR:   cir.base_class_addr %{{[0-9]+}} : !cir.ptr<!rec_D> nonnull [16] -> !cir.ptr<!rec_C>
 // CIR:   cir.cast(bitcast, %{{[0-9]+}} : !cir.ptr<!rec_C>), !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.store{{.*}} %{{[0-9]+}}, %{{[0-9]+}} : !cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.func<() -> !u32i>>>>
 // CIR:   cir.return
@@ -172,7 +172,7 @@ namespace other {
 // CIR:           %[[VAL_2:.*]] = cir.load{{.*}} %[[VAL_1]] : !cir.ptr<!cir.ptr<!rec_other3A3AB>>, !cir.ptr<!rec_other3A3AB>
 // CIR:           %[[VAL_3:.*]] = cir.vtt.address_point @_ZTTN5other1BE, offset = 0 -> !cir.ptr<!cir.ptr<!void>>
 // CIR:           cir.call @_ZN5other1BD2Ev(%[[VAL_2]], %[[VAL_3]]) : (!cir.ptr<!rec_other3A3AB>, !cir.ptr<!cir.ptr<!void>>) -> ()
-// CIR:           %[[VAL_4:.*]] = cir.base_class_addr(%[[VAL_2]] : !cir.ptr<!rec_other3A3AB> nonnull) [0] -> !cir.ptr<!rec_other3A3AA>
+// CIR:           %[[VAL_4:.*]] = cir.base_class_addr %[[VAL_2]] : !cir.ptr<!rec_other3A3AB> nonnull [0] -> !cir.ptr<!rec_other3A3AA>
 // CIR:           cir.call @_ZN5other1AD2Ev(%[[VAL_4]]) : (!cir.ptr<!rec_other3A3AA>) -> ()
 // CIR:           cir.return
 // CIR:         }


### PR DESCRIPTION
This removes unnecessary parens from the assembly format of BaseClassAddrOp, DerivedClassAddrOp, BaseDataMemberOp, DerivedDataMemberOp, BaseMethodOp, and DerivedMethodOp to bring them into conformance with the CIR ASM Style Guide.

The is no function change beyond the assembly format change.