### PR TITLE
[CIR] Implement SizedTypeInterface to make isSized hookable.

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -27,6 +27,9 @@ struct RecordTypeStorage;
 
 bool isValidFundamentalIntWidth(unsigned width);
 
+// Returns true if the type is a CIR sized type.
+bool isSized(mlir::Type ty);
+
 } // namespace cir
 
 mlir::ParseResult parseAddrSpaceAttribute(mlir::AsmParser &p,

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -35,8 +35,10 @@ class CIR_Type<string name, string typeMnemonic, list<Trait> traits = [],
 // IntType
 //===----------------------------------------------------------------------===//
 
-def CIR_IntType : CIR_Type<"Int", "int",
-    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
+def CIR_IntType : CIR_Type<"Int", "int", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>,
+]> {
   let summary = "Integer type with arbitrary precision up to a fixed limit";
   let description = [{
     CIR type that represents integer types with arbitrary precision.
@@ -81,8 +83,9 @@ def CIR_IntType : CIR_Type<"Int", "int",
 //===----------------------------------------------------------------------===//
 
 class CIR_FloatType<string name, string mnemonic> : CIR_Type<name, mnemonic, [
-  DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-  DeclareTypeInterfaceMethods<CIR_FPTypeInterface>
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_FPTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>
 ]>;
 
 def CIR_Single : CIR_FloatType<"Single", "float"> {
@@ -151,9 +154,10 @@ def CIR_LongDouble : CIR_FloatType<"LongDouble", "long_double"> {
 // ComplexType
 //===----------------------------------------------------------------------===//
 
-def CIR_ComplexType : CIR_Type<"Complex", "complex",
-    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
-
+def CIR_ComplexType : CIR_Type<"Complex", "complex", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>
+]> {
   let summary = "CIR complex type";
   let description = [{
     CIR type that represents a C complex number. `cir.complex` models the C type
@@ -194,9 +198,10 @@ def CIR_ComplexType : CIR_Type<"Complex", "complex",
 // PointerType
 //===----------------------------------------------------------------------===//
 
-def CIR_PointerType : CIR_Type<"Pointer", "ptr",
-    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
-
+def CIR_PointerType : CIR_Type<"Pointer", "ptr", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>
+]> {
   let summary = "CIR pointer type";
   let description = [{
     `CIR.ptr` is a type returned by any op generating a pointer in C++.
@@ -295,9 +300,10 @@ def CIR_DataMemberType : CIR_Type<"DataMember", "data_member",
 // BoolType
 //===----------------------------------------------------------------------===//
 
-def CIR_BoolType : CIR_Type<"Bool", "bool",
-    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
-
+def CIR_BoolType : CIR_Type<"Bool", "bool", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>
+]> {
   let summary = "CIR bool type";
   let description = [{
     `cir.bool` represent's C++ bool type.
@@ -308,9 +314,10 @@ def CIR_BoolType : CIR_Type<"Bool", "bool",
 // ArrayType
 //===----------------------------------------------------------------------===//
 
-def CIR_ArrayType : CIR_Type<"Array", "array",
-    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
-
+def CIR_ArrayType : CIR_Type<"Array", "array", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface, ["isSized"]>,
+]> {
   let summary = "CIR array type";
   let description = [{
     `CIR.array` represents C/C++ constant arrays.
@@ -329,14 +336,22 @@ def CIR_ArrayType : CIR_Type<"Array", "array",
   let assemblyFormat = [{
     `<` $elementType `x` $size `>`
   }];
+
+  let extraClassDefinition = [{
+    bool $cppClass::isSized() const {
+      return ::cir::isSized(getElementType());
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
 // VectorType (fixed size)
 //===----------------------------------------------------------------------===//
 
-def CIR_VectorType : CIR_Type<"Vector", "vector",
-    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
+def CIR_VectorType : CIR_Type<"Vector", "vector", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface, ["isSized"]>,
+]> {
 
   let summary = "CIR vector type";
   let description = [{
@@ -376,6 +391,12 @@ def CIR_VectorType : CIR_Type<"Vector", "vector",
 
   let assemblyFormat = [{
     `<` $elementType `x` $size `>`
+  }];
+
+  let extraClassDefinition = [{
+    bool $cppClass::isSized() const {
+      return ::cir::isSized(getElementType());
+    }
   }];
 
   let genVerifyDecl = 1;
@@ -524,11 +545,11 @@ def CIR_VoidType : CIR_Type<"Void", "void"> {
 // The base type for all RecordDecls.
 //===----------------------------------------------------------------------===//
 
-def CIR_RecordType : CIR_Type<"Record", "record",
-    [
-      DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-      MutableType,
-    ]> {
+def CIR_RecordType : CIR_Type<"Record", "record", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>,
+    MutableType,
+]> {
   let summary = "CIR record type";
   let description = [{
     Each unique clang::RecordDecl is mapped to a `cir.record` and any object in

--- a/clang/include/clang/CIR/Interfaces/CIRTypeInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIRTypeInterfaces.td
@@ -53,4 +53,32 @@ def CIR_FPTypeInterface : TypeInterface<"FPTypeInterface"> {
   ];
 }
 
+def CIR_SizedTypeInterface : TypeInterface<"SizedTypeInterface"> {
+  let description = [{
+    Annotates types that have known size. Types that don't have a size are
+    abstract types and void.
+  }];
+
+  let cppNamespace = "::cir";
+
+  let methods = [
+    InterfaceMethod<[{
+        Returns true if this is a sized type. This mirrors sizedness from the
+        clang AST, where a type is sized if it has a known size.
+
+        By default type defining this interface returns true,
+        but this can be overridden if sizedness depends on properties of the type.
+        For example, whether a struct is not sized if it is incomplete.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isSized",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return true;
+      }]
+    >,
+  ];
+}
+
 #endif // CLANG_CIR_INTERFACES_CIRTYPEINTERFACES_TD

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -527,18 +527,6 @@ public:
       return getCompleteRecordTy(members, name, packed, padded, ast);
   }
 
-  bool isSized(mlir::Type ty) {
-    if (mlir::isa<cir::PointerType, cir::RecordType, cir::ArrayType,
-                  cir::BoolType, cir::IntType, cir::FPTypeInterface,
-                  cir::ComplexType>(ty))
-      return true;
-    if (mlir::isa<cir::VectorType>(ty)) {
-      return isSized(mlir::cast<cir::VectorType>(ty).getElementType());
-    }
-    assert(0 && "Unimplemented size for type");
-    return false;
-  }
-
   //
   // Constant creation helpers
   // -------------------------

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -646,7 +646,7 @@ mlir::Type CIRGenTypes::convertType(QualType T) {
     // int X[] -> [0 x int], unless the element type is not sized.  If it is
     // unsized (e.g. an incomplete record) just use [0 x i8].
     ResultType = convertTypeForMem(A->getElementType());
-    if (!Builder.isSized(ResultType)) {
+    if (!cir::isSized(ResultType)) {
       SkippedLayout = true;
       ResultType = Builder.getUInt8Ty();
     }
@@ -659,7 +659,7 @@ mlir::Type CIRGenTypes::convertType(QualType T) {
 
     // FIXME: In LLVM, "lower arrays of undefined struct type to arrays of
     // i8 just to have a concrete type". Not sure this makes sense in CIR yet.
-    assert(Builder.isSized(EltTy) && "not implemented");
+    assert(cir::isSized(EltTy) && "not implemented");
     ResultType = cir::ArrayType::get(EltTy, A->getSize().getZExtValue());
     break;
   }

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -39,6 +39,18 @@
 using cir::MissingFeatures;
 
 //===----------------------------------------------------------------------===//
+// CIR Helpers
+//===----------------------------------------------------------------------===//
+
+bool cir::isSized(mlir::Type ty) {
+  if (auto sizedTy = mlir::dyn_cast<cir::SizedTypeInterface>(ty))
+    return sizedTy.isSized();
+  // TODO: Remove this once all sized types are annotated.
+  assert(0 && "Unimplemented size for type");
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
 // CIR Custom Parser/Printer Signatures
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This resolves issues pointed out in https://github.com/llvm/llvm-project/pull/143960/files#r2164047625  of needing to update sized list of types on each new type.