### PR TITLE
[CIR][Lowering] Fix inconditional sign extension on vec.cmp op

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2004,8 +2004,14 @@ mlir::LogicalResult CIRToLLVMVecCmpOpLowering::matchAndRewrite(
   } else {
     return op.emitError() << "unsupported type for VecCmpOp: " << elementType;
   }
-  rewriter.replaceOpWithNewOp<mlir::LLVM::SExtOp>(
-      op, typeConverter->convertType(op.getType()), bitResult);
+
+  // Check if the types are the same before generating SExtOp
+  auto targetType = typeConverter->convertType(op.getType());
+  if (bitResult.getType() == targetType)
+    rewriter.replaceOp(op, bitResult);
+  else
+    rewriter.replaceOpWithNewOp<mlir::LLVM::SExtOp>(op, targetType, bitResult);
+
   return mlir::success();
 }
 

--- a/clang/test/CIR/Lowering/vec-cmp.cir
+++ b/clang/test/CIR/Lowering/vec-cmp.cir
@@ -1,0 +1,16 @@
+// RUN: cir-opt %s -cir-to-llvm -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=MLIR
+
+!s16i = !cir.int<s, 16>
+!u16i = !cir.int<u, 16>
+
+cir.func @vec_cmp(%0: !cir.vector<!s16i x 16>, %1: !cir.vector<!s16i x 16>) -> () {
+  %2 = cir.vec.cmp(lt, %0, %1) : !cir.vector<!s16i x 16>, !cir.vector<!cir.int<u, 1> x 16> 
+  %3 = cir.cast(bitcast, %2 : !cir.vector<!cir.int<u, 1> x 16>), !u16i
+  cir.return
+}
+    
+// MLIR: llvm.func @vec_cmp
+// MLIR-NEXT: %{{[0-9]+}} = llvm.icmp "slt" %arg0, %arg1 : vector<16xi16>
+// MLIR-NEXT: %{{[0-9]+}} = llvm.bitcast %{{[0-9]+}} : vector<16xi1> to i16
+// MLIR-NEXT: llvm.return


### PR DESCRIPTION
(Copied from my question on Discord)
 
 I’ve been working on the vector to bit-mask related intrinsics for X86. I’ve been stuck specifically on `X86::BI__builtin_ia32_cvtb2mask128(_mm256_movepi16_mask`) and its variations with different vector/mask sizes.

In this case, we perform a vector comparison of `vector<16xi16>` and bitcast the resulting `vector<16xi1>` directly into a scalar integer mask (i16). 

I’m successfully able to lower to cir:
```
    ...
    %5 = cir.vec.cmp(lt, %3, %4) : !cir.vector<!s16i x 16>, !cir.vector<!cir.int<u, 1> x 16>
    %6 = cir.cast(bitcast, %5 : !cir.vector<!cir.int<u, 1> x 16>), !u16i
    ...
```

There's an issue arises when lowering this to LLVM, the error message I'm getting is:

```
error: integer width of the output type is smaller or equal to the integer width of the input type
```

By looking at the test cases on the llvm dialect, this is related to the  sext / zext instruction.

This is the cir → llvm dialect lowered for the latter:

```
        ...
    %14 = "llvm.icmp"(%12, %13) <{predicate = 2 : i64}> : (vector<16xi16>, vector<16xi16>) -> vector<16xi1>
    %15 = "llvm.sext"(%14) : (vector<16xi1>) -> vector<16xi1>
    %16 = "llvm.bitcast"(%15) : (vector<16xi1>) -> i16
        ...
```

This is seems to be the cause:

```
 %15 = "llvm.sext"(%14) : (vector<16xi1>) -> vector<16xi1>
 ```
 
 **The fix**: Added a type check: if the result type does not differ from the expected type, we won't insert a sextOp