### PR TITLE
[CIR] Add IITDescriptor type cases

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -472,15 +472,63 @@ decodeFixedType(ArrayRef<llvm::Intrinsic::IITDescriptor> &infos,
   switch (descriptor.Kind) {
   case IITDescriptor::Void:
     return VoidType::get(context);
-  case IITDescriptor::Integer:
-    return IntType::get(context, descriptor.Integer_Width, /*signed=*/true);
+  case IITDescriptor::VarArg:
+    llvm_unreachable("NYI: IITDescriptor::VarArg");
+  case IITDescriptor::MMX:
+    llvm_unreachable("NYI: IITDescriptor::MMX");
+  case IITDescriptor::Token:
+    llvm_unreachable("NYI: IITDescriptor::Token");
+  case IITDescriptor::Metadata:
+    llvm_unreachable("NYI: IITDescriptor::Metadata");
+  case IITDescriptor::Half:
+    llvm_unreachable("NYI: IITDescriptor::Half");
+  case IITDescriptor::BFloat:
+    llvm_unreachable("NYI: IITDescriptor::BFloat");
   case IITDescriptor::Float:
     return SingleType::get(context);
   case IITDescriptor::Double:
     return DoubleType::get(context);
-  default:
-    llvm_unreachable("NYI");
+  case IITDescriptor::Quad:
+    llvm_unreachable("NYI: IITDescriptor::Quad");
+  case IITDescriptor::Integer:
+    return IntType::get(context, descriptor.Integer_Width, /*isSigned=*/true);
+  case IITDescriptor::Vector: {
+    mlir::Type elementType = decodeFixedType(infos, context);
+    unsigned numElements = descriptor.Vector_Width.getFixedValue();
+    return cir::VectorType::get(context, elementType, numElements);
   }
+  case IITDescriptor::Pointer:
+    llvm_unreachable("NYI: IITDescriptor::Pointer");
+  case IITDescriptor::Struct:
+    llvm_unreachable("NYI: IITDescriptor::Struct");
+  case IITDescriptor::Argument:
+    llvm_unreachable("NYI: IITDescriptor::Argument");
+  case IITDescriptor::ExtendArgument:
+    llvm_unreachable("NYI: IITDescriptor::ExtendArgument");
+  case IITDescriptor::TruncArgument:
+    llvm_unreachable("NYI: IITDescriptor::TruncArgument");
+  case IITDescriptor::OneNthEltsVecArgument:
+    llvm_unreachable("NYI: IITDescriptor::OneNthEltsVecArgument");
+  case IITDescriptor::SameVecWidthArgument:
+    llvm_unreachable("NYI: IITDescriptor::SameVecWidthArgument");
+  case IITDescriptor::VecOfAnyPtrsToElt:
+    llvm_unreachable("NYI: IITDescriptor::VecOfAnyPtrsToElt");
+  case IITDescriptor::VecElementArgument:
+    llvm_unreachable("NYI: IITDescriptor::VecElementArgument");
+  case IITDescriptor::Subdivide2Argument:
+    llvm_unreachable("NYI: IITDescriptor::Subdivide2Argument");
+  case IITDescriptor::Subdivide4Argument:
+    llvm_unreachable("NYI: IITDescriptor::Subdivide4Argument");
+  case IITDescriptor::VecOfBitcastsToInt:
+    llvm_unreachable("NYI: IITDescriptor::VecOfBitcastsToInt");
+  case IITDescriptor::AMX:
+    llvm_unreachable("NYI: IITDescriptor::AMX");
+  case IITDescriptor::PPCQuad:
+    llvm_unreachable("NYI: IITDescriptor::PPCQuad");
+  case IITDescriptor::AArch64Svcount:
+    llvm_unreachable("NYI: IITDescriptor::AArch64Svcount");
+  }
+  llvm_unreachable("Unhandled IITDescriptor, must return from switch");
 }
 
 // llvm::Intrinsics accepts only LLVMContext. We need to reimplement it here.

--- a/clang/test/CIR/CodeGen/builtin-types.c
+++ b/clang/test/CIR/CodeGen/builtin-types.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -flax-vector-conversions=none -ffreestanding %s -triple=x86_64-unknown-linux -target-feature +avx10.2-256 -fclangir -emit-cir -o %t.cir
+// RUN: FileCheck --check-prefix=CIR-CHECK --input-file=%t.cir %s
+
+// CIR-CHECK: !cir.vector<!s16i x 8>
+#include <emmintrin.h>
+int A() { __m128i h = _mm_srli_epi16(h, 0); }


### PR DESCRIPTION
This patch adds support for IITDescriptor::Vector type and adds
NYI for the others.