### PR TITLE
[CIR] Backport fix verifier error messages for Complex Real and Imag

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -921,7 +921,7 @@ OpFoldResult cir::ComplexCreateOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult cir::ComplexRealOp::verify() {
   if (getType() != getOperand().getType().getElementType()) {
-    emitOpError() << "cir.complex.real result type does not match operand type";
+    emitOpError() << ": result type does not match operand type";
     return failure();
   }
   return success();
@@ -936,7 +936,7 @@ OpFoldResult cir::ComplexRealOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult cir::ComplexImagOp::verify() {
   if (getType() != getOperand().getType().getElementType()) {
-    emitOpError() << "cir.complex.imag result type does not match operand type";
+    emitOpError() << ": result type does not match operand type";
     return failure();
   }
   return success();

--- a/clang/test/CIR/IR/invalid-complex.cir
+++ b/clang/test/CIR/IR/invalid-complex.cir
@@ -1,0 +1,23 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+module {
+  cir.func @complex_real_invalid_result_type() -> !cir.double {
+    %0 = cir.alloca !cir.complex<!cir.double>, !cir.ptr<!cir.complex<!cir.double>>, ["c"]
+    %2 = cir.load align(8) %0 : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
+    // expected-error @below {{op : result type does not match operand type}}
+    %3 = cir.complex.real %2 : !cir.complex<!cir.double> -> !cir.float
+    cir.return
+  }
+}
+
+// -----
+
+module {
+  cir.func @complex_imag_invalid_result_type() -> !cir.double {
+    %0 = cir.alloca !cir.complex<!cir.double>, !cir.ptr<!cir.complex<!cir.double>>, ["c"]
+    %2 = cir.load align(8) %0 : !cir.ptr<!cir.complex<!cir.double>>, !cir.complex<!cir.double>
+    // expected-error @below {{op : result type does not match operand type}}
+    %3 = cir.complex.imag %2 : !cir.complex<!cir.double> -> !cir.float
+    cir.return
+  }
+}


### PR DESCRIPTION
Fix the verifier error messages from `unexpected error: 'cir.complex.imag' op cir.complex.imag result type does not match operand type` to `unexpected error: 'cir.complex.imag' op : result type does not match operand type`