### PR TITLE
[CIR] Improved `cir::CastOp` verifier to allow bitcasts between types of the same size

### DIFF
--- a/clang/test/CIR/CodeGen/vectype.cpp
+++ b/clang/test/CIR/CodeGen/vectype.cpp
@@ -120,19 +120,31 @@ void vector_int_test(int x, unsigned short usx) {
 
   // Shifts
   vi4 w = a << b;
-  // CHECK: %{{[0-9]+}} = cir.shift(left, {{%.*}} : !cir.vector<!s32i x 4>, 
+  // CHECK: %{{[0-9]+}} = cir.shift(left, {{%.*}} : !cir.vector<!s32i x 4>,
   // CHECK-SAME: {{%.*}} : !cir.vector<!s32i x 4>) -> !cir.vector<!s32i x 4>
   vi4 y = a >> b;
-  // CHECK: %{{[0-9]+}} = cir.shift(right, {{%.*}} : !cir.vector<!s32i x 4>, 
+  // CHECK: %{{[0-9]+}} = cir.shift(right, {{%.*}} : !cir.vector<!s32i x 4>,
   // CHECK-SAME: {{%.*}} : !cir.vector<!s32i x 4>) -> !cir.vector<!s32i x 4>
 
-  vus2 z = { usx, usx };  
+  vus2 z = { usx, usx };
   // CHECK: %{{[0-9]+}} = cir.vec.create(%{{[0-9]+}}, %{{[0-9]+}} : !u16i, !u16i) : !cir.vector<!u16i x 2>
   vus2 zamt = { 3, 4 };
   // CHECK: %{{[0-9]+}} = cir.const #cir.const_vector<[#cir.int<3> : !u16i, #cir.int<4> : !u16i]> : !cir.vector<!u16i x 2>
   vus2 zzz = z >> zamt;
-  // CHECK: %{{[0-9]+}} = cir.shift(right, {{%.*}} : !cir.vector<!u16i x 2>, 
-  // CHECK-SAME: {{%.*}} : !cir.vector<!u16i x 2>) -> !cir.vector<!u16i x 2> 
+  // CHECK: %{{[0-9]+}} = cir.shift(right, {{%.*}} : !cir.vector<!u16i x 2>,
+  // CHECK-SAME: {{%.*}} : !cir.vector<!u16i x 2>) -> !cir.vector<!u16i x 2>
+
+  // Vector to scalar conversion
+  unsigned int zi = (unsigned int)z;
+  // CHECK: %{{[0-9]+}} = cir.cast(bitcast, {{%.*}} : !cir.vector<!u16i x 2>), !u32i
+
+  // Scalar to vector conversion
+  vus2 zz = (vus2)zi;
+  // CHECK: %{{[0-9]+}} = cir.cast(bitcast, {{%.*}} : !u32i), !cir.vector<!u16i x 2>
+
+  // Vector to vector conversion
+  vll2 aaa = (vll2)a;
+  // CHECK: %{{[0-9]+}} = cir.cast(bitcast, {{%.*}} : !cir.vector<!s32i x 4>), !cir.vector<!s64i x 2>
 }
 
 void vector_double_test(int x, double y) {

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1405,7 +1405,35 @@ module {
     // expected-error@+1 {{'cir.cast' op result type address space does not match the address space of the operand}}
     %1 = cir.cast(bitcast, %0 : !cir.ptr<!s32i>), !cir.ptr<!s32i, addrspace(offload_local)>
   }
+}
 
+// -----
+
+!s16i = !cir.int<s, 16>
+!s64i = !cir.int<s, 64>
+
+module {
+  cir.func @test_bitcast_vec2scalar_diff_size() {
+    %0 = cir.const #cir.int<1> : !s16i
+    %1 = cir.vec.create(%0, %0 : !s16i, !s16i) : !cir.vector<!s16i x 2>
+    // expected-error@+1 {{'cir.cast' op requires !cir.ptr or !cir.vector type for source and result}}
+    %2 = cir.cast(bitcast, %1 : !cir.vector<!s16i x 2>), !s64i
+    cir.return
+  }
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+module {
+  cir.func @test_bitcast_scalar2vec_diff_size() {
+    %0 = cir.const #cir.int<1> : !s64i
+    // expected-error@+1 {{'cir.cast' op requires !cir.ptr or !cir.vector type for source and result}}
+    %1 = cir.cast(bitcast, %0 : !s64i), !cir.vector<!s32i x 4>
+    cir.return
+  }
 }
 
 // -----


### PR DESCRIPTION
The `cir::CastOp::verify` method was overly conservative, and would fail on any `bitcast` from vector to scalar or scalar to vector. 

Change List:
- Extends the `cir::CastOp::verify` method to check if the source and result types are the same size using the `mlir::DataLayout` of the current scope, and succeeds if the sizes match. 
- Extends the CodeGen vectype tests with vector to scalar, scalar to vector and vector to vector conversions.
- Extends the IR invalid tests with vector to scalar and scalar to vector conversions with different source and result sizes.