### PR TITLE
[CIR][CIRGen][Builtin][X86] Lower __rdtscp

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -144,5 +144,30 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned BuiltinID,
             getLoc(E->getExprLoc()), builder.getStringAttr("x86.rdtsc"), intTy)
         .getResult();
   }
+  case X86::BI__builtin_ia32_rdtscp: {
+
+    // For rdtscp, we need to create a proper struct type to hold {i64, i32}
+    mlir::Type i64Ty = cir::IntType::get(&getMLIRContext(), 64, false);
+    mlir::Type i32Ty = cir::IntType::get(&getMLIRContext(), 32, false);
+
+    mlir::Type ResTy = cir::RecordType::get(&getMLIRContext(), {i64Ty, i32Ty},
+                                            mlir::StringAttr(), false, false,
+                                            cir::RecordType::Struct);
+
+    auto Call = builder
+                    .create<cir::LLVMIntrinsicCallOp>(
+                        getLoc(E->getExprLoc()),
+                        builder.getStringAttr("x86.rdtscp"), ResTy)
+                    .getResult();
+
+    // Store processor ID in address param
+    mlir::Value PID = builder.create<cir::ExtractMemberOp>(
+        getLoc(E->getExprLoc()), i32Ty, Call, 1);
+    builder.create<cir::StoreOp>(getLoc(E->getExprLoc()), PID, Ops[0]);
+
+    // Return the timestamp at index 0
+    return builder.create<cir::ExtractMemberOp>(getLoc(E->getExprLoc()), i64Ty,
+                                                Call, 0);
+  }
   }
 }

--- a/clang/test/CIR/CodeGen/X86/builtins-x86.c
+++ b/clang/test/CIR/CodeGen/X86/builtins-x86.c
@@ -45,12 +45,3 @@ void test_mm_sfence() {
   // CIR: {{%.*}} = cir.llvm.intrinsic "x86.sse.sfence" : () -> !void
   // LLVM: call void @llvm.x86.sse.sfence()
 }
-
-unsigned long long test_rdtsc() {
-  // CIR-LABEL: @test_rdtsc
-  // LLVM-LABEL: @test_rdtsc
-  return __rdtsc();
-  // CIR: {{%.*}} = cir.llvm.intrinsic "x86.rdtsc"  : () -> !u64i 
-  // LLVM: call i64 @llvm.x86.rdtsc
-}
-

--- a/clang/test/CIR/CodeGen/X86/rd-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/rd-builtins.c
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -ffreestanding  -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// This test mimics clang/test/CodeGen/X86/rd-builtins.c, which eventually
+// CIR shall be able to support fully.
+
+#include <x86intrin.h>
+
+unsigned long long test_rdtsc() {
+  // CIR-LABEL: @test_rdtsc
+  // LLVM-LABEL: @test_rdtsc
+  return __rdtsc();
+  // CIR: {{%.*}} = cir.llvm.intrinsic "x86.rdtsc"  : () -> !u64i
+  // LLVM: call i64 @llvm.x86.rdtsc
+}
+
+unsigned long long test_rdtscp(unsigned int *a) {
+
+  return __rdtscp(a);
+
+  // CIR-LABEL: @__rdtscp
+  // CIR: [[RDTSCP:%.*]] = cir.llvm.intrinsic "x86.rdtscp"  : () -> !rec_anon_struct
+  // CIR: [[TSC_AUX:%.*]] = cir.extract_member [[RDTSCP]][1] : !rec_anon_struct -> !u32i
+  // CIR: cir.store [[TSC_AUX]], %{{.*}} : !u32i, !cir.ptr<!u32i>
+  // CIR: {{%.*}} = cir.extract_member [[RDTSCP]][0] : !rec_anon_struct -> !u64i
+
+  // LLVM: @test_rdtscp
+  // LLVM: [[RDTSCP:%.*]] = call { i64, i32 } @llvm.x86.rdtscp
+  // LLVM: [[TSC_AUX:%.*]] = extractvalue { i64, i32 } [[RDTSCP]], 1
+  // LLVM: store i32 [[TSC_AUX]], ptr %{{.*}}
+  // LLVM: [[TSC:%.*]] = extractvalue { i64, i32 } [[RDTSCP]], 0
+}
+


### PR DESCRIPTION
Moved rd related intrinsic tests, to a different file similar to `clang/test/CodeGen/X86/rd-builtins.c`. Let me know if that's the right call.