### PR TITLE
[CIR] support union without field in C++

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp
@@ -364,7 +364,7 @@ void CIRRecordLowering::lowerUnion() {
   }
   // If we have no storage type just pad to the appropriate size and return.
   if (!StorageType)
-    llvm_unreachable("no-storage union NYI");
+    return appendPaddingBytes(LayoutSize);
   // If our storage size was bigger than our required size (can happen in the
   // case of packed bitfields on Itanium) then just use an I8 array.
   if (LayoutSize < getSize(StorageType))

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -453,8 +453,9 @@ RecordType::computeUnionSize(const mlir::DataLayout &dataLayout) const {
   unsigned recordSize = 0;
   llvm::Align recordAlignment{1};
 
-  auto largestMember = getLargestMember(dataLayout);
-  recordSize = dataLayout.getTypeSize(largestMember);
+  Type largestMember = getLargestMember(dataLayout);
+  if (largestMember)
+    recordSize = dataLayout.getTypeSize(largestMember);
 
   // If the union is padded, add the padding to the size.
   if (getPadded()) {
@@ -517,7 +518,9 @@ RecordType::computeStructAlignment(const mlir::DataLayout &dataLayout) const {
 
 uint64_t
 RecordType::computeUnionAlignment(const mlir::DataLayout &dataLayout) const {
-  auto largestMember = getLargestMember(dataLayout);
+  Type largestMember = getLargestMember(dataLayout);
+  if (!largestMember)
+    return 1;
   return dataLayout.getTypeABIAlignment(largestMember);
 }
 

--- a/clang/test/CIR/CodeGen/union-empty.cpp
+++ b/clang/test/CIR/CodeGen/union-empty.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+
+union EmptyUnion {
+  EmptyUnion() = default;
+};
+
+void f0() {
+  EmptyUnion e{};
+};
+
+// CIR: !rec_EmptyUnion = !cir.record<union "EmptyUnion" padded {!u8i}>
+// CIR: cir.func dso_local @_Z2f0v()
+// CIR:   %0 = cir.alloca !rec_EmptyUnion, !cir.ptr<!rec_EmptyUnion>, ["e"] {alignment = 1 : i64}
+// CIR:   %1 = cir.const #cir.undef : !rec_EmptyUnion
+// CIR:   cir.store align(1) %1, %0 : !rec_EmptyUnion, !cir.ptr<!rec_EmptyUnion>
+// CIR:   cir.return
+
+// LLVM: %union.EmptyUnion = type { i8 }
+// LLVM: define dso_local void @_Z2f0v()
+// LLVM:   %1 = alloca %union.EmptyUnion, i64 1, align 1
+// LLVM:   store %union.EmptyUnion undef, ptr %1, align 1
+// LLVM:   ret void


### PR DESCRIPTION
In [libstdc++ std::variant implementation](https://github.com/gcc-mirror/gcc/blob/b0419798447ae25de2f58d1a695db6dadb5d8547/libstdc%2B%2B-v3/include/std/variant#L387-L394), union without any fields is used.

According to current CodeGen logic, append 1 byte padding for this kind of union.
Handle this union in `mlir::RecordType` for getLargestMember` return nullptr also.
