### PR TITLE
[CIR] Untie Type and Attribute definitions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.h
@@ -10,16 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_DIALECT_CIR_IR_CIRATTRS_H_
-#define MLIR_DIALECT_CIR_IR_CIRATTRS_H_
-
-#include "clang/CIR/Dialect/IR/CIROpsEnums.h"
-#include "clang/CIR/Dialect/IR/CIRTypes.h"
+#ifndef CLANG_CIR_DIALECT_IR_CIRATTRS_H
+#define CLANG_CIR_DIALECT_IR_CIRATTRS_H
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
-
-#include "llvm/ADT/SmallVector.h"
 
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 
@@ -32,17 +27,23 @@
 
 namespace clang {
 class FunctionDecl;
-class VarDecl;
 class RecordDecl;
+class VarDecl;
 } // namespace clang
 
 namespace cir {
 class ArrayType;
-class RecordType;
 class BoolType;
+class ComplexType;
+class DataMemberType;
+class IntType;
+class MethodType;
+class PointerType;
+class RecordType;
+class VectorType;
 } // namespace cir
 
 #define GET_ATTRDEF_CLASSES
 #include "clang/CIR/Dialect/IR/CIROpsAttributes.h.inc"
 
-#endif // MLIR_DIALECT_CIR_IR_CIRATTRS_H_
+#endif // CLANG_CIR_DIALECT_IR_CIRATTRS_H

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -199,29 +199,39 @@ def CIR_TypeSizeInfoAttr : CIR_Attr<"TypeSizeInfo", "type_size_info"> {
   }];
 
   let extraClassDeclaration = [{
-    unsigned getPointerSize() const { return getSizeTSize(); }
+    unsigned getPointerSize() const;
+    mlir::Type getCharType(mlir::MLIRContext *ctx) const;
+    mlir::Type getUCharType(mlir::MLIRContext *ctx) const;
+    mlir::Type getIntType(mlir::MLIRContext *ctx) const;
+    mlir::Type getUIntType(mlir::MLIRContext *ctx) const;
+    mlir::Type getSizeType(mlir::MLIRContext *ctx) const;
+    mlir::Type getPtrDiffType(mlir::MLIRContext *ctx) const;
+  }];
 
-    mlir::Type getCharType(mlir::MLIRContext *ctx) const {
+  let extraClassDefinition = [{
+    unsigned $cppClass::getPointerSize() const { return getSizeTSize(); }
+
+    mlir::Type $cppClass::getCharType(mlir::MLIRContext *ctx) const {
       return cir::IntType::get(ctx, getCharSize(), /*signed=*/true);
     }
 
-    mlir::Type getUCharType(mlir::MLIRContext *ctx) const {
+    mlir::Type $cppClass::getUCharType(mlir::MLIRContext *ctx) const {
       return cir::IntType::get(ctx, getCharSize(), /*signed=*/false);
     }
 
-    mlir::Type getIntType(mlir::MLIRContext *ctx) const {
+    mlir::Type $cppClass::getIntType(mlir::MLIRContext *ctx) const {
       return cir::IntType::get(ctx, getIntSize(), /*signed=*/true);
     }
 
-    mlir::Type getUIntType(mlir::MLIRContext *ctx) const {
+    mlir::Type $cppClass::getUIntType(mlir::MLIRContext *ctx) const {
       return cir::IntType::get(ctx, getIntSize(), /*signed=*/false);
     }
 
-    mlir::Type getSizeType(mlir::MLIRContext *ctx) const {
+    mlir::Type $cppClass::getSizeType(mlir::MLIRContext *ctx) const {
       return cir::IntType::get(ctx, getSizeTSize(), /*signed=*/false);
     }
 
-    mlir::Type getPtrDiffType(mlir::MLIRContext *ctx) const {
+    mlir::Type $cppClass::getPtrDiffType(mlir::MLIRContext *ctx) const {
       return cir::IntType::get(ctx, getSizeTSize(), /*signed=*/true);
     }
   }];


### PR DESCRIPTION
This will allow to use Attributes and Types together in tablegen without inducing cyclic dependency.