### PR TITLE
[CIR] Clean up FPAttr

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -477,34 +477,34 @@ def CIR_IntAttr : CIR_Attr<"Int", "int", [TypedAttrInterface]> {
 // FPAttr
 //===----------------------------------------------------------------------===//
 
-def FPAttr : CIR_Attr<"FP", "fp", [TypedAttrInterface]> {
+def CIR_FPAttr : CIR_Attr<"FP", "fp", [TypedAttrInterface]> {
   let summary = "An attribute containing a floating-point value";
   let description = [{
     An fp attribute is a literal attribute that represents a floating-point
     value of the specified floating-point type. Supporting only CIR FP types.
   }];
+
   let parameters = (ins
     AttributeSelfTypeParameter<"", "::cir::FPTypeInterface">:$type,
     APFloatParameter<"">:$value
   );
+
   let builders = [
     AttrBuilderWithInferredContext<(ins "mlir::Type":$type,
                                         "const llvm::APFloat &":$value), [{
       return $_get(type.getContext(), mlir::cast<FPTypeInterface>(type), value);
-    }]>,
-    AttrBuilder<(ins "mlir::Type":$type,
-                     "const llvm::APFloat &":$value), [{
-      return $_get($_ctxt, mlir::cast<FPTypeInterface>(type), value);
-    }]>,
+    }]>
   ];
+
   let extraClassDeclaration = [{
     static FPAttr getZero(mlir::Type type);
   }];
-  let genVerifyDecl = 1;
 
   let assemblyFormat = [{
     `<` custom<FloatLiteral>($value, ref($type)) `>`
   }];
+
+  let genVerifyDecl = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -562,7 +562,7 @@ public:
                              llvm::APFloat fpVal) {
     assert((mlir::isa<cir::SingleType, cir::DoubleType>(t)) &&
            "expected cir::SingleType or cir::DoubleType");
-    return create<cir::ConstantOp>(loc, getAttr<cir::FPAttr>(t, fpVal));
+    return create<cir::ConstantOp>(loc, cir::FPAttr::get(t, fpVal));
   }
 
   cir::IsFPClassOp createIsFPClass(mlir::Location loc, mlir::Value src,

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1917,7 +1917,7 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
       mlir::Type ty = CGM.convertType(DestType);
       assert(mlir::isa<cir::FPTypeInterface>(ty) &&
              "expected floating-point type");
-      return CGM.getBuilder().getAttr<cir::FPAttr>(ty, Init);
+      return cir::FPAttr::get(ty, Init);
     }
   }
   case APValue::Array: {
@@ -2026,8 +2026,8 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
     llvm::APFloat real = Value.getComplexFloatReal();
     llvm::APFloat imag = Value.getComplexFloatImag();
     return builder.getAttr<cir::ComplexAttr>(
-        complexType, builder.getAttr<cir::FPAttr>(complexElemTy, real),
-        builder.getAttr<cir::FPAttr>(complexElemTy, imag));
+        complexType, cir::FPAttr::get(complexElemTy, real),
+        cir::FPAttr::get(complexElemTy, imag));
   }
   case APValue::FixedPoint:
   case APValue::AddrLabelDiff:

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -188,9 +188,8 @@ public:
   mlir::Value VisitFloatingLiteral(const FloatingLiteral *E) {
     mlir::Type Ty = CGF.convertType(E->getType());
     assert(mlir::isa<cir::FPTypeInterface>(Ty) && "expect floating-point type");
-    return Builder.create<cir::ConstantOp>(
-        CGF.getLoc(E->getExprLoc()),
-        Builder.getAttr<cir::FPAttr>(Ty, E->getValue()));
+    return Builder.create<cir::ConstantOp>(CGF.getLoc(E->getExprLoc()),
+                                           cir::FPAttr::get(Ty, E->getValue()));
   }
   mlir::Value VisitCharacterLiteral(const CharacterLiteral *E) {
     mlir::Type Ty = CGF.convertType(E->getType());


### PR DESCRIPTION
- Adds CIR_ prefix to the definition
- Removes redundant builder and cleans up attribute creations