### PR TITLE
[CIR] Implemented Opportunistic VTable Emission

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -573,6 +573,9 @@ public:
   /// A queue of (optional) vtables to consider emitting.
   std::vector<const clang::CXXRecordDecl *> DeferredVTables;
 
+  /// A queue of (optional) vtables that may be emitted opportunistically.
+  std::vector<const CXXRecordDecl *> opportunisticVTables;
+
   mlir::Type getVTableComponentType();
   CIRGenVTables &getVTables() { return VTables; }
 
@@ -782,6 +785,12 @@ public:
 
   /// Emit any needed decls for which code generation was deferred.
   void emitDeferred(unsigned recursionLimit);
+
+  /// Try to emit external vtables as available_externally if they have emitted
+  /// all inlined virtual functions.  It runs after EmitDeferred() and therefore
+  /// is not allowed to create new references to things that need to be emitted
+  /// lazily.
+  void emitVTablesOpportunistically();
 
   /// Helper for `emitDeferred` to apply actual codegen.
   void emitGlobalDecl(clang::GlobalDecl &D);

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -137,11 +137,10 @@ void CIRGenModule::emitDeferredVTables() {
 #endif
 
   for (const CXXRecordDecl *RD : DeferredVTables)
-    if (shouldEmitVTableAtEndOfTranslationUnit(*this, RD)) {
+    if (shouldEmitVTableAtEndOfTranslationUnit(*this, RD))
       VTables.GenerateClassData(RD);
-    } else if (shouldOpportunisticallyEmitVTables()) {
-      llvm_unreachable("NYI");
-    }
+    else if (shouldOpportunisticallyEmitVTables())
+      opportunisticVTables.push_back(RD);
 
   assert(savedSize == DeferredVTables.size() &&
          "deferred extra vtables during vtable emission?");

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2257,6 +2257,7 @@ LogicalResult cir::GlobalOp::verify() {
   case GlobalLinkageKind::CommonLinkage:
   case GlobalLinkageKind::WeakAnyLinkage:
   case GlobalLinkageKind::WeakODRLinkage:
+  case GlobalLinkageKind::AvailableExternallyLinkage:
     // FIXME: mlir's concept of visibility gets tricky with LLVM ones,
     // for instance, symbol declarations cannot be "public", so we
     // have to mark them "private" to workaround the symbol verifier.
@@ -2265,9 +2266,6 @@ LogicalResult cir::GlobalOp::verify() {
                          << stringifyGlobalLinkageKind(getLinkage())
                          << "' linkage";
     break;
-  default:
-    return emitError() << stringifyGlobalLinkageKind(getLinkage())
-                       << ": verifier not implemented\n";
   }
 
   // TODO: verify visibility for declarations?

--- a/clang/test/CIR/CodeGen/vtable-available-externally.cpp
+++ b/clang/test/CIR/CodeGen/vtable-available-externally.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 %s -I%S -triple x86_64-unknown-linux-gnu -std=c++98 -O0 -disable-llvm-passes -emit-cir -o %t
+// RUN: FileCheck -allow-deprecated-dag-overlap --check-prefix=CHECK %s < %t
+// RUN: %clang_cc1 %s -I%S -triple x86_64-unknown-linux-gnu -std=c++98 -O2 -disable-llvm-passes -emit-cir -o %t.opt
+// RUN: FileCheck -allow-deprecated-dag-overlap --check-prefix=CHECK-FORCE-EMIT %s < %t.opt
+
+// CHECK: cir.global{{.*}} external @_ZTV1A
+// CHECK-FORCE-EMIT-DAG: cir.global{{.*}} available_externally @_ZTV1A
+struct A {
+  A();
+  virtual void f();
+  virtual ~A() { }
+};
+
+A::A() { }
+
+void f(A* a) {
+  a->f();
+};
+
+void g() {
+  A a;
+  f(&a);
+}


### PR DESCRIPTION
Implemented opportunistic vtable emission, which marks vtables as `available_externally` to enable inlining if optimizations are enabled.
Added `GlobalOp` verifier support `available_externally` linkage type, all cases are covered now, so I removed the `default` case.
Added the `vtable-available-externally` CIRGen test.