### PR TITLE
[CIR] Use getDefiningOp<OpTy>() instead of dyn_cast<OpTy>(getDefiningOp()) (NFC)

### DIFF
--- a/clang/lib/CIR/CodeGen/Address.h
+++ b/clang/lib/CIR/CodeGen/Address.h
@@ -179,6 +179,10 @@ public:
       return nullptr;
     return getPointer().getDefiningOp();
   }
+
+  template <typename T> T getDefiningOp() const {
+    return mlir::dyn_cast_or_null<T>(getDefiningOp());
+  }
 };
 
 } // namespace clang::CIRGen

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -331,7 +331,7 @@ void CIRGenFunction::emitAutoVarInit(const AutoVarEmission &emission) {
     // out of it while trying to build the expression, mark it as such.
     auto addr = lv.getAddress().getPointer();
     assert(addr && "Should have an address");
-    auto allocaOp = dyn_cast_or_null<cir::AllocaOp>(addr.getDefiningOp());
+    auto allocaOp = addr.getDefiningOp<cir::AllocaOp>();
     assert(allocaOp && "Address should come straight out of the alloca");
 
     if (!allocaOp.use_empty())
@@ -617,7 +617,7 @@ void CIRGenFunction::emitStaticVarDecl(const VarDecl &D,
   // TODO(cir): we should have a way to represent global ops as values without
   // having to emit a get global op. Sometimes these emissions are not used.
   auto addr = getBuilder().createGetGlobal(globalOp);
-  auto getAddrOp = mlir::cast<cir::GetGlobalOp>(addr.getDefiningOp());
+  auto getAddrOp = addr.getDefiningOp<cir::GetGlobalOp>();
 
   CharUnits alignment = getContext().getDeclAlign(&D);
 

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -652,8 +652,7 @@ void CIRGenFunction::emitStoreOfScalar(mlir::Value value, Address addr,
 
   // Update the alloca with more info on initialization.
   assert(addr.getPointer() && "expected pointer to exist");
-  auto SrcAlloca =
-      dyn_cast_or_null<cir::AllocaOp>(addr.getPointer().getDefiningOp());
+  auto SrcAlloca = addr.getDefiningOp<cir::AllocaOp>();
   if (currVarDecl && SrcAlloca) {
     const VarDecl *VD = currVarDecl;
     assert(VD && "VarDecl expected");
@@ -1328,8 +1327,7 @@ LValue CIRGenFunction::emitUnaryOpLValue(const UnaryOperator *E) {
         emitPointerWithAlignment(E->getSubExpr(), &BaseInfo, &TBAAInfo);
 
     // Tag 'load' with deref attribute.
-    if (auto loadOp =
-            dyn_cast<cir::LoadOp>(Addr.getPointer().getDefiningOp())) {
+    if (auto loadOp = Addr.getDefiningOp<cir::LoadOp>()) {
       loadOp.setIsDerefAttr(mlir::UnitAttr::get(&getMLIRContext()));
     }
 
@@ -2221,8 +2219,7 @@ static Address createReferenceTemporary(CIRGenFunction &CGF,
     if (const clang::ValueDecl *extDecl = M->getExtendingDecl()) {
       auto extDeclAddrIter = CGF.LocalDeclMap.find(extDecl);
       if (extDeclAddrIter != CGF.LocalDeclMap.end()) {
-        extDeclAlloca = dyn_cast_if_present<cir::AllocaOp>(
-            extDeclAddrIter->second.getDefiningOp());
+        extDeclAlloca = extDeclAddrIter->second.getDefiningOp<cir::AllocaOp>();
       }
     }
     mlir::OpBuilder::InsertPoint ip;
@@ -2337,7 +2334,7 @@ LValue CIRGenFunction::emitMaterializeTemporaryExpr(
   Address Alloca = Address::invalid();
   Address Object = createReferenceTemporary(*this, M, E, &Alloca);
 
-  if (auto Var = dyn_cast<cir::GlobalOp>(Object.getPointer().getDefiningOp())) {
+  if (auto Var = Object.getDefiningOp<cir::GlobalOp>()) {
     // TODO(cir): add something akin to stripPointerCasts() to ptr above
     assert(0 && "NYI");
   } else {
@@ -2867,7 +2864,7 @@ mlir::Value CIRGenFunction::emitAlloca(StringRef name, mlir::Type ty,
     addr = builder.createAlloca(loc, /*addr type*/ localVarPtrTy,
                                 /*var type*/ ty, name, alignIntAttr, arraySize);
     if (currVarDecl) {
-      auto alloca = cast<cir::AllocaOp>(addr.getDefiningOp());
+      auto alloca = addr.getDefiningOp<cir::AllocaOp>();
       alloca.setAstAttr(ASTVarDeclAttr::get(&getMLIRContext(), currVarDecl));
     }
   }
@@ -3097,9 +3094,9 @@ cir::AllocaOp CIRGenFunction::CreateTempAlloca(mlir::Type Ty,
                                                const Twine &Name,
                                                mlir::Value ArraySize,
                                                bool insertIntoFnEntryBlock) {
-  return cast<cir::AllocaOp>(emitAlloca(Name.str(), Ty, Loc, CharUnits(),
-                                        insertIntoFnEntryBlock, ArraySize)
-                                 .getDefiningOp());
+  return emitAlloca(Name.str(), Ty, Loc, CharUnits(), insertIntoFnEntryBlock,
+                    ArraySize)
+      .getDefiningOp<cir::AllocaOp>();
 }
 
 /// This creates an alloca and inserts it into the provided insertion point
@@ -3109,9 +3106,8 @@ cir::AllocaOp CIRGenFunction::CreateTempAlloca(mlir::Type Ty,
                                                mlir::OpBuilder::InsertPoint ip,
                                                mlir::Value ArraySize) {
   assert(ip.isSet() && "Insertion point is not set");
-  return cast<cir::AllocaOp>(
-      emitAlloca(Name.str(), Ty, Loc, CharUnits(), ip, ArraySize)
-          .getDefiningOp());
+  return emitAlloca(Name.str(), Ty, Loc, CharUnits(), ip, ArraySize)
+      .getDefiningOp<cir::AllocaOp>();
 }
 
 /// Just like CreateTempAlloca above, but place the alloca into the function

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -370,7 +370,7 @@ public:
     // direclty in the parent scope removing the need to hoist it.
     assert(retAlloca.getDefiningOp() && "expected a alloca op");
     CGF.getBuilder().hoistAllocaToParentRegion(
-        cast<cir::AllocaOp>(retAlloca.getDefiningOp()));
+        retAlloca.getDefiningOp<cir::AllocaOp>());
 
     return CGF.emitLoadOfScalar(CGF.makeAddrLValue(retAlloca, E->getType()),
                                 E->getExprLoc());

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -293,7 +293,7 @@ mlir::LogicalResult CIRGenFunction::declare(const Decl *var, QualType ty,
   assert(!symbolTable.count(var) && "not supposed to be available just yet");
 
   addr = emitAlloca(namedVar->getName(), ty, loc, alignment);
-  auto allocaOp = cast<cir::AllocaOp>(addr.getDefiningOp());
+  auto allocaOp = addr.getDefiningOp<cir::AllocaOp>();
   if (isParam)
     allocaOp.setInitAttr(mlir::UnitAttr::get(&getMLIRContext()));
   if (ty->isReferenceType() || ty.isConstQualified())
@@ -313,7 +313,7 @@ mlir::LogicalResult CIRGenFunction::declare(Address addr, const Decl *var,
   assert(!symbolTable.count(var) && "not supposed to be available just yet");
 
   addrVal = addr.getPointer();
-  auto allocaOp = cast<cir::AllocaOp>(addrVal.getDefiningOp());
+  auto allocaOp = addrVal.getDefiningOp<cir::AllocaOp>();
   if (isParam)
     allocaOp.setInitAttr(mlir::UnitAttr::get(&getMLIRContext()));
   if (ty->isReferenceType() || ty.isConstQualified())
@@ -1986,7 +1986,7 @@ void CIRGenFunction::emitVarAnnotations(const VarDecl *decl, mlir::Value val) {
   for (const auto *annot : decl->specific_attrs<AnnotateAttr>()) {
     annotations.push_back(CGM.emitAnnotateAttr(annot));
   }
-  auto allocaOp = dyn_cast_or_null<cir::AllocaOp>(val.getDefiningOp());
+  auto allocaOp = val.getDefiningOp<cir::AllocaOp>();
   assert(allocaOp && "expects available alloca");
   allocaOp.setAnnotationsAttr(builder.getArrayAttr(annotations));
 }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -2653,10 +2653,10 @@ inline mlir::Value DominatingCIRValue::restore(CIRGenFunction &CGF,
     return value.getPointer();
 
   // Otherwise, it should be an alloca instruction, as set up in save().
-  auto alloca = mlir::cast<cir::AllocaOp>(value.getPointer().getDefiningOp());
+  auto alloca = value.getPointer().getDefiningOp<cir::AllocaOp>();
   mlir::Value val = CGF.getBuilder().createAlignedLoad(
       alloca.getLoc(), alloca.getType(), alloca);
-  cir::LoadOp loadOp = mlir::cast<cir::LoadOp>(val.getDefiningOp());
+  cir::LoadOp loadOp = val.getDefiningOp<cir::LoadOp>();
   loadOp.setAlignment(alloca.getAlignment());
   return val;
 }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -778,7 +778,7 @@ Value tryFoldCastChain(cir::CastOp op) {
     if (!isIntOrBoolCast(op))
       break;
     head = op;
-    op = dyn_cast_or_null<cir::CastOp>(head.getSrc().getDefiningOp());
+    op = head.getSrc().getDefiningOp<cir::CastOp>();
   }
 
   if (head == tail)
@@ -841,7 +841,7 @@ static bool isBoolNot(cir::UnaryOp op) {
 // and the argument of the first one (%0) will be used instead.
 OpFoldResult cir::UnaryOp::fold(FoldAdaptor adaptor) {
   if (isBoolNot(*this))
-    if (auto previous = dyn_cast_or_null<UnaryOp>(getInput().getDefiningOp()))
+    if (auto previous = getInput().getDefiningOp<UnaryOp>())
       if (isBoolNot(previous))
         return previous.getInput();
 

--- a/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LibOpt.cpp
@@ -172,8 +172,8 @@ void LibOptPass::xformStdFindIntoMemchr(StdFindOp findOp) {
   // Build memchr op:
   //  void *memchr(const void *s, int c, size_t n);
   auto memChr = [&] {
-    if (auto iterBegin = dyn_cast<IterBeginOp>(first.getDefiningOp());
-        iterBegin && isa<IterEndOp>(last.getDefiningOp())) {
+    if (auto iterBegin = first.getDefiningOp<IterBeginOp>();
+        iterBegin && last.getDefiningOp<IterEndOp>()) {
       // Both operands have the same type, use iterBegin.
 
       // Look at this pointer to retrieve container information.

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1412,7 +1412,7 @@ static std::string getGlobalVarNameForConstString(cir::StoreOp op,
     Out << "module.";
   }
 
-  auto allocaOp = dyn_cast_or_null<cir::AllocaOp>(op.getAddr().getDefiningOp());
+  auto allocaOp = op.getAddr().getDefiningOp<cir::AllocaOp>();
   if (allocaOp && !allocaOp.getName().empty())
     Out << allocaOp.getName();
   else

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRLoopToSCF.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRLoopToSCF.cpp
@@ -149,8 +149,8 @@ mlir::LogicalResult SCFLoop::findStepAndIV() {
       return mlir::failure();
 
     mlir::Value value = binary.getRhs();
-    if (auto constValue = dyn_cast<ConstantOp>(value.getDefiningOp());
-        isa<IntAttr>(constValue.getValue()))
+    if (auto constValue = value.getDefiningOp<cir::ConstantOp>();
+        constValue.getValueAttr<cir::IntAttr>())
       step = getConstant(constValue);
 
     if (binary.getKind() == BinOpKind::Add)


### PR DESCRIPTION
This applies similar changes to https://github.com/llvm/llvm-project/pull/150428