### PR TITLE
[CIR] Extend CIR canonicalize to rewrite `ptr_stride` and `array_to_ptrdecay` to `get_element` when possible

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -172,19 +172,19 @@ struct SimplifyPtrStrideOp : public OpRewritePattern<PtrStrideOp> {
   }
 };
 
-struct SimplifyCastOp : public OpRewritePattern<CastOp> {
-  using OpRewritePattern<CastOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(CastOp op,
+struct SimplifyCastOp : public OpRewritePattern<cir::CastOp> {
+  using OpRewritePattern<cir::CastOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(cir::CastOp op,
                                 PatternRewriter &rewriter) const override {
     if (op.getKind() != cir::CastKind::array_to_ptrdecay)
       return mlir::failure();
 
     auto elemTy = cast<cir::PointerType>(op.getType()).getPointee();
     for (auto *user : op->getUsers()) {
-      if (auto loadOp = dyn_cast<LoadOp>(user)) {
+      if (auto loadOp = dyn_cast<cir::LoadOp>(user)) {
         if (elemTy != loadOp.getType())
           return mlir::failure();
-      } else if (auto storeOp = dyn_cast<StoreOp>(user)) {
+      } else if (auto storeOp = dyn_cast<cir::StoreOp>(user)) {
         if (storeOp.getAddr() != op.getResult() ||
             elemTy != storeOp.getValue().getType())
           return mlir::failure();

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -14,6 +14,7 @@
 #include "mlir/IR/Region.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
 
@@ -138,6 +139,77 @@ struct SimplifyCallOp : public OpRewritePattern<CallOp> {
   }
 };
 
+struct SimplifyPtrStrideOp : public OpRewritePattern<PtrStrideOp> {
+  using OpRewritePattern<PtrStrideOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(PtrStrideOp op,
+                                PatternRewriter &rewriter) const override {
+    mlir::Value base = op.getBase(), index = op.getStride();
+    if (auto castOp = dyn_cast<cir::CastOp>(base.getDefiningOp())) {
+      // REWRITE ptr_stride(cast array_to_ptrdecay %base), %index)
+      //      => get_element %base[%index]
+      if (castOp.getKind() != cir::CastKind::array_to_ptrdecay)
+        return mlir::failure();
+
+      base = castOp.getOperand();
+
+    } else if (auto getElemOp =
+                   dyn_cast<cir::GetElementOp>(base.getDefiningOp())) {
+      // REWRITE ptr_stride(get_element %base[%index]), %stride)
+      //      => get_element %base[%index + %stride]
+      auto elemIndex = getElemOp.getIndex();
+      if (elemIndex.getType() != index.getType())
+        return mlir::failure();
+
+      base = getElemOp.getBase();
+      index = rewriter.create<cir::BinOp>(op->getLoc(), cir::BinOpKind::Add,
+                                          elemIndex, index);
+
+    } else
+      return mlir::failure();
+
+    rewriter.replaceOpWithNewOp<cir::GetElementOp>(op, op.getType(), base,
+                                                   index);
+    return mlir::success();
+  }
+};
+
+struct SimplifyCastOp : public OpRewritePattern<CastOp> {
+  using OpRewritePattern<CastOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(CastOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getKind() != cir::CastKind::array_to_ptrdecay)
+      return mlir::failure();
+
+    auto elemTy = cast<cir::PointerType>(op.getType()).getPointee();
+    for (auto *user : op->getUsers()) {
+      if (auto loadOp = dyn_cast<LoadOp>(user)) {
+        if (elemTy != loadOp.getType())
+          return mlir::failure();
+      } else if (auto storeOp = dyn_cast<StoreOp>(user)) {
+        if (storeOp.getAddr() != op.getResult() ||
+            elemTy != storeOp.getValue().getType())
+          return mlir::failure();
+      } else if (isa<cir::GetMemberOp>(user)) {
+        continue;
+      } else
+        return mlir::failure();
+    }
+
+    // REWRITE cast array_to_ptrdecay %base
+    //      => get_element %base[0]
+    auto *context = elemTy.getContext();
+    CIRDataLayout dataLayout(op->getParentOfType<ModuleOp>());
+    auto intType = cast<cir::IntType>(dataLayout.getIntType(context));
+    auto zeroAttr = rewriter.getAttr<cir::IntAttr>(
+        intType, llvm::APInt(intType.getWidth(), 0));
+    auto index = rewriter.create<cir::ConstantOp>(op->getLoc(), zeroAttr);
+
+    rewriter.replaceOpWithNewOp<cir::GetElementOp>(op, op.getType(),
+                                                   op.getOperand(), index);
+    return mlir::success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // CIRCanonicalizePass
 //===----------------------------------------------------------------------===//
@@ -163,7 +235,9 @@ void populateCIRCanonicalizePatterns(RewritePatternSet &patterns) {
     RemoveEmptyScope,
     RemoveEmptySwitch,
     RemoveTrivialTry,
-    SimplifyCallOp
+    SimplifyCallOp,
+    SimplifyPtrStrideOp,
+    SimplifyCastOp
   >(patterns.getContext());
   // clang-format on
 }
@@ -181,7 +255,7 @@ void CIRCanonicalizePass::runOnOperation() {
     if (isa<BrOp, BrCondOp, ScopeOp, SwitchOp, CastOp, TryOp, UnaryOp, SelectOp,
             ComplexCreateOp, ComplexRealOp, ComplexImagOp, CallOp, VecCmpOp,
             VecCreateOp, VecExtractOp, VecShuffleOp, VecShuffleDynamicOp,
-            VecTernaryOp>(op))
+            VecTernaryOp, PtrStrideOp>(op))
       ops.push_back(op);
   });
 

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -144,7 +144,7 @@ struct SimplifyPtrStrideOp : public OpRewritePattern<PtrStrideOp> {
   LogicalResult matchAndRewrite(PtrStrideOp op,
                                 PatternRewriter &rewriter) const override {
     mlir::Value base = op.getBase(), index = op.getStride();
-    if (auto castOp = dyn_cast<cir::CastOp>(base.getDefiningOp())) {
+    if (auto castOp = base.getDefiningOp<cir::CastOp>()) {
       // REWRITE ptr_stride(cast array_to_ptrdecay %base), %index)
       //      => get_element %base[%index]
       if (castOp.getKind() != cir::CastKind::array_to_ptrdecay)
@@ -152,8 +152,7 @@ struct SimplifyPtrStrideOp : public OpRewritePattern<PtrStrideOp> {
 
       base = castOp.getOperand();
 
-    } else if (auto getElemOp =
-                   dyn_cast<cir::GetElementOp>(base.getDefiningOp())) {
+    } else if (auto getElemOp = base.getDefiningOp<cir::GetElementOp>()) {
       // REWRITE ptr_stride(get_element %base[%index]), %stride)
       //      => get_element %base[%index + %stride]
       auto elemIndex = getElemOp.getIndex();

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -163,9 +163,9 @@ struct SimplifyPtrStrideOp : public OpRewritePattern<PtrStrideOp> {
       index = rewriter.create<cir::BinOp>(op->getLoc(), cir::BinOpKind::Add,
                                           elemIndex, index);
 
-    } else
+    } else {
       return mlir::failure();
-
+    }
     rewriter.replaceOpWithNewOp<cir::GetElementOp>(op, op.getType(), base,
                                                    index);
     return mlir::success();
@@ -190,8 +190,9 @@ struct SimplifyCastOp : public OpRewritePattern<CastOp> {
           return mlir::failure();
       } else if (isa<cir::GetMemberOp>(user)) {
         continue;
-      } else
+      } else {
         return mlir::failure();
+      }
     }
 
     // REWRITE cast array_to_ptrdecay %base

--- a/clang/test/CIR/CodeGen/OpenCL/array-decay.cl
+++ b/clang/test/CIR/CodeGen/OpenCL/array-decay.cl
@@ -19,7 +19,7 @@ kernel void func1(global int *data) {
 // LLVM: @func2
 kernel void func2(global int *data) {
     private int arr[32] = {data[2]};
-    // CIR: %{{[0-9]+}} = cir.cast(array_to_ptrdecay, %{{[0-9]+}} : !cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_private)>), !cir.ptr<!s32i, addrspace(offload_private)>
+    // CIR: %{{[0-9]+}} = cir.get_element %{{[0-9]+}}[%{{[0-9]+}}] : (!cir.ptr<!cir.array<!s32i x 32>, addrspace(offload_private)>, !s32i) -> !cir.ptr<!s32i, addrspace(offload_private)>
 
-    // LLVM: %{{[0-9]+}} = getelementptr i32, ptr %3, i32 0
+    // LLVM: %{{[0-9]+}} = getelementptr [32 x i32], ptr %3, i32 0, i64 0
 }

--- a/clang/test/CIR/CodeGen/array-init.c
+++ b/clang/test/CIR/CodeGen/array-init.c
@@ -10,24 +10,30 @@ typedef struct {
 } T;
 
 void buz(int x) {
-  T arr[] = { {0, x}, {0, 0} };
+  T arr[] = { {x, x}, {0, 0} };
 }
 // CIR: cir.func dso_local @buz
 // CIR-NEXT: [[X_ALLOCA:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
 // CIR-NEXT: [[ARR:%.*]] = cir.alloca !cir.array<!rec_T x 2>, !cir.ptr<!cir.array<!rec_T x 2>>, ["arr", init] {alignment = 16 : i64}
 // CIR-NEXT: cir.store{{.*}} %arg0, [[X_ALLOCA]] : !s32i, !cir.ptr<!s32i>
-// CIR-NEXT: [[ARR_INIT:%.*]] = cir.const #cir.zero : !cir.array<!rec_T x 2>
-// CIR-NEXT: cir.store{{.*}} [[ARR_INIT]], [[ARR]] : !cir.array<!rec_T x 2>, !cir.ptr<!cir.array<!rec_T x 2>>
-// CIR-NEXT: [[FI_EL:%.*]] = cir.cast(array_to_ptrdecay, [[ARR]] : !cir.ptr<!cir.array<!rec_T x 2>>), !cir.ptr<!rec_T>
+// CIR-NEXT: [[ZERO:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR-NEXT: [[FI_EL:%.*]] = cir.get_element [[ARR]][[[ZERO]]] : (!cir.ptr<!cir.array<!rec_T x 2>>, !s32i) -> !cir.ptr<!rec_T>
 // CIR-NEXT: [[A_STORAGE0:%.*]] = cir.get_member [[FI_EL]][0] {name = "a"} : !cir.ptr<!rec_T> -> !cir.ptr<!s32i>
+// CIR-NEXT: [[XA_VAL:%.*]] = cir.load{{.*}} [[X_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT: cir.store{{.*}} [[XA_VAL]], [[A_STORAGE0]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT: [[B_STORAGE0:%.*]] = cir.get_member [[FI_EL]][1] {name = "b"} : !cir.ptr<!rec_T> -> !cir.ptr<!s64i>
-// CIR-NEXT: [[X_VAL:%.*]] = cir.load{{.*}} [[X_ALLOCA]] : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT: [[X_CASTED:%.*]] = cir.cast(integral, [[X_VAL]] : !s32i), !s64i
-// CIR-NEXT: cir.store{{.*}} [[X_CASTED]], [[B_STORAGE0]] : !s64i, !cir.ptr<!s64i>
+// CIR-NEXT: [[XB_VAL:%.*]] = cir.load{{.*}} [[X_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT: [[XB_CASTED:%.*]] = cir.cast(integral, [[XB_VAL]] : !s32i), !s64i
+// CIR-NEXT: cir.store{{.*}} [[XB_CASTED]], [[B_STORAGE0]] : !s64i, !cir.ptr<!s64i>
 // CIR-NEXT: [[ONE:%.*]] = cir.const #cir.int<1> : !s64i
-// CIR-NEXT: [[SE_EL:%.*]] = cir.ptr_stride([[FI_EL]] : !cir.ptr<!rec_T>, [[ONE]] : !s64i), !cir.ptr<!rec_T>
+// CIR-NEXT: [[SE_EL:%.*]] = cir.get_element [[ARR]][[[ONE]]] : (!cir.ptr<!cir.array<!rec_T x 2>>, !s64i) -> !cir.ptr<!rec_T>
 // CIR-NEXT: [[A_STORAGE1:%.*]] = cir.get_member [[SE_EL]][0] {name = "a"} : !cir.ptr<!rec_T> -> !cir.ptr<!s32i>
+// CIR-NEXT: [[A1_ZERO:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR-NEXT: cir.store{{.*}} [[A1_ZERO]], [[A_STORAGE1]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT: [[B_STORAGE1:%.*]] = cir.get_member [[SE_EL]][1] {name = "b"} : !cir.ptr<!rec_T> -> !cir.ptr<!s64i>
+// CIR-NEXT: [[B1_ZERO:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR-NEXT: [[B1_CASTED:%.*]] = cir.cast(integral, [[B1_ZERO]] : !s32i), !s64i
+// CIR-NEXT: cir.store{{.*}} [[B1_CASTED]], [[B_STORAGE1]] : !s64i, !cir.ptr<!s64i>
 // CIR-NEXT: cir.return
 
 void foo() {
@@ -46,34 +52,36 @@ void bar(int a, int b, int c) {
 // CIR-NEXT: cir.store{{.*}} %arg0, [[A:%.*]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT: cir.store{{.*}} %arg1, [[B:%.*]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT: cir.store{{.*}} %arg2, [[C:%.*]] : !s32i, !cir.ptr<!s32i>
-// CIR-NEXT: [[FI_EL:%.*]] = cir.cast(array_to_ptrdecay, [[ARR]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+// CIR-NEXT: [[ZERO:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR-NEXT: [[ELEM0:%.*]] = cir.get_element [[ARR]][[[ZERO]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
 // CIR-NEXT: [[LOAD_A:%.*]] = cir.load{{.*}} [[A]] : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT: cir.store{{.*}} [[LOAD_A]], [[FI_EL]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT: cir.store{{.*}} [[LOAD_A]], [[ELEM0]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT: [[ONE:%.*]] = cir.const #cir.int<1> : !s64i
-// CIR-NEXT: [[SE_EL:%.*]] = cir.ptr_stride(%4 : !cir.ptr<!s32i>, [[ONE]] : !s64i), !cir.ptr<!s32i>
+// CIR-NEXT: [[ELEM1:%.*]] = cir.get_element [[ARR]][[[ONE]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s64i) -> !cir.ptr<!s32i>
 // CIR-NEXT: [[LOAD_B:%.*]] = cir.load{{.*}} [[B]] : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT: cir.store{{.*}} [[LOAD_B]], [[SE_EL]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT: cir.store{{.*}} [[LOAD_B]], [[ELEM1]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT: [[TWO:%.*]] = cir.const #cir.int<2> : !s64i
-// CIR-NEXT: [[TH_EL:%.*]] = cir.ptr_stride(%4 : !cir.ptr<!s32i>, [[TWO]] : !s64i), !cir.ptr<!s32i>
+// CIR-NEXT: [[ELEM2:%.*]] = cir.get_element [[ARR]][[[TWO]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s64i) -> !cir.ptr<!s32i>
 // CIR-NEXT: [[LOAD_C:%.*]] = cir.load{{.*}} [[C]] : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT: cir.store{{.*}} [[LOAD_C]], [[TH_EL]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT: cir.store{{.*}} [[LOAD_C]], [[ELEM2]] : !s32i, !cir.ptr<!s32i>
 
 void zero_init(int x) {
   int arr[3] = {x};
 }
 // CIR:  cir.func dso_local @zero_init
 // CIR:    [[VAR_ALLOC:%.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
-// CIR:    %1 = cir.alloca !cir.array<!s32i x 3>, !cir.ptr<!cir.array<!s32i x 3>>, ["arr", init] {alignment = 4 : i64}
+// CIR:    [[ARR:%.*]] = cir.alloca !cir.array<!s32i x 3>, !cir.ptr<!cir.array<!s32i x 3>>, ["arr", init] {alignment = 4 : i64}
 // CIR:    [[TEMP:%.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arrayinit.temp", init] {alignment = 8 : i64}
 // CIR:    cir.store{{.*}} %arg0, [[VAR_ALLOC]] : !s32i, !cir.ptr<!s32i>
-// CIR:    [[BEGIN:%.*]] = cir.cast(array_to_ptrdecay, %1 : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+// CIR:    [[ZERO:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR:    [[BEGIN:%.*]] = cir.get_element [[ARR]][[[ZERO]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
 // CIR:    [[VAR:%.*]] = cir.load{{.*}} [[VAR_ALLOC]] : !cir.ptr<!s32i>, !s32i
 // CIR:    cir.store{{.*}} [[VAR]], [[BEGIN]] : !s32i, !cir.ptr<!s32i>
 // CIR:    [[ONE:%.*]] = cir.const #cir.int<1> : !s64i
-// CIR:    [[ZERO_INIT_START:%.*]] = cir.ptr_stride([[BEGIN]] : !cir.ptr<!s32i>, [[ONE]] : !s64i), !cir.ptr<!s32i>
+// CIR:    [[ZERO_INIT_START:%.*]] = cir.get_element [[ARR]][[[ONE]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s64i) -> !cir.ptr<!s32i>
 // CIR:    cir.store{{.*}} [[ZERO_INIT_START]], [[TEMP]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CIR:    [[SIZE:%.*]] = cir.const #cir.int<3> : !s64i
-// CIR:    [[END:%.*]] = cir.ptr_stride([[BEGIN]] : !cir.ptr<!s32i>, [[SIZE]] : !s64i), !cir.ptr<!s32i>
+// CIR:    [[END:%.*]] = cir.get_element [[ARR]][[[SIZE]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s64i) -> !cir.ptr<!s32i>
 // CIR:    cir.do {
 // CIR:      [[CUR:%.*]] = cir.load{{.*}} [[TEMP]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CIR:      [[FILLER:%.*]] = cir.const #cir.int<0> : !s32i
@@ -99,26 +107,28 @@ void aggr_init() {
 // CIR:    [[TEMP:%.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arrayinit.temp", init] {alignment = 8 : i64}
 // CIR:    %3 = cir.const #cir.int<5> : !s32i
 // CIR:    cir.store{{.*}} %3, [[VAR_ALLOC]] : !s32i, !cir.ptr<!s32i>
-// CIR:    [[BEGIN:%.*]] = cir.cast(array_to_ptrdecay, %1 : !cir.ptr<!cir.array<!s32i x 5>>), !cir.ptr<!s32i>
-// CIR:    %5 = cir.const #cir.int<1> : !s32i
-// CIR:    cir.store{{.*}} %5, [[BEGIN]] : !s32i, !cir.ptr<!s32i>
-// CIR:    [[ONE:%.*]] = cir.const #cir.int<1> : !s64i
-// CIR:    %7 = cir.ptr_stride([[BEGIN]] : !cir.ptr<!s32i>, [[ONE]] : !s64i), !cir.ptr<!s32i>
-// CIR:    %8 = cir.const #cir.int<2> : !s32i
-// CIR:    cir.store{{.*}} %8, %7 : !s32i, !cir.ptr<!s32i>
-// CIR:    [[TWO:%.*]] = cir.const #cir.int<2> : !s64i
-// CIR:    %10 = cir.ptr_stride([[BEGIN]] : !cir.ptr<!s32i>, [[TWO]] : !s64i), !cir.ptr<!s32i>
-// CIR:    %11 = cir.const #cir.int<3> : !s32i
-// CIR:    cir.store{{.*}} %11, %10 : !s32i, !cir.ptr<!s32i>
-// CIR:    [[THREE:%.*]] = cir.const #cir.int<3> : !s64i
-// CIR:    %13 = cir.ptr_stride([[BEGIN]] : !cir.ptr<!s32i>, [[THREE]] : !s64i), !cir.ptr<!s32i>
+// CIR:    [[OFFSET0:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR:    [[BEGIN:%.*]] = cir.get_element %1[[[OFFSET0]]] : (!cir.ptr<!cir.array<!s32i x 5>>, !s32i) -> !cir.ptr<!s32i>
+// CIR:    [[ONE:%.*]] = cir.const #cir.int<1> : !s32i
+// CIR:    cir.store{{.*}} [[ONE]], [[BEGIN]] : !s32i, !cir.ptr<!s32i>
+// CIR:    [[OFFSET1:%.*]] = cir.const #cir.int<1> : !s64i
+// CIR:    [[ELEM1:%.*]] = cir.get_element %1[[[OFFSET1]]] : (!cir.ptr<!cir.array<!s32i x 5>>, !s64i) -> !cir.ptr<!s32i>
+// CIR:    [[TWO:%.*]] = cir.const #cir.int<2> : !s32i
+// CIR:    cir.store{{.*}} [[TWO]], [[ELEM1]] : !s32i, !cir.ptr<!s32i>
+// CIR:    [[OFFSET2:%.*]] = cir.const #cir.int<2> : !s64i
+// CIR:    [[ELEM2:%.*]] = cir.get_element %1[[[OFFSET2]]] : (!cir.ptr<!cir.array<!s32i x 5>>, !s64i) -> !cir.ptr<!s32i>
+// CIR:    [[THREE:%.*]] = cir.const #cir.int<3> : !s32i
+// CIR:    cir.store{{.*}} [[THREE]], [[ELEM2]] : !s32i, !cir.ptr<!s32i>
+// CIR:    [[OFFSET3:%.*]] = cir.const #cir.int<3> : !s64i
+// CIR:    [[ELEM3:%.*]] = cir.get_element %1[[[OFFSET3]]] : (!cir.ptr<!cir.array<!s32i x 5>>, !s64i) -> !cir.ptr<!s32i>
 // CIR:    [[VAR:%.*]] = cir.load{{.*}} [[VAR_ALLOC]] : !cir.ptr<!s32i>, !s32i
-// CIR:    cir.store{{.*}} [[VAR]], %13 : !s32i, !cir.ptr<!s32i>
+// CIR:    cir.store{{.*}} [[VAR]], [[ELEM3]] : !s32i, !cir.ptr<!s32i>
 // CIR:    [[ONE_VAR:%.*]] = cir.const #cir.int<1> : !s64i
-// CIR:    %16 = cir.ptr_stride(%13 : !cir.ptr<!s32i>, [[ONE_VAR]] : !s64i), !cir.ptr<!s32i>
-// CIR:    cir.store{{.*}} %16, [[TEMP]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
+// CIR:    [[OFFSET4:%.*]] = cir.binop(add, [[OFFSET3]], [[ONE_VAR]]) : !s64i
+// CIR:    [[LAST:%.*]] = cir.get_element %1[[[OFFSET4]]] : (!cir.ptr<!cir.array<!s32i x 5>>, !s64i) -> !cir.ptr<!s32i>
+// CIR:    cir.store{{.*}} [[LAST]], [[TEMP]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CIR:    [[SIZE:%.*]] = cir.const #cir.int<5> : !s64i
-// CIR:    [[END:%.*]] = cir.ptr_stride([[BEGIN]] : !cir.ptr<!s32i>, [[SIZE]] : !s64i), !cir.ptr<!s32i>
+// CIR:    [[END:%.*]] = cir.get_element %1[[[SIZE]]] : (!cir.ptr<!cir.array<!s32i x 5>>, !s64i) -> !cir.ptr<!s32i>
 // CIR:    cir.do {
 // CIR:      [[CUR:%.*]] = cir.load{{.*}} [[TEMP]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CIR:      [[FILLER:%.*]] = cir.const #cir.int<0> : !s32i
@@ -139,18 +149,18 @@ void aggr_init() {
 // LLVM:   %2 = alloca [5 x i32], i64 1, align 16
 // LLVM:   [[TEMP:%.*]] = alloca ptr, i64 1, align 8
 // LLVM:   store i32 5, ptr [[VAR_ALLOC]], align 4
-// LLVM:   [[BEGIN:%.*]] = getelementptr i32, ptr %2, i32 0
+// LLVM:   [[BEGIN:%.*]] = getelementptr [5 x i32], ptr %2, i32 0, i64 0
 // LLVM:   store i32 1, ptr [[BEGIN]], align 4
-// LLVM:   [[ONE:%.*]] = getelementptr i32, ptr [[BEGIN]], i64 1
+// LLVM:   [[ONE:%.*]] = getelementptr [5 x i32], ptr %2, i32 0, i64 1
 // LLVM:   store i32 2, ptr [[ONE]], align 4
-// LLVM:   [[TWO:%.*]] = getelementptr i32, ptr [[BEGIN]], i64 2
+// LLVM:   [[TWO:%.*]] = getelementptr [5 x i32], ptr %2, i32 0, i64 2
 // LLVM:   store i32 3, ptr [[TWO]], align 4
-// LLVM:   [[THREE:%.*]] = getelementptr i32, ptr [[BEGIN]], i64 3
+// LLVM:   [[THREE:%.*]] = getelementptr [5 x i32], ptr %2, i32 0, i64 3
 // LLVM:   [[VAR:%.*]] = load i32, ptr [[VAR_ALLOC]], align 4
 // LLVM:   store i32 [[VAR]], ptr [[THREE]], align 4
-// LLVM:   %9 = getelementptr i32, ptr [[THREE]], i64 1
-// LLVM:   store ptr %9, ptr [[TEMP]], align 8
-// LLVM:   [[END:%.*]] = getelementptr i32, ptr [[BEGIN]], i64 5
+// LLVM:   [[LAST:%.*]] = getelementptr [5 x i32], ptr %2, i32 0, i64 4
+// LLVM:   store ptr [[LAST]], ptr [[TEMP]], align 8
+// LLVM:   [[END:%.*]] = getelementptr [5 x i32], ptr %2, i32 0, i64 5
 // LLVM:   br label %14
 //
 // LLVM: 11:                                               ; preds = %14

--- a/clang/test/CIR/CodeGen/array-init.cpp
+++ b/clang/test/CIR/CodeGen/array-init.cpp
@@ -22,7 +22,7 @@ void foo() {
 // CHECK: %[[VAL_5:.*]] = cir.cast(array_to_ptrdecay, %[[VAL_4]] : !cir.ptr<!cir.array<!s32i x 2>>), !cir.ptr<!s32i>
 // CHECK: cir.store{{.*}} %[[VAL_5]], %[[VAL_1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CHECK: %[[VAL_6:.*]] = cir.const #cir.int<2> : !s64i
-// CHECK: %[[VAL_7:.*]] = cir.ptr_stride(%[[VAL_5]] : !cir.ptr<!s32i>, %[[VAL_6]] : !s64i), !cir.ptr<!s32i>
+// CHECK: %[[VAL_7:.*]] = cir.get_element %[[VAL_4]][%[[VAL_6]]] : (!cir.ptr<!cir.array<!s32i x 2>>, !s64i) -> !cir.ptr<!s32i>
 // CHECK: cir.do {
 // CHECK:     %[[VAL_8:.*]] = cir.load{{.*}} %[[VAL_1]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CHECK:     %[[VAL_9:.*]] = cir.const #cir.int<0> : !s32i

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -70,20 +70,24 @@ struct S {
 
 void testPointerDecaySubscriptAccess(int arr[]) {
 // CHECK: cir.func dso_local @{{.+}}testPointerDecaySubscriptAccess
-  arr[1];
+  arr[1] = 2;
+  // CHECK: %[[#TWO:]] = cir.const #cir.int<2> : !s32i
   // CHECK: %[[#BASE:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
   // CHECK: %[[#DIM1:]] = cir.const #cir.int<1> : !s32i
-  // CHECK: cir.ptr_stride(%[[#BASE]] : !cir.ptr<!s32i>, %[[#DIM1]] : !s32i), !cir.ptr<!s32i>
+  // CHECK: %[[#ELEM:]] = cir.ptr_stride(%[[#BASE]] : !cir.ptr<!s32i>, %[[#DIM1]] : !s32i), !cir.ptr<!s32i>
+  // CHECK: cir.store{{.*}} %[[#TWO]], %[[#ELEM]] : !s32i, !cir.ptr<!s32i>
 }
 
 void testPointerDecayedArrayMultiDimSubscriptAccess(int arr[][3]) {
 // CHECK: cir.func dso_local @{{.+}}testPointerDecayedArrayMultiDimSubscriptAccess
-  arr[1][2];
+  arr[1][2] = 3;
+  // CHECK: %[[#THREE:]] = cir.const #cir.int<3> : !s32i
   // CHECK: %[[#ARRAY:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.array<!s32i x 3>>>, !cir.ptr<!cir.array<!s32i x 3>>
   // CHECK: %[[#ONE:]] = cir.const #cir.int<1> : !s32i
   // CHECK: %[[#OUTER:]] = cir.ptr_stride(%[[#ARRAY]] : !cir.ptr<!cir.array<!s32i x 3>>, %[[#ONE]] : !s32i), !cir.ptr<!cir.array<!s32i x 3>>
   // CHECK: %[[#TWO:]] = cir.const #cir.int<2> : !s32i
   // CHECK: %[[#INNER:]] = cir.get_element %[[#OUTER]][%[[#TWO]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
+  // CHECK: cir.store{{.*}} %[[#THREE]], %[[#INNER]] : !s32i, !cir.ptr<!s32i>
 }
 
 void testArrayOfComplexType() { int _Complex a[4]; }

--- a/clang/test/CIR/CodeGen/clear_cache.c
+++ b/clang/test/CIR/CodeGen/clear_cache.c
@@ -13,9 +13,8 @@ char buffer[32] = "This is a largely unused buffer";
 // CIR:  %[[VAL_2:.*]] = cir.cast(array_to_ptrdecay, %[[VAL_1]] : !cir.ptr<!cir.array<!s8i x 32>>), !cir.ptr<!s8i>
 // CIR:  %[[VAL_3:.*]] = cir.cast(bitcast, %[[VAL_2]] : !cir.ptr<!s8i>), !cir.ptr<!void>
 // CIR:  %[[VAL_4:.*]] = cir.get_global @buffer : !cir.ptr<!cir.array<!s8i x 32>>
-// CIR:  %[[VAL_5:.*]] = cir.cast(array_to_ptrdecay, %[[VAL_4]] : !cir.ptr<!cir.array<!s8i x 32>>), !cir.ptr<!s8i>
 // CIR:  %[[VAL_6:.*]] = cir.const #cir.int<32> : !s32i
-// CIR:  %[[VAL_7:.*]] = cir.ptr_stride(%[[VAL_5]] : !cir.ptr<!s8i>, %[[VAL_6]] : !s32i), !cir.ptr<!s8i>
+// CIR:  %[[VAL_7:.*]] = cir.get_element %[[VAL_4]][%[[VAL_6]]] : (!cir.ptr<!cir.array<!s8i x 32>>, !s32i) -> !cir.ptr<!s8i>
 // CIR:  %[[VAL_8:.*]] = cir.cast(bitcast, %[[VAL_7]] : !cir.ptr<!s8i>), !cir.ptr<!void>
 // CIR:  cir.clear_cache %[[VAL_3]] : !cir.ptr<!void>, %[[VAL_8]],
 

--- a/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
+++ b/clang/test/CIR/CodeGen/initlist-ptr-ptr.cpp
@@ -28,12 +28,13 @@ void test() {
 // CIR: cir.scope {
 // CIR: [[INITLIST_LOCAL:%.*]] = cir.alloca [[INITLIST_TYPE]], !cir.ptr<[[INITLIST_TYPE]]>,
 // CIR: [[LOCAL_ELEM_ARRAY:%.*]] = cir.alloca !cir.array<!cir.ptr<!s8i> x 2>, !cir.ptr<!cir.array<!cir.ptr<!s8i> x 2>>,
-// CIR: [[FIRST_ELEM_PTR:%.*]] = cir.cast(array_to_ptrdecay, [[LOCAL_ELEM_ARRAY]] : !cir.ptr<!cir.array<!cir.ptr<!s8i> x 2>>), !cir.ptr<!cir.ptr<!s8i>>
+// CIR: [[ZERO:%.*]] = cir.const #cir.int<0>
+// CIR: [[FIRST_ELEM_PTR:%.*]] = cir.get_element [[LOCAL_ELEM_ARRAY]][[[ZERO]]] : (!cir.ptr<!cir.array<!cir.ptr<!s8i> x 2>>, !s32i) -> !cir.ptr<!cir.ptr<!s8i>>
 // CIR: [[XY_CHAR_ARRAY:%.*]] = cir.get_global [[STR_XY]]  : !cir.ptr<!cir.array<!s8i x 3>>
 // CIR: [[STR_XY_PTR:%.*]] = cir.cast(array_to_ptrdecay, [[XY_CHAR_ARRAY]] : !cir.ptr<!cir.array<!s8i x 3>>), !cir.ptr<!s8i>
 // CIR:  cir.store{{.*}} [[STR_XY_PTR]], [[FIRST_ELEM_PTR]] : !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
 // CIR: [[ONE:%.*]] = cir.const #cir.int<1>
-// CIR: [[NEXT_ELEM_PTR:%.*]] = cir.ptr_stride([[FIRST_ELEM_PTR]] : !cir.ptr<!cir.ptr<!s8i>>, [[ONE]] : !s64i), !cir.ptr<!cir.ptr<!s8i>>
+// CIR: [[NEXT_ELEM_PTR:%.*]] = cir.get_element [[LOCAL_ELEM_ARRAY]][[[ONE]]] : (!cir.ptr<!cir.array<!cir.ptr<!s8i> x 2>>, !s64i) -> !cir.ptr<!cir.ptr<!s8i>>
 // CIR: [[UV_CHAR_ARRAY:%.*]] = cir.get_global [[STR_UV]]  : !cir.ptr<!cir.array<!s8i x 3>>
 // CIR: [[STR_UV_PTR:%.*]] = cir.cast(array_to_ptrdecay, [[UV_CHAR_ARRAY]] : !cir.ptr<!cir.array<!s8i x 3>>), !cir.ptr<!s8i>
 // CIR:  cir.store{{.*}} [[STR_UV_PTR]], [[NEXT_ELEM_PTR]] : !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
@@ -67,9 +68,9 @@ void test() {
 // LLVM:  [[ELEM_ARRAY_PTR:%.*]] = alloca [2 x ptr], i64 1, align 8
 // LLVM: br label %[[SCOPE_START:.*]]
 // LLVM: [[SCOPE_START]]: ; preds = %0
-// LLVM:  [[PTR_FIRST_ELEM:%.*]] = getelementptr ptr, ptr [[ELEM_ARRAY_PTR]], i32 0
+// LLVM:  [[PTR_FIRST_ELEM:%.*]] = getelementptr [2 x ptr], ptr [[ELEM_ARRAY_PTR]], i32 0, i64 0
 // LLVM:  store ptr @.str, ptr [[PTR_FIRST_ELEM]], align 8
-// LLVM:  [[PTR_SECOND_ELEM:%.*]] = getelementptr ptr, ptr [[PTR_FIRST_ELEM]], i64 1
+// LLVM:  [[PTR_SECOND_ELEM:%.*]] = getelementptr [2 x ptr], ptr [[ELEM_ARRAY_PTR]], i32 0, i64 1
 // LLVM:  store ptr @.str.1, ptr [[PTR_SECOND_ELEM]], align 8
 // LLVM:  [[INIT_START_FLD_PTR:%.*]] = getelementptr %"class.std::initializer_list<const char *>", ptr [[INIT_STRUCT]], i32 0, i32 0
 // LLVM:  store ptr [[ELEM_ARRAY_PTR]], ptr [[INIT_START_FLD_PTR]], align 8

--- a/clang/test/CIR/CodeGen/initlist-ptr-unsigned.cpp
+++ b/clang/test/CIR/CodeGen/initlist-ptr-unsigned.cpp
@@ -26,9 +26,10 @@ void test() {
 // CIR: cir.scope {
 // CIR: [[LIST_PTR:%.*]] = cir.alloca [[INITLIST_TYPE]], !cir.ptr<[[INITLIST_TYPE]]>,
 // CIR: [[ARRAY:%.*]] = cir.alloca !cir.array<!s32i x 1>, !cir.ptr<!cir.array<!s32i x 1>>,
-// CIR: [[DECAY_PTR:%.*]] = cir.cast(array_to_ptrdecay, [[ARRAY]] : !cir.ptr<!cir.array<!s32i x 1>>), !cir.ptr<!s32i>
+// CIR: [[ZERO:%.*]] = cir.const #cir.int<0> : !s32i
+// CIR: [[FIRST_ELEM:%.*]] = cir.get_element [[ARRAY]][[[ZERO]]] : (!cir.ptr<!cir.array<!s32i x 1>>, !s32i) -> !cir.ptr<!s32i>
 // CIR: [[SEVEN:%.*]] = cir.const #cir.int<7> : !s32i
-// CIR: cir.store{{.*}} [[SEVEN]], [[DECAY_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR: cir.store{{.*}} [[SEVEN]], [[FIRST_ELEM]] : !s32i, !cir.ptr<!s32i>
 // CIR: [[FLD_C:%.*]] = cir.get_member [[LIST_PTR]][0] {name = "c"} : !cir.ptr<[[INITLIST_TYPE]]> -> !cir.ptr<!cir.ptr<!s32i>>
 // CIR: [[ARRAY_PTR:%.*]] = cir.cast(bitcast, [[FLD_C]] : !cir.ptr<!cir.ptr<!s32i>>), !cir.ptr<!cir.ptr<!cir.array<!s32i x 1>>>
 // CIR: cir.store{{.*}} [[ARRAY]], [[ARRAY_PTR]] : !cir.ptr<!cir.array<!s32i x 1>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 1>>>
@@ -51,7 +52,7 @@ void test() {
 // LLVM:  [[ELEM_ARRAY:%.*]] = alloca [1 x i32], i64 1, align 4
 // LLVM: br label %[[SCOPE_START:.*]]
 // LLVM: [[SCOPE_START]]: ; preds = %0
-// LLVM:  [[PTR_FIRST_ELEM:%.*]] = getelementptr i32, ptr [[ELEM_ARRAY]], i32 0
+// LLVM:  [[PTR_FIRST_ELEM:%.*]] = getelementptr [1 x i32], ptr [[ELEM_ARRAY]], i32 0, i64 0
 // LLVM:  store i32 7, ptr [[PTR_FIRST_ELEM]], align 4
 // LLVM:  [[ELEM_ARRAY_PTR:%.*]] = getelementptr %"class.std::initializer_list<int>", ptr [[INIT_STRUCT]], i32 0, i32 0
 // LLVM:  store ptr [[ELEM_ARRAY]], ptr [[ELEM_ARRAY_PTR]], align 8

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -303,27 +303,29 @@ void t_multidim_init() {
 // CHECK:    %[[NEW_PTR:.*]] = cir.call @_Znam(%2) : (!u64i) -> !cir.ptr<!void>
 // CHECK:    %[[ELEMENT_PTR:.*]] = cir.cast(bitcast, %[[NEW_PTR]] : !cir.ptr<!void>), !cir.ptr<!s32i>
 // CHECK:    %[[ARRAY_ELEM0_PTR:.*]] = cir.cast(bitcast, %[[ELEMENT_PTR]] : !cir.ptr<!s32i>), !cir.ptr<!cir.array<!s32i x 3>>
-// CHECK:    %[[ELEM_00_PTR:.*]] = cir.cast(array_to_ptrdecay, %[[ARRAY_ELEM0_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET0:.*]] = cir.const #cir.int<0> : !s32i
+// CHECK:    %[[ELEM_00_PTR:.*]] = cir.get_element %[[ARRAY_ELEM0_PTR]][%[[OFFSET0]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
 // CHECK:    %[[ELEM_00_VAL:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:    cir.store{{.*}} %[[ELEM_00_VAL]], %[[ELEM_00_PTR]] : !s32i, !cir.ptr<!s32i>
-// CHECK:    %[[OFFSET:.*]] = cir.const #cir.int<1> : !s64i
-// CHECK:    %[[ELEM_01_PTR:.*]] = cir.ptr_stride(%[[ELEM_00_PTR]] : !cir.ptr<!s32i>, %[[OFFSET]] : !s64i), !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET1:.*]] = cir.const #cir.int<1> : !s64i
+// CHECK:    %[[ELEM_01_PTR:.*]] = cir.get_element %[[ARRAY_ELEM0_PTR]][%[[OFFSET1]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s64i) -> !cir.ptr<!s32i>
 // CHECK:    %[[ELEM_01_VAL:.*]] = cir.const #cir.int<2> : !s32i
 // CHECK:    cir.store{{.*}} %[[ELEM_01_VAL]], %[[ELEM_01_PTR]] : !s32i, !cir.ptr<!s32i>
-// CHECK:    %[[OFFSET1:.*]] = cir.const #cir.int<2> : !s64i
-// CHECK:    %[[ELEM_02_PTR:.*]] = cir.ptr_stride(%[[ELEM_00_PTR]] : !cir.ptr<!s32i>, %[[OFFSET1]] : !s64i), !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET2:.*]] = cir.const #cir.int<2> : !s64i
+// CHECK:    %[[ELEM_02_PTR:.*]] = cir.get_element %[[ARRAY_ELEM0_PTR]][%[[OFFSET2]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s64i) -> !cir.ptr<!s32i>
 // CHECK:    %[[ELEM_02_VAL:.*]] = cir.const #cir.int<3> : !s32i
 // CHECK:    cir.store{{.*}} %[[ELEM_02_VAL]], %[[ELEM_02_PTR]] : !s32i, !cir.ptr<!s32i>
 // CHECK:    %[[OFFSET3:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:    %[[ARRAY_ELEM1_PTR:.*]] = cir.ptr_stride(%[[ARRAY_ELEM0_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>, %[[OFFSET3]] : !s32i), !cir.ptr<!cir.array<!s32i x 3>>
-// CHECK:    %[[ELEM_10_PTR:.*]] = cir.cast(array_to_ptrdecay, %[[ARRAY_ELEM1_PTR]] : !cir.ptr<!cir.array<!s32i x 3>>), !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET4:.*]] = cir.const #cir.int<0> : !s32i
+// CHECK:    %[[ELEM_10_PTR:.*]] = cir.get_element %[[ARRAY_ELEM1_PTR]][%[[OFFSET4]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s32i) -> !cir.ptr<!s32i>
 // CHECK:    %[[ELEM_10_VAL:.*]] = cir.const #cir.int<4> : !s32i
 // CHECK:    cir.store{{.*}} %[[ELEM_10_VAL]], %[[ELEM_10_PTR]] : !s32i, !cir.ptr<!s32i>
-// CHECK:    %[[OFFSET4:.*]] = cir.const #cir.int<1> : !s64i
-// CHECK:    %[[ELEM_11_PTR:.*]] = cir.ptr_stride(%[[ELEM_10_PTR]] : !cir.ptr<!s32i>, %[[OFFSET4]] : !s64i), !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET5:.*]] = cir.const #cir.int<1> : !s64i
+// CHECK:    %[[ELEM_11_PTR:.*]] = cir.get_element %[[ARRAY_ELEM1_PTR]][%[[OFFSET5]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s64i) -> !cir.ptr<!s32i>
 // CHECK:    %[[ELEM_11_VAL:.*]] = cir.const #cir.int<5> : !s32i
 // CHECK:    cir.store{{.*}} %[[ELEM_11_VAL]], %[[ELEM_11_PTR]] : !s32i, !cir.ptr<!s32i>
-// CHECK:    %[[OFFSET5:.*]] = cir.const #cir.int<2> : !s64i
-// CHECK:    %[[ELEM_12_PTR:.*]] = cir.ptr_stride(%[[ELEM_10_PTR]] : !cir.ptr<!s32i>, %21 : !s64i), !cir.ptr<!s32i>
+// CHECK:    %[[OFFSET6:.*]] = cir.const #cir.int<2> : !s64i
+// CHECK:    %[[ELEM_12_PTR:.*]] = cir.get_element %[[ARRAY_ELEM1_PTR]][%[[OFFSET6]]] : (!cir.ptr<!cir.array<!s32i x 3>>, !s64i) -> !cir.ptr<!s32i>
 // CHECK:    %[[ELEM_12_VAL:.*]] = cir.const #cir.int<6> : !s32i
 // CHECK:    cir.store{{.*}} %[[ELEM_12_VAL]], %[[ELEM_12_PTR]] : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGen/pointer-arith-ext.c
+++ b/clang/test/CIR/CodeGen/pointer-arith-ext.c
@@ -82,7 +82,8 @@ FP f7(FP a, int b) { return a - b; }
 // Similar to f7, just make sure it does not crash.
 FP f7_1(FP a, int b) { return (a -= b); }
 
-void f8(void *a, int b) { return *(a + b); }
+void *id(void *a) { return a; }
+void f8(void *a, int b) { return *(id(a + b)); }
 // CIR-LABEL: f8
 // CIR: %[[PTR:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR: %[[STRIDE:.*]] = cir.load{{.*}} {{.*}} : !cir.ptr<!s32i>, !s32i

--- a/clang/test/CIR/CodeGen/pointers.cpp
+++ b/clang/test/CIR/CodeGen/pointers.cpp
@@ -3,26 +3,26 @@
 
 // Should generate basic pointer arithmetics.
 void foo(int *iptr, char *cptr, unsigned ustride) {
-  iptr + 2;
+  *(iptr + 2) = 1;
   // CHECK: %[[#STRIDE:]] = cir.const #cir.int<2> : !s32i
   // CHECK: cir.ptr_stride(%{{.+}} : !cir.ptr<!s32i>, %[[#STRIDE]] : !s32i), !cir.ptr<!s32i>
-  cptr + 3;
+  *(cptr + 3) = 1;
   // CHECK: %[[#STRIDE:]] = cir.const #cir.int<3> : !s32i
   // CHECK: cir.ptr_stride(%{{.+}} : !cir.ptr<!s8i>, %[[#STRIDE]] : !s32i), !cir.ptr<!s8i>
-  iptr - 2;
+  *(iptr - 2) = 1;
   // CHECK: %[[#STRIDE:]] = cir.const #cir.int<2> : !s32i
   // CHECK: %[[#NEGSTRIDE:]] = cir.unary(minus, %[[#STRIDE]]) : !s32i, !s32i
   // CHECK: cir.ptr_stride(%{{.+}} : !cir.ptr<!s32i>, %[[#NEGSTRIDE]] : !s32i), !cir.ptr<!s32i>
-  cptr - 3;
+  *(cptr - 3) = 1;
   // CHECK: %[[#STRIDE:]] = cir.const #cir.int<3> : !s32i
   // CHECK: %[[#NEGSTRIDE:]] = cir.unary(minus, %[[#STRIDE]]) : !s32i, !s32i
   // CHECK: cir.ptr_stride(%{{.+}} : !cir.ptr<!s8i>, %[[#NEGSTRIDE]] : !s32i), !cir.ptr<!s8i>
-  iptr + ustride;
+  *(iptr + ustride) = 1;
   // CHECK: %[[#STRIDE:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
   // CHECK: cir.ptr_stride(%{{.+}} : !cir.ptr<!s32i>, %[[#STRIDE]] : !u32i), !cir.ptr<!s32i>
 
   // Must convert unsigned stride to a signed one.
-  iptr - ustride;
+  *(iptr - ustride) = 1;
   // CHECK: %[[#STRIDE:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!u32i>, !u32i
   // CHECK: %[[#SIGNSTRIDE:]] = cir.cast(integral, %[[#STRIDE]] : !u32i), !s32i
   // CHECK: %[[#NEGSTRIDE:]] = cir.unary(minus, %[[#SIGNSTRIDE]]) : !s32i, !s32i
@@ -31,7 +31,7 @@ void foo(int *iptr, char *cptr, unsigned ustride) {
 
 void testPointerSubscriptAccess(int *ptr) {
 // CHECK: testPointerSubscriptAccess
-  ptr[1];
+  ptr[1] = 2;
   // CHECK: %[[#V1:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
   // CHECK: %[[#V2:]] = cir.const #cir.int<1> : !s32i
   // CHECK: cir.ptr_stride(%[[#V1]] : !cir.ptr<!s32i>, %[[#V2]] : !s32i), !cir.ptr<!s32i>
@@ -39,7 +39,7 @@ void testPointerSubscriptAccess(int *ptr) {
 
 void testPointerMultiDimSubscriptAccess(int **ptr) {
 // CHECK: testPointerMultiDimSubscriptAccess
-  ptr[1][2];
+  ptr[1][2] = 3;
   // CHECK: %[[#V1:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.ptr<!s32i>>>, !cir.ptr<!cir.ptr<!s32i>>
   // CHECK: %[[#V2:]] = cir.const #cir.int<1> : !s32i
   // CHECK: %[[#V3:]] = cir.ptr_stride(%[[#V1]] : !cir.ptr<!cir.ptr<!s32i>>, %[[#V2]] : !s32i), !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGen/std-array.cpp
+++ b/clang/test/CIR/CodeGen/std-array.cpp
@@ -10,8 +10,4 @@ void t() {
 
 // CHECK: ![[array:.*]] = !cir.record<struct "std::array<unsigned char, 9U>"
 
-// CHECK: {{.*}} = cir.get_member
-// CHECK: {{.*}} = cir.cast(array_to_ptrdecay
-// CHECK: {{.*}} = cir.const #cir.int<9> : !u32i
-
 // CHECK: cir.call @_ZNSt5arrayIhLj9EE3endEv

--- a/clang/test/CIR/Lowering/new.cpp
+++ b/clang/test/CIR/Lowering/new.cpp
@@ -222,16 +222,16 @@ void t_multidim_init() {
 
 // LLVM:  @_Z15t_multidim_initv()
 // LLVM:    %[[ALLOC_PTR:.*]] = call ptr @_Znam(i64 24)
-// LLVM:    %[[ELEM_00_PTR:.*]] = getelementptr i32, ptr %[[ALLOC_PTR]], i32 0
+// LLVM:    %[[ELEM_00_PTR:.*]] = getelementptr [3 x i32], ptr %[[ALLOC_PTR]], i32 0, i64 0
 // LLVM:    store i32 1, ptr %[[ELEM_00_PTR]], align 4
-// LLVM:    %[[ELEM_01_PTR:.*]] = getelementptr i32, ptr %[[ELEM_00_PTR]], i64 1
+// LLVM:    %[[ELEM_01_PTR:.*]] = getelementptr [3 x i32], ptr %[[ALLOC_PTR]], i32 0, i64 1
 // LLVM:    store i32 2, ptr %[[ELEM_01_PTR]], align 4
-// LLVM:    %[[ELEM_02_PTR:.*]] = getelementptr i32, ptr %[[ELEM_00_PTR]], i64 2
+// LLVM:    %[[ELEM_02_PTR:.*]] = getelementptr [3 x i32], ptr %[[ALLOC_PTR]], i32 0, i64 2
 // LLVM:    store i32 3, ptr %[[ELEM_02_PTR]], align 4
 // LLVM:    %[[ELEM_1_PTR:.*]] = getelementptr [3 x i32], ptr %[[ALLOC_PTR]], i64 1
-// LLVM:    %[[ELEM_10_PTR:.*]] = getelementptr i32, ptr %[[ELEM_1_PTR]], i32 0
+// LLVM:    %[[ELEM_10_PTR:.*]] = getelementptr [3 x i32], ptr %[[ELEM_1_PTR]], i32 0, i64 0
 // LLVM:    store i32 4, ptr %[[ELEM_10_PTR]], align 4
-// LLVM:    %[[ELEM_11_PTR:.*]] = getelementptr i32, ptr %[[ELEM_10_PTR]], i64 1
+// LLVM:    %[[ELEM_11_PTR:.*]] = getelementptr [3 x i32], ptr %[[ELEM_1_PTR]], i32 0, i64 1
 // LLVM:    store i32 5, ptr %[[ELEM_11_PTR]], align 4
-// LLVM:    %[[ELEM_12_PTR:.*]] = getelementptr i32, ptr %[[ELEM_10_PTR]], i64 2
+// LLVM:    %[[ELEM_12_PTR:.*]] = getelementptr [3 x i32], ptr %[[ELEM_1_PTR]], i32 0, i64 2
 // LLVM:    store i32 6, ptr %[[ELEM_12_PTR]], align 4

--- a/clang/test/CIR/Transforms/simpl.cir
+++ b/clang/test/CIR/Transforms/simpl.cir
@@ -42,9 +42,14 @@ module {
   // CHECK:    %2 = cir.cast(integral, %1 : !s32i), !s64i
   // CHECK:    cir.return %2 : !s64i
 
+  cir.func @get_element(%arg0: !cir.ptr<!cir.array<!s32i x 5>>, %arg1: !s32i) -> !s32i {
+    %0 = cir.cast(array_to_ptrdecay, %arg0 : !cir.ptr<!cir.array<!s32i x 5>>), !cir.ptr<!s32i>
+    %1 = cir.ptr_stride(%0 : !cir.ptr<!s32i>, %arg1 : !s32i), !cir.ptr<!s32i>
+    %2 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+    cir.return %2 : !s32i
+  }
+  // CHECK: cir.func @get_element(%arg0: !cir.ptr<!cir.array<!s32i x 5>>, %arg1: !s32i) -> !s32i
+  // CHECK:   %0 = cir.get_element %arg0[%arg1] : (!cir.ptr<!cir.array<!s32i x 5>>, !s32i) -> !cir.ptr<!s32i>
+  // CHECK:   %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+  // CHECK:   cir.return %1 : !s32i
 }
-
-
-
-
-


### PR DESCRIPTION
Extended the `CIRCanonicalizePass` with new rewrite rules: 
- Rewrite `ptr_stride (cast array_to_ptrdecay %base), %index` to `get_element %base[%index]` 
- Rewrite `ptr_stride (get_element %base[%index]), %stride` to `get_element %base[%index + %stride]` 
- Rewrite `cast array_to_ptrdecay %base, ptr<T>` to `get_element %base[0], ptr<T>` if it is only used by `load %ptr : T`, `store %val : T, %ptr`, or `get_member %ptr[field] : ptr<T> -> U`

Updated CodeGen tests, and extended CIR-to-CIR test.