### PR TITLE
[CIR][CIRGen][Builtin][X86] Lower `vec_ext` related intrinsics

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -2608,9 +2608,10 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   // can move this up to the beginning of the function.
   //   checkTargetFeatures(E, FD);
 
-  if ([[maybe_unused]] unsigned VectorWidth =
-          getContext().BuiltinInfo.getRequiredVectorWidth(BuiltinID))
-    llvm_unreachable("NYI");
+  if (unsigned vectorWidth =
+          getContext().BuiltinInfo.getRequiredVectorWidth(BuiltinID)) {
+    LargestVectorWidth = std::max(LargestVectorWidth, vectorWidth);
+  }
 
   // See if we have a target specific intrinsic.
   std::string Name = getContext().BuiltinInfo.getName(BuiltinID);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -508,6 +508,11 @@ public:
   /// dropped.
   using SymTableTy = llvm::ScopedHashTable<const clang::Decl *, mlir::Value>;
   SymTableTy symbolTable;
+
+  /// Largest vector width used in this function. Will be used to create a
+  /// function attribute.
+  unsigned LargestVectorWidth = 0;
+
   /// True if we need to emit the life-time markers. This is initially set in
   /// the constructor, but could be overwrriten to true if this is a coroutine.
   bool ShouldEmitLifetimeMarkers;

--- a/clang/test/CIR/CodeGen/X86/avx-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/avx-builtins.c
@@ -1,0 +1,60 @@
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefixes=CIR-CHECK,CIR-X64 --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefixes=CIR-CHECK,CIR-X64 --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM-CHECK,LLVM-X64 --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx -fno-signed-char -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM-CHECK,LLVM-X64 --input-file=%t.ll %s
+
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefixes=CIR-CHECK,CIR-X64 --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefixes=CIR-CHECK,CIR-X64 --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM-CHECK,LLVM-X64 --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx -fno-signed-char -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM-CHECK,LLVM-X64 --input-file=%t.ll %s
+
+#include <immintrin.h>
+
+int test_mm256_extract_epi8(__m256i A) {
+  // CIR-CHECK-LABEL: test_mm256_extract_epi8
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!s8i x 32>
+  // CIR-CHECK %{{.*}} = cir.cast(integral, %{{.*}} : !u8i), !s32i
+
+  // LLVM-CHECK-LABEL: test_mm256_extract_epi8
+  // LLVM-CHECK: extractelement <32 x i8> %{{.*}}, {{i32|i64}} 31
+  // LLVM-CHECK: zext i8 %{{.*}} to i32
+  return _mm256_extract_epi8(A, 31);
+}
+
+int test_mm256_extract_epi16(__m256i A) {
+  // CIR-CHECK-LABEL: test_mm256_extract_epi16
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!s16i x 16>
+  // CIR-CHECK %{{.*}} = cir.cast(integral, %{{.*}} : !u16i), !s32i
+
+  // LLVM-CHECK-LABEL: test_mm256_extract_epi16
+  // LLVM-CHECK: extractelement <16 x i16> %{{.*}}, {{i32|i64}} 15
+  // LLVM-CHECK: zext i16 %{{.*}} to i32
+  return _mm256_extract_epi16(A, 15);
+}
+
+int test_mm256_extract_epi32(__m256i A) {
+  // CIR-CHECK-LABEL: test_mm256_extract_epi32
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!s32i x 8>
+
+  // LLVM-CHECK-LABEL: test_mm256_extract_epi32
+  // LLVM-CHECK: extractelement <8 x i32> %{{.*}}, {{i32|i64}} 7
+  return _mm256_extract_epi32(A, 7);
+}
+
+#if __x86_64__
+long long test_mm256_extract_epi64(__m256i A) {
+  // CIR-X64-LABEL: test_mm256_extract_epi64
+  // LLVM-X64-LABEL: test_mm256_extract_epi64
+  return _mm256_extract_epi64(A, 3);
+}
+#endif

