### PR TITLE
[CIR][CodeGen] Implemented `noexcept` expression handling

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -728,7 +728,7 @@ public:
     return nullptr;
   }
   mlir::Value VisitCXXNoexceptExpr(CXXNoexceptExpr *E) {
-    llvm_unreachable("NYI");
+    return CGF.getBuilder().getBool(E->getValue(), CGF.getLoc(E->getExprLoc()));
   }
 
   /// Perform a pointer to boolean conversion.

--- a/clang/test/CIR/CodeGen/noexcept.cpp
+++ b/clang/test/CIR/CodeGen/noexcept.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -x c++ -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -std=c++11 %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+void may_throw();
+void no_throw() noexcept;
+
+bool test_noexcept_func_false() {
+  return noexcept(may_throw());
+}
+// CHECK-LABEL: cir.func{{.*}} @_Z24test_noexcept_func_falsev
+// CHECK:         %[[CONST:.*]] = cir.const #false
+// CHECK:         cir.return
+
+bool test_noexcept_func_true() {
+  return noexcept(no_throw());
+}
+// CHECK-LABEL: cir.func{{.*}} @_Z23test_noexcept_func_truev
+// CHECK:         %[[CONST:.*]] = cir.const #true
+// CHECK:         cir.return
+
+auto lambda_may_throw = []() {};
+auto lambda_no_throw = []() noexcept {};
+
+bool test_noexcept_lambda_false() {
+  return noexcept(lambda_may_throw());
+}
+// CHECK-LABEL: cir.func{{.*}} @_Z26test_noexcept_lambda_falsev
+// CHECK:         %[[CONST:.*]] = cir.const #false
+// CHECK:         cir.return
+
+bool test_noexcept_lambda_true() {
+  return noexcept(lambda_no_throw());
+}
+// CHECK-LABEL: cir.func{{.*}} @_Z25test_noexcept_lambda_truev
+// CHECK:         %[[CONST:.*]] = cir.const #true
+// CHECK:         cir.return


### PR DESCRIPTION
Implemented `noexcept` expression handling in CIR generation. 
Added a `noexcept.cpp` test based on cppreference. There was no OG test to base it off of, so I used the example code from [cppreference](https://en.cppreference.com/w/cpp/language/noexcept.html).