### PR TITLE
[CIR] Fix array init loop condition

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1382,7 +1382,7 @@ static void lowerArrayDtorCtorIntoLoop(CIRBaseBuilderTy &builder,
       [&](mlir::OpBuilder &b, mlir::Location loc) {
         auto currentElement = b.create<cir::LoadOp>(loc, eltTy, tmpAddr);
         mlir::Type boolTy = cir::BoolType::get(b.getContext());
-        auto cmp = builder.create<cir::CmpOp>(loc, boolTy, cir::CmpOpKind::eq,
+        auto cmp = builder.create<cir::CmpOp>(loc, boolTy, cir::CmpOpKind::ne,
                                               currentElement, end);
         builder.createCondition(cmp);
       },

--- a/clang/test/CIR/CodeGen/array-init-destroy.cpp
+++ b/clang/test/CIR/CodeGen/array-init-destroy.cpp
@@ -50,7 +50,7 @@ void x() {
 // AFTER:   cir.yield
 // AFTER: } while {
 // AFTER:   %[[ArrayElt:.*]] = cir.load %[[TmpIdx]] : !cir.ptr<!cir.ptr<!rec_xpto>>, !cir.ptr<!rec_xpto>
-// AFTER:   %[[ExitCond:.*]] = cir.cmp(eq, %[[ArrayElt]], %[[ArrayPastEnd]]) : !cir.ptr<!rec_xpto>, !cir.bool
+// AFTER:   %[[ExitCond:.*]] = cir.cmp(ne, %[[ArrayElt]], %[[ArrayPastEnd]]) : !cir.ptr<!rec_xpto>, !cir.bool
 // AFTER:   cir.condition(%[[ExitCond]])
 // AFTER: }
 

--- a/clang/test/CIR/CodeGen/array-new-init.cpp
+++ b/clang/test/CIR/CodeGen/array-new-init.cpp
@@ -55,6 +55,6 @@ void t_new_constant_size_constructor() {
 // AFTER:      cir.yield
 // AFTER:    } while {
 // AFTER:      %[[CUR_ELEM_PTR2:.*]] = cir.load %[[CUR_ELEM_ALLOCA]] : !cir.ptr<!cir.ptr<!rec_E>>, !cir.ptr<!rec_E>
-// AFTER:      %[[END_TEST:.*]] = cir.cmp(eq, %[[CUR_ELEM_PTR2]], %[[END_PTR]]) : !cir.ptr<!rec_E>, !cir.bool
+// AFTER:      %[[END_TEST:.*]] = cir.cmp(ne, %[[CUR_ELEM_PTR2]], %[[END_PTR]]) : !cir.ptr<!rec_E>, !cir.bool
 // AFTER:      cir.condition(%[[END_TEST]])
 // AFTER:    }

--- a/clang/test/CIR/Lowering/new.cpp
+++ b/clang/test/CIR/Lowering/new.cpp
@@ -207,7 +207,7 @@ void t_new_constant_size_constructor() {
 // LLVM:    br label %[[INIT_ELEM_BB:.*]]
 // LLVM:  [[LOOP_INC_BB:.*]]:
 // LLVM:    %[[NEXT_ELEM_PTR:.*]] = load ptr
-// LLVM:    %[[END_TEST:.*]] = icmp eq ptr %[[NEXT_ELEM_PTR]], %[[END_PTR]]
+// LLVM:    %[[END_TEST:.*]] = icmp ne ptr %[[NEXT_ELEM_PTR]], %[[END_PTR]]
 // LLVM:    br i1 %[[END_TEST]], label %[[INIT_ELEM_BB]], label %[[EXIT_BB:.*]]
 // LLVM:  [[INIT_ELEM_BB]]:
 // LLVM:    %[[CUR_ELEM_PTR:.*]] = load ptr


### PR DESCRIPTION
The LoweringPrepare pass was generating the wrong condition for loops when lowering the ArrayCtor op, causing only one element in an array of objects to be constructed. This fixes that problem.