### PR TITLE
[CIR] Simplify ConstantOp accesses and its getDefiningOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -459,6 +459,21 @@ def CIR_ConstantOp : CIR_Op<"const",[
        return ptrAttr.isNullValue();
       return false;
      }
+
+     template <typename T>
+     T getValueAttr() { return mlir::dyn_cast<T>(getValue()); }
+
+     llvm::APInt getIntValue() {
+       if (const auto intAttr = getValueAttr<cir::IntAttr>())
+         return intAttr.getValue();
+       llvm_unreachable("Expected an IntAttr in ConstantOp");
+     }
+
+     bool getBoolValue() {
+       if (const auto boolAttr = getValueAttr<cir::BoolAttr>())
+         return boolAttr.getValue();
+       llvm_unreachable("Expected a BoolAttr in ConstantOp");
+     }
   }];
 
   let hasFolder = 1;

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -382,14 +382,11 @@ static mlir::Value makeAtomicFenceValue(CIRGenFunction &cgf,
   auto &builder = cgf.getBuilder();
   mlir::Value orderingVal = cgf.emitScalarExpr(expr->getArg(0));
 
-  auto constOrdering =
-      mlir::dyn_cast<cir::ConstantOp>(orderingVal.getDefiningOp());
+  auto constOrdering = orderingVal.getDefiningOp<cir::ConstantOp>();
   if (!constOrdering)
     llvm_unreachable("NYI: variable ordering not supported");
 
-  auto constOrderingAttr =
-      mlir::dyn_cast<cir::IntAttr>(constOrdering.getValue());
-  if (constOrderingAttr) {
+  if (auto constOrderingAttr = constOrdering.getValueAttr<cir::IntAttr>()) {
     cir::MemOrder ordering =
         static_cast<cir::MemOrder>(constOrderingAttr.getUInt());
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -2123,10 +2123,7 @@ castVecOfFPTypeToVecOfIntWithSameWidth(CIRGenBuilderTy &builder,
 
 /// Get integer from a mlir::Value that is an int constant or a constant op.
 static int64_t getIntValueFromConstOp(mlir::Value val) {
-  auto constOp = mlir::cast<cir::ConstantOp>(val.getDefiningOp());
-  return (mlir::cast<cir::IntAttr>(constOp.getValue()))
-      .getValue()
-      .getSExtValue();
+  return val.getDefiningOp<cir::ConstantOp>().getIntValue().getSExtValue();
 }
 
 static mlir::Value emitNeonSplat(CIRGenBuilderTy &builder, mlir::Location loc,

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -68,10 +68,7 @@ translateX86ToMsvcIntrin(unsigned BuiltinID) {
 
 /// Get integer from a mlir::Value that is an int constant or a constant op.
 static int64_t getIntValueFromConstOp(mlir::Value val) {
-  auto constOp = mlir::cast<cir::ConstantOp>(val.getDefiningOp());
-  return (mlir::cast<cir::IntAttr>(constOp.getValue()))
-      .getValue()
-      .getSExtValue();
+  return val.getDefiningOp<cir::ConstantOp>().getIntValue().getSExtValue();
 }
 
 // Convert the mask from an integer type to a vector of i1.
@@ -274,9 +271,8 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned BuiltinID,
   case X86::BI__builtin_ia32_vec_ext_v4di: {
     unsigned NumElts = cast<cir::VectorType>(Ops[0].getType()).getSize();
 
-    auto constOp = cast<cir::ConstantOp>(Ops[1].getDefiningOp());
-    auto intAttr = cast<cir::IntAttr>(constOp.getValue());
-    uint64_t index = intAttr.getValue().getZExtValue();
+    uint64_t index =
+        Ops[1].getDefiningOp<cir::ConstantOp>().getIntValue().getZExtValue();
 
     index &= NumElts - 1;
 
@@ -301,9 +297,8 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned BuiltinID,
   case X86::BI__builtin_ia32_vec_set_v4di: {
     unsigned NumElts = cast<cir::VectorType>(Ops[0].getType()).getSize();
 
-    auto constOp = cast<cir::ConstantOp>(Ops[2].getDefiningOp());
-    auto intAttr = cast<cir::IntAttr>(constOp.getValue());
-    uint64_t index = intAttr.getValue().getZExtValue();
+    uint64_t index =
+        Ops[2].getDefiningOp<cir::ConstantOp>().getIntValue().getZExtValue();
 
     index &= NumElts - 1;
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -1678,8 +1678,8 @@ static bool isPreserveAIArrayBase(CIRGenFunction &CGF, const Expr *ArrayBase) {
 
 static mlir::IntegerAttr getConstantIndexOrNull(mlir::Value idx) {
   // TODO(cir): should we consider using MLIRs IndexType instead of IntegerAttr?
-  if (auto constantOp = dyn_cast<cir::ConstantOp>(idx.getDefiningOp()))
-    return mlir::dyn_cast<mlir::IntegerAttr>(constantOp.getValue());
+  if (auto constantOp = idx.getDefiningOp<cir::ConstantOp>())
+    return constantOp.getValueAttr<mlir::IntegerAttr>();
   return {};
 }
 
@@ -1687,8 +1687,7 @@ static CharUnits getArrayElementAlign(CharUnits arrayAlign, mlir::Value idx,
                                       CharUnits eltSize) {
   // If we have a constant index, we can use the exact offset of the
   // element we're accessing.
-  auto constantIdx = getConstantIndexOrNull(idx);
-  if (constantIdx) {
+  if (auto constantIdx = getConstantIndexOrNull(idx)) {
     CharUnits offset = constantIdx.getValue().getZExtValue() * eltSize;
     return arrayAlign.alignmentAtOffset(offset);
     // Otherwise, use the worst-case alignment for any element.

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1099,12 +1099,12 @@ void CIRGenFunction::emitNewArrayInitializer(
 
   // If all elements have already been initialized, skip any further
   // initialization.
-  auto ConstOp = dyn_cast<cir::ConstantOp>(NumElements.getDefiningOp());
-  if (ConstOp) {
-    auto ConstIntAttr = mlir::dyn_cast<cir::IntAttr>(ConstOp.getValue());
-    // Just skip out if the constant count is zero.
-    if (ConstIntAttr && ConstIntAttr.getUInt() <= InitListElements)
-      return;
+  if (auto ConstOp = NumElements.getDefiningOp<cir::ConstantOp>()) {
+    if (auto ConstIntAttr = ConstOp.getValueAttr<cir::IntAttr>()) {
+      // Just skip out if the constant count is zero.
+      if (ConstIntAttr.getUInt() <= InitListElements)
+        return;
+    }
   }
 
   assert(Init && "have trailing elements to initialize but no initializer");

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -2113,8 +2113,7 @@ mlir::Attribute ConstantEmitter::emitAbstract(SourceLocation loc,
 mlir::Attribute ConstantEmitter::emitNullForMemory(mlir::Location loc,
                                                    CIRGenModule &CGM,
                                                    QualType T) {
-  auto cstOp =
-      dyn_cast<cir::ConstantOp>(CGM.emitNullConstant(T, loc).getDefiningOp());
+  auto cstOp = CGM.emitNullConstant(T, loc).getDefiningOp<cir::ConstantOp>();
   assert(cstOp && "expected cir.const op");
   return emitForMemory(CGM, cstOp.getValue(), T);
 }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -54,8 +54,8 @@ struct BinOpInfo {
   /// Check if the binop can result in integer overflow.
   bool mayHaveIntegerOverflow() const {
     // Without constant input, we can't rule out overflow.
-    auto LHSCI = dyn_cast<cir::ConstantOp>(LHS.getDefiningOp());
-    auto RHSCI = dyn_cast<cir::ConstantOp>(RHS.getDefiningOp());
+    auto LHSCI = LHS.getDefiningOp<cir::ConstantOp>();
+    auto RHSCI = RHS.getDefiningOp<cir::ConstantOp>();
     if (!LHSCI || !RHSCI)
       return true;
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1025,7 +1025,7 @@ void cir::StoreOp::setAtomic(cir::MemOrder order) {
 
 OpFoldResult cir::VecCreateOp::fold(FoldAdaptor adaptor) {
   if (llvm::any_of(getElements(), [](mlir::Value value) {
-        return !mlir::isa<cir::ConstantOp>(value.getDefiningOp());
+        return !value.getDefiningOp<cir::ConstantOp>();
       }))
     return {};
 

--- a/clang/lib/CIR/Dialect/Transforms/CIRSimplify.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRSimplify.cpp
@@ -97,8 +97,8 @@ private:
     // Check whether the region/block contains a cir.const followed by a
     // cir.yield that yields the value.
     auto yieldOp = mlir::cast<cir::YieldOp>(onlyBlock.getTerminator());
-    auto yieldValueDefOp = mlir::dyn_cast_if_present<cir::ConstantOp>(
-        yieldOp.getArgs()[0].getDefiningOp());
+    auto yieldValueDefOp =
+        yieldOp.getArgs()[0].getDefiningOp<cir::ConstantOp>();
     return yieldValueDefOp && yieldValueDefOp->getBlock() == &onlyBlock;
   }
 };
@@ -108,18 +108,13 @@ struct SimplifySelect : public OpRewritePattern<SelectOp> {
 
   LogicalResult matchAndRewrite(SelectOp op,
                                 PatternRewriter &rewriter) const final {
-    mlir::Operation *trueValueOp = op.getTrueValue().getDefiningOp();
-    mlir::Operation *falseValueOp = op.getFalseValue().getDefiningOp();
-    auto trueValueConstOp =
-        mlir::dyn_cast_if_present<cir::ConstantOp>(trueValueOp);
-    auto falseValueConstOp =
-        mlir::dyn_cast_if_present<cir::ConstantOp>(falseValueOp);
-    if (!trueValueConstOp || !falseValueConstOp)
+    auto trueValueOp = op.getTrueValue().getDefiningOp<cir::ConstantOp>();
+    auto falseValueOp = op.getFalseValue().getDefiningOp<cir::ConstantOp>();
+    if (!trueValueOp || !falseValueOp)
       return mlir::failure();
 
-    auto trueValue = mlir::dyn_cast<cir::BoolAttr>(trueValueConstOp.getValue());
-    auto falseValue =
-        mlir::dyn_cast<cir::BoolAttr>(falseValueConstOp.getValue());
+    auto trueValue = trueValueOp.getValueAttr<cir::BoolAttr>();
+    auto falseValue = falseValueOp.getValueAttr<cir::BoolAttr>();
     if (!trueValue || !falseValue)
       return mlir::failure();
 
@@ -145,9 +140,7 @@ struct SimplifyVecSplat : public OpRewritePattern<VecSplatOp> {
   using OpRewritePattern<VecSplatOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(VecSplatOp op,
                                 PatternRewriter &rewriter) const override {
-    mlir::Value splatValue = op.getValue();
-    auto constant =
-        mlir::dyn_cast_if_present<cir::ConstantOp>(splatValue.getDefiningOp());
+    auto constant = op.getValue().getDefiningOp<cir::ConstantOp>();
     if (!constant)
       return mlir::failure();
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1423,8 +1423,7 @@ static std::string getGlobalVarNameForConstString(cir::StoreOp op,
 void LoweringPreparePass::lowerToMemCpy(StoreOp op) {
   // Now that basic filter is done, do more checks before proceding with the
   // transformation.
-  auto cstOp =
-      dyn_cast_if_present<cir::ConstantOp>(op.getValue().getDefiningOp());
+  auto cstOp = op.getValue().getDefiningOp<cir::ConstantOp>();
   if (!cstOp)
     return;
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -3657,12 +3657,11 @@ mlir::LogicalResult CIRToLLVMSelectOpLowering::matchAndRewrite(
     cir::SelectOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   auto getConstantBool = [](mlir::Value value) -> std::optional<bool> {
-    auto definingOp =
-        mlir::dyn_cast_if_present<cir::ConstantOp>(value.getDefiningOp());
+    auto definingOp = value.getDefiningOp<cir::ConstantOp>();
     if (!definingOp)
       return std::nullopt;
 
-    auto constValue = mlir::dyn_cast<cir::BoolAttr>(definingOp.getValue());
+    auto constValue = definingOp.getValueAttr<cir::BoolAttr>();
     if (!constValue)
       return std::nullopt;
 


### PR DESCRIPTION
- Replaces  dyn_cast<cir::ConstantOp>(v.getDefiningOp()) and similar with v.getDefiningOp<cir::ConstantOp>()
- Adds `getValueAttr`, `getIntValue` and `getBoolValue` methods to ConstantOp