--- a/clang/test/CIR/CodeGen/X86/mmx-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/mmx-builtins.c
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +ssse3 -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefix=CIR-CHECK --implicit-check-not=x86mmx --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +ssse3 -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefix=CIR-CHECK --implicit-check-not=x86mmx --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +ssse3 -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefix=LLVM-CHECK --implicit-check-not=x86mmx --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +ssse3 -fno-signed-char -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefix=LLVM-CHECK --implicit-check-not=x86mmx --input-file=%t.ll %s
+
+#include <immintrin.h>
+
+int test_mm_extract_pi16(__m64 a) {
+
+  // CIR-CHECK-LABEL: test_mm_extract_pi16
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : !u64i : !cir.vector<!s16i x 4>
+
+  // LLVM-CHECK-LABEL: test_mm_extract_pi16
+  // LLVM-CHECK: extractelement <4 x i16> %{{.*}}, i64 2
+  return _mm_extract_pi16(a, 2);
+}

--- a/clang/test/CIR/CodeGen/X86/sse2-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse2-builtins.c
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefixes=CIR-CHECK --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefixes=CIR-CHECK --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM-CHECK --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fno-signed-char -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefixes=LLVM-CHECK --input-file=%t.ll %s
+
+#include <immintrin.h>
+
+// Lowering to pextrw requires optimization.
+int test_mm_extract_epi16(__m128i A) {
+    
+  // CIR-CHECK-LABEL: test_mm_extract_epi16
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!s16i x 8>
+  // CIR-CHECK %{{.*}} = cir.cast(integral, %{{.*}} : !u16i), !s32i
+
+  // LLVM-CHECK-LABEL: test_mm_extract_epi16
+  // LLVM-CHECK: extractelement <8 x i16> %{{.*}}, {{i32|i64}} 1
+  // LLVM-CHECK: zext i16 %{{.*}} to i32
+  return _mm_extract_epi16(A, 1);
+}

--- a/clang/test/CIR/CodeGen/X86/sse41-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse41-builtins.c
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse4.1 -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefix=CIR-CHECK --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse4.1 -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
+// RUN: FileCheck --check-prefix=CIR-CHECK --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse4.1 -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefix=LLVM-CHECK --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse4.1 -fno-signed-char -fclangir -emit-llvm -o %t.ll -Wall -Werror
+// RUN: FileCheck --check-prefix=LLVM-CHECK --input-file=%t.ll %s
+
+
+#include <immintrin.h>
+
+int test_mm_extract_epi8(__m128i x) {
+  // CIR-CHECK-LABEL: test_mm_extract_epi8
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!s8i x 16>
+  // CIR-CHECK %{{.*}} = cir.cast(integral, %{{.*}} : !u8i), !s32i
+
+  // LLVM-CHECK-LABEL: test_mm_extract_epi8
+  // LLVM-CHECK: extractelement <16 x i8> %{{.*}}, {{i32|i64}} 1
+  // LLVM-CHECK: zext i8 %{{.*}} to i32
+  return _mm_extract_epi8(x, 1);
+}
+
+int test_mm_extract_epi32(__m128i x) {
+  // CIR-CHECK-LABEL: test_mm_extract_epi32
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!s32i x 4>
+
+  // LLVM-CHECK-LABEL: test_mm_extract_epi32
+  // LLVM-CHECK: extractelement <4 x i32> %{{.*}}, {{i32|i64}} 1
+  return _mm_extract_epi32(x, 1);
+}
+
+long long test_mm_extract_epi64(__m128i x) {
+  // CIR-CHECK-LABEL: test_mm_extract_epi64
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!s64i x 2>
+
+  // LLVM-CHECK-LABEL: test_mm_extract_epi64
+  // LLVM-CHECK: extractelement <2 x i64> %{{.*}}, {{i32|i64}} 1
+  return _mm_extract_epi64(x, 1);
+}
+
+int test_mm_extract_ps(__m128 x) {
+  // CIR-CHECK-LABEL: test_mm_extract_ps
+  // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!cir.float x 4>
+
+  // LLVM-CHECK-LABEL: test_mm_extract_ps
+  // LLVM-CHECK: extractelement <4 x float> %{{.*}}, {{i32|i64}} 1
+  return _mm_extract_ps(x, 1);
+}


### PR DESCRIPTION
Big question mark here:
When lowering target specific vector types: (`__m256i`, `__m128i`, `__m64`), I was hitting an unreachable statement which I removed and were preventing these types from being lowered. Not too familiar with it but it's related to the attribute `"min-legal-vector-width"="N"` which is not implemented for `cir::VectorType` as compared to OG. Is that a blocker for these intrinsics as of now? or is that something we wanna target before we merge x86 vector specific intrinsics?.