### PR TITLE
[CIR] Add `get_element` operation for computing pointer to array element

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3133,6 +3133,58 @@ def CIR_GetMethodOp : CIR_Op<"get_method"> {
 }
 
 //===----------------------------------------------------------------------===//
+// GetElementOp
+//===----------------------------------------------------------------------===//
+
+def CIR_GetElementOp : CIR_Op<"get_element"> {
+  let summary = "Get the address of an array element";
+  let description = [{
+    The `cir.get_element` operation gets the address of a particular element
+    from the `base` array.
+
+    It expects a pointer to the `base` array and the `index` of the element.
+
+    Example:
+    ```mlir
+    // Suppose we have a array.
+    !s32i = !cir.int<s, 32>
+    !arr_ty = !cir.array<!s32i x 4>
+
+    // Get the address of the element at index 1.
+    %elem_1 = cir.get_element %0[1] : (!cir.ptr<!array_ty>, !s32i) -> !cir.ptr<!s32i>
+
+    // Get the address of the element at index %i.
+    %i = ...
+    %elem_i = cir.get_element %0[%i] : (!cir.ptr<!array_ty>, !s32i) -> !cir.ptr<!s32i>
+    ```
+  }];
+
+  let arguments = (ins
+    Arg<CIR_PtrToArray, "the base address of the array ">:$base,
+    Arg<CIR_AnyFundamentalIntType, "the index of the element">:$index
+  );
+
+  let results = (outs CIR_PointerType:$result);
+
+  let assemblyFormat = [{
+    $base `[` $index `]` `:` `(` qualified(type($base)) `,` qualified(type($index)) `)`
+    `->` qualified(type($result)) attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    // Get the type of the element.
+    mlir::Type getElementType() {
+      return getType().getPointee();
+    }
+    cir::PointerType getBaseType() {
+      return mlir::cast<cir::PointerType>(getBase().getType());
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // VecInsertOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -28,7 +28,7 @@ mlir::Value CIRGenBuilderTy::maybeBuildArrayDecay(mlir::Location loc,
   return arrayPtr;
 }
 
-mlir::Value CIRGenBuilderTy::promoteArrayIndex(const clang::TargetInfo &TI,
+mlir::Value CIRGenBuilderTy::promoteArrayIndex(const clang::TargetInfo &ti,
                                                mlir::Location loc,
                                                mlir::Value index) {
   // Get the array index type.

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -28,11 +28,47 @@ mlir::Value CIRGenBuilderTy::maybeBuildArrayDecay(mlir::Location loc,
   return arrayPtr;
 }
 
-mlir::Value CIRGenBuilderTy::getArrayElement(mlir::Location arrayLocBegin,
+mlir::Value CIRGenBuilderTy::promoteArrayIndex(const clang::TargetInfo &TI,
+                                               mlir::Location loc,
+                                               mlir::Value index) {
+  // Get the array index type.
+  auto arrayIndexWidth = TI.getTypeWidth(clang::TargetInfo::IntType::SignedInt);
+  mlir::Type arrayIndexType = getSIntNTy(arrayIndexWidth);
+
+  // If this is a boolean, zero-extend it to the array index type.
+  if (auto boolTy = mlir::dyn_cast<cir::BoolType>(index.getType()))
+    return create<cir::CastOp>(loc, arrayIndexType, cir::CastKind::bool_to_int,
+                               index);
+
+  // If this an integer, ensure that it is at least as width as the array index
+  // type.
+  if (auto intTy = mlir::dyn_cast<cir::IntType>(index.getType()))
+    if (intTy.getWidth() < arrayIndexWidth)
+      return create<cir::CastOp>(loc, arrayIndexType, cir::CastKind::integral,
+                                 index);
+
+  return index;
+}
+
+mlir::Value CIRGenBuilderTy::getArrayElement(const clang::TargetInfo &TI,
+                                             mlir::Location arrayLocBegin,
                                              mlir::Location arrayLocEnd,
                                              mlir::Value arrayPtr,
                                              mlir::Type eltTy, mlir::Value idx,
                                              bool shouldDecay) {
+  // If the array pointer is not decayed, emit a GetElementOp.
+  if (shouldDecay)
+    if (auto arrayPtrTy = dyn_cast<cir::PointerType>(arrayPtr.getType()))
+      if (auto arrayTy = dyn_cast<cir::ArrayType>(arrayPtrTy.getPointee()))
+        if (arrayTy == eltTy) {
+          auto eltPtrTy =
+              getPointerTo(arrayTy.getElementType(), arrayPtrTy.getAddrSpace());
+          return create<cir::GetElementOp>(
+              arrayLocEnd, eltPtrTy, arrayPtr,
+              promoteArrayIndex(TI, arrayLocBegin, idx));
+        }
+
+  // If we don't have sufficient type information, emit a PtrStrideOp.
   mlir::Value basePtr = arrayPtr;
   if (shouldDecay)
     basePtr = maybeBuildArrayDecay(arrayLocBegin, arrayPtr, eltTy);

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -57,11 +57,11 @@ mlir::Value CIRGenBuilderTy::getArrayElement(const clang::TargetInfo &ti,
                                              mlir::Value arrayPtr,
                                              mlir::Type eltTy, mlir::Value idx,
                                              bool shouldDecay) {
-  auto arrayPtrTy = dyn_cast<cir::PointerType>(arrayPtr.getType());
+  auto arrayPtrTy = mlir::dyn_cast<cir::PointerType>(arrayPtr.getType());
   assert(arrayPtrTy && "expected pointer type");
 
   // If the array pointer is not decayed, emit a GetElementOp.
-  auto arrayTy = dyn_cast<cir::ArrayType>(arrayPtrTy.getPointee());
+  auto arrayTy = mlir::dyn_cast<cir::ArrayType>(arrayPtrTy.getPointee());
   if (shouldDecay && arrayTy && arrayTy == eltTy) {
     auto eltPtrTy =
         getPointerTo(arrayTy.getElementType(), arrayPtrTy.getAddrSpace());

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -42,10 +42,11 @@ mlir::Value CIRGenBuilderTy::promoteArrayIndex(const clang::TargetInfo &ti,
 
   // If this an integer, ensure that it is at least as width as the array index
   // type.
-  if (auto intTy = mlir::dyn_cast<cir::IntType>(index.getType()))
+  if (auto intTy = mlir::dyn_cast<cir::IntType>(index.getType())) {
     if (intTy.getWidth() < arrayIndexWidth)
       return create<cir::CastOp>(loc, arrayIndexType, cir::CastKind::integral,
                                  index);
+  }
 
   return index;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -16,6 +16,7 @@
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
@@ -1030,10 +1031,15 @@ public:
     return create<cir::GetRuntimeMemberOp>(loc, resultTy, objectPtr, memberPtr);
   }
 
+  /// Promote a value for use as an array index.
+  mlir::Value promoteArrayIndex(const clang::TargetInfo &TargetInfo,
+                                mlir::Location loc, mlir::Value index);
+
   /// Create a cir.ptr_stride operation to get access to an array element.
   /// idx is the index of the element to access, shouldDecay is true if the
   /// result should decay to a pointer to the element type.
-  mlir::Value getArrayElement(mlir::Location arrayLocBegin,
+  mlir::Value getArrayElement(const clang::TargetInfo &TargetInfo,
+                              mlir::Location arrayLocBegin,
                               mlir::Location arrayLocEnd, mlir::Value arrayPtr,
                               mlir::Type eltTy, mlir::Value idx,
                               bool shouldDecay);

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -1038,7 +1038,7 @@ public:
   /// Create a cir.ptr_stride operation to get access to an array element.
   /// idx is the index of the element to access, shouldDecay is true if the
   /// result should decay to a pointer to the element type.
-  mlir::Value getArrayElement(const clang::TargetInfo &TargetInfo,
+  mlir::Value getArrayElement(const clang::TargetInfo &targetInfo,
                               mlir::Location arrayLocBegin,
                               mlir::Location arrayLocEnd, mlir::Value arrayPtr,
                               mlir::Type eltTy, mlir::Value idx,

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1710,8 +1710,8 @@ emitArraySubscriptPtr(CIRGenFunction &CGF, mlir::Location beginLoc,
   // that would enhance tracking this later in CIR?
   if (inbounds)
     assert(!cir::MissingFeatures::emitCheckedInBoundsGEP() && "NYI");
-  return CGM.getBuilder().getArrayElement(beginLoc, endLoc, ptr, eltTy, idx,
-                                          shouldDecay);
+  return CGM.getBuilder().getArrayElement(CGF.getTarget(), beginLoc, endLoc,
+                                          ptr, eltTy, idx, shouldDecay);
 }
 
 static QualType getFixedSizeElementType(const ASTContext &astContext,

--- a/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAgg.cpp
@@ -954,9 +954,9 @@ void AggExprEmitter::VisitCXXStdInitializerListExpr(
                            ArrayType->getElementType()) &&
            "Expected std::initializer_list second field to be const E *");
 
-    auto ArrayEnd =
-        Builder.getArrayElement(loc, loc, ArrayPtr.getPointer(),
-                                ArrayPtr.getElementType(), Size, false);
+    auto ArrayEnd = Builder.getArrayElement(
+        CGF.getTarget(), loc, loc, ArrayPtr.getPointer(),
+        ArrayPtr.getElementType(), Size, false);
     CGF.emitStoreThroughLValue(RValue::get(ArrayEnd), EndOrLength);
   }
 }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3842,7 +3842,7 @@ LogicalResult cir::GetMethodOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult cir::GetElementOp::verify() {
-  auto arrayTy = cast<ArrayType>(getBaseType().getPointee());
+  auto arrayTy = mlir::cast<cir::ArrayType>(getBaseType().getPointee());
   if (getElementType() != arrayTy.getElementType())
     return emitError() << "element type mismatch";
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3838,6 +3838,18 @@ LogicalResult cir::GetMethodOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// GetMemberOp Definitions
+//===----------------------------------------------------------------------===//
+
+LogicalResult cir::GetElementOp::verify() {
+  auto arrayTy = cast<ArrayType>(getBaseType().getPointee());
+  if (getElementType() != arrayTy.getElementType())
+    return emitError() << "element type mismatch";
+
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // InlineAsmOp Definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -1254,7 +1254,7 @@ void LifetimeCheckPass::updatePointsTo(mlir::Value addr, mlir::Value data,
     return;
   }
 
-  if (auto getElemOp = dyn_cast<GetElementOp>(dataSrcOp)) {
+  if (auto getElemOp = mlir::dyn_cast<cir::GetElementOp>(dataSrcOp)) {
     getPmap()[addr].clear();
     getPmap()[addr].insert(State::getLocalValue(getElemOp.getBase()));
     return;

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -1951,7 +1951,7 @@ void LifetimeCheckPass::dumpPmap(PMapType &pmap) {
   int entry = 0;
   for (auto &mapEntry : pmap) {
     llvm::errs() << "  " << entry << ": " << getVarNameFromValue(mapEntry.first)
-                 << "  " << "=> ";
+                 << "  => ";
     printPset(mapEntry.second);
     llvm::errs() << "\n";
     entry++;

--- a/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LifetimeCheck.cpp
@@ -1254,6 +1254,12 @@ void LifetimeCheckPass::updatePointsTo(mlir::Value addr, mlir::Value data,
     return;
   }
 
+  if (auto getElemOp = dyn_cast<GetElementOp>(dataSrcOp)) {
+    getPmap()[addr].clear();
+    getPmap()[addr].insert(State::getLocalValue(getElemOp.getBase()));
+    return;
+  }
+
   // Initializes ptr types out of known lib calls marked with pointer
   // attributes. TODO: find a better way to tag this.
   if (auto callOp = dyn_cast<CallOp>(dataSrcOp)) {
@@ -1945,8 +1951,7 @@ void LifetimeCheckPass::dumpPmap(PMapType &pmap) {
   int entry = 0;
   for (auto &mapEntry : pmap) {
     llvm::errs() << "  " << entry << ": " << getVarNameFromValue(mapEntry.first)
-                 << "  "
-                 << "=> ";
+                 << "  " << "=> ";
     printPset(mapEntry.second);
     llvm::errs() << "\n";
     entry++;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1008,8 +1008,7 @@ mlir::LogicalResult CIRToLLVMPtrStrideOpLowering::matchAndRewrite(
   // make it i8 instead.
   if (mlir::isa<mlir::LLVM::LLVMVoidType>(elementTy) ||
       mlir::isa<mlir::LLVM::LLVMFunctionType>(elementTy))
-    elementTy = mlir::IntegerType::get(ctx, 8,
-                                       mlir::IntegerType::Signless);
+    elementTy = mlir::IntegerType::get(ctx, 8, mlir::IntegerType::Signless);
 
   // Zero-extend, sign-extend or trunc the pointer value.
   auto index = adaptor.getStride();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -967,7 +967,7 @@ static mlir::Value promoteIndex(mlir::ConversionPatternRewriter &rewriter,
   // to
   bool rewriteSub = false;
   auto sub = dyn_cast<mlir::LLVM::SubOp>(indexOp);
-  if (sub)
+  if (sub) {
     if (auto lhsConst = dyn_cast<mlir::LLVM::ConstantOp>(
             sub.getOperand(0).getDefiningOp())) {
       auto lhsConstInt = dyn_cast<mlir::IntegerAttr>(lhsConst.getValue());
@@ -976,6 +976,7 @@ static mlir::Value promoteIndex(mlir::ConversionPatternRewriter &rewriter,
         index = sub.getOperand(1);
       }
     }
+  }
 
   // Handle the cast
   auto llvmDstType = mlir::IntegerType::get(rewriter.getContext(), layoutWidth);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -958,7 +958,7 @@ static mlir::Value promoteIndex(mlir::ConversionPatternRewriter &rewriter,
   if (!indexOp)
     return index;
 
-  auto indexType = cast<mlir::IntegerType>(index.getType());
+  auto indexType = mlir::cast<mlir::IntegerType>(index.getType());
   auto width = indexType.getWidth();
   if (layoutWidth == width)
     return index;
@@ -966,11 +966,11 @@ static mlir::Value promoteIndex(mlir::ConversionPatternRewriter &rewriter,
   // If the index definition is a unary minus (index = sub 0, x), then we need
   // to
   bool rewriteSub = false;
-  auto sub = dyn_cast<mlir::LLVM::SubOp>(indexOp);
+  auto sub = mlir::dyn_cast<mlir::LLVM::SubOp>(indexOp);
   if (sub) {
     if (auto lhsConst = dyn_cast<mlir::LLVM::ConstantOp>(
             sub.getOperand(0).getDefiningOp())) {
-      auto lhsConstInt = dyn_cast<mlir::IntegerAttr>(lhsConst.getValue());
+      auto lhsConstInt = mlir::dyn_cast<mlir::IntegerAttr>(lhsConst.getValue());
       if (lhsConstInt && lhsConstInt.getValue() == 0) {
         rewriteSub = true;
         index = sub.getOperand(1);
@@ -1018,7 +1018,7 @@ mlir::LogicalResult CIRToLLVMPtrStrideOpLowering::matchAndRewrite(
           LLVMLayout.getTypeIndexBitwidth(adaptor.getBase().getType())) {
     bool isUnsigned = false;
     if (auto strideTy =
-            dyn_cast<cir::IntType>(ptrStrideOp.getOperand(1).getType()))
+            mlir::dyn_cast<cir::IntType>(ptrStrideOp.getOperand(1).getType()))
       isUnsigned = strideTy.isUnsigned();
     index = promoteIndex(rewriter, index, *layoutWidth, isUnsigned);
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -951,6 +951,50 @@ static mlir::Value getLLVMIntCast(mlir::ConversionPatternRewriter &rewriter,
   return rewriter.create<mlir::LLVM::TruncOp>(loc, llvmDstIntTy, llvmSrc);
 }
 
+static mlir::Value promoteIndex(mlir::ConversionPatternRewriter &rewriter,
+                                mlir::Value index, uint64_t layoutWidth,
+                                bool isUnsigned) {
+  auto indexOp = index.getDefiningOp();
+  if (!indexOp)
+    return index;
+
+  auto indexType = cast<mlir::IntegerType>(index.getType());
+  auto width = indexType.getWidth();
+  if (layoutWidth == width)
+    return index;
+
+  // If the index definition is a unary minus (index = sub 0, x), then we need
+  // to
+  bool rewriteSub = false;
+  auto sub = dyn_cast<mlir::LLVM::SubOp>(indexOp);
+  if (sub)
+    if (auto lhsConst = dyn_cast<mlir::LLVM::ConstantOp>(
+            sub.getOperand(0).getDefiningOp())) {
+      auto lhsConstInt = dyn_cast<mlir::IntegerAttr>(lhsConst.getValue());
+      if (lhsConstInt && lhsConstInt.getValue() == 0) {
+        rewriteSub = true;
+        index = sub.getOperand(1);
+      }
+    }
+
+  // Handle the cast
+  auto llvmDstType = mlir::IntegerType::get(rewriter.getContext(), layoutWidth);
+  index = getLLVMIntCast(rewriter, index, llvmDstType, isUnsigned, width,
+                         layoutWidth);
+
+  if (rewriteSub) {
+    index = rewriter.create<mlir::LLVM::SubOp>(
+        index.getLoc(),
+        rewriter.create<mlir::LLVM::ConstantOp>(index.getLoc(), index.getType(),
+                                                0),
+        index);
+    // TODO: check if the sub is trivially dead now.
+    rewriter.eraseOp(sub);
+  }
+
+  return index;
+}
+
 mlir::LogicalResult CIRToLLVMPtrStrideOpLowering::matchAndRewrite(
     cir::PtrStrideOp ptrStrideOp, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -964,48 +1008,66 @@ mlir::LogicalResult CIRToLLVMPtrStrideOpLowering::matchAndRewrite(
   // make it i8 instead.
   if (mlir::isa<mlir::LLVM::LLVMVoidType>(elementTy) ||
       mlir::isa<mlir::LLVM::LLVMFunctionType>(elementTy))
-    elementTy = mlir::IntegerType::get(elementTy.getContext(), 8,
+    elementTy = mlir::IntegerType::get(ctx, 8,
                                        mlir::IntegerType::Signless);
 
   // Zero-extend, sign-extend or trunc the pointer value.
   auto index = adaptor.getStride();
-  auto width = mlir::cast<mlir::IntegerType>(index.getType()).getWidth();
   mlir::DataLayout LLVMLayout(ptrStrideOp->getParentOfType<mlir::ModuleOp>());
-  auto layoutWidth =
-      LLVMLayout.getTypeIndexBitwidth(adaptor.getBase().getType());
-  auto indexOp = index.getDefiningOp();
-  if (indexOp && layoutWidth && width != *layoutWidth) {
-    // If the index comes from a subtraction, make sure the extension happens
-    // before it. To achieve that, look at unary minus, which already got
-    // lowered to "sub 0, x".
-    auto sub = dyn_cast<mlir::LLVM::SubOp>(indexOp);
-    auto unary = dyn_cast_if_present<cir::UnaryOp>(
-        ptrStrideOp.getStride().getDefiningOp());
-    bool rewriteSub =
-        unary && unary.getKind() == cir::UnaryOpKind::Minus && sub;
-    if (rewriteSub)
-      index = indexOp->getOperand(1);
-
-    // Handle the cast
-    auto llvmDstType = mlir::IntegerType::get(ctx, *layoutWidth);
-    index = getLLVMIntCast(rewriter, index, llvmDstType,
-                           ptrStrideOp.getStride().getType().isUnsigned(),
-                           width, *layoutWidth);
-
-    // Rewrite the sub in front of extensions/trunc
-    if (rewriteSub) {
-      index = rewriter.create<mlir::LLVM::SubOp>(
-          index.getLoc(),
-          rewriter.create<mlir::LLVM::ConstantOp>(index.getLoc(),
-                                                  index.getType(), 0),
-          index);
-      rewriter.eraseOp(sub);
-    }
+  if (auto layoutWidth =
+          LLVMLayout.getTypeIndexBitwidth(adaptor.getBase().getType())) {
+    bool isUnsigned = false;
+    if (auto strideTy =
+            dyn_cast<cir::IntType>(ptrStrideOp.getOperand(1).getType()))
+      isUnsigned = strideTy.isUnsigned();
+    index = promoteIndex(rewriter, index, *layoutWidth, isUnsigned);
   }
 
   rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
       ptrStrideOp, resultTy, elementTy, adaptor.getBase(), index);
   return mlir::success();
+}
+
+mlir::LogicalResult CIRToLLVMGetElementOpLowering::matchAndRewrite(
+    cir::GetElementOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+
+  if (auto arrayTy =
+          mlir::dyn_cast<cir::ArrayType>(op.getBaseType().getPointee())) {
+    auto *tc = getTypeConverter();
+    const auto llResultTy = tc->convertType(op.getType());
+    auto elementTy = convertTypeForMemory(*tc, dataLayout, op.getElementType());
+    auto *ctx = elementTy.getContext();
+
+    // void and function types doesn't really have a layout to use in GEPs,
+    // make it i8 instead.
+    if (mlir::isa<mlir::LLVM::LLVMVoidType>(elementTy) ||
+        mlir::isa<mlir::LLVM::LLVMFunctionType>(elementTy))
+      elementTy = mlir::IntegerType::get(ctx, 8, mlir::IntegerType::Signless);
+
+    // Zero-extend, sign-extend or trunc the index value.
+    auto index = adaptor.getIndex();
+    mlir::DataLayout LLVMLayout(op->getParentOfType<mlir::ModuleOp>());
+    if (auto layoutWidth =
+            LLVMLayout.getTypeIndexBitwidth(adaptor.getBase().getType())) {
+      bool isUnsigned = false;
+      if (auto strideTy = dyn_cast<cir::IntType>(op.getOperand(1).getType()))
+        isUnsigned = strideTy.isUnsigned();
+      index = promoteIndex(rewriter, index, *layoutWidth, isUnsigned);
+    }
+
+    // Since the base address is a pointer to an aggregate, the first
+    // offset is always zero. The second offset tell us which member it
+    // will access.
+    const auto llArrayTy = getTypeConverter()->convertType(arrayTy);
+    llvm::SmallVector<mlir::LLVM::GEPArg, 2> offset{0, index};
+    rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(op, llResultTy, llArrayTy,
+                                                   adaptor.getBase(), offset);
+
+    return mlir::success();
+  }
+
+  llvm_unreachable("NYI, GetElementOp lowering to LLVM for non-Array");
 }
 
 mlir::LogicalResult CIRToLLVMBaseClassAddrOpLowering::matchAndRewrite(
@@ -4388,6 +4450,7 @@ void populateCIRToLLVMConversionPatterns(
   patterns.add<
       // clang-format off
       CIRToLLVMPtrStrideOpLowering,
+      CIRToLLVMGetElementOpLowering,
       CIRToLLVMInlineAsmOpLowering
       // clang-format on
       >(converter, patterns.getContext(), dataLayout);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -158,6 +158,22 @@ public:
                   mlir::ConversionPatternRewriter &) const override;
 };
 
+class CIRToLLVMGetElementOpLowering
+    : public mlir::OpConversionPattern<cir::GetElementOp> {
+  mlir::DataLayout const &dataLayout;
+
+public:
+  CIRToLLVMGetElementOpLowering(const mlir::TypeConverter &typeConverter,
+                                mlir::MLIRContext *context,
+                                mlir::DataLayout const &dataLayout)
+      : OpConversionPattern(typeConverter, context), dataLayout(dataLayout) {}
+  using mlir::OpConversionPattern<cir::GetElementOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::GetElementOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
 class CIRToLLVMBaseClassAddrOpLowering
     : public mlir::OpConversionPattern<cir::BaseClassAddrOp> {
 public:

--- a/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/aarch64-cc-structs.c
@@ -399,8 +399,7 @@ void qux(void) {
 // CHECK: %[[#V1:]] = cir.alloca !u64i, !cir.ptr<!u64i>, ["tmp"]
 // CHECK: %[[#V2:]] = cir.get_global @g : !cir.ptr<!cir.array<!rec_PackedS2 x 3>>
 // CHECK: %[[#V3:]] = cir.const #cir.int<1> : !s32i
-// CHECK: %[[#V4:]] = cir.cast(array_to_ptrdecay, %[[#V2]] : !cir.ptr<!cir.array<!rec_PackedS2 x 3>>), !cir.ptr<!rec_PackedS2>
-// CHECK: %[[#V5:]] = cir.ptr_stride(%[[#V4]] : !cir.ptr<!rec_PackedS2>, %[[#V3]] : !s32i), !cir.ptr<!rec_PackedS2>
+// CHECK: %[[#V5:]] = cir.get_element %[[#V2]][%[[#V3]]] : (!cir.ptr<!cir.array<!rec_PackedS2 x 3>>, !s32i) -> !cir.ptr<!rec_PackedS2>
 // CHECK: cir.store{{.*}} %[[#V5]], %[[#V0]] : !cir.ptr<!rec_PackedS2>, !cir.ptr<!cir.ptr<!rec_PackedS2>>
 // CHECK: %[[#V6:]] = cir.load deref{{.*}}  %[[#V0]] : !cir.ptr<!cir.ptr<!rec_PackedS2>>, !cir.ptr<!rec_PackedS2>
 // CHECK: %[[#V7:]] = cir.cast(bitcast, %[[#V6]] : !cir.ptr<!rec_PackedS2>), !cir.ptr<!void>

--- a/clang/test/CIR/CodeGen/array.c
+++ b/clang/test/CIR/CodeGen/array.c
@@ -8,7 +8,7 @@ struct S {
 // CHECK: cir.global external @arr = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s32i}> : !rec_S, #cir.zero : !rec_S, #cir.zero : !rec_S]> : !cir.array<!rec_S x 3>
 
 int a[4];
-// CHECK: cir.global external @a = #cir.zero : !cir.array<!s32i x 4> 
+// CHECK: cir.global external @a = #cir.zero : !cir.array<!s32i x 4>
 
 // Should create a pointer to a complete array.
 int (*complete_ptr_a)[4] = &a;
@@ -27,6 +27,5 @@ void useFoo(int i) {
 // CHECK: @useFoo
 // CHECK: %[[#V2:]] = cir.get_global @foo : !cir.ptr<!cir.array<!s32i x 0>>
 // CHECK: %[[#V3:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
-// CHECK: %[[#V4:]] = cir.cast(array_to_ptrdecay, %[[#V2]] : !cir.ptr<!cir.array<!s32i x 0>>), !cir.ptr<!s32i>
-// CHECK: %[[#V5:]] = cir.ptr_stride(%[[#V4]] : !cir.ptr<!s32i>, %[[#V3]] : !s32i), !cir.ptr<!s32i>
-// CHECK: cir.store{{.*}} %{{.+}}, %[[#V5]] : !s32i, !cir.ptr<!s32i>
+// CHECK: %[[#V4:]] = cir.get_element %[[#V2]][%[[#V3]]] : (!cir.ptr<!cir.array<!s32i x 0>>, !s32i) -> !cir.ptr<!s32i>
+// CHECK: cir.store{{.*}} %{{.+}}, %[[#V4]] : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -17,9 +17,8 @@ void a1() {
 // CHECK-NEXT:  %0 = cir.alloca !cir.array<!s32i x 10>, !cir.ptr<!cir.array<!s32i x 10>>, ["a"] {alignment = 16 : i64}
 // CHECK-NEXT:  %1 = cir.const #cir.int<1> : !s32i
 // CHECK-NEXT:  %2 = cir.const #cir.int<0> : !s32i
-// CHECK-NEXT:  %3 = cir.cast(array_to_ptrdecay, %0 : !cir.ptr<!cir.array<!s32i x 10>>), !cir.ptr<!s32i>
-// CHECK-NEXT:  %4 = cir.ptr_stride(%3 : !cir.ptr<!s32i>, %2 : !s32i), !cir.ptr<!s32i>
-// CHECK-NEXT:  cir.store{{.*}} %1, %4 : !s32i, !cir.ptr<!s32i>
+// CHECK-NEXT:  %3 = cir.get_element %0[%2] : (!cir.ptr<!cir.array<!s32i x 10>>, !s32i) -> !cir.ptr<!s32i>
+// CHECK-NEXT:  cir.store{{.*}} %1, %3 : !s32i, !cir.ptr<!s32i>
 
 int *a2() {
   int a[4];
@@ -30,11 +29,10 @@ int *a2() {
 // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["__retval"] {alignment = 8 : i64}
 // CHECK-NEXT:   %1 = cir.alloca !cir.array<!s32i x 4>, !cir.ptr<!cir.array<!s32i x 4>>, ["a"] {alignment = 16 : i64}
 // CHECK-NEXT:   %2 = cir.const #cir.int<0> : !s32i
-// CHECK-NEXT:   %3 = cir.cast(array_to_ptrdecay, %1 : !cir.ptr<!cir.array<!s32i x 4>>), !cir.ptr<!s32i>
-// CHECK-NEXT:   %4 = cir.ptr_stride(%3 : !cir.ptr<!s32i>, %2 : !s32i), !cir.ptr<!s32i>
-// CHECK-NEXT:   cir.store{{.*}} %4, %0 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
-// CHECK-NEXT:   %5 = cir.load{{.*}} %0 : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
-// CHECK-NEXT:   cir.return %5 : !cir.ptr<!s32i>
+// CHECK-NEXT:   %3 = cir.get_element %1[%2] : (!cir.ptr<!cir.array<!s32i x 4>>, !s32i) -> !cir.ptr<!s32i>
+// CHECK-NEXT:   cir.store{{.*}} %3, %0 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
+// CHECK-NEXT:   %4 = cir.load{{.*}} %0 : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
+// CHECK-NEXT:   cir.return %4 : !cir.ptr<!s32i>
 
 void local_stringlit() {
   const char *s = "whatnow";
@@ -53,14 +51,12 @@ int multidim(int i, int j) {
 }
 
 // CHECK: %3 = cir.alloca !cir.array<!cir.array<!s32i x 2> x 2>, !cir.ptr<!cir.array<!cir.array<!s32i x 2> x 2>>
-// Stride first dimension (stride = 2)
+// Index first dimension (index = 2)
 // CHECK: %4 = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
-// CHECK: %5 = cir.cast(array_to_ptrdecay, %3 : !cir.ptr<!cir.array<!cir.array<!s32i x 2> x 2>>), !cir.ptr<!cir.array<!s32i x 2>>
-// CHECK: %6 = cir.ptr_stride(%5 : !cir.ptr<!cir.array<!s32i x 2>>, %4 : !s32i), !cir.ptr<!cir.array<!s32i x 2>>
-// Stride second dimension (stride = 1)
-// CHECK: %7 = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
-// CHECK: %8 = cir.cast(array_to_ptrdecay, %6 : !cir.ptr<!cir.array<!s32i x 2>>), !cir.ptr<!s32i>
-// CHECK: %9 = cir.ptr_stride(%8 : !cir.ptr<!s32i>, %7 : !s32i), !cir.ptr<!s32i>
+// CHECK: %5 = cir.get_element %3[%4] : (!cir.ptr<!cir.array<!cir.array<!s32i x 2> x 2>>, !s32i) -> !cir.ptr<!cir.array<!s32i x 2>>
+// Index second dimension (index = 1)
+// CHECK: %6 = cir.load{{.*}} %{{.+}} : !cir.ptr<!s32i>, !s32i
+// CHECK: %7 = cir.get_element %5[%6] : (!cir.ptr<!cir.array<!s32i x 2>>, !s32i) -> !cir.ptr<!s32i>
 
 // Should globally zero-initialize null arrays.
 int globalNullArr[] = {0, 0};
@@ -83,12 +79,11 @@ void testPointerDecaySubscriptAccess(int arr[]) {
 void testPointerDecayedArrayMultiDimSubscriptAccess(int arr[][3]) {
 // CHECK: cir.func dso_local @{{.+}}testPointerDecayedArrayMultiDimSubscriptAccess
   arr[1][2];
-  // CHECK: %[[#V1:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>, !cir.ptr<!cir.array<!s32i x 3>>
-  // CHECK: %[[#V2:]] = cir.const #cir.int<1> : !s32i
-  // CHECK: %[[#V3:]] = cir.ptr_stride(%[[#V1]] : !cir.ptr<!cir.array<!s32i x 3>>, %[[#V2]] : !s32i), !cir.ptr<!cir.array<!s32i x 3>>
-  // CHECK: %[[#V4:]] = cir.const #cir.int<2> : !s32i
-  // CHECK: %[[#V5:]] = cir.cast(array_to_ptrdecay, %[[#V3]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
-  // CHECK: cir.ptr_stride(%[[#V5]] : !cir.ptr<!s32i>, %[[#V4]] : !s32i), !cir.ptr<!s32i>
+  // CHECK: %[[#ARRAY:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>, !cir.ptr<!cir.array<!s32i x 3>>
+  // CHECK: %[[#ONE:]] = cir.const #cir.int<1> : !s32i
+  // CHECK: %[[#OUTER:]] = cir.ptr_stride(%[[#ARRAY]] : !cir.ptr<!cir.array<!s32i x 3>>, %[[#ONE]] : !s32i), !cir.ptr<!cir.array<!s32i x 3>>
+  // CHECK: %[[#TWO:]] = cir.const #cir.int<2> : !s32i
+  // CHECK: %[[#INNER:]] = cir.get_element %[[#OUTER]][%[[#TWO]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
 }
 
 void testArrayOfComplexType() { int _Complex a[4]; }

--- a/clang/test/CIR/CodeGen/bitint.cpp
+++ b/clang/test/CIR/CodeGen/bitint.cpp
@@ -58,9 +58,8 @@ void Size1ExtIntParam(unsigned _BitInt(1) A) {
 //      CHECK: cir.func dso_local @_Z16Size1ExtIntParamDU1_
 //      CHECK:   %[[#A:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.int<u, 1>>, !cir.int<u, 1>
 // CHECK-NEXT:   %[[#IDX:]] = cir.const #cir.int<2> : !s32i
-// CHECK-NEXT:   %[[#ARRAY:]] = cir.cast(array_to_ptrdecay, %1 : !cir.ptr<!cir.array<!cir.int<u, 1> x 5>>), !cir.ptr<!cir.int<u, 1>>
-// CHECK-NEXT:   %[[#PTR:]] = cir.ptr_stride(%[[#ARRAY]] : !cir.ptr<!cir.int<u, 1>>, %[[#IDX]] : !s32i), !cir.ptr<!cir.int<u, 1>>
-// CHECK-NEXT:   cir.store{{.*}} %[[#A]], %[[#PTR]] : !cir.int<u, 1>, !cir.ptr<!cir.int<u, 1>>
+// CHECK-NEXT:   %[[#ELEM:]] = cir.get_element %1[%[[#IDX]]] : (!cir.ptr<!cir.array<!cir.int<u, 1> x 5>>, !s32i) -> !cir.ptr<!cir.int<u, 1>>
+// CHECK-NEXT:   cir.store{{.*}} %[[#A]], %[[#ELEM]] : !cir.int<u, 1>, !cir.ptr<!cir.int<u, 1>>
 //      CHECK: }
 
 struct S {

--- a/clang/test/CIR/CodeGen/complex.c
+++ b/clang/test/CIR/CodeGen/complex.c
@@ -407,14 +407,12 @@ void complex_array_subscript() {
 // CHECK: %[[ARR:.*]] = cir.alloca !cir.array<!cir.complex<!s32i> x 2>, !cir.ptr<!cir.array<!cir.complex<!s32i> x 2>>, ["arr"]
 // CHECK: %[[RESULT:.*]] = cir.alloca !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>, ["r", init]
 // CHECK: %[[IDX:.*]] = cir.const #cir.int<1> : !s32i
-// CHECK: %[[ARR_PTR:.*]] = cir.cast(array_to_ptrdecay, %[[ARR]] : !cir.ptr<!cir.array<!cir.complex<!s32i> x 2>>), !cir.ptr<!cir.complex<!s32i>>
-// CHECK: %[[RESULT_VAL:.*]] = cir.ptr_stride(%[[ARR_PTR]] : !cir.ptr<!cir.complex<!s32i>>, %[[IDX]] : !s32i), !cir.ptr<!cir.complex<!s32i>>
+// CHECK: %[[RESULT_VAL:.*]] = cir.get_element %[[ARR]][%[[IDX]]] : (!cir.ptr<!cir.complex<!s32i>>, !s32i) -> !cir.ptr<!cir.complex<!s32i>>
 // CHECK: %[[TMP:.*]] = cir.load{{.*}} %[[RESULT_VAL]] : !cir.ptr<!cir.complex<!s32i>>, !cir.complex<!s32i>
 // CHECK: cir.store{{.*}} %[[TMP]], %[[RESULT]] : !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>
 
 // LLVM: %[[ARR:.*]] = alloca [2 x { i32, i32 }], i64 1, align 16
 // LLVM: %[[RESULT:.*]] = alloca { i32, i32 }, i64 1, align 4
-// LLVM: %[[ARR_PTR:.*]] = getelementptr { i32, i32 }, ptr %[[ARR]], i32 0
-// LLVM: %[[RESULT_VAL:.*]] = getelementptr { i32, i32 }, ptr %[[ARR_PTR]], i64 1
+// LLVM: %[[RESULT_VAL:.*]] = getelementptr [2 x { i32, i32 }], ptr %[[ARR]], i32 0, i64 1
 // LLVM: %[[TMP:.*]] = load { i32, i32 }, ptr %[[RESULT_VAL]], align 8
 // LLVM: store { i32, i32 } %[[TMP]], ptr %[[RESULT]], align 4

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -88,8 +88,7 @@ struct Bar shouldGenerateAndAccessStructArrays(void) {
 }
 // CHECK-DAG: cir.func dso_local @shouldGenerateAndAccessStructArrays
 // CHECK-DAG: %[[#STRIDE:]] = cir.const #cir.int<0> : !s32i
-// CHECK-DAG: %[[#DARR:]] = cir.cast(array_to_ptrdecay, %{{.+}} : !cir.ptr<!cir.array<!rec_Bar x 1>>), !cir.ptr<!rec_Bar>
-// CHECK-DAG: %[[#ELT:]] = cir.ptr_stride(%[[#DARR]] : !cir.ptr<!rec_Bar>, %[[#STRIDE]] : !s32i), !cir.ptr<!rec_Bar>
+// CHECK-DAG: %[[#ELT:]] = cir.get_element %{{.+}}[%[[#STRIDE]]] : (!cir.ptr<!cir.array<!rec_Bar x 1>>, !s32i) -> !cir.ptr<!rec_Bar>
 // CHECK-DAG: cir.copy %[[#ELT]] to %{{.+}} : !cir.ptr<!rec_Bar>
 
 // CHECK-DAG: cir.func dso_local @local_decl

--- a/clang/test/CIR/Lowering/ThroughMLIR/array.c
+++ b/clang/test/CIR/Lowering/ThroughMLIR/array.c
@@ -6,43 +6,40 @@
 int test_array1() {
     // CIR-LABEL: cir.func {{.*}} @test_array1
     // CIR: %[[ARRAY:.*]] = cir.alloca !cir.array<!s32i x 3>, !cir.ptr<!cir.array<!s32i x 3>>, ["a"] {alignment = 4 : i64}
-    // CIR: %{{.*}} = cir.cast(array_to_ptrdecay, %[[ARRAY]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+    // CIR: %{{.*}} = cir.get_element %[[ARRAY]][{{.*}}] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
 
     // MLIR-LABEL: func @test_array1
     // MLIR: %{{.*}} = memref.alloca() {alignment = 4 : i64} : memref<i32>
     // MLIR: %[[ARRAY:.*]] = memref.alloca() {alignment = 4 : i64} : memref<3xi32>
     // MLIR: %{{.*}} = memref.load %[[ARRAY]][%{{.*}}] : memref<3xi32>
     int a[3];
-    return a[1]; 
+    return a[1];
 }
 
 int test_array2() {
     // CIR-LABEL: cir.func {{.*}} @test_array2
     // CIR: %[[ARRAY:.*]] = cir.alloca !cir.array<!cir.array<!s32i x 4> x 3>, !cir.ptr<!cir.array<!cir.array<!s32i x 4> x 3>>, ["a"] {alignment = 16 : i64}
-    // CIR: %{{.*}} = cir.cast(array_to_ptrdecay, %[[ARRAY]] : !cir.ptr<!cir.array<!cir.array<!s32i x 4> x 3>>), !cir.ptr<!cir.array<!s32i x 4>>
-    // CIR: %{{.*}} = cir.cast(array_to_ptrdecay, %{{.*}} : !cir.ptr<!cir.array<!s32i x 4>>), !cir.ptr<!s32i>
+    // CIR: %{{.*}} = cir.get_element %[[ARRAY]][%{{.*}}] : (!cir.ptr<!cir.array<!cir.array<!s32i x 4> x 3>>, !s32i) -> !cir.ptr<!cir.array<!s32i x 4>>
+    // CIR: %{{.*}} = cir.get_element %{{.*}}[%{{.*}}] : (!cir.ptr<!cir.array<!s32i x 4>>, !s32i) -> !cir.ptr<!s32i>
 
     // MLIR-LABEL: func @test_array2
     // MLIR: %{{.*}} = memref.alloca() {alignment = 4 : i64} : memref<i32>
     // MLIR: %[[ARRAY:.*]] = memref.alloca() {alignment = 16 : i64} : memref<3x4xi32>
     // MLIR: %{{.*}} = memref.load %[[ARRAY]][%{{.*}}, %{{.*}}] : memref<3x4xi32>
     int a[3][4];
-    return a[1][2]; 
+    return a[1][2];
 }
 
 int test_array3() {
     // CIR-LABEL: cir.func {{.*}} @test_array3()
     // CIR: %[[ARRAY:.*]] = cir.alloca !cir.array<!s32i x 3>, !cir.ptr<!cir.array<!s32i x 3>>, ["a"] {alignment = 4 : i64}
-    // CIR: %[[PTRDECAY1:.*]] = cir.cast(array_to_ptrdecay, %[[ARRAY]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i> 
-    // CIR: %[[PTRSTRIDE1:.*]] = cir.ptr_stride(%[[PTRDECAY1]] : !cir.ptr<!s32i>, {{.*}} : !s32i), !cir.ptr<!s32i>
-    // CIR: {{.*}} = cir.load align(4) %[[PTRSTRIDE1]] : !cir.ptr<!s32i>, !s32i
-    // CIR: %[[PTRDECAY2:.*]] = cir.cast(array_to_ptrdecay, %[[ARRAY]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
-    // CIR: %[[PTRSTRIDE2:.*]] = cir.ptr_stride(%[[PTRDECAY2]] : !cir.ptr<!s32i>, {{.*}} : !s32i), !cir.ptr<!s32i>
-    // CIR: %{{.*}} = cir.load align(4) %[[PTRSTRIDE2]] : !cir.ptr<!s32i>, !s32i
-    // CIR: cir.store align(4) {{.*}}, %[[PTRSTRIDE2]] : !s32i, !cir.ptr<!s32i>
-    // CIR: %[[PTRDECAY3:.*]] = cir.cast(array_to_ptrdecay, %[[ARRAY]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i> 
-    // CIR: %[[PTRSTRIDE3:.*]] = cir.ptr_stride(%[[PTRDECAY3]] : !cir.ptr<!s32i>, {{.*}} : !s32i), !cir.ptr<!s32i>
-    // CIR: %{{.*}} = cir.load align(4) %[[PTRSTRIDE3]] : !cir.ptr<!s32i>, !s32i  
+    // CIR: %[[ELEM1:.*]] = cir.get_element %[[ARRAY]][{{.*}}] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
+    // CIR: {{.*}} = cir.load align(4) %[[ELEM1]] : !cir.ptr<!s32i>, !s32i
+    // CIR: %[[ELEM2:.*]] = cir.get_element %[[ARRAY]][{{.*}}] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
+    // CIR: %{{.*}} = cir.load align(4) %[[ELEM2]] : !cir.ptr<!s32i>, !s32i
+    // CIR: cir.store align(4) {{.*}}, %[[ELEM2]] : !s32i, !cir.ptr<!s32i>
+    // CIR: %[[ELEM3:.*]] = cir.get_element %[[ARRAY]][{{.*}}] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
+    // CIR: %{{.*}} = cir.load align(4) %[[ELEM3]] : !cir.ptr<!s32i>, !s32i
 
     // MLIR-LABEL: func @test_array3
     // MLIR: %{{.*}} = memref.alloca() {alignment = 4 : i64} : memref<i32>
@@ -50,11 +47,11 @@ int test_array3() {
     // MLIR: %[[IDX1:.*]] = arith.index_cast %{{.*}} : i32 to index
     // MLIR: %{{.*}} = memref.load %[[ARRAY]][%[[IDX1]]] : memref<3xi32>
     // MLIR: %[[IDX2:.*]] = arith.index_cast %{{.*}} : i32 to index
-    // MLIR: %{{.*}} = memref.load %[[ARRAY]][%[[IDX2]]] : memref<3xi32> 
-    // MLIR: memref.store %{{.*}}, %[[ARRAY]][%[[IDX2]]] : memref<3xi32> 
+    // MLIR: %{{.*}} = memref.load %[[ARRAY]][%[[IDX2]]] : memref<3xi32>
+    // MLIR: memref.store %{{.*}}, %[[ARRAY]][%[[IDX2]]] : memref<3xi32>
     // MLIR: %[[IDX3:.*]] = arith.index_cast %{{.*}} : i32 to index
-    // MLIR: %{{.*}} = memref.load %[[ARRAY]][%[[IDX3]]] : memref<3xi32> 
+    // MLIR: %{{.*}} = memref.load %[[ARRAY]][%[[IDX3]]] : memref<3xi32>
     int a[3];
     a[0] += a[2];
-    return a[1];  
+    return a[1];
 }


### PR DESCRIPTION
## Overview
Currently, getting the pointer to an element of an array requires a pointer decay and a (possible) pointer stride. A similar pattern for records has been eliminated with the `cir.get_member` operation. This PR provides a similar level of abstraction for arrays with the `get_element` operation.
`get_element` replaces the above pattern with a single operation, which takes a pointer to an array and an index, and produces a pointer to the element at that index.
There are many places in CIR analysis and lowering where the `ptr_stride(array_to_ptrdecay(x), i)` pattern is handled as a special case. By subsuming the special case pattern with an explicit operation, we make these analyses and lowering more robust.

## Changes
Adds the `cir.get_element` operation.
Extends CIRGen to emit `cir.get_element` for array subscript expressions.
Updated LifetimeCheck to handle `get_element` operation, subsuming special case analysis of `cir.ptr_stride` operation (did not remove the special case).
Extends CIR-to-LLVM lowering to lower `cir.get_element` to `llvm.getelementptr`
Extends CIR-to-MLIR lowering to lower `cir.get_element` to `memref` operations, matching existing special case `cir.ptr_stride` lowering.

## Additional Notes
Currently, 47.6% of `cir.ptr_stride` operations in the llvm-test-suite (SingleSource and MultiSource) can be replaced by `cir.get_element` operations.

### Operator Breakdown (current)
name | count | %
-- | -- | --
cir.load | 825221 | 22.27%
cir.br | 429822 | 11.60%
cir.const | 380381 | 10.26%
cir.cast | 325646 | 8.79%
cir.store | 309586 | 8.35%
cir.get_member | 226895 | 6.12%
cir.get_global | 186851 | 5.04%
cir.ptr_stride | 158094 | 4.27%
cir.call | 144522 | 3.90%
cir.binop | 141142 | 3.81%
cir.alloca | 134346 | 3.63%
cir.brcond | 112864 | 3.05%
cir.cmp | 83532 | 2.25%

### Operator Breakdown (with `get_element`)
name | count | %
-- | -- | --
cir.load | 825221 | 22.74%
cir.br | 429822 | 11.84%
cir.const | 380381 | 10.48%
cir.store | 309586 | 8.53%
cir.cast | 248645 | 6.85%
cir.get_member | 226895 | 6.25%
cir.get_global | 186851 | 5.15%
cir.call | 144522 | 3.98%
cir.binop | 141142 | 3.89%
cir.alloca | 134346 | 3.70%
cir.brcond | 112864 | 3.11%
cir.cmp | 83532 | 2.30%
cir.ptr_stride | 81093 | 2.23%
cir.get_elem | 77001 | 2.12%