### PR TITLE
[CIR] Backport a fix for array element destruction order.

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1333,8 +1333,8 @@ void LoweringPreparePass::lowerDynamicCastOp(DynamicCastOp op) {
 
 static void lowerArrayDtorCtorIntoLoop(CIRBaseBuilderTy &builder,
                                        mlir::Operation *op, mlir::Type eltTy,
-                                       mlir::Value arrayAddr,
-                                       uint64_t arrayLen) {
+                                       mlir::Value arrayAddr, uint64_t arrayLen,
+                                       bool isCtor) {
   // Generate loop to call into ctor/dtor for every element.
   auto loc = op->getLoc();
 
@@ -1342,18 +1342,21 @@ static void lowerArrayDtorCtorIntoLoop(CIRBaseBuilderTy &builder,
   // with CIRGen stuff.
   auto ptrDiffTy =
       cir::IntType::get(builder.getContext(), 64, /*signed=*/false);
-  auto numArrayElementsConst = builder.create<cir::ConstantOp>(
-      loc, ptrDiffTy, cir::IntAttr::get(ptrDiffTy, arrayLen));
+  uint64_t endOffset = isCtor ? arrayLen : arrayLen - 1;
+  mlir::Value endOffsetVal = builder.create<cir::ConstantOp>(
+      loc, ptrDiffTy, cir::IntAttr::get(ptrDiffTy, endOffset));
 
   auto begin = builder.create<cir::CastOp>(
       loc, eltTy, cir::CastKind::array_to_ptrdecay, arrayAddr);
-  mlir::Value end = builder.create<cir::PtrStrideOp>(loc, eltTy, begin,
-                                                     numArrayElementsConst);
+  mlir::Value end =
+      builder.create<cir::PtrStrideOp>(loc, eltTy, begin, endOffsetVal);
+  mlir::Value start = isCtor ? begin : end;
+  mlir::Value stop = isCtor ? end : begin;
 
   auto tmpAddr = builder.createAlloca(
       loc, /*addr type*/ builder.getPointerTo(eltTy),
       /*var type*/ eltTy, "__array_idx", clang::CharUnits::One());
-  builder.createStore(loc, begin, tmpAddr);
+  builder.createStore(loc, start, tmpAddr);
 
   auto loop = builder.createDoWhile(
       loc,
@@ -1362,7 +1365,7 @@ static void lowerArrayDtorCtorIntoLoop(CIRBaseBuilderTy &builder,
         auto currentElement = b.create<cir::LoadOp>(loc, eltTy, tmpAddr);
         mlir::Type boolTy = cir::BoolType::get(b.getContext());
         auto cmp = builder.create<cir::CmpOp>(loc, boolTy, cir::CmpOpKind::ne,
-                                              currentElement, end);
+                                              currentElement, stop);
         builder.createCondition(cmp);
       },
       /*bodyBuilder=*/
@@ -1373,15 +1376,20 @@ static void lowerArrayDtorCtorIntoLoop(CIRBaseBuilderTy &builder,
         op->walk([&](CallOp c) { ctorCall = c; });
         assert(ctorCall && "expected ctor call");
 
-        auto one = builder.create<cir::ConstantOp>(
-            loc, ptrDiffTy, cir::IntAttr::get(ptrDiffTy, 1));
+        cir::ConstantOp stride;
+        if (isCtor)
+          stride = builder.create<cir::ConstantOp>(
+              loc, ptrDiffTy, cir::IntAttr::get(ptrDiffTy, 1));
+        else
+          stride = builder.create<cir::ConstantOp>(
+              loc, ptrDiffTy, cir::IntAttr::get(ptrDiffTy, -1));
 
-        ctorCall->moveAfter(one);
+        ctorCall->moveBefore(stride);
         ctorCall->setOperand(0, currentElement);
 
         // Advance pointer and store them to temporary variable
-        auto nextElement =
-            builder.create<cir::PtrStrideOp>(loc, eltTy, currentElement, one);
+        auto nextElement = builder.create<cir::PtrStrideOp>(
+            loc, eltTy, currentElement, stride);
         builder.createStore(loc, nextElement, tmpAddr);
         builder.createYield(loc);
       });
@@ -1397,7 +1405,7 @@ void LoweringPreparePass::lowerArrayDtor(ArrayDtor op) {
   auto eltTy = op->getRegion(0).getArgument(0).getType();
   auto arrayLen =
       mlir::cast<cir::ArrayType>(op.getAddr().getType().getPointee()).getSize();
-  lowerArrayDtorCtorIntoLoop(builder, op, eltTy, op.getAddr(), arrayLen);
+  lowerArrayDtorCtorIntoLoop(builder, op, eltTy, op.getAddr(), arrayLen, false);
 }
 
 static std::string getGlobalVarNameForConstString(cir::StoreOp op,
@@ -1460,7 +1468,7 @@ void LoweringPreparePass::lowerArrayCtor(ArrayCtor op) {
   auto eltTy = op->getRegion(0).getArgument(0).getType();
   auto arrayLen =
       mlir::cast<cir::ArrayType>(op.getAddr().getType().getPointee()).getSize();
-  lowerArrayDtorCtorIntoLoop(builder, op, eltTy, op.getAddr(), arrayLen);
+  lowerArrayDtorCtorIntoLoop(builder, op, eltTy, op.getAddr(), arrayLen, true);
 }
 
 void LoweringPreparePass::lowerStdFindOp(StdFindOp op) {

--- a/clang/test/CIR/CodeGen/array-init-destroy.cpp
+++ b/clang/test/CIR/CodeGen/array-init-destroy.cpp
@@ -46,25 +46,8 @@ void x() {
 // AFTER: cir.store %[[ArrayBegin]], %[[TmpIdx]] : !cir.ptr<!rec_xpto>, !cir.ptr<!cir.ptr<!rec_xpto>>
 // AFTER: cir.do {
 // AFTER:   %[[ArrayElt:.*]] = cir.load %[[TmpIdx]] : !cir.ptr<!cir.ptr<!rec_xpto>>, !cir.ptr<!rec_xpto>
-// AFTER:   %[[ConstOne:.*]] = cir.const #cir.int<1> : !u64i
 // AFTER:   cir.call @_ZN4xptoC1Ev(%[[ArrayElt]]) : (!cir.ptr<!rec_xpto>) -> ()
-// AFTER:   %[[NextElt:.*]] = cir.ptr_stride(%[[ArrayElt]] : !cir.ptr<!rec_xpto>, %[[ConstOne]] : !u64i), !cir.ptr<!rec_xpto>
-// AFTER:   cir.store %[[NextElt]], %[[TmpIdx]] : !cir.ptr<!rec_xpto>, !cir.ptr<!cir.ptr<!rec_xpto>>
-// AFTER:   cir.yield
-// AFTER: } while {
-// AFTER:   %[[ArrayElt:.*]] = cir.load %[[TmpIdx]] : !cir.ptr<!cir.ptr<!rec_xpto>>, !cir.ptr<!rec_xpto>
-// AFTER:   %[[ExitCond:.*]] = cir.cmp(ne, %[[ArrayElt]], %[[ArrayPastEnd]]) : !cir.ptr<!rec_xpto>, !cir.bool
-// AFTER:   cir.condition(%[[ExitCond]])
-// AFTER: }
-// AFTER: %[[ConstTwo:.*]] = cir.const #cir.int<2> : !u64i
-// AFTER: %[[ArrayBegin:.*]] = cir.cast(array_to_ptrdecay, %[[ArrayAddr0]] : !cir.ptr<!cir.array<!rec_xpto x 2>>), !cir.ptr<!rec_xpto>
-// AFTER: %[[ArrayPastEnd:.*]] = cir.ptr_stride(%[[ArrayBegin]] : !cir.ptr<!rec_xpto>, %[[ConstTwo]] : !u64i), !cir.ptr<!rec_xpto>
-// AFTER: %[[TmpIdx:.*]] = cir.alloca !cir.ptr<!rec_xpto>, !cir.ptr<!cir.ptr<!rec_xpto>>, ["__array_idx"] {alignment = 1 : i64}
-// AFTER: cir.store %[[ArrayBegin]], %[[TmpIdx]] : !cir.ptr<!rec_xpto>, !cir.ptr<!cir.ptr<!rec_xpto>>
-// AFTER: cir.do {
-// AFTER:   %[[ArrayElt:.*]] = cir.load %[[TmpIdx]] : !cir.ptr<!cir.ptr<!rec_xpto>>, !cir.ptr<!rec_xpto>
 // AFTER:   %[[ConstOne:.*]] = cir.const #cir.int<1> : !u64i
-// AFTER:   cir.call @_ZN4xptoD1Ev(%[[ArrayElt]]) : (!cir.ptr<!rec_xpto>) -> ()
 // AFTER:   %[[NextElt:.*]] = cir.ptr_stride(%[[ArrayElt]] : !cir.ptr<!rec_xpto>, %[[ConstOne]] : !u64i), !cir.ptr<!rec_xpto>
 // AFTER:   cir.store %[[NextElt]], %[[TmpIdx]] : !cir.ptr<!rec_xpto>, !cir.ptr<!cir.ptr<!rec_xpto>>
 // AFTER:   cir.yield
@@ -73,4 +56,21 @@ void x() {
 // AFTER:   %[[ExitCond:.*]] = cir.cmp(ne, %[[ArrayElt]], %[[ArrayPastEnd]]) : !cir.ptr<!rec_xpto>, !cir.bool
 // AFTER:   cir.condition(%[[ExitCond]])
 // AFTER: }
+// AFTER: %[[ConstOne:.*]] = cir.const #cir.int<1> : !u64i
+// AFTER: %[[ArrayBegin:.*]] = cir.cast(array_to_ptrdecay, %[[ArrayAddr0]] : !cir.ptr<!cir.array<!rec_xpto x 2>>), !cir.ptr<!rec_xpto>
+// AFTER: %[[ArrayEnd:.*]] = cir.ptr_stride(%[[ArrayBegin]] : !cir.ptr<!rec_xpto>, %[[ConstOne]] : !u64i), !cir.ptr<!rec_xpto>
+// AFTER: %[[TmpIdx:.*]] = cir.alloca !cir.ptr<!rec_xpto>, !cir.ptr<!cir.ptr<!rec_xpto>>, ["__array_idx"] {alignment = 1 : i64}
+// AFTER: cir.store %[[ArrayEnd]], %[[TmpIdx]] : !cir.ptr<!rec_xpto>, !cir.ptr<!cir.ptr<!rec_xpto>>
+// AFTER  cir.do {
+// AFTER    %[[ArrElt:.*]] = cir.load{{.*}} %[[TmpIdx]]
+// AFTER    cir.call @_ZN13array_elementD1Ev(%[[ArrElt]])  : (!cir.ptr<!rec_xpto>) -> ()
+// AFTER    %[[ConstNegOne:.*]] = cir.const #cir.int<-1> : !s64i
+// AFTER    %[[NextElt:.*]] = cir.ptr_stride(%[[ARR_CUR]] : !cir.ptr<!rec_xpto>, %[[ConstNegOne]] : !s64i), !cir.ptr<!rec_xpto>
+// AFTER    cir.store %[[NextElt]], %[[TmpIdx]] : !cir.ptr<!rec_xpto>, !cir.ptr<!cir.ptr<!rec_xpto>>
+// AFTER    cir.yield
+// AFTER  } while {
+// AFTER    %[[ArrElt:.*]] = cir.load %[[TmpIdx]] : !cir.ptr<!cir.ptr<!rec_xpto>>, !cir.ptr<!rec_xpto>
+// AFTER:   %[[ExitCond:.*]] = cir.cmp(ne, %[[ArrayElt]], %[[ArrayBegin]]) : !cir.ptr<!rec_xpto>, !cir.bool
+// AFTER    cir.condition(%[[ExitCond]])
+// AFTER   }
 // AFTER: cir.return

--- a/clang/test/CIR/CodeGen/array-new-init.cpp
+++ b/clang/test/CIR/CodeGen/array-new-init.cpp
@@ -48,8 +48,8 @@ void t_new_constant_size_constructor() {
 // AFTER:    cir.store{{.*}} %[[ELEM_PTR]], %[[CUR_ELEM_ALLOCA]] : !cir.ptr<!rec_E>, !cir.ptr<!cir.ptr<!rec_E>>
 // AFTER:    cir.do {
 // AFTER:      %[[CUR_ELEM_PTR:.*]] = cir.load %[[CUR_ELEM_ALLOCA]] : !cir.ptr<!cir.ptr<!rec_E>>, !cir.ptr<!rec_E>
-// AFTER:      %[[OFFSET:.*]] = cir.const #cir.int<1> : !u64i
 // AFTER:      cir.call @_ZN1EC1Ev(%[[CUR_ELEM_PTR]]) : (!cir.ptr<!rec_E>) -> ()
+// AFTER:      %[[OFFSET:.*]] = cir.const #cir.int<1> : !u64i
 // AFTER:      %[[NEXT_PTR:.*]] = cir.ptr_stride(%[[CUR_ELEM_PTR]] : !cir.ptr<!rec_E>, %[[OFFSET]] : !u64i), !cir.ptr<!rec_E>
 // AFTER:      cir.store{{.*}} %[[NEXT_PTR]], %[[CUR_ELEM_ALLOCA]] : !cir.ptr<!rec_E>, !cir.ptr<!cir.ptr<!rec_E>>
 // AFTER:      cir.yield


### PR DESCRIPTION
Previously, when an array of destructible object went out of scope, the object destructors were called in the same order that they were constructed. This is incorrect. The objects should be destructed in reverse order. This change fixes that.

This fixes https://github.com/llvm/clangir/issues/1759