### PR TITLE
[CIR] Added missing argument handling to `clang` toolchain

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5099,15 +5099,15 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_fclangir_mem2reg))
     CmdArgs.push_back("-fclangir-mem2reg");
 
-  if (Args.hasArg(options::OPT_fclangir_idiom_recognizer,
-                  options::OPT_fclangir_idiom_recognizer_EQ))
+  bool enable_idiom_recognizer = Args.hasArg(options::OPT_fclangir_idiom_recognizer,
+                                             options::OPT_fclangir_idiom_recognizer_EQ);
+  if (enable_idiom_recognizer)
     CmdArgs.push_back("-fclangir-idiom-recognizer");
 
   // ClangIR lib opt requires idiom recognizer.
   if (Args.hasArg(options::OPT_fclangir_lib_opt,
                   options::OPT_fclangir_lib_opt_EQ)) {
-    if (!Args.hasArg(options::OPT_fclangir_idiom_recognizer,
-                     options::OPT_fclangir_idiom_recognizer_EQ))
+    if (!enable_idiom_recognizer)
       CmdArgs.push_back("-fclangir-idiom-recognizer");
     CmdArgs.push_back("-fclangir-lib-opt");
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5099,6 +5099,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_fclangir_mem2reg))
     CmdArgs.push_back("-fclangir-mem2reg");
 
+  if (Args.hasArg(options::OPT_fclangir_idiom_recognizer,
+                  options::OPT_fclangir_idiom_recognizer_EQ))
+    CmdArgs.push_back("-fclangir-idiom-recognizer");
+
   // ClangIR lib opt requires idiom recognizer.
   if (Args.hasArg(options::OPT_fclangir_lib_opt,
                   options::OPT_fclangir_lib_opt_EQ)) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5109,6 +5109,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     if (!Args.hasArg(options::OPT_fclangir_idiom_recognizer,
                      options::OPT_fclangir_idiom_recognizer_EQ))
       CmdArgs.push_back("-fclangir-idiom-recognizer");
+    CmdArgs.push_back("-fclangir-lib-opt");
   }
 
   if (Args.hasArg(options::OPT_fclangir_analysis_only)) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5099,8 +5099,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_fclangir_mem2reg))
     CmdArgs.push_back("-fclangir-mem2reg");
 
-  bool enable_idiom_recognizer = Args.hasArg(options::OPT_fclangir_idiom_recognizer,
-                                             options::OPT_fclangir_idiom_recognizer_EQ);
+  bool enable_idiom_recognizer =
+      Args.hasArg(options::OPT_fclangir_idiom_recognizer,
+                  options::OPT_fclangir_idiom_recognizer_EQ);
   if (enable_idiom_recognizer)
     CmdArgs.push_back("-fclangir-idiom-recognizer");
 

--- a/clang/test/CIR/Driver/idiom-recognizer.cpp
+++ b/clang/test/CIR/Driver/idiom-recognizer.cpp
@@ -1,0 +1,2 @@
+// RUN: %clang %s -fclangir-idiom-recognizer -### -c %s 2>&1 | FileCheck --check-prefix=ENABLE %s
+// ENABLE: "-fclangir-idiom-recognizer"

--- a/clang/test/CIR/Driver/lib-opt.cpp
+++ b/clang/test/CIR/Driver/lib-opt.cpp
@@ -1,0 +1,2 @@
+// RUN: %clang %s -fclangir-lib-opt -### -c %s 2>&1 | FileCheck --check-prefix=ENABLE %s
+// ENABLE: "-fclangir-lib-opt"

--- a/clang/test/CIR/Driver/lib-opt.cpp
+++ b/clang/test/CIR/Driver/lib-opt.cpp
@@ -1,2 +1,3 @@
 // RUN: %clang %s -fclangir-lib-opt -### -c %s 2>&1 | FileCheck --check-prefix=ENABLE %s
 // ENABLE: "-fclangir-lib-opt"
+// ENABLE: "-fclangir-idiom-recognizer"


### PR DESCRIPTION
We were missing argument handling for `-fclangir-idiom-recognizer` on its own, and were not propagating `-fclangir-lib-opt` for the clang toolchain.