### PR TITLE
[CIR][NFC] Backport upstream bit operations changes

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1608,7 +1608,7 @@ class CIR_BitOp<string mnemonic, TypeConstraint inputTy> : CIR_Op<mnemonic, [
   let results = (outs inputTy:$result);
 
   let assemblyFormat = [{
-    `(` $input `:` type($input) `)` `:` type($result) attr-dict
+    $input `:` type($result) attr-dict
   }];
 }
 
@@ -1616,20 +1616,20 @@ class CIR_CountZerosBitOp<string mnemonic, TypeConstraint inputTy>
     : CIR_BitOp<mnemonic, inputTy> {
   let arguments = (ins inputTy:$input, UnitAttr:$is_zero_poison);
   let assemblyFormat = [{
-    `(` $input `:` type($input) `)` (`zero_poison` $is_zero_poison^)?
+    $input (`zero_poison` $is_zero_poison^)?
     `:` type($result) attr-dict
   }];
 }
 
-def CIR_BitClrsbOp : CIR_BitOp<"bit.clrsb", CIR_SIntOfWidths<[32, 64]>> {
+def CIR_BitClrsbOp : CIR_BitOp<"clrsb", CIR_SIntOfWidths<[32, 64]>> {
   let summary = "Get the number of leading redundant sign bits in the input";
   let description = [{
     Compute the number of leading redundant sign bits in the input integer.
 
     The input integer must be a signed integer. The most significant bit of the
-    input integer is the sign bit. The `cir.bit.clrsb` operation returns the
-    number of redundant sign bits in the input, that is, the number of bits
-    following the most significant bit that are identical to it.
+    input integer is the sign bit. The `cir.clrsb` operation returns the number
+    of redundant sign bits in the input, that is, the number of bits following
+    the most significant bit that are identical to it.
 
     The bit width of the input integer must be either 32 or 64.
 
@@ -1642,24 +1642,22 @@ def CIR_BitClrsbOp : CIR_BitOp<"bit.clrsb", CIR_SIntOfWidths<[32, 64]>> {
     %0 = cir.const #cir.int<3735928559> : !s32i
     // %1 will be 1 because there is 1 bit following the most significant bit
     // that is identical to it.
-    %1 = cir.bit.clrsb(%0 : !s32i) : !s32i
+    %1 = cir.clrsb(%0 : !s32i) : !s32i
 
     // %2 = 1, 0b0000_0000_0000_0000_0000_0000_0000_0001
     %2 = cir.const #cir.int<1> : !s32i
     // %3 will be 30
-    %3 = cir.bit.clrsb(%2 : !s32i) : !s32i
+    %3 = cir.clrsb(%2 : !s32i) : !s32i
     ```
   }];
 }
 
-def CIR_BitClzOp : CIR_CountZerosBitOp<"bit.clz",
-  CIR_UIntOfWidths<[16, 32, 64]>
-> {
+def CIR_BitClzOp : CIR_CountZerosBitOp<"clz", CIR_UIntOfWidths<[16, 32, 64]>> {
   let summary = "Get the number of leading 0-bits in the input";
   let description = [{
     Compute the number of leading 0-bits in the input.
 
-    The input integer must be an unsigned integer. The `cir.bit.clz` operation
+    The input integer must be an unsigned integer. The `cir.clz` operation
     returns the number of consecutive 0-bits at the most significant bit
     position in the input.
 
@@ -1674,19 +1672,17 @@ def CIR_BitClzOp : CIR_CountZerosBitOp<"bit.clz",
     // %0 = 0b0000_0000_0000_0000_0000_0000_0000_1000
     %0 = cir.const #cir.int<8> : !u32i
     // %1 will be 28
-    %1 = cir.bit.clz(%0 : !u32i) zero_poison : !u32i
+    %1 = cir.clz(%0 : !u32i) zero_poison : !u32i
     ```
   }];
 }
 
-def CIR_BitCtzOp : CIR_CountZerosBitOp<"bit.ctz",
-  CIR_UIntOfWidths<[16, 32, 64]>
-> {
+def CIR_BitCtzOp : CIR_CountZerosBitOp<"ctz", CIR_UIntOfWidths<[16, 32, 64]>> {
   let summary = "Get the number of trailing 0-bits in the input";
   let description = [{
     Compute the number of trailing 0-bits in the input.
 
-    The input integer must be an unsigned integer. The `cir.bit.ctz` operation
+    The input integer must be an unsigned integer. The `cir.ctz` operation
     returns the number of consecutive 0-bits at the least significant bit
     position in the input.
 
@@ -1702,20 +1698,19 @@ def CIR_BitCtzOp : CIR_CountZerosBitOp<"bit.ctz",
     // %0 = 0b1000
     %0 = cir.const #cir.int<8> : !u32i
     // %1 will be 3
-    %1 = cir.bit.ctz(%0 : !u32i) : !u32i
+    %1 = cir.ctz(%0 : !u32i) : !u32i
     ```
   }];
 }
 
-def CIR_BitFfsOp : CIR_BitOp<"bit.ffs", CIR_SIntOfWidths<[32, 64]>> {
+def CIR_BitFfsOp : CIR_BitOp<"ffs", CIR_SIntOfWidths<[32, 64]>> {
   let summary = "Get the position of the least significant 1-bit of input";
   let description = [{
     Compute the position of the least significant 1-bit of the input.
 
-    The input integer must be a signed integer. The `cir.bit.ffs` operation
-    returns one plus the index of the least significant 1-bit of the input
-    signed integer. As a special case, if the input integer is 0, `cir.bit.ffs`
-    returns 0.
+    The input integer must be a signed integer. The `cir.ffs` operation returns
+    one plus the index of the least significant 1-bit of the input signed
+    integer. As a special case, if the input integer is 0, `cir.ffs` returns 0.
 
     Example:
 
@@ -1725,12 +1720,12 @@ def CIR_BitFfsOp : CIR_BitOp<"bit.ffs", CIR_SIntOfWidths<[32, 64]>> {
     // %0 = 0x0010_1000
     %0 = cir.const #cir.int<40> : !s32i
     // #1 will be 4 since the 4th least significant bit is 1.
-    %1 = cir.bit.ffs(%0 : !s32i) : !s32i
+    %1 = cir.ffs(%0 : !s32i) : !s32i
     ```
   }];
 }
 
-def CIR_BitParityOp : CIR_BitOp<"bit.parity", CIR_UIntOfWidths<[32, 64]>> {
+def CIR_BitParityOp : CIR_BitOp<"parity", CIR_UIntOfWidths<[32, 64]>> {
   let summary = "Get the parity of input";
   let description = [{
     Compute the parity of the input. The parity of an integer is the number of
@@ -1747,14 +1742,12 @@ def CIR_BitParityOp : CIR_BitOp<"bit.parity", CIR_UIntOfWidths<[32, 64]>> {
     // %0 = 0x0110_1000
     %0 = cir.const #cir.int<104> : !u32i
     // %1 will be 1 since there are 3 1-bits in %0
-    %1 = cir.bit.parity(%0 : !u32i) : !u32i
+    %1 = cir.parity(%0 : !u32i) : !u32i
     ```
   }];
 }
 
-def CIR_BitPopcountOp : CIR_BitOp<"bit.popcount",
-  CIR_UIntOfWidths<[16, 32, 64]>
-> {
+def CIR_BitPopcountOp : CIR_BitOp<"popcount", CIR_UIntOfWidths<[16, 32, 64]>> {
   let summary = "Get the number of 1-bits in input";
   let description = [{
     Compute the number of 1-bits in the input.
@@ -1769,7 +1762,7 @@ def CIR_BitPopcountOp : CIR_BitOp<"bit.popcount",
     // %0 = 0x0110_1000
     %0 = cir.const #cir.int<104> : !u32i
     // %1 will be 3 since there are 3 1-bits in %0
-    %1 = cir.bit.popcount(%0 : !u32i) : !u32i
+    %1 = cir.popcount(%0 : !u32i) : !u32i
     ```
   }];
 }
@@ -1778,11 +1771,11 @@ def CIR_BitPopcountOp : CIR_BitOp<"bit.popcount",
 // ByteswapOp
 //===----------------------------------------------------------------------===//
 
-def CIR_ByteswapOp : CIR_Op<"bswap", [Pure, SameOperandsAndResultType]> {
+def CIR_ByteswapOp : CIR_Op<"byte_swap", [Pure, SameOperandsAndResultType]> {
   let summary = "Reverse the bytes that constitute the operand integer";
   let description = [{
-    The `cir.bswap` operation takes an integer as operand, and returns it with
-    the order of bytes that constitute the operand reversed.
+    The `cir.byte_swap` operation takes an integer as operand, and returns it
+    with the order of bytes that constitute the operand reversed.
 
     The operand integer must be an unsigned integer. Its widths must be either
     16, 32, or 64.
@@ -1796,7 +1789,7 @@ def CIR_ByteswapOp : CIR_Op<"bswap", [Pure, SameOperandsAndResultType]> {
     %0 = cir.const #cir.int<305419896> : !u32i
 
     // %1 should be 0x78563412
-    %1 = cir.bswap(%0 : !u32i) : !u32i
+    %1 = cir.byte_swap(%0 : !u32i) : !u32i
     ```
   }];
 
@@ -1804,7 +1797,7 @@ def CIR_ByteswapOp : CIR_Op<"bswap", [Pure, SameOperandsAndResultType]> {
   let arguments = (ins CIR_UIntOfWidths<[16, 32, 64]>:$input);
 
   let assemblyFormat = [{
-    `(` $input `:` type($input) `)` `:` type($result) attr-dict
+    $input `:` type($result) attr-dict
   }];
 }
 

--- a/clang/test/CIR/CodeGen/bswap.cpp
+++ b/clang/test/CIR/CodeGen/bswap.cpp
@@ -10,7 +10,7 @@ u16 bswap_u16(u16 x) {
 }
 
 // CHECK: cir.func dso_local @_Z9bswap_u16t
-// CHECK:   %{{.+}} = cir.bswap(%{{.+}} : !u16i) : !u16i
+// CHECK:   %{{.+}} = cir.byte_swap %{{.+}} : !u16i
 // CHECK: }
 
 u32 bswap_u32(u32 x) {
@@ -18,7 +18,7 @@ u32 bswap_u32(u32 x) {
 }
 
 // CHECK: cir.func dso_local @_Z9bswap_u32j
-// CHECK:   %{{.+}} = cir.bswap(%{{.+}} : !u32i) : !u32i
+// CHECK:   %{{.+}} = cir.byte_swap %{{.+}} : !u32i
 // CHECK: }
 
 u64 bswap_u64(u64 x) {
@@ -26,5 +26,5 @@ u64 bswap_u64(u64 x) {
 }
 
 // CHECK: cir.func dso_local @_Z9bswap_u64y
-// CHECK:   %{{.+}} = cir.bswap(%{{.+}} : !u64i) : !u64i
+// CHECK:   %{{.+}} = cir.byte_swap %{{.+}} : !u64i
 // CHECK: }

--- a/clang/test/CIR/CodeGen/builtin-bits.cpp
+++ b/clang/test/CIR/CodeGen/builtin-bits.cpp
@@ -6,14 +6,14 @@ int test_builtin_clrsb(int x) {
 }
 
 // CIR-LABEL: _Z18test_builtin_clrsbi
-// CIR: [[TMP:%.+]] = cir.bit.clrsb(%{{.+}} : !s32i) : !s32i
+// CIR: [[TMP:%.+]] = cir.clrsb %{{.+}} : !s32i
 
 int test_builtin_clrsbl(long x) {
   return __builtin_clrsbl(x);
 }
 
 // CIR-LABEL: _Z19test_builtin_clrsbll
-// CIR: [[TMP:%.+]] = cir.bit.clrsb(%{{.+}} : !s64i) : !s64i
+// CIR: [[TMP:%.+]] = cir.clrsb %{{.+}} : !s64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !s64i), !s32i
 
 int test_builtin_clrsbll(long long x) {
@@ -21,7 +21,7 @@ int test_builtin_clrsbll(long long x) {
 }
 
 // CIR-LABEL: _Z20test_builtin_clrsbllx
-// CIR: [[TMP:%.+]] = cir.bit.clrsb(%{{.+}} : !s64i) : !s64i
+// CIR: [[TMP:%.+]] = cir.clrsb %{{.+}} : !s64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !s64i), !s32i
 
 int test_builtin_ctzs(unsigned short x) {
@@ -29,7 +29,7 @@ int test_builtin_ctzs(unsigned short x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_ctzst
-// CIR: [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u16i) zero_poison : !u16i
+// CIR: [[TMP:%.+]] = cir.ctz %{{.+}} zero_poison : !u16i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u16i), !s32i
 
 int test_builtin_ctz(unsigned x) {
@@ -37,7 +37,7 @@ int test_builtin_ctz(unsigned x) {
 }
 
 // CIR-LABEL: _Z16test_builtin_ctzj
-// CIR: [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u32i) zero_poison : !u32i
+// CIR: [[TMP:%.+]] = cir.ctz %{{.+}} zero_poison : !u32i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 int test_builtin_ctzl(unsigned long x) {
@@ -45,7 +45,7 @@ int test_builtin_ctzl(unsigned long x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_ctzlm
-// CIR: [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u64i) zero_poison : !u64i
+// CIR: [[TMP:%.+]] = cir.ctz %{{.+}} zero_poison : !u64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 int test_builtin_ctzll(unsigned long long x) {
@@ -53,7 +53,7 @@ int test_builtin_ctzll(unsigned long long x) {
 }
 
 // CIR-LABEL: _Z18test_builtin_ctzlly
-// CIR: [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u64i) zero_poison : !u64i
+// CIR: [[TMP:%.+]] = cir.ctz %{{.+}} zero_poison : !u64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 int test_builtin_ctzg(unsigned x) {
@@ -61,7 +61,7 @@ int test_builtin_ctzg(unsigned x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_ctzgj
-// CIR: [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u32i) zero_poison : !u32i
+// CIR: [[TMP:%.+]] = cir.ctz %{{.+}} zero_poison : !u32i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 int test_builtin_clzs(unsigned short x) {
@@ -69,7 +69,7 @@ int test_builtin_clzs(unsigned short x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_clzst
-// CIR: [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u16i) zero_poison : !u16i
+// CIR: [[TMP:%.+]] = cir.clz %{{.+}} zero_poison : !u16i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u16i), !s32i
 
 int test_builtin_clz(unsigned x) {
@@ -77,7 +77,7 @@ int test_builtin_clz(unsigned x) {
 }
 
 // CIR-LABEL: _Z16test_builtin_clzj
-// CIR: [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u32i) zero_poison : !u32i
+// CIR: [[TMP:%.+]] = cir.clz %{{.+}} zero_poison : !u32i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 int test_builtin_clzl(unsigned long x) {
@@ -85,7 +85,7 @@ int test_builtin_clzl(unsigned long x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_clzlm
-// CIR: [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u64i) zero_poison : !u64i
+// CIR: [[TMP:%.+]] = cir.clz %{{.+}} zero_poison : !u64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 int test_builtin_clzll(unsigned long long x) {
@@ -93,7 +93,7 @@ int test_builtin_clzll(unsigned long long x) {
 }
 
 // CIR-LABEL: _Z18test_builtin_clzlly
-// CIR: [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u64i) zero_poison : !u64i
+// CIR: [[TMP:%.+]] = cir.clz %{{.+}} zero_poison : !u64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 int test_builtin_clzg(unsigned x) {
@@ -101,7 +101,7 @@ int test_builtin_clzg(unsigned x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_clzgj
-// CIR: [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u32i) zero_poison : !u32i
+// CIR: [[TMP:%.+]] = cir.clz %{{.+}} zero_poison : !u32i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 int test_builtin_ffs(int x) {
@@ -109,14 +109,14 @@ int test_builtin_ffs(int x) {
 }
 
 // CIR-LABEL: _Z16test_builtin_ffsi
-// CIR: [[TMP:%.+]] = cir.bit.ffs(%{{.+}} : !s32i) : !s32i
+// CIR: [[TMP:%.+]] = cir.ffs %{{.+}} : !s32i
 
 int test_builtin_ffsl(long x) {
   return __builtin_ffsl(x);
 }
 
 // CIR-LABEL: _Z17test_builtin_ffsll
-// CIR: [[TMP:%.+]] = cir.bit.ffs(%{{.+}} : !s64i) : !s64i
+// CIR: [[TMP:%.+]] = cir.ffs %{{.+}} : !s64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !s64i), !s32i
 
 int test_builtin_ffsll(long long x) {
@@ -124,7 +124,7 @@ int test_builtin_ffsll(long long x) {
 }
 
 // CIR-LABEL: _Z18test_builtin_ffsllx
-// CIR: [[TMP:%.+]] = cir.bit.ffs(%{{.+}} : !s64i) : !s64i
+// CIR: [[TMP:%.+]] = cir.ffs %{{.+}} : !s64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !s64i), !s32i
 
 int test_builtin_parity(unsigned x) {
@@ -132,7 +132,7 @@ int test_builtin_parity(unsigned x) {
 }
 
 // CIR-LABEL: _Z19test_builtin_parityj
-// CIR: [[TMP:%.+]] = cir.bit.parity(%{{.+}} : !u32i) : !u32i
+// CIR: [[TMP:%.+]] = cir.parity %{{.+}} : !u32i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 int test_builtin_parityl(unsigned long x) {
@@ -140,7 +140,7 @@ int test_builtin_parityl(unsigned long x) {
 }
 
 // CIR-LABEL: _Z20test_builtin_paritylm
-// CIR: [[TMP:%.+]] = cir.bit.parity(%{{.+}} : !u64i) : !u64i
+// CIR: [[TMP:%.+]] = cir.parity %{{.+}} : !u64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 int test_builtin_parityll(unsigned long long x) {
@@ -148,7 +148,7 @@ int test_builtin_parityll(unsigned long long x) {
 }
 
 // CIR-LABEL: _Z21test_builtin_paritylly
-// CIR: [[TMP:%.+]] = cir.bit.parity(%{{.+}} : !u64i) : !u64i
+// CIR: [[TMP:%.+]] = cir.parity %{{.+}} : !u64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 int test_builtin_popcount(unsigned x) {
@@ -156,7 +156,7 @@ int test_builtin_popcount(unsigned x) {
 }
 
 // CIR-LABEL: _Z21test_builtin_popcountj
-// CIR: [[TMP:%.+]] = cir.bit.popcount(%{{.+}} : !u32i) : !u32i
+// CIR: [[TMP:%.+]] = cir.popcount %{{.+}} : !u32i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 int test_builtin_popcountl(unsigned long x) {
@@ -164,7 +164,7 @@ int test_builtin_popcountl(unsigned long x) {
 }
 
 // CIR-LABEL: _Z22test_builtin_popcountlm
-// CIR: [[TMP:%.+]] = cir.bit.popcount(%{{.+}} : !u64i) : !u64i
+// CIR: [[TMP:%.+]] = cir.popcount %{{.+}} : !u64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 int test_builtin_popcountll(unsigned long long x) {
@@ -172,7 +172,7 @@ int test_builtin_popcountll(unsigned long long x) {
 }
 
 // CIR-LABEL: _Z23test_builtin_popcountlly
-// CIR: [[TMP:%.+]] = cir.bit.popcount(%{{.+}} : !u64i) : !u64i
+// CIR: [[TMP:%.+]] = cir.popcount %{{.+}} : !u64i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 int test_builtin_popcountg(unsigned x) {
@@ -180,5 +180,5 @@ int test_builtin_popcountg(unsigned x) {
 }
 
 // CIR-LABEL: _Z22test_builtin_popcountgj
-// CIR: [[TMP:%.+]] = cir.bit.popcount(%{{.+}} : !u32i) : !u32i
+// CIR: [[TMP:%.+]] = cir.popcount %{{.+}} : !u32i
 // CIR: {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i

--- a/clang/test/CIR/CodeGen/ms-intrinsics-other.c
+++ b/clang/test/CIR/CodeGen/ms-intrinsics-other.c
@@ -10,7 +10,7 @@ unsigned short test__lzcnt16(unsigned short x) {
   return __lzcnt16(x);
 }
 // CIR-LABEL: test__lzcnt16
-// CIR: {{%.*}} = cir.bit.clz({{%.*}} : !u16i) : !u16i
+// CIR: {{%.*}} = cir.clz {{%.*}} : !u16i
 // LLVM-LABEL: test__lzcnt16
 // LLVM: {{%.*}} = call i16 @llvm.ctlz.i16(i16 {{%.*}}, i1 false)
 
@@ -18,7 +18,7 @@ unsigned int test__lzcnt(unsigned int x) {
   return __lzcnt(x);
 }
 // CIR-LABEL: test__lzcnt
-// CIR: {{%.*}} = cir.bit.clz({{%.*}} : !u32i) : !u32i
+// CIR: {{%.*}} = cir.clz {{%.*}} : !u32i
 // LLVM-LABEL: test__lzcnt
 // LLVM:  {{%.*}} = call i32 @llvm.ctlz.i32(i32 {{%.*}}, i1 false)
 
@@ -26,7 +26,7 @@ unsigned __int64 test__lzcnt64(unsigned __int64 x) {
   return __lzcnt64(x);
 }
 // CIR-LABEL: test__lzcnt64
-// CIR: {{%.*}} = cir.bit.clz({{%.*}} : !u64i) : !u64i
+// CIR: {{%.*}} = cir.clz {{%.*}} : !u64i
 // LLVM-LABEL: test__lzcnt64
 // LLVM: {{%.*}} = call i64 @llvm.ctlz.i64(i64 {{%.*}}, i1 false)
 
@@ -34,7 +34,7 @@ unsigned short test__popcnt16(unsigned short x) {
   return __popcnt16(x);
 }
 // CIR-LABEL: test__popcnt16
-// CIR: {{%.*}} = cir.bit.popcount({{%.*}} : !u16i) : !u16i
+// CIR: {{%.*}} = cir.popcount {{%.*}} : !u16i
 // LLVM-LABEL: test__popcnt16
 // LLVM: {{%.*}} = call i16 @llvm.ctpop.i16(i16 {{%.*}})
 
@@ -42,7 +42,7 @@ unsigned int test__popcnt(unsigned int x) {
   return __popcnt(x);
 }
 // CIR-LABEL: test__popcnt
-// CIR: {{%.*}} = cir.bit.popcount({{%.*}} : !u32i) : !u32i
+// CIR: {{%.*}} = cir.popcount {{%.*}} : !u32i
 // LLVM-LABEL: test__popcnt
 // LLVM: {{%.*}} = call i32 @llvm.ctpop.i32(i32 {{%.*}})
 
@@ -50,6 +50,6 @@ unsigned __int64 test__popcnt64(unsigned __int64 x) {
   return __popcnt64(x);
 }
 // CIR-LABEL: test__popcnt64
-// CIR: {{%.*}} = cir.bit.popcount({{%.*}} : !u64i) : !u64i
+// CIR: {{%.*}} = cir.popcount {{%.*}} : !u64i
 // LLVM-LABEL: test__popcnt64
 // LLVM: {{%.*}} = call i64 @llvm.ctpop.i64(i64 {{%.*}})

--- a/clang/test/CIR/IR/bit.cir
+++ b/clang/test/CIR/IR/bit.cir
@@ -20,26 +20,26 @@ module {
     %u32 = cir.const #cir.int<1> : !u32i
     %u64 = cir.const #cir.int<1> : !u64i
 
-    %2 = cir.bit.clrsb(%s32 : !s32i) : !s32i
-    %3 = cir.bit.clrsb(%s64 : !s64i) : !s64i
+    %2 = cir.clrsb %s32 : !s32i
+    %3 = cir.clrsb %s64 : !s64i
 
-    %4 = cir.bit.clz(%u16 : !u16i) zero_poison : !u16i
-    %5 = cir.bit.clz(%u32 : !u32i) : !u32i
-    %6 = cir.bit.clz(%u64 : !u64i) zero_poison : !u64i
+    %4 = cir.clz %u16 zero_poison : !u16i
+    %5 = cir.clz %u32 : !u32i
+    %6 = cir.clz %u64 zero_poison : !u64i
 
-    %7 = cir.bit.ctz(%u16 : !u16i) zero_poison : !u16i
-    %8 = cir.bit.ctz(%u32 : !u32i) : !u32i
-    %9 = cir.bit.ctz(%u64 : !u64i) zero_poison : !u64i
+    %7 = cir.ctz %u16 zero_poison : !u16i
+    %8 = cir.ctz %u32 : !u32i
+    %9 = cir.ctz %u64 zero_poison : !u64i
 
-    %10 = cir.bit.ffs(%s32 : !s32i) : !s32i
-    %11 = cir.bit.ffs(%s64 : !s64i) : !s64i
+    %10 = cir.ffs %s32 : !s32i
+    %11 = cir.ffs %s64 : !s64i
 
-    %12 = cir.bit.parity(%u32 : !u32i) : !u32i
-    %13 = cir.bit.parity(%u64 : !u64i) : !u64i
+    %12 = cir.parity %u32 : !u32i
+    %13 = cir.parity %u64 : !u64i
 
-    %14 = cir.bit.popcount(%u16 : !u16i) : !u16i
-    %15 = cir.bit.popcount(%u32 : !u32i) : !u32i
-    %16 = cir.bit.popcount(%u64 : !u64i) : !u64i
+    %14 = cir.popcount %u16 : !u16i
+    %15 = cir.popcount %u32 : !u32i
+    %16 = cir.popcount %u64 : !u64i
 
     cir.return
   }
@@ -55,21 +55,21 @@ module {
 // CHECK-NEXT:     %5 = cir.const #cir.int<1> : !u16i
 // CHECK-NEXT:     %6 = cir.const #cir.int<1> : !u32i
 // CHECK-NEXT:     %7 = cir.const #cir.int<1> : !u64i
-// CHECK-NEXT:     %8 = cir.bit.clrsb(%2 : !s32i) : !s32i
-// CHECK-NEXT:     %9 = cir.bit.clrsb(%3 : !s64i) : !s64i
-// CHECK-NEXT:     %10 = cir.bit.clz(%5 : !u16i) zero_poison : !u16i
-// CHECK-NEXT:     %11 = cir.bit.clz(%6 : !u32i) : !u32i
-// CHECK-NEXT:     %12 = cir.bit.clz(%7 : !u64i) zero_poison : !u64i
-// CHECK-NEXT:     %13 = cir.bit.ctz(%5 : !u16i) zero_poison : !u16i
-// CHECK-NEXT:     %14 = cir.bit.ctz(%6 : !u32i) : !u32i
-// CHECK-NEXT:     %15 = cir.bit.ctz(%7 : !u64i) zero_poison : !u64i
-// CHECK-NEXT:     %16 = cir.bit.ffs(%2 : !s32i) : !s32i
-// CHECK-NEXT:     %17 = cir.bit.ffs(%3 : !s64i) : !s64i
-// CHECK-NEXT:     %18 = cir.bit.parity(%6 : !u32i) : !u32i
-// CHECK-NEXT:     %19 = cir.bit.parity(%7 : !u64i) : !u64i
-// CHECK-NEXT:     %20 = cir.bit.popcount(%5 : !u16i) : !u16i
-// CHECK-NEXT:     %21 = cir.bit.popcount(%6 : !u32i) : !u32i
-// CHECK-NEXT:     %22 = cir.bit.popcount(%7 : !u64i) : !u64i
+// CHECK-NEXT:     %8 = cir.clrsb %2 : !s32i
+// CHECK-NEXT:     %9 = cir.clrsb %3 : !s64i
+// CHECK-NEXT:     %10 = cir.clz %5 zero_poison : !u16i
+// CHECK-NEXT:     %11 = cir.clz %6 : !u32i
+// CHECK-NEXT:     %12 = cir.clz %7 zero_poison : !u64i
+// CHECK-NEXT:     %13 = cir.ctz %5 zero_poison : !u16i
+// CHECK-NEXT:     %14 = cir.ctz %6 : !u32i
+// CHECK-NEXT:     %15 = cir.ctz %7 zero_poison : !u64i
+// CHECK-NEXT:     %16 = cir.ffs %2 : !s32i
+// CHECK-NEXT:     %17 = cir.ffs %3 : !s64i
+// CHECK-NEXT:     %18 = cir.parity %6 : !u32i
+// CHECK-NEXT:     %19 = cir.parity %7 : !u64i
+// CHECK-NEXT:     %20 = cir.popcount %5 : !u16i
+// CHECK-NEXT:     %21 = cir.popcount %6 : !u32i
+// CHECK-NEXT:     %22 = cir.popcount %7 : !u64i
 // CHECK-NEXT:     cir.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -952,8 +952,8 @@ module {
 !u32i = !cir.int<u, 32>
 
 cir.func @clrsb_invalid_input_ty(%arg0 : !u32i) -> () {
-  // expected-error@+1 {{'cir.bit.clrsb' op operand #0 must be signed integer type of widths 32/64, but got '!cir.int<u, 32>'}}
-  %0 = cir.bit.clrsb(%arg0 : !u32i) : !u32i
+  // expected-error@+1 {{'cir.clrsb' op operand #0 must be signed integer type of widths 32/64, but got '!cir.int<u, 32>'}}
+  %0 = cir.clrsb %arg0 : !u32i
   cir.return
 }
 
@@ -962,9 +962,9 @@ cir.func @clrsb_invalid_input_ty(%arg0 : !u32i) -> () {
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-cir.func @clrsb_invalid_result_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.clrsb' op result #0 must be signed integer type of widths 32/64, but got '!cir.int<u, 32>'}}
-  %0 = cir.bit.clrsb(%arg0 : !s32i) : !u32i
+cir.func @clrsb_invalid_result_ty(%arg0 : !s32i) -> () {  // expected-note {{prior use here}}
+  // expected-error@+1 {{use of value '%arg0' expects different type than prior uses: '!cir.int<u, 32>' vs '!cir.int<s, 32>'}}
+  %0 = cir.clrsb %arg0 : !u32i
   cir.return
 }
 
@@ -973,8 +973,8 @@ cir.func @clrsb_invalid_result_ty(%arg0 : !s32i) -> () {
 !s32i = !cir.int<s, 32>
 
 cir.func @clz_invalid_input_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.clz' op operand #0 must be unsigned integer type of widths 16/32/64, but got '!cir.int<s, 32>'}}
-  %0 = cir.bit.clz(%arg0 : !s32i) zero_poison : !s32i
+  // expected-error@+1 {{'cir.clz' op operand #0 must be unsigned integer type of widths 16/32/64, but got '!cir.int<s, 32>'}}
+  %0 = cir.clz %arg0 zero_poison : !s32i
   cir.return
 }
 
@@ -983,9 +983,9 @@ cir.func @clz_invalid_input_ty(%arg0 : !s32i) -> () {
 !u32i = !cir.int<u, 32>
 !s32i = !cir.int<s, 32>
 
-cir.func @clz_invalid_result_ty(%arg0 : !u32i) -> () {
-  // expected-error@+1 {{'cir.bit.clz' op result #0 must be unsigned integer type of widths 16/32/64, but got '!cir.int<s, 32>'}}
-  %0 = cir.bit.clz(%arg0 : !u32i) : !s32i
+cir.func @clz_invalid_result_ty(%arg0 : !u32i) -> () {  // expected-note {{prior use here}}
+  // expected-error@+1 {{use of value '%arg0' expects different type than prior uses: '!cir.int<s, 32>' vs '!cir.int<u, 32>'}}
+  %0 = cir.clz %arg0 : !s32i
   cir.return
 }
 
@@ -994,8 +994,8 @@ cir.func @clz_invalid_result_ty(%arg0 : !u32i) -> () {
 !s32i = !cir.int<s, 32>
 
 cir.func @ctz_invalid_input_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.ctz' op operand #0 must be unsigned integer type of widths 16/32/64, but got '!cir.int<s, 32>'}}
-  %0 = cir.bit.ctz(%arg0 : !s32i) zero_poison : !s32i
+  // expected-error@+1 {{'cir.ctz' op operand #0 must be unsigned integer type of widths 16/32/64, but got '!cir.int<s, 32>'}}
+  %0 = cir.ctz %arg0 zero_poison : !s32i
   cir.return
 }
 
@@ -1004,9 +1004,9 @@ cir.func @ctz_invalid_input_ty(%arg0 : !s32i) -> () {
 !u32i = !cir.int<u, 32>
 !s32i = !cir.int<s, 32>
 
-cir.func @ctz_invalid_result_ty(%arg0 : !u32i) -> () {
-  // expected-error@+1 {{'cir.bit.ctz' op result #0 must be unsigned integer type of widths 16/32/64, but got '!cir.int<s, 32>'}}
-  %0 = cir.bit.ctz(%arg0 : !u32i) : !s32i
+cir.func @ctz_invalid_result_ty(%arg0 : !u32i) -> () {  // expected-note {{prior use here}}
+  // expected-error@+1 {{use of value '%arg0' expects different type than prior uses: '!cir.int<s, 32>' vs '!cir.int<u, 32>'}}
+  %0 = cir.ctz %arg0 : !s32i
   cir.return
 }
 
@@ -1015,9 +1015,9 @@ cir.func @ctz_invalid_result_ty(%arg0 : !u32i) -> () {
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-cir.func @ffs_invalid_input_ty(%arg0 : !u32i) -> () {
-  // expected-error@+1 {{'cir.bit.ffs' op operand #0 must be signed integer type of widths 32/64, but got '!cir.int<u, 32>'}}
-  %0 = cir.bit.ffs(%arg0 : !u32i) : !s32i
+cir.func @ffs_invalid_input_ty(%arg0 : !u32i) -> () {  // expected-note {{prior use here}}
+  // expected-error@+1 {{use of value '%arg0' expects different type than prior uses: '!cir.int<s, 32>' vs '!cir.int<u, 32>'}}
+  %0 = cir.ffs %arg0 : !s32i
   cir.return
 }
 
@@ -1026,9 +1026,9 @@ cir.func @ffs_invalid_input_ty(%arg0 : !u32i) -> () {
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-cir.func @ffs_invalid_result_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.ffs' op result #0 must be signed integer type of widths 32/64, but got '!cir.int<u, 32>'}}
-  %0 = cir.bit.ffs(%arg0 : !s32i) : !u32i
+cir.func @ffs_invalid_result_ty(%arg0 : !s32i) -> () {  // expected-note {{prior use here}}
+  // expected-error@+1 {{use of value '%arg0' expects different type than prior uses: '!cir.int<u, 32>' vs '!cir.int<s, 32>'}}
+  %0 = cir.ffs %arg0 : !u32i
   cir.return
 }
 
@@ -1037,8 +1037,8 @@ cir.func @ffs_invalid_result_ty(%arg0 : !s32i) -> () {
 !s32i = !cir.int<s, 32>
 
 cir.func @parity_invalid_input_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.parity' op operand #0 must be unsigned integer type of widths 32/64, but got '!cir.int<s, 32>'}}
-  %0 = cir.bit.parity(%arg0 : !s32i) : !s32i
+  // expected-error@+1 {{'cir.parity' op operand #0 must be unsigned integer type of widths 32/64, but got '!cir.int<s, 32>'}}
+  %0 = cir.parity %arg0 : !s32i
   cir.return
 }
 
@@ -1047,9 +1047,9 @@ cir.func @parity_invalid_input_ty(%arg0 : !s32i) -> () {
 !u32i = !cir.int<u, 32>
 !s32i = !cir.int<s, 32>
 
-cir.func @parity_invalid_result_ty(%arg0 : !u32i) -> () {
-  // expected-error@+1 {{'cir.bit.parity' op result #0 must be unsigned integer type of widths 32/64, but got '!cir.int<s, 32>'}}
-  %0 = cir.bit.parity(%arg0 : !u32i) : !s32i
+cir.func @parity_invalid_result_ty(%arg0 : !u32i) -> () {  // expected-note {{prior use here}}
+  // expected-error@+1 {{use of value '%arg0' expects different type than prior uses: '!cir.int<s, 32>' vs '!cir.int<u, 32>'}}
+  %0 = cir.parity %arg0 : !s32i
   cir.return
 }
 
@@ -1058,8 +1058,8 @@ cir.func @parity_invalid_result_ty(%arg0 : !u32i) -> () {
 !s32i = !cir.int<s, 32>
 
 cir.func @popcount_invalid_input_ty(%arg0 : !s32i) -> () {
-  // expected-error@+1 {{'cir.bit.popcount' op operand #0 must be unsigned integer type of widths 16/32/64, but got '!cir.int<s, 32>'}}
-  %0 = cir.bit.popcount(%arg0 : !s32i) : !s32i
+  // expected-error@+1 {{'cir.popcount' op operand #0 must be unsigned integer type of widths 16/32/64, but got '!cir.int<s, 32>'}}
+  %0 = cir.popcount %arg0 : !s32i
   cir.return
 }
 
@@ -1068,9 +1068,9 @@ cir.func @popcount_invalid_input_ty(%arg0 : !s32i) -> () {
 !u32i = !cir.int<u, 32>
 !u64i = !cir.int<u, 64>
 
-cir.func @popcount_invalid_result_ty(%arg0 : !u32i) -> () {
-  // expected-error@+1 {{'cir.bit.popcount' op requires the same type for all operands and results}}
-  %0 = cir.bit.popcount(%arg0 : !u32i) : !u64i
+cir.func @popcount_invalid_result_ty(%arg0 : !u32i) -> () {  // expected-note {{prior use here}}
+  // expected-error@+1 {{use of value '%arg0' expects different type than prior uses: '!cir.int<u, 64>' vs '!cir.int<u, 32>'}}
+  %0 = cir.popcount %arg0 : !u64i
   cir.return
 }
 

--- a/clang/test/CIR/Lowering/bit.cir
+++ b/clang/test/CIR/Lowering/bit.cir
@@ -9,7 +9,7 @@
 !u64i = !cir.int<u, 64>
 
 cir.func @clrsb_s32(%arg : !s32i) {
-  %0 = cir.bit.clrsb(%arg : !s32i) : !s32i
+  %0 = cir.clrsb %arg : !s32i
   cir.return
 }
 
@@ -26,7 +26,7 @@ cir.func @clrsb_s32(%arg : !s32i) {
 // CHECK-NEXT: }
 
 cir.func @clrsb_s64(%arg : !s64i) {
-  %0 = cir.bit.clrsb(%arg : !s64i) : !s64i
+  %0 = cir.clrsb %arg : !s64i
   cir.return
 }
 
@@ -43,7 +43,7 @@ cir.func @clrsb_s64(%arg : !s64i) {
 // CHECK-NEXT: }
 
 cir.func @clz_u16(%arg : !u16i) {
-  %0 = cir.bit.clz(%arg : !u16i) zero_poison : !u16i
+  %0 = cir.clz %arg zero_poison : !u16i
   cir.return
 }
 
@@ -53,7 +53,7 @@ cir.func @clz_u16(%arg : !u16i) {
 // CHECK-NEXT: }
 
 cir.func @clz_u32(%arg : !u32i) {
-  %0 = cir.bit.clz(%arg : !u32i) : !u32i
+  %0 = cir.clz %arg : !u32i
   cir.return
 }
 
@@ -63,7 +63,7 @@ cir.func @clz_u32(%arg : !u32i) {
 // CHECK-NEXT: }
 
 cir.func @clz_u64(%arg : !u64i) {
-  %0 = cir.bit.clz(%arg : !u64i) zero_poison : !u64i
+  %0 = cir.clz %arg zero_poison : !u64i
   cir.return
 }
 
@@ -73,7 +73,7 @@ cir.func @clz_u64(%arg : !u64i) {
 // CHECK-NEXT: }
 
 cir.func @ctz_u16(%arg : !u16i) {
-  %0 = cir.bit.ctz(%arg : !u16i) : !u16i
+  %0 = cir.ctz %arg : !u16i
   cir.return
 }
 
@@ -83,7 +83,7 @@ cir.func @ctz_u16(%arg : !u16i) {
 // CHECK-NEXT: }
 
 cir.func @ctz_u32(%arg : !u32i) {
-  %0 = cir.bit.ctz(%arg : !u32i) zero_poison : !u32i
+  %0 = cir.ctz %arg zero_poison : !u32i
   cir.return
 }
 
@@ -93,7 +93,7 @@ cir.func @ctz_u32(%arg : !u32i) {
 // CHECK-NEXT: }
 
 cir.func @ctz_u64(%arg : !u64i) {
-  %0 = cir.bit.ctz(%arg : !u64i) : !u64i
+  %0 = cir.ctz %arg : !u64i
   cir.return
 }
 
@@ -103,7 +103,7 @@ cir.func @ctz_u64(%arg : !u64i) {
 // CHECK-NEXT: }
 
 cir.func @ffs_s32(%arg : !s32i) {
-  %0 = cir.bit.ffs(%arg : !s32i) : !s32i
+  %0 = cir.ffs %arg : !s32i
   cir.return
 }
 
@@ -119,7 +119,7 @@ cir.func @ffs_s32(%arg : !s32i) {
 // CHECK-NEXT: }
 
 cir.func @ffs_s64(%arg : !s64i) {
-  %0 = cir.bit.ffs(%arg : !s64i) : !s64i
+  %0 = cir.ffs %arg : !s64i
   cir.return
 }
 
@@ -135,7 +135,7 @@ cir.func @ffs_s64(%arg : !s64i) {
 // CHECK-NEXT: }
 
 cir.func @parity_s32(%arg : !u32i) {
-  %0 = cir.bit.parity(%arg : !u32i) : !u32i
+  %0 = cir.parity %arg : !u32i
   cir.return
 }
 
@@ -147,7 +147,7 @@ cir.func @parity_s32(%arg : !u32i) {
 // CHECK-NEXT: }
 
 cir.func @parity_s64(%arg : !u64i) {
-  %0 = cir.bit.parity(%arg : !u64i) : !u64i
+  %0 = cir.parity %arg : !u64i
   cir.return
 }
 
@@ -159,7 +159,7 @@ cir.func @parity_s64(%arg : !u64i) {
 // CHECK-NEXT: }
 
 cir.func @popcount_u16(%arg : !u16i) {
-  %0 = cir.bit.popcount(%arg : !u16i) : !u16i
+  %0 = cir.popcount %arg : !u16i
   cir.return
 }
 
@@ -169,7 +169,7 @@ cir.func @popcount_u16(%arg : !u16i) {
 // CHECK-NEXT: }
 
 cir.func @popcount_u32(%arg : !u32i) {
-  %0 = cir.bit.popcount(%arg : !u32i) : !u32i
+  %0 = cir.popcount %arg : !u32i
   cir.return
 }
 
@@ -179,7 +179,7 @@ cir.func @popcount_u32(%arg : !u32i) {
 // CHECK-NEXT: }
 
 cir.func @popcount_u64(%arg : !u64i) {
-  %0 = cir.bit.popcount(%arg : !u64i) : !u64i
+  %0 = cir.popcount %arg : !u64i
   cir.return
 }
 

--- a/clang/test/CIR/Lowering/bswap.cir
+++ b/clang/test/CIR/Lowering/bswap.cir
@@ -4,7 +4,7 @@
 !u32i = !cir.int<u, 32>
 
 cir.func @test(%arg0: !u32i) -> !u32i {
-  %0 = cir.bswap(%arg0 : !u32i) : !u32i
+  %0 = cir.byte_swap %arg0 : !u32i
   cir.return %0 : !u32i
 }
 


### PR DESCRIPTION
This patch backports changes made to the bit operations in the upstream PR llvm/llvm-project#148378. Namely, this patch includes the following changes:

- This patch removes the `bit.` prefix in the op mnemonic. The operation names now directly correspond to the builtin function names except for bswap which is represented by `cir.byte_swap` for more clarity.
- Since all bit operations are `SameOperandsAndResultType`, this patch updates their assembly format and avoids spelling out the operand type twice.