### PR TITLE
[CIR][CIRGen][Builtin][X86] lower undef intrinsics

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -271,7 +271,8 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned BuiltinID,
     // IR optimizer and backend.
     // TODO: If we had a "freeze" IR instruction to generate a fixed undef
     // value, we should use that here instead of a zero.
-    llvm_unreachable("__builtin_ia32_undefXX NYI");
+    return builder.getNullValue(convertType(E->getType()),
+                                getLoc(E->getExprLoc()));
   case X86::BI__builtin_ia32_vec_ext_v4hi:
   case X86::BI__builtin_ia32_vec_ext_v16qi:
   case X86::BI__builtin_ia32_vec_ext_v8hi:

--- a/clang/test/CIR/CodeGen/X86/avx-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/avx-builtins.c
@@ -23,6 +23,46 @@
 
 #include <immintrin.h>
 
+__m256 test_mm256_undefined_ps(void) {
+  // CIR-X64-LABEL: _mm256_undefined_ps
+  // CIR-X64: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 4>
+  // CIR-X64: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 4>), !cir.vector<!cir.float x 8>
+  // CIR-X64: cir.return %{{.*}} : !cir.vector<!cir.float x 8>
+
+  // LLVM-X64-LABEL: test_mm256_undefined_ps
+  // LLVM-X64: store <8 x float> zeroinitializer, ptr %[[A:.*]], align 32
+  // LLVM-X64: %{{.*}} = load <8 x float>, ptr %[[A]], align 32
+  // LLVM-X64: ret <8 x float> %{{.*}}
+
+  return _mm256_undefined_ps();
+}
+
+__m256d test_mm256_undefined_pd(void) {
+  // CIR-X64-LABEL: _mm256_undefined_pd
+  // CIR-X64: %{{.*}} = cir.const #cir.zero : !cir.vector<!cir.double x 4>
+  // CIR-X64: cir.return %{{.*}} : !cir.vector<!cir.double x 4>
+
+  // LLVM-X64-LABEL: test_mm256_undefined_pd
+  // LLVM-X64: store <4 x double> zeroinitializer, ptr %[[A:.*]], align 32
+  // LLVM-X64: %{{.*}} = load <4 x double>, ptr %[[A]], align 32
+  // LLVM-X64: ret <4 x double> %{{.*}}
+
+  return _mm256_undefined_pd();
+}
+
+__m256i test_mm256_undefined_si256(void) {
+  // CIR-X64-LABEL: _mm256_undefined_si256
+  // CIR-X64: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 4>
+  // CIR-X64: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 4>), !cir.vector<!s64i x 4>
+  // CIR-X64: cir.return %{{.*}} : !cir.vector<!s64i x 4>
+  
+  // LLVM-X64-LABEL: test_mm256_undefined_si256
+  // LLVM-X64: store <4 x i64> zeroinitializer, ptr %[[A:.*]], align 32
+  // LLVM-X64: %{{.*}} = load <4 x i64>, ptr %[[A]], align 32
+  // LLVM-X64: ret <4 x i64> %{{.*}}
+  return _mm256_undefined_si256();
+}
+
 int test_mm256_extract_epi8(__m256i A) {
   // CIR-CHECK-LABEL: test_mm256_extract_epi8
   // CIR-CHECK %{{.*}} = cir.vec.extract %{{.*}}[%{{.*}} : {{!u32i|!u64i}}] : !cir.vector<!s8i x 32>

--- a/clang/test/CIR/CodeGen/X86/avx10_2_512bf16-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/avx10_2_512bf16-builtins.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx10.2-512 -fclangir -emit-cir -o %t.cir -Wno-invalid-feature-combination -Wall -Werror -Wsign-conversion 
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx10.2-512 -fclangir -emit-llvm -o %t.ll -Wno-invalid-feature-combination -Wall -Werror -Wsign-conversion
+// RUN: FileCheck --check-prefixes=LLVM --input-file=%t.ll %s
+
+#include <immintrin.h>
+
+__m512bh test_mm512_undefined_pbh(void) {
+
+  // CIR-LABEL: _mm512_undefined_pbh
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 8>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 8>), !cir.vector<!cir.bf16 x 32>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.bf16 x 32>
+
+  // LLVM-LABEL: test_mm512_undefined_pbh
+  // LLVM: store <32 x bfloat> zeroinitializer, ptr %[[A:.*]], align 64
+  // LLVM: %{{.*}} = load <32 x bfloat>, ptr %[[A]], align 64
+  // LLVM: ret <32 x bfloat> %{{.*}}
+  return _mm512_undefined_pbh();
+}

