### PR TITLE
[ThroughMLIR] basic printf support

### DIFF
--- a/clang/test/CIR/Lowering/ThroughMLIR/call.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/call.c
@@ -12,3 +12,41 @@ int test(void) {
 //       CHECK:   %[[ARG:.+]] = arith.constant 2 : i32
 //  CHECK-NEXT:   call @foo(%[[ARG]]) : (i32) -> ()
 //       CHECK: }
+
+extern int printf(const char *str, ...);
+
+// CHECK-LABEL: llvm.func @printf(!llvm.ptr, ...) -> i32
+//       CHECK: llvm.mlir.global internal constant @[[FRMT_STR:.*]](dense<[37, 100, 44, 32, 37, 102, 44, 32, 37, 100, 44, 32, 37, 108, 108, 100, 44, 32, 37, 100, 44, 32, 37, 102, 10, 0]> : tensor<26xi8>) {addr_space = 0 : i32} : !llvm.array<26 x i8>
+
+void testfunc(short s, float X, char C, long long LL, int I, double D) {
+	printf("%d, %f, %d, %lld, %d, %f\n", s, X, C, LL, I, D);
+}
+
+// CHECK: func.func @testfunc(%[[ARG0:.*]]: i16 {{.*}}, %[[ARG1:.*]]: f32 {{.*}}, %[[ARG2:.*]]: i8 {{.*}}, %[[ARG3:.*]]: i64 {{.*}}, %[[ARG4:.*]]: i32 {{.*}}, %[[ARG5:.*]]: f64 {{.*}}) {
+// CHECK: %[[ALLOCA_S:.*]] = memref.alloca() {alignment = 2 : i64} : memref<i16>
+// CHECK: %[[ALLOCA_X:.*]] = memref.alloca() {alignment = 4 : i64} : memref<f32>  
+// CHECK: %[[ALLOCA_C:.*]] = memref.alloca() {alignment = 1 : i64} : memref<i8> 
+// CHECK: %[[ALLOCA_LL:.*]] = memref.alloca() {alignment = 8 : i64} : memref<i64> 
+// CHECK: %[[ALLOCA_I:.*]] = memref.alloca() {alignment = 4 : i64} : memref<i32> 
+// CHECK: %[[ALLOCA_D:.*]] = memref.alloca() {alignment = 8 : i64} : memref<f64> 
+// CHECK: memref.store %[[ARG0]], %[[ALLOCA_S]][] : memref<i16> 
+// CHECK: memref.store %[[ARG1]], %[[ALLOCA_X]][] : memref<f32>
+// CHECK: memref.store %[[ARG2]], %[[ALLOCA_C]][] : memref<i8> 
+// CHECK: memref.store %[[ARG3]], %[[ALLOCA_LL]][] : memref<i64> 
+// CHECK: memref.store %[[ARG4]], %[[ALLOCA_I]][] : memref<i32> 
+// CHECK: memref.store %[[ARG5]], %[[ALLOCA_D]][] : memref<f64> 
+// CHECK: %[[FRMT_STR_ADDR:.*]] = llvm.mlir.addressof @[[FRMT_STR]] : !llvm.ptr 
+// CHECK: %[[C0:.*]] = llvm.mlir.constant(0 : index) : i8 
+// CHECK: %[[FRMT_STR_DATA:.*]] = llvm.getelementptr %[[FRMT_STR_ADDR]][%[[C0]], %[[C0]]] : (!llvm.ptr, i8, i8) -> !llvm.ptr, !llvm.array<26 x i8> 
+// CHECK: %[[S:.*]] = memref.load %[[ALLOCA_S]][] : memref<i16> 
+// CHECK: %[[S_EXT:.*]] = arith.extsi %3 : i16 to i32 
+// CHECK: %[[X:.*]] = memref.load %[[ALLOCA_X]][] : memref<f32> 
+// CHECK: %[[X_EXT:.*]] = arith.extf %5 : f32 to f64 
+// CHECK: %[[C:.*]] = memref.load %[[ALLOCA_C]][] : memref<i8> 
+// CHECK: %[[C_EXT:.*]] = arith.extsi %7 : i8 to i32
+// CHECK: %[[LL:.*]] = memref.load %[[ALLOCA_LL]][] : memref<i64> 
+// CHECK: %[[I:.*]] = memref.load %[[ALLOCA_I]][] : memref<i32> 
+// CHECK: %[[D:.*]] = memref.load %[[ALLOCA_D]][] : memref<f64> 
+// CHECK: {{.*}} = llvm.call @printf(%[[FRMT_STR_DATA]], %[[S_EXT]], %[[X_EXT]], %[[C_EXT]], %[[LL]], %[[I]], %[[D]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, i32, f64, i32, i64, i32, f64) -> i32 
+// CHECK: return
+// CHECK: } 


### PR DESCRIPTION
This PR is related to #1685 and adds some basic support for the printf function. 

Limitations:
1. It only works if all variadic params are of basic interger/float type (for more info why memref type operands don't work see #1685)
2. Only works if the format string is definied directly inside the printf function

The downside of this PR is also that the handling this edge case adds significant code bloat and reduces readability for the cir.call op lowering (I tried to insert some meanigful comments to improve the readability), but I think its worth to do this so we have some basic printf support (without adding an extra cir operation) until upstream support for variadic functions is added to the func dialect. Also a few more test (which use such a basic form of printf) in the llvm Single Source test suite are working with this PR:

before this PR:

Testing Time: 4.00s

Total Discovered Tests: 1833
Passed : 420 (22.91%)
Failed : 10 (0.55%)
Executable Missing: 1403 (76.54%)

with this PR:

Testing Time: 10.29s

Total Discovered Tests: 1833
  Passed            :  458 (24.99%)
  Failed            :    6 (0.33%)
  Executable Missing: 1369 (74.69%)