### PR TITLE
[CIR] Update Accumulate Bits Algorithm

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -651,8 +651,7 @@ CIRRecordLowering::accumulateBitFields(RecordDecl::field_iterator Field,
           } else if (cirGenTypes.getModule()
                          .getCodeGenOpts()
                          .FineGrainedBitfieldAccesses) {
-            // Fine-grained access, so no merging of spans.
-            InstallBest = true;
+            llvm_unreachable("NYI");
           } else {
             // Otherwise, we're not installing. Update the bit size
             // of the current span to go all the way to LimitOffset, which is

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -3,6 +3,7 @@
 #include "CIRGenModule.h"
 #include "CIRGenTypes.h"
 
+#include "TargetInfo.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
@@ -77,8 +78,9 @@ struct CIRRecordLowering final {
   void accumulateVPtrs();
   void accumulateVBases();
   void accumulateFields();
-  void accumulateBitFields(RecordDecl::field_iterator Field,
-                           RecordDecl::field_iterator FieldEnd);
+  RecordDecl::field_iterator
+  accumulateBitFields(RecordDecl::field_iterator Field,
+                      RecordDecl::field_iterator FieldEnd);
 
   mlir::Type getVFPtrType();
 
@@ -509,101 +511,198 @@ void CIRRecordLowering::fillOutputFields() {
   }
 }
 
-void CIRRecordLowering::accumulateBitFields(
-    RecordDecl::field_iterator Field, RecordDecl::field_iterator FieldEnd) {
-  // Run stores the first element of the current run of bitfields.  FieldEnd is
-  // used as a special value to note that we don't have a current run.  A
-  // bitfield run is a contiguous collection of bitfields that can be stored in
-  // the same storage block.  Zero-sized bitfields and bitfields that would
-  // cross an alignment boundary break a run and start a new one.
-  RecordDecl::field_iterator Run = FieldEnd;
-  // Tail is the offset of the first bit off the end of the current run.  It's
-  // used to determine if the ASTRecordLayout is treating these two bitfields as
-  // contiguous.  StartBitOffset is offset of the beginning of the Run.
-  uint64_t StartBitOffset, Tail = 0;
-  if (isDiscreteBitFieldABI()) {
-    llvm_unreachable("NYI");
-  }
+RecordDecl::field_iterator
+CIRRecordLowering::accumulateBitFields(RecordDecl::field_iterator Field,
+                                       RecordDecl::field_iterator FieldEnd) {
 
-  // Check if OffsetInRecord (the size in bits of the current run) is better
-  // as a single field run. When OffsetInRecord has legal integer width, and
-  // its bitfield offset is naturally aligned, it is better to make the
-  // bitfield a separate storage component so as it can be accessed directly
-  // with lower cost.
-  auto IsBetterAsSingleFieldRun = [&](uint64_t OffsetInRecord,
-                                      uint64_t StartBitOffset,
-                                      uint64_t nextTail = 0) {
-    if (!cirGenTypes.getModule().getCodeGenOpts().FineGrainedBitfieldAccesses)
-      return false;
+  if (isDiscreteBitFieldABI())
     llvm_unreachable("NYI");
-    // if (OffsetInRecord < 8 || !llvm::isPowerOf2_64(OffsetInRecord) ||
-    //     !DataLayout.fitsInLegalInteger(OffsetInRecord))
-    //   return false;
-    // Make sure StartBitOffset is naturally aligned if it is treated as an
-    // IType integer.
-    // if (StartBitOffset %
-    //         astContext.toBits(getAlignment(getUIntNType(OffsetInRecord))) !=
-    //     0)
-    //   return false;
-    return true;
-  };
 
-  // The start field is better as a single field run.
-  bool StartFieldAsSingleRun = false;
+  CharUnits RegSize =
+      bitsToCharUnits(astContext.getTargetInfo().getRegisterWidth());
+  unsigned CharBits = astContext.getCharWidth();
+
+  // Data about the start of the span we're accumulating to create an access
+  // unit from. Begin is the first bitfield of the span. If Begin is FieldEnd,
+  // we've not got a current span. The span starts at the BeginOffset character
+  // boundary. BitSizeSinceBegin is the size (in bits) of the span -- this might
+  // include padding when we've advanced to a subsequent bitfield run.
+  RecordDecl::field_iterator Begin = FieldEnd;
+  CharUnits BeginOffset;
+  uint64_t BitSizeSinceBegin;
+
+  // The (non-inclusive) end of the largest acceptable access unit we've found
+  // since Begin. If this is Begin, we're gathering the initial set of bitfields
+  // of a new span. BestEndOffset is the end of that acceptable access unit --
+  // it might extend beyond the last character of the bitfield run, using
+  // available padding characters.
+  RecordDecl::field_iterator BestEnd = Begin;
+  CharUnits BestEndOffset;
+  bool BestClipped; // Whether the representation must be in a byte array.
+
   for (;;) {
-    // Check to see if we need to start a new run.
-    if (Run == FieldEnd) {
-      // If we're out of fields, return.
-      if (Field == FieldEnd)
-        break;
-      // Any non-zero-length bitfield can start a new run.
-      if (!Field->isZeroLengthBitField()) {
-        Run = Field;
-        StartBitOffset = getFieldBitOffset(*Field);
-        Tail = StartBitOffset + Field->getBitWidthValue();
-        StartFieldAsSingleRun =
-            IsBetterAsSingleFieldRun(Tail - StartBitOffset, StartBitOffset);
+    // AtAlignedBoundary is true if Field is the (potential) start of a new
+    // span (or the end of the bitfields). When true, LimitOffset is the
+    // character offset of that span and Barrier indicates whether the new
+    // span cannot be merged into the current one.
+    bool AtAlignedBoundary = false;
+    bool Barrier = false; // a barrier can be a zero Bit Width or non bit member
+    if (Field != FieldEnd && Field->isBitField()) {
+      uint64_t BitOffset = getFieldBitOffset(*Field);
+      if (Begin == FieldEnd) {
+        // Beginning a new span.
+        Begin = Field;
+        BestEnd = Begin;
+
+        assert((BitOffset % CharBits) == 0 && "Not at start of char");
+        BeginOffset = bitsToCharUnits(BitOffset);
+        BitSizeSinceBegin = 0;
+      } else if ((BitOffset % CharBits) != 0) {
+        // Bitfield occupies the same character as previous bitfield, it must be
+        // part of the same span. This can include zero-length bitfields, should
+        // the target not align them to character boundaries. Such non-alignment
+        // is at variance with the standards, which require zero-length
+        // bitfields be a barrier between access units. But of course we can't
+        // achieve that in the middle of a character.
+        assert(BitOffset ==
+                   astContext.toBits(BeginOffset) + BitSizeSinceBegin &&
+               "Concatenating non-contiguous bitfields");
+      } else {
+        // Bitfield potentially begins a new span. This includes zero-length
+        // bitfields on non-aligning targets that lie at character boundaries
+        // (those are barriers to merging).
+        if (Field->isZeroLengthBitField())
+          Barrier = true;
+        AtAlignedBoundary = true;
       }
-      ++Field;
-      continue;
+    } else {
+      // We've reached the end of the bitfield run. Either we're done, or this
+      // is a barrier for the current span.
+      if (Begin == FieldEnd)
+        break;
+
+      Barrier = true;
+      AtAlignedBoundary = true;
     }
 
-    // If the start field of a new run is better as a single run, or if current
-    // field (or consecutive fields) is better as a single run, or if current
-    // field has zero width bitfield and either UseZeroLengthBitfieldAlignment
-    // or UseBitFieldTypeAlignment is set to true, or if the offset of current
-    // field is inconsistent with the offset of previous field plus its offset,
-    // skip the block below and go ahead to emit the storage. Otherwise, try to
-    // add bitfields to the run.
-    uint64_t nextTail = Tail;
-    if (Field != FieldEnd)
-      nextTail += Field->getBitWidthValue();
+    // InstallBest indicates whether we should create an access unit for the
+    // current best span: fields [Begin, BestEnd) occupying characters
+    // [BeginOffset, BestEndOffset).
+    bool InstallBest = false;
+    if (AtAlignedBoundary) {
+      // Field is the start of a new span or the end of the bitfields. The
+      // just-seen span now extends to BitSizeSinceBegin.
 
-    if (!StartFieldAsSingleRun && Field != FieldEnd &&
-        !IsBetterAsSingleFieldRun(Tail - StartBitOffset, StartBitOffset,
-                                  nextTail) &&
-        (!Field->isZeroLengthBitField() ||
-         (!astContext.getTargetInfo().useZeroLengthBitfieldAlignment() &&
-          !astContext.getTargetInfo().useBitFieldTypeAlignment())) &&
-        Tail == getFieldBitOffset(*Field)) {
-      Tail = nextTail;
-      ++Field;
-      continue;
+      // Determine if we can accumulate that just-seen span into the current
+      // accumulation.
+      CharUnits AccessSize = bitsToCharUnits(BitSizeSinceBegin + CharBits - 1);
+      if (BestEnd == Begin) {
+        // This is the initial run at the start of a new span. By definition,
+        // this is the best seen so far.
+        BestEnd = Field;
+        BestEndOffset = BeginOffset + AccessSize;
+        // Assume clipped until proven not below.
+        BestClipped = true;
+        if (!BitSizeSinceBegin)
+          // A zero-sized initial span -- this will install nothing and reset
+          // for another.
+          InstallBest = true;
+      } else if (AccessSize > RegSize) {
+        // Accumulating the just-seen span would create a multi-register access
+        // unit, which would increase register pressure.
+        InstallBest = true;
+      }
+
+      if (!InstallBest) {
+        // Determine if accumulating the just-seen span will create an expensive
+        // access unit or not.
+        mlir::Type Type = getBitfieldStorageType(astContext.toBits(AccessSize));
+        if (!astContext.getTargetInfo().hasCheapUnalignedBitFieldAccess())
+          llvm_unreachable("NYI");
+
+        if (!InstallBest) {
+          // Find the next used storage offset to determine what the limit of
+          // the current span is. That's either the offset of the next field
+          // with storage (which might be Field itself) or the end of the
+          // non-reusable tail padding.
+          CharUnits LimitOffset;
+          for (auto Probe = Field; Probe != FieldEnd; ++Probe)
+            if (!isEmptyFieldForLayout(astContext, *Probe)) {
+              // A member with storage sets the limit.
+              assert((getFieldBitOffset(*Probe) % CharBits) == 0 &&
+                     "Next storage is not byte-aligned");
+              LimitOffset = bitsToCharUnits(getFieldBitOffset(*Probe));
+              goto FoundLimit;
+            }
+          LimitOffset = cxxRecordDecl ? astRecordLayout.getNonVirtualSize()
+                                      : astRecordLayout.getDataSize();
+        FoundLimit:
+          CharUnits TypeSize = getSize(Type);
+          if (BeginOffset + TypeSize <= LimitOffset) {
+            // There is space before LimitOffset to create a naturally-sized
+            // access unit.
+            BestEndOffset = BeginOffset + TypeSize;
+            BestEnd = Field;
+            BestClipped = false;
+          }
+          if (Barrier) {
+            // The next field is a barrier that we cannot merge across.
+            InstallBest = true;
+          } else if (cirGenTypes.getModule()
+                         .getCodeGenOpts()
+                         .FineGrainedBitfieldAccesses) {
+            // Fine-grained access, so no merging of spans.
+            InstallBest = true;
+          } else {
+            // Otherwise, we're not installing. Update the bit size
+            // of the current span to go all the way to LimitOffset, which is
+            // the (aligned) offset of next bitfield to consider.
+            BitSizeSinceBegin = astContext.toBits(LimitOffset - BeginOffset);
+          }
+        }
+      }
     }
 
-    // We've hit a break-point in the run and need to emit a storage field.
-    auto Type = getBitfieldStorageType(Tail - StartBitOffset);
-
-    // Add the storage member to the record and set the bitfield info for all of
-    // the bitfields in the run. Bitfields get the offset of their storage but
-    // come afterward and remain there after a stable sort.
-    members.push_back(StorageInfo(bitsToCharUnits(StartBitOffset), Type));
-    for (; Run != Field; ++Run)
-      members.push_back(MemberInfo(bitsToCharUnits(StartBitOffset),
-                                   MemberInfo::InfoKind::Field, nullptr, *Run));
-    Run = FieldEnd;
-    StartFieldAsSingleRun = false;
+    if (InstallBest) {
+      assert((Field == FieldEnd || !Field->isBitField() ||
+              (getFieldBitOffset(*Field) % CharBits) == 0) &&
+             "Installing but not at an aligned bitfield or limit");
+      CharUnits AccessSize = BestEndOffset - BeginOffset;
+      if (!AccessSize.isZero()) {
+        // Add the storage member for the access unit to the record. The
+        // bitfields get the offset of their storage but come afterward and
+        // remain there after a stable sort.
+        mlir::Type Type;
+        if (BestClipped) {
+          assert(getSize(getBitfieldStorageType(
+                     astContext.toBits(AccessSize))) > AccessSize &&
+                 "Clipped access need not be clipped");
+          Type = getByteArrayType(AccessSize);
+        } else {
+          Type = getBitfieldStorageType(astContext.toBits(AccessSize));
+          assert(getSize(Type) == AccessSize &&
+                 "Unclipped access must be clipped");
+        }
+        members.push_back(StorageInfo(BeginOffset, Type));
+        for (; Begin != BestEnd; ++Begin)
+          if (!Begin->isZeroLengthBitField())
+            members.push_back(MemberInfo(
+                BeginOffset, MemberInfo::InfoKind::Field, nullptr, *Begin));
+      }
+      // Reset to start a new span.
+      Field = BestEnd;
+      Begin = FieldEnd;
+    } else {
+      assert(Field != FieldEnd && Field->isBitField() &&
+             "Accumulating past end of bitfields");
+      assert(!Barrier && "Accumulating across barrier");
+      // Accumulate this bitfield into the current (potential) span.
+      BitSizeSinceBegin += Field->getBitWidthValue();
+      ++Field;
+    }
   }
+
+  return Field;
 }
 
 void CIRRecordLowering::accumulateFields() {
@@ -611,11 +710,9 @@ void CIRRecordLowering::accumulateFields() {
                                   fieldEnd = recordDecl->field_end();
        field != fieldEnd;) {
     if (field->isBitField()) {
-      RecordDecl::field_iterator start = field;
-      // Iterate to gather the list of bitfields.
-      for (++field; field != fieldEnd && field->isBitField(); ++field)
-        ;
-      accumulateBitFields(start, field);
+      field = accumulateBitFields(field, fieldEnd);
+      assert((field == fieldEnd || !field->isBitField()) &&
+             "Failed to accumulate all the bitfields");
     } else if (!field->isZeroSize(astContext)) {
       members.push_back(MemberInfo{bitsToCharUnits(getFieldBitOffset(*field)),
                                    MemberInfo::InfoKind::Field,

--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -616,7 +616,7 @@ CIRRecordLowering::accumulateBitFields(RecordDecl::field_iterator Field,
       if (!InstallBest) {
         // Determine if accumulating the just-seen span will create an expensive
         // access unit or not.
-        mlir::Type Type = getBitfieldStorageType(astContext.toBits(AccessSize));
+        mlir::Type Type = getUIntNType(astContext.toBits(AccessSize));
         if (!astContext.getTargetInfo().hasCheapUnalignedBitFieldAccess())
           llvm_unreachable("NYI");
 
@@ -674,12 +674,12 @@ CIRRecordLowering::accumulateBitFields(RecordDecl::field_iterator Field,
         // remain there after a stable sort.
         mlir::Type Type;
         if (BestClipped) {
-          assert(getSize(getBitfieldStorageType(
-                     astContext.toBits(AccessSize))) > AccessSize &&
+          assert(getSize(getUIntNType(astContext.toBits(AccessSize))) >
+                     AccessSize &&
                  "Clipped access need not be clipped");
           Type = getByteArrayType(AccessSize);
         } else {
-          Type = getBitfieldStorageType(astContext.toBits(AccessSize));
+          Type = getUIntNType(astContext.toBits(AccessSize));
           assert(getSize(Type) == AccessSize &&
                  "Unclipped access must be clipped");
         }

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -25,6 +25,16 @@
 
 namespace clang::CIRGen {
 
+/// isEmptyFieldForLayout - Return true if the field is "empty", that is,
+/// either a zero-width bit-field or an isEmptyRecordForLayout.
+bool isEmptyFieldForLayout(const ASTContext &Context, const FieldDecl *FD);
+
+/// isEmptyRecordForLayout - Return true if a structure contains only empty
+/// base classes (per  isEmptyRecordForLayout) and fields (per
+/// isEmptyFieldForLayout). Note, C++ record fields are considered empty
+/// if the [[no_unique_address]] attribute would have made them empty.
+bool isEmptyRecordForLayout(const ASTContext &Context, QualType T);
+
 class CIRGenFunction;
 class CIRGenModule;
 class CIRGenBuilderTy;

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -11,7 +11,9 @@ struct __long {
   unsigned __size_;
   unsigned *__data_;
 };
-
+// CHECK-DAG: !rec_anon2E0 = !cir.record<struct "anon.0" {!u32i} #cir.record.decl.ast>
+// CHECK-DAG: !rec___long = !cir.record<struct "__long" {!rec_anon2E0, !u32i, !cir.ptr<!u32i>}>
+// CHECK-DAG: !rec_anon_struct = !cir.record<struct  {!u8i, !u8i, !cir.array<!u8i x 2>, !s32i}>
 void m() {
   struct __long l;
 }
@@ -21,6 +23,7 @@ typedef struct {
   int b : 5;
   int c;
 } D;
+// CHECK-DAG: !rec_D = !cir.record<struct "D" {!u16i, !s32i}>
 
 typedef struct {
   int a : 4;
@@ -30,11 +33,15 @@ typedef struct {
   int e : 15;
   unsigned f; // type other than int above, not a bitfield
 } S;
-
+// CHECK-DAG: !rec_S = !cir.record<struct "S" {!cir.array<!u8i x 7>, !u16i, !u32i}>
+// CHECK-DAG: #bfi_d = #cir.bitfield_info<name = "d", storage_type = !cir.array<!u8i x 7>, size = 2, offset = 49, is_signed = true>
+// CHECK-DAG: #bfi_e = #cir.bitfield_info<name = "e", storage_type = !u16i, size = 15, offset = 0, is_signed = true>
 typedef struct {
   int a : 3;  // one bitfield with size < 8
   unsigned b;
 } T;
+// CHECK-DAG: !rec_T = !cir.record<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
+// CHECK-DAG: #bfi_a = #cir.bitfield_info<name = "a", storage_type = !u8i, size = 3, offset = 0, is_signed = true>
 
 typedef struct {
     char a;
@@ -54,23 +61,14 @@ typedef struct {
     int l: 14; // need to be a part of the new storage
                // because (tail - startOffset) is 65 after 'l' field
 } U;
+// CHECK-DAG: !rec_U = !cir.record<struct "U" {!s8i, !s8i, !s8i, !cir.array<!u8i x 5>, !u32i}>
 
-// CHECK: !rec_D = !cir.record<struct "D" {!u16i, !s32i}>
-// CHECK: !rec_G = !cir.record<struct "G" {!u16i, !s32i} #cir.record.decl.ast>
-// CHECK: !rec_T = !cir.record<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK: !rec_anon2E0 = !cir.record<struct "anon.0" {!u32i} #cir.record.decl.ast>
-// CHECK: #bfi_a = #cir.bitfield_info<name = "a", storage_type = !u8i, size = 3, offset = 0, is_signed = true>
-// CHECK: #bfi_e = #cir.bitfield_info<name = "e", storage_type = !u16i, size = 15, offset = 0, is_signed = true>
-// CHECK: !rec_S = !cir.record<struct "S" {!u32i, !cir.array<!u8i x 3>, !u16i, !u32i}>
-// CHECK: !rec_U = !cir.record<struct "U" {!s8i, !s8i, !s8i, !cir.array<!u8i x 9>}>
-// CHECK: !rec___long = !cir.record<struct "__long" {!rec_anon2E0, !u32i, !cir.ptr<!u32i>}>
-// CHECK: !rec_anon_struct = !cir.record<struct  {!u8i, !u8i, !cir.array<!u8i x 2>, !s32i}>
-// CHECK: #bfi_d = #cir.bitfield_info<name = "d", storage_type = !cir.array<!u8i x 3>, size = 2, offset = 17, is_signed = true>
+// CHECK-DAG: !rec_G = !cir.record<struct "G" {!u16i, !s32i} #cir.record.decl.ast>
 
 // CHECK: cir.func {{.*@store_field}}
 // CHECK:   [[TMP0:%.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>
 // CHECK:   [[TMP1:%.*]] = cir.const #cir.int<3> : !s32i
-// CHECK:   [[TMP2:%.*]] = cir.get_member [[TMP0]][2] {name = "e"} : !cir.ptr<!rec_S> -> !cir.ptr<!u16i>
+// CHECK:   [[TMP2:%.*]] = cir.get_member [[TMP0]][1] {name = "e"} : !cir.ptr<!rec_S> -> !cir.ptr<!u16i>
 // CHECK:   cir.set_bitfield(#bfi_e, [[TMP2]] : !cir.ptr<!u16i>, [[TMP1]] : !s32i)
 void store_field() {
   S s;
@@ -79,35 +77,35 @@ void store_field() {
 
 // CHECK: cir.func {{.*@load_field}}
 // CHECK:   [[TMP0:%.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["s", init]
-// CHECK:   [[TMP1:%.*]] = cir.load{{.*}} [[TMP0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
-// CHECK:   [[TMP2:%.*]] = cir.get_member [[TMP1]][1] {name = "d"} : !cir.ptr<!rec_S> -> !cir.ptr<!cir.array<!u8i x 3>>
-// CHECK:   [[TMP3:%.*]] = cir.get_bitfield(#bfi_d, [[TMP2]] : !cir.ptr<!cir.array<!u8i x 3>>) -> !s32i
+// CHECK:   [[TMP1:%.*]] = cir.load [[TMP0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
+// CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP1]] : !cir.ptr<!rec_S>), !cir.ptr<!cir.array<!u8i x 7>>
+// CHECK:   [[TMP3:%.*]] = cir.get_bitfield(#bfi_d, [[TMP2]] : !cir.ptr<!cir.array<!u8i x 7>>) -> !s32i
 int load_field(S* s) {
   return s->d;
 }
 
 // CHECK: cir.func {{.*@unOp}}
-// CHECK:   [[TMP0:%.*]] = cir.get_member {{.*}}[1] {name = "d"} : !cir.ptr<!rec_S> -> !cir.ptr<!cir.array<!u8i x 3>>
-// CHECK:   [[TMP1:%.*]] = cir.get_bitfield(#bfi_d, [[TMP0]] : !cir.ptr<!cir.array<!u8i x 3>>) -> !s32i
+// CHECK:   [[TMP0:%.*]] = cir.cast(bitcast, {{.*}} : !cir.ptr<!rec_S>), !cir.ptr<!cir.array<!u8i x 7>>
+// CHECK:   [[TMP1:%.*]] = cir.get_bitfield(#bfi_d, [[TMP0]] : !cir.ptr<!cir.array<!u8i x 7>>) -> !s32i
 // CHECK:   [[TMP2:%.*]] = cir.unary(inc, [[TMP1]]) nsw : !s32i, !s32i
-// CHECK:   cir.set_bitfield(#bfi_d, [[TMP0]] : !cir.ptr<!cir.array<!u8i x 3>>, [[TMP2]] : !s32i)
+// CHECK:   cir.set_bitfield(#bfi_d, [[TMP0]] : !cir.ptr<!cir.array<!u8i x 7>>, [[TMP2]] : !s32i)
 void unOp(S* s) {
   s->d++;
 }
 
 // CHECK: cir.func {{.*@binOp}}
 // CHECK:   [[TMP0:%.*]] = cir.const #cir.int<42> : !s32i
-// CHECK:   [[TMP1:%.*]] = cir.get_member {{.*}}[1] {name = "d"} : !cir.ptr<!rec_S> -> !cir.ptr<!cir.array<!u8i x 3>>
-// CHECK:   [[TMP2:%.*]] = cir.get_bitfield(#bfi_d, [[TMP1]] : !cir.ptr<!cir.array<!u8i x 3>>) -> !s32i
+// CHECK:   [[TMP1:%.*]] = cir.cast(bitcast, {{.*}} : !cir.ptr<!rec_S>), !cir.ptr<!cir.array<!u8i x 7>>
+// CHECK:   [[TMP2:%.*]] = cir.get_bitfield(#bfi_d, [[TMP1]] : !cir.ptr<!cir.array<!u8i x 7>>) -> !s32i
 // CHECK:   [[TMP3:%.*]] = cir.binop(or, [[TMP2]], [[TMP0]]) : !s32i
-// CHECK:   cir.set_bitfield(#bfi_d, [[TMP1]] : !cir.ptr<!cir.array<!u8i x 3>>, [[TMP3]] : !s32i)
+// CHECK:   cir.set_bitfield(#bfi_d, [[TMP1]] : !cir.ptr<!cir.array<!u8i x 7>>, [[TMP3]] : !s32i)
 void binOp(S* s) {
    s->d |= 42;
 }
 
 
 // CHECK: cir.func {{.*@load_non_bitfield}}
-// CHECK:   cir.get_member {{%.}}[3] {name = "f"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
+// CHECK:   cir.get_member {{%.}}[2] {name = "f"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
 unsigned load_non_bitfield(S *s) {
   return s->f;
 }

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -77,7 +77,7 @@ void store_field() {
 
 // CHECK: cir.func {{.*@load_field}}
 // CHECK:   [[TMP0:%.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["s", init]
-// CHECK:   [[TMP1:%.*]] = cir.load [[TMP0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
+// CHECK:   [[TMP1:%.*]] = cir.load{{.*}} [[TMP0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
 // CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP1]] : !cir.ptr<!rec_S>), !cir.ptr<!cir.array<!u8i x 7>>
 // CHECK:   [[TMP3:%.*]] = cir.get_bitfield(#bfi_d, [[TMP2]] : !cir.ptr<!cir.array<!u8i x 7>>) -> !s32i
 int load_field(S* s) {

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -9,6 +9,7 @@ struct __long {
   unsigned __size_;
   unsigned *__data_;
 };
+// CHECK-DAG: !rec___long = !cir.record<struct "__long" {!rec_anon2E0, !u32i, !cir.ptr<!u32i>}>
 
 void m() {
   __long l;
@@ -22,21 +23,21 @@ typedef struct {
   int e : 15;
   unsigned f; // type other than int above, not a bitfield
 } S;
-
+// CHECK-DAG: !rec_S = !cir.record<struct "S" {!cir.array<!u8i x 7>, !u16i, !u32i}>
+// CHECK-DAG: #bfi_a1 = #cir.bitfield_info<name = "a", storage_type = !cir.array<!u8i x 7>, size = 4, offset = 0, is_signed = true>
 typedef struct {
   int a : 3;  // one bitfield with size < 8
   unsigned b;
 } T;
-// CHECK: !rec_T = !cir.record<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK: !rec_anon2E0 = !cir.record<struct "anon.0" {!u32i} #cir.record.decl.ast>
-// CHECK: !rec_S = !cir.record<struct "S" {!u32i, !cir.array<!u8i x 3>, !u16i, !u32i}>
-// CHECK: !rec___long = !cir.record<struct "__long" {!rec_anon2E0, !u32i, !cir.ptr<!u32i>}>
+// CHECK-DAG: !rec_T = !cir.record<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
+// CHECK-DAG: #bfi_a = #cir.bitfield_info<name = "a", storage_type = !u8i, size = 3, offset = 0, is_signed = true>
+// CHECK-DAG: !rec_anon2E0 = !cir.record<struct "anon.0" {!u32i} #cir.record.decl.ast>
 
 // CHECK: cir.func dso_local @_Z11store_field
 // CHECK:   [[TMP0:%.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>
 // CHECK:   [[TMP1:%.*]] = cir.const #cir.int<3> : !s32i
-// CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP0]] : !cir.ptr<!rec_S>), !cir.ptr<!u32i>
-// CHECK:   cir.set_bitfield(#bfi_a, [[TMP2]] : !cir.ptr<!u32i>, [[TMP1]] : !s32i)
+// CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP0]] : !cir.ptr<!rec_S>), !cir.ptr<!cir.array<!u8i x 7>>
+// CHECK:   cir.set_bitfield(#bfi_a1, [[TMP2]] : !cir.ptr<!cir.array<!u8i x 7>>, [[TMP1]] : !s32i)
 void store_field() {
   S s;
   s.a = 3;
@@ -44,15 +45,15 @@ void store_field() {
 
 // CHECK: cir.func dso_local @_Z10load_field
 // CHECK:   [[TMP0:%.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["s", init, const]
-// CHECK:   [[TMP1:%.*]] = cir.load{{.*}} [[TMP0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
-// CHECK:   [[TMP2:%.*]] = cir.get_member [[TMP1]][1] {name = "d"} : !cir.ptr<!rec_S> -> !cir.ptr<!cir.array<!u8i x 3>>
-// CHECK:   [[TMP3:%.*]] = cir.get_bitfield(#bfi_d, [[TMP2]] : !cir.ptr<!cir.array<!u8i x 3>>) -> !s32i
+// CHECK:   [[TMP1:%.*]] = cir.load [[TMP0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
+// CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP1]] : !cir.ptr<!rec_S>), !cir.ptr<!cir.array<!u8i x 7>>
+// CHECK:   [[TMP3:%.*]] = cir.get_bitfield(#bfi_d, [[TMP2]] : !cir.ptr<!cir.array<!u8i x 7>>) -> !s32i
 int load_field(S& s) {
   return s.d;
 }
 
-// CHECK: cir.func dso_local @_Z17load_non_bitfield
-// CHECK:   cir.get_member {{%.}}[3] {name = "f"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
+// CHECK: cir.func @_Z17load_non_bitfield
+// CHECK:   cir.get_member {{%.}}[2] {name = "f"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
 unsigned load_non_bitfield(S& s) {
   return s.f;
 }

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -52,7 +52,7 @@ int load_field(S& s) {
   return s.d;
 }
 
-// CHECK: cir.func @_Z17load_non_bitfield
+// CHECK: cir.func dso_local @_Z17load_non_bitfield
 // CHECK:   cir.get_member {{%.}}[2] {name = "f"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
 unsigned load_non_bitfield(S& s) {
   return s.f;

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -23,21 +23,21 @@ typedef struct {
   int e : 15;
   unsigned f; // type other than int above, not a bitfield
 } S;
-// CHECK-DAG: !rec_S = !cir.record<struct "S" {!cir.array<!u8i x 7>, !u16i, !u32i}>
-// CHECK-DAG: #bfi_a1 = #cir.bitfield_info<name = "a", storage_type = !cir.array<!u8i x 7>, size = 4, offset = 0, is_signed = true>
+// CHECK-DAG: !rec_S = !cir.record<struct "S" {!u64i, !u16i, !u32i}>
+// CHECK-DAG: #bfi_a = #cir.bitfield_info<name = "a", storage_type = !u64i, size = 4, offset = 0, is_signed = true>
 typedef struct {
   int a : 3;  // one bitfield with size < 8
   unsigned b;
 } T;
 // CHECK-DAG: !rec_T = !cir.record<struct "T" {!u8i, !u32i} #cir.record.decl.ast>
-// CHECK-DAG: #bfi_a = #cir.bitfield_info<name = "a", storage_type = !u8i, size = 3, offset = 0, is_signed = true>
+// CHECK-DAG: #bfi_a1 = #cir.bitfield_info<name = "a", storage_type = !u8i, size = 3, offset = 0, is_signed = true>
 // CHECK-DAG: !rec_anon2E0 = !cir.record<struct "anon.0" {!u32i} #cir.record.decl.ast>
 
 // CHECK: cir.func dso_local @_Z11store_field
 // CHECK:   [[TMP0:%.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>
 // CHECK:   [[TMP1:%.*]] = cir.const #cir.int<3> : !s32i
-// CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP0]] : !cir.ptr<!rec_S>), !cir.ptr<!cir.array<!u8i x 7>>
-// CHECK:   cir.set_bitfield(#bfi_a1, [[TMP2]] : !cir.ptr<!cir.array<!u8i x 7>>, [[TMP1]] : !s32i)
+// CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP0]] : !cir.ptr<!rec_S>), !cir.ptr<!u64i>
+// CHECK:   cir.set_bitfield(#bfi_a, [[TMP2]] : !cir.ptr<!u64i>, [[TMP1]] : !s32i)
 void store_field() {
   S s;
   s.a = 3;
@@ -46,8 +46,8 @@ void store_field() {
 // CHECK: cir.func dso_local @_Z10load_field
 // CHECK:   [[TMP0:%.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["s", init, const]
 // CHECK:   [[TMP1:%.*]] = cir.load [[TMP0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
-// CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP1]] : !cir.ptr<!rec_S>), !cir.ptr<!cir.array<!u8i x 7>>
-// CHECK:   [[TMP3:%.*]] = cir.get_bitfield(#bfi_d, [[TMP2]] : !cir.ptr<!cir.array<!u8i x 7>>) -> !s32i
+// CHECK:   [[TMP2:%.*]] = cir.cast(bitcast, [[TMP1]] : !cir.ptr<!rec_S>), !cir.ptr<!u64i>
+// CHECK:   [[TMP3:%.*]] = cir.get_bitfield(#bfi_d, [[TMP2]] : !cir.ptr<!u64i>) -> !s32i
 int load_field(S& s) {
   return s.d;
 }

--- a/clang/test/CIR/CodeGen/const-bitfields.c
+++ b/clang/test/CIR/CodeGen/const-bitfields.c
@@ -14,10 +14,10 @@ struct Inner {
   unsigned d : 30;
 };
 
-// CHECK: !rec_anon_struct = !cir.record<struct  {!u8i, !u8i, !u8i, !u8i, !s32i}>
-// CHECK: !rec_T = !cir.record<struct "T" {!cir.array<!u8i x 3>, !s32i} #cir.record.decl.ast>
-// CHECK: !rec_anon_struct1 = !cir.record<struct  {!u8i, !cir.array<!u8i x 3>, !u8i, !u8i, !u8i, !u8i}>
-// CHECK: #bfi_Z = #cir.bitfield_info<name = "Z", storage_type = !cir.array<!u8i x 3>, size = 9, offset = 11, is_signed = true>
+// CHECK-DAG: !rec_anon_struct = !cir.record<struct  {!u8i, !u8i, !u8i, !u8i, !s32i}>
+// CHECK-DAG: !rec_T = !cir.record<struct "T" {!u32i, !s32i} #cir.record.decl.ast>
+// CHECK-DAG: !rec_anon_struct1 = !cir.record<struct  {!u8i, !cir.array<!u8i x 3>, !u8i, !u8i, !u8i, !u8i}>
+// CHECK-DAG: #bfi_Z = #cir.bitfield_info<name = "Z", storage_type = !u32i, size = 9, offset = 11, is_signed = true>
 
 struct T GV = { 1, 5, 26, 42 };
 // CHECK: cir.global external @GV = #cir.const_record<{#cir.int<161> : !u8i, #cir.int<208> : !u8i, #cir.int<0> : !u8i,  #cir.zero : !u8i, #cir.int<42> : !s32i}> : !rec_anon_struct
@@ -30,8 +30,8 @@ struct Inner var = { 1, 0, 1, 21};
 // CHECK: cir.func {{.*@getZ()}}
 // CHECK:   %1 = cir.get_global @GV : !cir.ptr<!rec_anon_struct>
 // CHECK:   %2 = cir.cast(bitcast, %1 : !cir.ptr<!rec_anon_struct>), !cir.ptr<!rec_T>
-// CHECK:   %3 = cir.cast(bitcast, %2 : !cir.ptr<!rec_T>), !cir.ptr<!cir.array<!u8i x 3>>
-// CHECK:   %4 = cir.get_bitfield(#bfi_Z, %3 : !cir.ptr<!cir.array<!u8i x 3>>) -> !s32i
+// CHECK:   %3 = cir.cast(bitcast, %2 : !cir.ptr<!rec_T>), !cir.ptr<!u32i>
+// CHECK:   %4 = cir.get_bitfield(#bfi_Z, %3 : !cir.ptr<!u32i>) -> !s32i
 int getZ() {
   return GV.Z;
 }

--- a/clang/test/CIR/CodeGen/dumb-record.cpp
+++ b/clang/test/CIR/CodeGen/dumb-record.cpp
@@ -30,14 +30,14 @@ struct BitfieldsInOrder {
 } bitfield_order;
 
 // CHECK: Layout: <CIRecordLayout
-// CHECK:  CIR Type:!cir.record<struct "BitfieldsInOrder" padded {!cir.int<s, 8>, !cir.int<u, 8>, !cir.array<!cir.int<u, 8> x 2>, !cir.array<!cir.int<u, 8> x 3>, !cir.int<u, 8>} #cir.record.decl.ast>
-// CHECK:  NonVirtualBaseCIRType:!cir.record<struct "BitfieldsInOrder" padded {!cir.int<s, 8>, !cir.int<u, 8>, !cir.array<!cir.int<u, 8> x 2>, !cir.array<!cir.int<u, 8> x 3>, !cir.int<u, 8>} #cir.record.decl.ast>
+// CHECK:  CIR Type:!cir.record<struct "BitfieldsInOrder" padded {!cir.int<s, 8>, !cir.array<!cir.int<u, 8> x 6>, !cir.int<u, 8>} #cir.record.decl.ast>
+// CHECK:  NonVirtualBaseCIRType:!cir.record<struct "BitfieldsInOrder" padded {!cir.int<s, 8>, !cir.array<!cir.int<u, 8> x 6>, !cir.int<u, 8>} #cir.record.decl.ast>
 // CHECK:  IsZeroInitializable:1
 // CHECK:  BitFields:[
-// CHECK-NEXT:  <CIRBitFieldInfo name:bit offset:0 size:8 isSigned:0 storageSize:8 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
-// CHECK-NEXT:   <CIRBitFieldInfo name:should offset:0 size:20 isSigned:0 storageSize:24 storageOffset:4 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
-// CHECK-NEXT:   <CIRBitFieldInfo name:have offset:20 size:3 isSigned:0 storageSize:24 storageOffset:4 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
-// CHECK-NEXT:   <CIRBitFieldInfo name:order offset:23 size:1 isSigned:0 storageSize:24 storageOffset:4 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
+// CHECK-NEXT:  <CIRBitFieldInfo name:bit offset:0 size:8 isSigned:0 storageSize:48 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
+// CHECK-NEXT:   <CIRBitFieldInfo name:should offset:24 size:20 isSigned:0 storageSize:48 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
+// CHECK-NEXT:   <CIRBitFieldInfo name:have offset:44 size:3 isSigned:0 storageSize:48 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
+// CHECK-NEXT:   <CIRBitFieldInfo name:order offset:47 size:1 isSigned:0 storageSize:48 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
 // CHECK:]>
 
 struct Inner {

--- a/clang/test/CIR/CodeGen/dumb-record.cpp
+++ b/clang/test/CIR/CodeGen/dumb-record.cpp
@@ -30,14 +30,14 @@ struct BitfieldsInOrder {
 } bitfield_order;
 
 // CHECK: Layout: <CIRecordLayout
-// CHECK:  CIR Type:!cir.record<struct "BitfieldsInOrder" padded {!cir.int<s, 8>, !cir.array<!cir.int<u, 8> x 6>, !cir.int<u, 8>} #cir.record.decl.ast>
-// CHECK:  NonVirtualBaseCIRType:!cir.record<struct "BitfieldsInOrder" padded {!cir.int<s, 8>, !cir.array<!cir.int<u, 8> x 6>, !cir.int<u, 8>} #cir.record.decl.ast>
+// CHECK:  CIR Type:!cir.record<struct "BitfieldsInOrder" {!cir.int<s, 8>, !cir.int<u, 8>, !cir.int<u, 32>} #cir.record.decl.ast>
+// CHECK:  NonVirtualBaseCIRType:!cir.record<struct "BitfieldsInOrder" {!cir.int<s, 8>, !cir.int<u, 8>, !cir.int<u, 32>} #cir.record.decl.ast>
 // CHECK:  IsZeroInitializable:1
 // CHECK:  BitFields:[
-// CHECK-NEXT:  <CIRBitFieldInfo name:bit offset:0 size:8 isSigned:0 storageSize:48 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
-// CHECK-NEXT:   <CIRBitFieldInfo name:should offset:24 size:20 isSigned:0 storageSize:48 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
-// CHECK-NEXT:   <CIRBitFieldInfo name:have offset:44 size:3 isSigned:0 storageSize:48 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
-// CHECK-NEXT:   <CIRBitFieldInfo name:order offset:47 size:1 isSigned:0 storageSize:48 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
+// CHECK-NEXT:   <CIRBitFieldInfo name:bit offset:0 size:8 isSigned:0 storageSize:8 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
+// CHECK-NEXT:   <CIRBitFieldInfo name:should offset:0 size:20 isSigned:0 storageSize:32 storageOffset:4 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
+// CHECK-NEXT:   <CIRBitFieldInfo name:have offset:20 size:3 isSigned:0 storageSize:32 storageOffset:4 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
+// CHECK-NEXT:   <CIRBitFieldInfo name:order offset:23 size:1 isSigned:0 storageSize:32 storageOffset:4 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>
 // CHECK:]>
 
 struct Inner {


### PR DESCRIPTION
This PR addresses the feedback from https://github.com/llvm/llvm-project/pull/142041#discussion_r2116554849. Our algorithm for accumulating bitfields has diverged from CodeGen since Clang 19.

There is one key difference: in CIR, we use the function `getBitfieldStorageType`, which checks whether the bit width of the current accumulation run is a valid fundamental width (i.e., a power of two: 8, 16, 32, 64). If it is, it returns a CIR type of that size otherwise, it returns an array with the closest alignment.

For example, given the following struct:

```c
struct S {
  int a : 4;
  int b : 27;
  int c : 17;
  int d : 2;
  int e : 15;
  unsigned f;
};
```

The CodeGen output is:

```llvm
%struct.S = type { i64, i16, i32 }
```

Whereas the new CIR algorithm produces:

```mlir
!cir.record<struct "S" {!cir.array<!u8i x 7>, !u16i, !u32i}>
```
In CIR, the algorithm accumulates up to field `d`, resulting in 50 accumulated bits. Since 50 is not a fundamental width, the closest alignment is 56 bits, which leads to the type `!cir.array<!u8i x 7>`. The algorithm stops before accumulating field `e` because including it would exceed the register size (64), which is not ideal.

At this point, it's unclear whether this divergence from CodeGen represents an improvement. If we wanted to match CodeGen exactly, we would need to replace the use of `getBitfieldStorageType` with `getUIntNType`. The difference is that `getUIntNType` always returns the closest power-of-two integer type instead of falling back to an array when the size is not a fundamental width.

With this change, CIR would match CodeGen's layout exactly. It would require the following small code change:
```diff
diff --git a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
index 7c1802bff077..17538b191738 100644
--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -616,7 +616,7 @@ CIRRecordLowering::accumulateBitFields(RecordDecl::field_iterator Field,
       if (!InstallBest) {
         // Determine if accumulating the just-seen span will create an expensive
         // access unit or not.
-        mlir::Type Type = getBitfieldStorageType(astContext.toBits(AccessSize));
+        mlir::Type Type = getUIntNType(astContext.toBits(AccessSize));
         if (!astContext.getTargetInfo().hasCheapUnalignedBitFieldAccess())
           llvm_unreachable("NYI");

@@ -674,12 +674,12 @@ CIRRecordLowering::accumulateBitFields(RecordDecl::field_iterator Field,
         // remain there after a stable sort.
         mlir::Type Type;
         if (BestClipped) {
-          assert(getSize(getBitfieldStorageType(
+          assert(getSize(getUIntNType(
                      astContext.toBits(AccessSize))) > AccessSize &&
                  "Clipped access need not be clipped");
           Type = getByteArrayType(AccessSize);
         } else {
-          Type = getBitfieldStorageType(astContext.toBits(AccessSize));
+          Type = getUIntNType(astContext.toBits(AccessSize));
           assert(getSize(Type) == AccessSize &&
                  "Unclipped access must be clipped");
         }
```
You can see a comparison between the two functions https://godbolt.org/z/qjx1MaEWG.

I'm currently unsure whether using one function over the other has performance implications. Regarding the **ARM error I mentioned in the meeting: it was an `assert` I had forgotten to update. It's now fixed sorry for the confusion.**

