### PR TITLE
[CIR][CIRGen][Builtin][X86] Add support for tzcnt_u16, tzcnt_u32, and tzcnt_u64

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -144,5 +144,16 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned BuiltinID,
             getLoc(E->getExprLoc()), builder.getStringAttr("x86.rdtsc"), intTy)
         .getResult();
   }
+  case X86::BI__builtin_ia32_tzcnt_u16:
+  case X86::BI__builtin_ia32_tzcnt_u32:
+  case X86::BI__builtin_ia32_tzcnt_u64: {
+    mlir::Value V = builder.create<cir::ConstantOp>(
+        getLoc(E->getExprLoc()), cir::BoolAttr::get(&getMLIRContext(), false));
+    return builder
+        .create<cir::LLVMIntrinsicCallOp>(
+            getLoc(E->getExprLoc()), builder.getStringAttr("cttz"),
+            Ops[0].getType(), mlir::ValueRange{Ops[0], V})
+        .getResult();
+  }
   }
 }

--- a/clang/test/CIR/CodeGen/X86/amd-bmi-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/amd-bmi-builtins.c
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// Intel and AMD use different names for the same BMI intrinsics:
+// Intel uses single underscores (e.g. _tzcnt_u16),
+// AMD uses double underscores (e.g. __tzcnt_u16).
+// Unlike the traditinal tests in clang/test/CodeGen/X86/bmi-builtins.c
+// which combines both, we split them into separate files to avoid symbol 
+// conflicts and keep tests isolated.
+
+#include <immintrin.h>
+
+unsigned short test__tzcnt_u16(unsigned short __X) {
+  // CIR-LABEL: __tzcnt_u16
+  // LLVM-LABEL: __tzcnt_u16
+  return __tzcnt_u16(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "cttz" {{%.*}} : (!u16i, !cir.bool) -> !u16i
+  // LLVM: i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
+}
+
+unsigned int test__tzcnt_u32(unsigned int __X) {
+  // CIR-LABEL: __tzcnt_u32
+  // LLVM-LABEL: __tzcnt_u32
+  return __tzcnt_u32(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "cttz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // LLVM: i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+}
+
+#ifdef __x86_64__
+unsigned long long test__tzcnt_u64(unsigned long long __X) {
+  // CIR-LABEL: __tzcnt_u64
+  // LLVM-LABEL: __tzcnt_u64
+  return __tzcnt_u64(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "cttz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // LLVM: i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+}
+#endif

--- a/clang/test/CIR/CodeGen/X86/intel-bmi-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/intel-bmi-builtins.c
@@ -1,0 +1,55 @@
+// RUN: %clang_cc1 -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// Intel and AMD use different names for the same BMI intrinsics:
+// Intel uses single underscores (e.g. _tzcnt_u16),
+// AMD uses double underscores (e.g. __tzcnt_u16).
+// Unlike the traditinal tests in clang/test/CodeGen/X86/bmi-builtins.c
+// which combines both, we split them into separate files to avoid symbol 
+// conflicts and keep tests isolated.
+
+#include <immintrin.h>
+
+unsigned short test_tzcnt_u16(unsigned short __X) {
+  // CIR-LABEL: _tzcnt_u16
+  // LLVM-LABEL: _tzcnt_u16
+  return _tzcnt_u16(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "cttz" {{%.*}} : (!u16i, !cir.bool) -> !u16i
+  // LLVM: i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
+}
+
+unsigned int test_tzcnt_u32(unsigned int __X) {
+  // CIR-LABEL: _tzcnt_u32
+  // LLVM-LABEL: _tzcnt_u32
+  return _tzcnt_u32(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "cttz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // LLVM: i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+}
+
+int test_mm_tzcnt_32(unsigned int __X) {
+  // CIR-LABEL: _mm_tzcnt_32
+  // LLVM-LABEL: _mm_tzcnt_32
+  return _mm_tzcnt_32(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "cttz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // LLVM: i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+}
+
+#ifdef __x86_64__
+unsigned long long test_tzcnt_u64(unsigned long long __X) {
+  // CIR-LABEL: _tzcnt_u64
+  // LLVM-LABEL: _tzcnt_u64
+  return _tzcnt_u64(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "cttz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // LLVM: i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+}
+
+long long test_mm_tzcnt_64(unsigned long long __X) {
+  // CIR-LABEL: _mm_tzcnt_64
+  // LLVM-LABEL: _mm_tzcnt_64
+  return _mm_tzcnt_64(__X);
+  // CIR: {{%.*}} = cir.llvm.intrinsic "cttz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // LLVM: i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+}
+#endif


### PR DESCRIPTION
Related: https://github.com/llvm/clangir/issues/1404

Implements codegen for the X86 builtins `tzcnt_u16`, `tzcnt_u32`, and `tzcnt_u64`.

While adding tests for both the Intel and AMD variants of BMI intrinsics, I ran into issues when placing them in the same file.

Both `_tzcnt_u16` (Intel) and `__tzcnt_u16`(AMD) map to the same inline wrapper in <immintrin.h>. Whether they're isolated or both are present in a test file, Clang emits only one definition (`__tzcnt_u16`) which I think causes FileCheck mismatches i.e., the CHECK lines for the Intel version (`test_tzcnt_u16`) would fail when looking for `_tzcnt_u16`.

I tried updating the CHECK lines for the Intel test to match the emitted symbol (`__tzcnt_u16`), but it still failed unless the Intel test was run in isolation, and only when CHECK was updated to `_tzcnt_u16` even though `__tzcnt_u16` is what is emitted. I also experimented with split-file to isolate the tests, but that didn’t resolve the issue either.

To keep the tests independent, I split the Intel and AMD tests into separate files. Was wondering if this was fine as in OG clang, both Intel and AMD variants are in the same file (https://github.com/llvm/clangir/blob/main/clang/test/CodeGen/X86/bmi-builtins.c)