### PR TITLE
[CIR][CIRGen][Builtin][X86] Lower lzcnt_u16, lzcnt_u32, lzcnt_u64

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -144,5 +144,20 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned BuiltinID,
             getLoc(E->getExprLoc()), builder.getStringAttr("x86.rdtsc"), intTy)
         .getResult();
   }
+  case X86::BI__builtin_ia32_rdtscp: {
+    llvm_unreachable("__rdtscp NYI");
+  }
+  case X86::BI__builtin_ia32_lzcnt_u16:
+  case X86::BI__builtin_ia32_lzcnt_u32:
+  case X86::BI__builtin_ia32_lzcnt_u64: {
+    mlir::Value V = builder.create<cir::ConstantOp>(
+        getLoc(E->getExprLoc()), cir::BoolAttr::get(&getMLIRContext(), false));
+
+    return builder
+        .create<cir::LLVMIntrinsicCallOp>(
+            getLoc(E->getExprLoc()), builder.getStringAttr("ctlz"),
+            Ops[0].getType(), mlir::ValueRange{Ops[0], V})
+        .getResult();
+  }
   }
 }

--- a/clang/test/CIR/CodeGen/X86/lzcnt-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/lzcnt-builtins.c
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+#include <immintrin.h>
+
+unsigned int test_lzcnt_u32(unsigned int __X)
+{
+  // CIR-LABEL: _lzcnt_u32
+  // LLVM-LABEL: _lzcnt_u32
+  return _lzcnt_u32(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "ctlz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // LLVM: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+}
+
+unsigned long long test__lzcnt_u64(unsigned long long __X)
+{
+  // CIR-LABEL: _lzcnt_u64
+  // LLVM-LABEL: _lzcnt_u64
+  return _lzcnt_u64(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "ctlz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // LLVM: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+}


### PR DESCRIPTION
No test cases provided for `lzcnt_u16` as presented in the OG codegen equivalent: `test/CodeGen/X86/lzcnt-builtins.c`.

related: #1404 