### PR TITLE
[CIR] Support inheritance in `InitListExpr`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -1252,9 +1252,8 @@ void AggExprEmitter::VisitCXXParenListOrInitListExpr(
     return;
   }
 #endif
-
-  AggValueSlot Dest = EnsureSlot(CGF.getLoc(ExprToVisit->getSourceRange()),
-                                 ExprToVisit->getType());
+  const mlir::Location loc = CGF.getLoc(ExprToVisit->getSourceRange());
+  AggValueSlot Dest = EnsureSlot(loc, ExprToVisit->getType());
 
   LValue DestLV = CGF.makeAddrLValue(Dest.getAddress(), ExprToVisit->getType());
 
@@ -1294,8 +1293,20 @@ void AggExprEmitter::VisitCXXParenListOrInitListExpr(
   if (auto *CXXRD = dyn_cast<CXXRecordDecl>(record)) {
     assert(NumInitElements >= CXXRD->getNumBases() &&
            "missing initializer for base class");
-    for ([[maybe_unused]] auto &Base : CXXRD->bases()) {
-      llvm_unreachable("NYI");
+    for (auto &Base : CXXRD->bases()) {
+      assert(!Base.isVirtual() && "should not see vbases here");
+      auto *BaseRD = Base.getType()->getAsCXXRecordDecl();
+      Address address = CGF.getAddressOfDirectBaseInCompleteClass(
+          loc, Dest.getAddress(), CXXRD, BaseRD,
+          /*isBaseVirtual*/ false);
+      AggValueSlot aggSlot = AggValueSlot::forAddr(
+          address, Qualifiers(), AggValueSlot::IsDestructed,
+          AggValueSlot::DoesNotNeedGCBarriers, AggValueSlot::IsNotAliased,
+          CGF.getOverlapForBaseInit(CXXRD, BaseRD, false));
+      CGF.emitAggExpr(InitExprs[curInitIndex++], aggSlot);
+      if (QualType::DestructionKind dtorKind =
+              Base.getType().isDestructedType())
+        CGF.pushDestroyAndDeferDeactivation(dtorKind, address, Base.getType());
     }
   }
 
@@ -1329,8 +1340,7 @@ void AggExprEmitter::VisitCXXParenListOrInitListExpr(
       emitInitializationToLValue(InitExprs[0], FieldLoc);
     } else {
       // Default-initialize to null.
-      emitNullInitializationToLValue(CGF.getLoc(ExprToVisit->getSourceRange()),
-                                     FieldLoc);
+      emitNullInitializationToLValue(loc, FieldLoc);
     }
 
     return;

--- a/clang/test/CIR/CodeGen/agg-init-inherit.cpp
+++ b/clang/test/CIR/CodeGen/agg-init-inherit.cpp
@@ -1,5 +1,7 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
 
 struct A1 {
   A1();
@@ -11,11 +13,15 @@ void f1() {
   B v{};
 }
 
-// CHECK: cir.func dso_local @_Z2f1v()
-// CHECK:     %0 = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["v", init]
-// CHECK:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_B> nonnull [0] -> !cir.ptr<!rec_A1>
-// CHECK:     cir.call @_ZN2A1C2Ev(%1) : (!cir.ptr<!rec_A1>) -> ()
-// CHECK:     cir.return
+// CIR: cir.func dso_local @_Z2f1v()
+// CIR:     %0 = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["v", init]
+// CIR:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_B> nonnull [0] -> !cir.ptr<!rec_A1>
+// CIR:     cir.call @_ZN2A1C2Ev(%1) : (!cir.ptr<!rec_A1>) -> ()
+// CIR:     cir.return
+// LLVM: define dso_local void @_Z2f1v()
+// LLVM:    %1 = alloca %class.B, i64 1, align 1
+// LLVM:    call void @_ZN2A1C2Ev(ptr %1)
+// LLVM:    ret void
 
 struct A2 {
     A2();
@@ -26,13 +32,18 @@ void f2() {
   C v{};
 }
 
-// CHECK: cir.func dso_local @_Z2f2v()
-// CHECK:     %0 = cir.alloca !rec_C, !cir.ptr<!rec_C>, ["v", init]
-// CHECK:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_C> nonnull [0] -> !cir.ptr<!rec_A1>
-// CHECK:     cir.call @_ZN2A1C2Ev(%1) : (!cir.ptr<!rec_A1>) -> ()
-// CHECK:     %2 = cir.base_class_addr %0 : !cir.ptr<!rec_C> nonnull [0] -> !cir.ptr<!rec_A2>
-// CHECK:     cir.call @_ZN2A2C2Ev(%2) : (!cir.ptr<!rec_A2>) -> ()
-// CHECK:     cir.return
+// CIR: cir.func dso_local @_Z2f2v()
+// CIR:     %0 = cir.alloca !rec_C, !cir.ptr<!rec_C>, ["v", init]
+// CIR:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_C> nonnull [0] -> !cir.ptr<!rec_A1>
+// CIR:     cir.call @_ZN2A1C2Ev(%1) : (!cir.ptr<!rec_A1>) -> ()
+// CIR:     %2 = cir.base_class_addr %0 : !cir.ptr<!rec_C> nonnull [0] -> !cir.ptr<!rec_A2>
+// CIR:     cir.call @_ZN2A2C2Ev(%2) : (!cir.ptr<!rec_A2>) -> ()
+// CIR:     cir.return
+// LLVM: define dso_local void @_Z2f2v()
+// LLVM:    %1 = alloca %class.C, i64 1, align 1
+// LLVM:    call void @_ZN2A1C2Ev(ptr %1)
+// LLVM:    call void @_ZN2A2C2Ev(ptr %1)
+// LLVM:    ret void
 
 struct A3 {
     A3();
@@ -44,9 +55,14 @@ void f3() {
   D v{};
 }
 
-// CHECK: cir.func dso_local @_Z2f3v()
-// CHECK:     %0 = cir.alloca !rec_D, !cir.ptr<!rec_D>, ["v", init]
-// CHECK:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_D> nonnull [0] -> !cir.ptr<!rec_A3>
-// CHECK:     cir.call @_ZN2A3C2Ev(%1) : (!cir.ptr<!rec_A3>) -> ()
-// CHECK:     cir.call @_ZN1DD1Ev(%0) : (!cir.ptr<!rec_D>) -> ()
-// CHECK:     cir.return
+// CIR: cir.func dso_local @_Z2f3v()
+// CIR:     %0 = cir.alloca !rec_D, !cir.ptr<!rec_D>, ["v", init]
+// CIR:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_D> nonnull [0] -> !cir.ptr<!rec_A3>
+// CIR:     cir.call @_ZN2A3C2Ev(%1) : (!cir.ptr<!rec_A3>) -> ()
+// CIR:     cir.call @_ZN1DD1Ev(%0) : (!cir.ptr<!rec_D>) -> ()
+// CIR:     cir.return
+// LLVM: define dso_local void @_Z2f3v()
+// LLVM:    %1 = alloca %class.D, i64 1, align 1
+// LLVM:    call void @_ZN2A3C2Ev(ptr %1)
+// LLVM:    call void @_ZN1DD1Ev(ptr %1)
+// LLVM:    ret void

--- a/clang/test/CIR/CodeGen/agg-init-inherit.cpp
+++ b/clang/test/CIR/CodeGen/agg-init-inherit.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++17 -fclangir -Wno-unused-value -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 struct A1 {
@@ -48,5 +48,5 @@ void f3() {
 // CHECK:     %0 = cir.alloca !rec_D, !cir.ptr<!rec_D>, ["v", init]
 // CHECK:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_D> nonnull [0] -> !cir.ptr<!rec_A3>
 // CHECK:     cir.call @_ZN2A3C2Ev(%1) : (!cir.ptr<!rec_A3>) -> ()
-// CHECK:     cir.call @_ZN1DD2Ev(%0) : (!cir.ptr<!rec_D>) -> ()
+// CHECK:     cir.call @_ZN1DD1Ev(%0) : (!cir.ptr<!rec_D>) -> ()
 // CHECK:     cir.return

--- a/clang/test/CIR/CodeGen/agg-init-inherit.cpp
+++ b/clang/test/CIR/CodeGen/agg-init-inherit.cpp
@@ -1,0 +1,52 @@
+// RUN: %clang_cc1 -std=c++17 -fclangir -Wno-unused-value -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+struct A1 {
+  A1();
+};
+
+class B : public A1 {};
+
+void f1() {
+  B v{};
+}
+
+// CHECK: cir.func dso_local @_Z2f1v()
+// CHECK:     %0 = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["v", init]
+// CHECK:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_B> nonnull [0] -> !cir.ptr<!rec_A1>
+// CHECK:     cir.call @_ZN2A1C2Ev(%1) : (!cir.ptr<!rec_A1>) -> ()
+// CHECK:     cir.return
+
+struct A2 {
+    A2();
+};
+class C : public A1, public A2 {};
+
+void f2() {
+  C v{};
+}
+
+// CHECK: cir.func dso_local @_Z2f2v()
+// CHECK:     %0 = cir.alloca !rec_C, !cir.ptr<!rec_C>, ["v", init]
+// CHECK:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_C> nonnull [0] -> !cir.ptr<!rec_A1>
+// CHECK:     cir.call @_ZN2A1C2Ev(%1) : (!cir.ptr<!rec_A1>) -> ()
+// CHECK:     %2 = cir.base_class_addr %0 : !cir.ptr<!rec_C> nonnull [0] -> !cir.ptr<!rec_A2>
+// CHECK:     cir.call @_ZN2A2C2Ev(%2) : (!cir.ptr<!rec_A2>) -> ()
+// CHECK:     cir.return
+
+struct A3 {
+    A3();
+    ~A3();
+};
+class D : public A3 {};
+
+void f3() {
+  D v{};
+}
+
+// CHECK: cir.func dso_local @_Z2f3v()
+// CHECK:     %0 = cir.alloca !rec_D, !cir.ptr<!rec_D>, ["v", init]
+// CHECK:     %1 = cir.base_class_addr %0 : !cir.ptr<!rec_D> nonnull [0] -> !cir.ptr<!rec_A3>
+// CHECK:     cir.call @_ZN2A3C2Ev(%1) : (!cir.ptr<!rec_A3>) -> ()
+// CHECK:     cir.call @_ZN1DD2Ev(%0) : (!cir.ptr<!rec_D>) -> ()
+// CHECK:     cir.return


### PR DESCRIPTION
convert from codegen
```c++
      assert(!Base.isVirtual() && "should not see vbases here");
      auto *BaseRD = Base.getType()->getAsCXXRecordDecl();
      Address V = CGF.GetAddressOfDirectBaseInCompleteClass(
          Dest.getAddress(), CXXRD, BaseRD,
          /*isBaseVirtual*/ false);
      AggValueSlot AggSlot = AggValueSlot::forAddr(
          V, Qualifiers(),
          AggValueSlot::IsDestructed,
          AggValueSlot::DoesNotNeedGCBarriers,
          AggValueSlot::IsNotAliased,
          CGF.getOverlapForBaseInit(CXXRD, BaseRD, Base.isVirtual()));
      CGF.EmitAggExpr(InitExprs[curInitIndex++], AggSlot);

      if (QualType::DestructionKind dtorKind =
              Base.getType().isDestructedType())
        CGF.pushDestroyAndDeferDeactivation(dtorKind, V, Base.getType());
```