### PR TITLE
[CIR][CodeGen] Attach hot attribute to CIR function

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -1201,6 +1201,10 @@ def CIR_ConvergentAttr : CIR_UnitAttr<"Convergent", "convergent"> {
   let storageType = [{ ConvergentAttr }];
 }
 
+def CIR_HotAttr : CIR_UnitAttr<"Hot", "hot"> {
+  let storageType = [{ HotAttr }];
+}
+
 //===----------------------------------------------------------------------===//
 // UWTableAttr
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2983,8 +2983,10 @@ void CIRGenModule::setCIRFunctionAttributesForDefinition(const Decl *decl,
     if (decl->hasAttr<ColdAttr>()) {
       llvm_unreachable("NYI");
     }
-    if (decl->hasAttr<HotAttr>())
-      llvm_unreachable("NYI");
+    if (decl->hasAttr<HotAttr>()) {
+      auto attr = cir::HotAttr::get(&getMLIRContext());
+      attrs.set(attr.getMnemonic(), attr);
+    }
     if (decl->hasAttr<MinSizeAttr>())
       assert(!MissingFeatures::minSize());
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -73,10 +73,10 @@ private:
             mlir::dyn_cast<cir::OpenCLVersionAttr>(attribute.getValue())) {
       auto *int32Ty = llvm::IntegerType::get(llvmContext, 32);
       llvm::Metadata *oclVerElts[] = {
-          llvm::ConstantAsMetadata::get(
-              llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMajorVersion())),
-          llvm::ConstantAsMetadata::get(
-              llvm::ConstantInt::get(int32Ty, openclVersionAttr.getMinorVersion()))};
+          llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
+              int32Ty, openclVersionAttr.getMajorVersion())),
+          llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
+              int32Ty, openclVersionAttr.getMinorVersion()))};
       llvm::NamedMDNode *oclVerMD =
           llvmModule->getOrInsertNamedMetadata("opencl.ocl.version");
       oclVerMD->addOperand(llvm::MDNode::get(llvmContext, oclVerElts));
@@ -116,6 +116,8 @@ private:
           llvmFunc->addFnAttr(llvm::Attribute::NoUnwind);
         } else if (mlir::dyn_cast<cir::ConvergentAttr>(attr.getValue())) {
           llvmFunc->addFnAttr(llvm::Attribute::Convergent);
+        } else if (mlir::isa<cir::HotAttr>(attr.getValue())) {
+          llvmFunc->addFnAttr(llvm::Attribute::Hot);
         } else if (mlir::dyn_cast<cir::OpenCLKernelAttr>(attr.getValue())) {
           const auto uniformAttrName =
               cir::OpenCLKernelUniformWorkGroupSizeAttr::getMnemonic();
@@ -229,7 +231,7 @@ private:
     };
 
     bool shouldEmitArgName = !!clArgMetadata.getName();
-    
+
     auto addressSpaceValues =
         clArgMetadata.getAddrSpace().getAsValueRange<mlir::IntegerAttr>();
 

--- a/clang/test/CIR/CodeGen/hot-attr.cpp
+++ b/clang/test/CIR/CodeGen/hot-attr.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -O2 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -O2 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+__attribute__((hot)) int s0(int a, int b) {
+  int x = a + b;
+  return x;
+}
+
+// CIR:      #[[ATTR0:.+]] = #cir<extra({{{.*}}hot = #cir.hot
+// CIR:      cir.func dso_local @_Z2s0ii(
+// CIR-SAME:     -> !s32i extra(#[[ATTR0]])
+
+// LLVM: define dso_local i32 @_Z2s0ii({{.*}} #[[#ATTR1:]] {
+// LLVM: attributes #[[#ATTR1]] = {{.*}} hot


### PR DESCRIPTION
Implemented missing feature for issue #1793. Also implemented LLVM lowering for the hot attribute, and added a new test case.