--- a/clang/test/CIR/CodeGen/X86/avx10_2bf16-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/avx10_2bf16-builtins.c
@@ -5,6 +5,32 @@
 
 #include <immintrin.h>
 
+__m128bh test_mm_undefined_pbh(void) {
+  // CIR-LABEL: _mm_undefined_pbh
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 2>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 2>), !cir.vector<!cir.bf16 x 8>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.bf16 x 8>
+
+  // LLVM-LABEL: @test_mm_undefined_pbh
+  // LLVM: store <8 x bfloat> zeroinitializer, ptr %[[A:.*]], align 16
+  // LLVM: %{{.*}} = load <8 x bfloat>, ptr %[[A]], align 16
+  // LLVM: ret <8 x bfloat> %{{.*}}
+  return _mm_undefined_pbh();
+}
+
+__m256bh test_mm256_undefined_pbh(void) {
+  // CIR-LABEL: _mm256_undefined_pbh
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 4>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 4>), !cir.vector<!cir.bf16 x 16>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.bf16 x 16>
+
+  // LLVM-LABEL: @test_mm256_undefined_pbh
+  // LLVM: store <16 x bfloat> zeroinitializer, ptr %[[A:.*]], align 32
+  // LLVM: %{{.*}} = load <16 x bfloat>, ptr %[[A]], align 32
+  // LLVM: ret <16 x bfloat> %{{.*}}
+  return _mm256_undefined_pbh();
+}
+
 void test_mm_mask_store_sbh(void *__P, __mmask8 __U, __m128bh __A) {
   // CIR-LABEL: _mm_mask_store_sbh
   // CIR: cir.llvm.intrinsic "masked.store" %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (!cir.vector<!cir.bf16 x 8>, !cir.ptr<!cir.vector<!cir.bf16 x 8>>, !u32i, !cir.vector<!cir.int<s, 1> x 8>) -> !void

--- a/clang/test/CIR/CodeGen/X86/avx512f-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/avx512f-builtins.c
@@ -10,6 +10,57 @@
 
 #include <immintrin.h>
 
+__m512 test_mm512_undefined(void) {
+  // CIR-LABEL: _mm512_undefined
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 8>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 8>), !cir.vector<!cir.float x 16>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.float x 16>
+
+  // LLVM-LABEL: test_mm512_undefined
+  // LLVM: store <16 x float> zeroinitializer, ptr %[[A:.*]], align 64
+  // LLVM: %{{.*}} = load <16 x float>, ptr %[[A]], align 64
+  // LLVM: ret <16 x float> %{{.*}}
+  return _mm512_undefined();
+}
+
+__m512 test_mm512_undefined_ps(void) {
+  // CIR-LABEL: _mm512_undefined_ps
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 8>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 8>), !cir.vector<!cir.float x 16>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.float x 16>
+
+  // LLVM-LABEL: test_mm512_undefined_ps
+  // LLVM: store <16 x float> zeroinitializer, ptr %[[A:.*]], align 64
+  // LLVM: %{{.*}} = load <16 x float>, ptr %[[A]], align 64
+  // LLVM: ret <16 x float> %{{.*}}
+  return _mm512_undefined_ps();
+}
+
+__m512d test_mm512_undefined_pd(void) {
+  // CIR-LABEL: _mm512_undefined_pd
+  // CIR: %{{.*}} = cir.const #cir.zero : !cir.vector<!cir.double x 8>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.double x 8>
+
+  // LLVM-LABEL: test_mm512_undefined_pd
+  // LLVM: store <8 x double> zeroinitializer, ptr %[[A:.*]], align 64
+  // LLVM: %{{.*}} = load <8 x double>, ptr %[[A]], align 64
+  // LLVM: ret <8 x double> %{{.*}}
+  return _mm512_undefined_pd();
+}
+
+__m512i test_mm512_undefined_epi32(void) {
+  // CIR-LABEL: _mm512_undefined_epi32
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 8>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 8>), !cir.vector<!s64i x 8>
+  // CIR: cir.return %{{.*}} : !cir.vector<!s64i x 8>
+
+  // LLVM-LABEL: test_mm512_undefined_epi32
+  // LLVM: store <8 x i64> zeroinitializer, ptr %[[A:.*]], align 64
+  // LLVM: %{{.*}} = load <8 x i64>, ptr %[[A]], align 64
+  // LLVM: ret <8 x i64> %{{.*}}
+  return _mm512_undefined_epi32();
+}
+
 void test_mm512_mask_storeu_epi64(void *__P, __mmask8 __U, __m512i __A) {
   // CIR-LABEL: _mm512_mask_storeu_epi64
   // CIR: %{{.*}} = cir.llvm.intrinsic "masked.store" %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (!cir.vector<!s64i x 8>, !cir.ptr<!s64i>, !u32i, !cir.vector<!cir.int<s, 1> x 8>) -> !void

--- a/clang/test/CIR/CodeGen/X86/avx512fp16-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/avx512fp16-builtins.c
@@ -6,6 +6,45 @@
 
 #include <immintrin.h>
 
+__m128h test_mm_undefined_ph(void) {
+  // CIR-LABEL: _mm_undefined_ph
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 2>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 2>), !cir.vector<!cir.f16 x 8>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.f16 x 8>
+
+  // LLVM-LABEL: @test_mm_undefined_ph
+  // LLVM: store <8 x half> zeroinitializer, ptr %[[A:.*]], align 16
+  // LLVM: %{{.*}} = load <8 x half>, ptr %[[A]], align 16
+  // LLVM: ret <8 x half> %{{.*}}
+    return _mm_undefined_ph();
+}
+
+__m256h test_mm256_undefined_ph(void) {
+  // CIR-LABEL: _mm256_undefined_ph
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 4>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 4>), !cir.vector<!cir.f16 x 16>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.f16 x 16>
+
+  // LLVM-LABEL: @test_mm256_undefined_ph
+  // LLVM: store <16 x half> zeroinitializer, ptr %[[A:.*]], align 32
+  // LLVM: %{{.*}} = load <16 x half>, ptr %[[A]], align 32
+  // LLVM: ret <16 x half> %{{.*}}
+  return _mm256_undefined_ph();
+}
+
+__m512h test_mm512_undefined_ph(void) {
+  // CIR-LABEL: _mm512_undefined_ph
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 8>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 8>), !cir.vector<!cir.f16 x 32>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.f16 x 32>
+
+  // LLVM-LABEL: @test_mm512_undefined_ph
+  // LLVM: store <32 x half> zeroinitializer, ptr %[[A:.*]], align 64
+  // LLVM: %{{.*}} = load <32 x half>, ptr %[[A]], align 64
+  // LLVM: ret <32 x half> %{{.*}}
+  return _mm512_undefined_ph();
+}
+
 void test_mm_mask_store_sh(void *__P, __mmask8 __U, __m128h __A) {
   // CIR-LABEL: _mm_mask_store_sh
   // CIR: cir.llvm.intrinsic "masked.store" %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (!cir.vector<!cir.f16 x 8>, !cir.ptr<!cir.vector<!cir.f16 x 8>>, !u32i, !cir.vector<!cir.int<s, 1> x 8>) -> !void

--- a/clang/test/CIR/CodeGen/X86/sse-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse-builtins.c
@@ -29,3 +29,16 @@ void test_mm_sfence(void) {
   // CIR: {{%.*}} = cir.llvm.intrinsic "x86.sse.sfence" : () -> !void
   // LLVM: call void @llvm.x86.sse.sfence()
 }
+
+__m128 test_mm_undefined_ps(void) {
+  // CIR-LABEL: _mm_undefined_ps
+  // CIR: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 2>
+  // CIR: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 2>), !cir.vector<!cir.float x 4>
+  // CIR: cir.return %{{.*}} : !cir.vector<!cir.float x 4>
+
+  // LLVM-LABEL: test_mm_undefined_ps
+  // LLVM: store <4 x float> zeroinitializer, ptr %[[A:.*]], align 16
+  // LLVM: %{{.*}} = load <4 x float>, ptr %[[A]], align 16
+  // LLVM: ret <4 x float> %{{.*}}
+  return _mm_undefined_ps();
+}

--- a/clang/test/CIR/CodeGen/X86/sse2-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/sse2-builtins.c
@@ -1,12 +1,12 @@
 // RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fclangir -emit-cir -o %t.cir -Wall -Werror
-// RUN: FileCheck --check-prefixes=CIR-CHECK --input-file=%t.cir %s
+// RUN: FileCheck --check-prefixes=CIR-CHECK,CIR-X64 --input-file=%t.cir %s
 // RUN: %clang_cc1 -x c -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fno-signed-char -fclangir -emit-cir -o %t.cir -Wall -Werror
-// RUN: FileCheck --check-prefixes=CIR-CHECK --input-file=%t.cir %s
+// RUN: FileCheck --check-prefixes=CIR-CHECK,CIR-X64 --input-file=%t.cir %s
 
 // RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fclangir -emit-llvm -o %t.ll -Wall -Werror
-// RUN: FileCheck --check-prefixes=LLVM-CHECK --input-file=%t.ll %s
+// RUN: FileCheck --check-prefixes=LLVM-CHECK,LLVM-X64 --input-file=%t.ll %s
 // RUN: %clang_cc1 -x c++ -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +sse2 -fno-signed-char -fclangir -emit-llvm -o %t.ll -Wall -Werror
-// RUN: FileCheck --check-prefixes=LLVM-CHECK --input-file=%t.ll %s
+// RUN: FileCheck --check-prefixes=LLVM-CHECK,LLVM-X64 --input-file=%t.ll %s
 
 // This test mimics clang/test/CodeGen/X86/sse2-builtins.c, which eventually
 // CIR shall be able to support fully.
@@ -19,6 +19,31 @@ void test_mm_clflush(void* A) {
   _mm_clflush(A);
   // CIR-CHECK: {{%.*}} = cir.llvm.intrinsic "x86.sse2.clflush" {{%.*}} : (!cir.ptr<!void>) -> !void
   // LLVM-CHECK: call void @llvm.x86.sse2.clflush(ptr {{%.*}})
+}
+
+__m128d test_mm_undefined_pd(void) {
+  // CIR-X64-LABEL: _mm_undefined_pd
+  // CIR-X64: %{{.*}} = cir.const #cir.zero : !cir.vector<!cir.double x 2>
+  // CIR-X64: cir.return %{{.*}} : !cir.vector<!cir.double x 2>
+
+  // LLVM-X64-LABEL: test_mm_undefined_pd
+  // LLVM-X64: store <2 x double> zeroinitializer, ptr %[[A:.*]], align 16
+  // LLVM-X64: %{{.*}} = load <2 x double>, ptr %[[A]], align 16
+  // LLVM-X64: ret <2 x double> %{{.*}}
+  return _mm_undefined_pd();
+}
+
+__m128i test_mm_undefined_si128(void) {
+  // CIR-LABEL: _mm_undefined_si128
+  // CIR-CHECK: %[[A:.*]] = cir.const #cir.zero : !cir.vector<!cir.double x 2>
+  // CIR-CHECK: %{{.*}} = cir.cast(bitcast, %[[A]] : !cir.vector<!cir.double x 2>), !cir.vector<!s64i x 2>
+  // CIR-CHECK: cir.return %{{.*}} : !cir.vector<!s64i x 2>
+
+  // LLVM-CHECK-LABEL: test_mm_undefined_si128
+  // LLVM-CHECK: store <2 x i64> zeroinitializer, ptr %[[A:.*]], align 16
+  // LLVM-CHECK: %{{.*}} = load <2 x i64>, ptr %[[A]], align 16
+  // LLVM-CHECK: ret <2 x i64> %{{.*}}
+  return _mm_undefined_si128();
 }
 
 // Lowering to pextrw requires optimization.


### PR DESCRIPTION
We have seem to be generating extra load/store instructions as noted here for all null values encoded in this patch: 

CIR:

```llvm
define dso_local <8 x bfloat> @test_mm_undefined_pbh() #0 {
  %1 = alloca <8 x bfloat>, i64 1, align 16
  %2 = alloca <8 x bfloat>, i64 1, align 16
  store <8 x bfloat> zeroinitializer, ptr %1, align 16
  %3 = load <8 x bfloat>, ptr %1, align 16
  store <8 x bfloat> %3, ptr %2, align 16
  %4 = load <8 x bfloat>, ptr %2, align 16
  ret <8 x bfloat> %4
}
```

whereas OG:

```llvm
define dso_local <8 x bfloat> @test_mm_undefined_pbh() #0 {
entry:
  ret <8 x bfloat> zeroinitializer
}
```