### PR TITLE
[CIR] Use ComplexRealOp for RValue __imag__ operator

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2068,9 +2068,11 @@ mlir::Value ScalarExprEmitter::VisitImag(const UnaryOperator *E) {
     // If it's an l-value, load through the appropriate subobject l-value.
     // Note that we have to ask E because Op might be an l-value that
     // this won't work for, e.g. an Obj-C property.
-    if (E->isGLValue())
-      return CGF.emitLoadOfLValue(CGF.emitLValue(E), E->getExprLoc())
-          .getScalarVal();
+    if (E->isGLValue()) {
+      mlir::Location Loc = CGF.getLoc(E->getExprLoc());
+      mlir::Value Complex = CGF.emitComplexExpr(Op);
+      return CGF.builder.createComplexImag(Loc, Complex);
+    }
     // Otherwise, calculate and project.
     llvm_unreachable("NYI");
   }


### PR DESCRIPTION
Update `__imag__` operation to use ComplexRealOp and act directly on the complex value.

Ref: https://github.com/llvm/llvm-project/pull/144235#pullrequestreview-2933105012