### PR TITLE
[CIR][Lowering] Enabled VAArg lowering for `cir::PointerType`

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareX86CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareX86CXXABI.cpp
@@ -91,7 +91,8 @@ mlir::Value LoweringPrepareX86CXXABI::lowerVAArgX86_64(
   // Let's hope LLVM's va_arg instruction can take care of it.
   // Remove this when X86_64ABIInfo::classify can take care of every type.
   if (!mlir::isa<VoidType, IntType, SingleType, DoubleType, BoolType,
-                 cir::RecordType, LongDoubleType>(op.getType()))
+                 cir::RecordType, LongDoubleType, cir::PointerType>(
+          op.getType()))
     return nullptr;
 
   // Assume that va_list type is correct; should be pointer to LLVM type:


### PR DESCRIPTION
`cir::PointerType` was not included in the applicability guard for `cir::VAArg` lowering during `LoweringPrepare`. 
Since we don't have generic LLVM `cir::VAArgOp` (see [more info](https://github.com/llvm/clangir/pull/1088#issuecomment-2465769265)) this causes an NYI error during lowering that doesn't need to happen. 
To fix this I added the missing `cir::PointerType` to the `isa`. 
There is probably a more comprehensive fix to this if someone is interested, this check should be removed and let the (possible) error occur at the actual NYI site.