### PR TITLE
[CIR] Provide syntax highlighting support of clang ir for vim/nvim users

### DIFF
--- a/mlir/utils/vim/ftdetect/cir.vim
+++ b/mlir/utils/vim/ftdetect/cir.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.cir set filetype=cir

--- a/mlir/utils/vim/syntax/cir.vim
+++ b/mlir/utils/vim/syntax/cir.vim
@@ -1,0 +1,165 @@
+" Vim syntax file
+" Language:   cir
+" Maintainer: The CIR team
+" Version:      $Revision$
+" Some parts adapted from the LLVM and MLIR vim syntax file.
+
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+syn case match
+
+" Types.
+"
+syn keyword mlirType index f16 f32 f64 bf16
+" Signless integer types.
+syn match mlirType /\<i\d\+\>/
+" Unsigned integer types.
+syn match mlirType /\<ui\d\+\>/
+" Signed integer types.
+syn match mlirType /\<si\d\+\>/
+
+" Elemental types inside memref, tensor, or vector types.
+syn match mlirType /x\s*\zs\(bf16|f16\|f32\|f64\|i\d\+\|ui\d\+\|si\d\+\)/
+
+" Shaped types.
+syn match mlirType /\<memref\ze\s*<.*>/
+syn match mlirType /\<tensor\ze\s*<.*>/
+syn match mlirType /\<vector\ze\s*<.*>/
+
+" vector types inside memref or tensor.
+syn match mlirType /x\s*\zsvector/
+
+" Operations.
+" TODO: this list is not exhaustive.
+syn keyword mlirOps alloc alloca addf addi and call call_indirect cmpf cmpi
+syn keyword mlirOps constant dealloc divf dma_start dma_wait dim exp
+syn keyword mlirOps getTensor index_cast load log memref_cast
+syn keyword mlirOps memref_shape_cast mulf muli negf powf prefetch rsqrt sitofp
+syn keyword mlirOps splat store select sqrt subf subi subview tanh
+syn keyword mlirOps view
+
+" Math ops.
+syn match mlirOps /\<math\.erf\>/
+syn match mlirOps /\<math\.erfc\>/
+
+" Affine ops.
+syn match mlirOps /\<affine\.apply\>/
+syn match mlirOps /\<affine\.dma_start\>/
+syn match mlirOps /\<affine\.dma_wait\>/
+syn match mlirOps /\<affine\.for\>/
+syn match mlirOps /\<affine\.if\>/
+syn match mlirOps /\<affine\.load\>/
+syn match mlirOps /\<affine\.parallel\>/
+syn match mlirOps /\<affine\.prefetch\>/
+syn match mlirOps /\<affine\.store\>/
+syn match mlirOps /\<scf\.execute_region\>/
+syn match mlirOps /\<scf\.for\>/
+syn match mlirOps /\<scf\.if\>/
+syn match mlirOps /\<scf\.yield\>/
+
+
+" TODO: dialect name prefixed ops (llvm or std).
+
+" Keywords.
+syn keyword mlirKeyword
+      \ affine_map
+      \ affine_set
+      \ dense
+      \ else
+      \ func
+      \ module
+      \ return
+      \ step
+      \ to
+
+" Misc syntax.
+
+syn match   mlirNumber /-\?\<\d\+\>/
+" Match numbers even in shaped types.
+syn match   mlirNumber /-\?\<\d\+\ze\s*x/
+syn match   mlirNumber /x\s*\zs-\?\d\+\ze\s*x/
+
+syn match   mlirFloat  /-\?\<\d\+\.\d*\(e[+-]\d\+\)\?\>/
+syn match   mlirFloat  /\<0x\x\+\>/
+syn keyword mlirBoolean true false
+" Spell checking is enabled only in comments by default.
+syn match   mlirComment /\/\/.*$/ contains=@Spell
+syn region  mlirString start=/"/ skip=/\\"/ end=/"/
+syn match   mlirLabel /[-a-zA-Z$._][-a-zA-Z$._0-9]*:/
+" Prefixed identifiers usually used for ssa values and symbols.
+syn match   mlirIdentifier /[%@][a-zA-Z$._-][a-zA-Z0-9$._-]*/
+syn match   mlirIdentifier /[%@]\d\+\>/
+" Prefixed identifiers usually used for blocks.
+syn match   mlirBlockIdentifier /\^[a-zA-Z$._-][a-zA-Z0-9$._-]*/
+syn match   mlirBlockIdentifier /\^\d\+\>/
+" Prefixed identifiers usually used for types.
+syn match   mlirTypeIdentifier /![a-zA-Z$._-][a-zA-Z0-9$._-]*/
+syn match   mlirTypeIdentifier /!\d\+\>/
+" Prefixed identifiers usually used for attribute aliases and result numbers.
+syn match   mlirAttrIdentifier /#[a-zA-Z$._-][a-zA-Z0-9$._-]*/
+syn match   mlirAttrIdentifier /#\d\+\>/
+
+" Syntax-highlight lit test commands and bug numbers.
+syn match  mlirSpecialComment /\/\/\s*RUN:.*$/
+syn match  mlirSpecialComment /\/\/\s*CHECK:.*$/
+syn match  mlirSpecialComment "\v\/\/\s*CHECK-(NEXT|NOT|DAG|SAME|LABEL):.*$"
+syn match  mlirSpecialComment /\/\/\s*expected-error.*$/
+syn match  mlirSpecialComment /\/\/\s*expected-remark.*$/
+syn match  mlirSpecialComment /;\s*XFAIL:.*$/
+syn match  mlirSpecialComment /\/\/\s*PR\d*\s*$/
+syn match  mlirSpecialComment /\/\/\s*REQUIRES:.*$/
+
+"""""""""""" CIR SECTION """"""""""""
+" CIR blanket operations
+syn match cirOps /\vcir(\.\w+)+/
+
+syn keyword cirKeyword
+      \ from to cond body step
+      \ align alignment init
+      \ cond exception
+      \ null
+      \ coroutine suspend resume cleanup
+      \ class union struct
+      \ do while
+      \ if then else
+      \ nsw nuw
+      \ equal default anyof
+      \ internal external private linkonce_odr
+
+syn keyword cirType bytes
+
+if version >= 508 || !exists("did_c_syn_inits")
+  if version < 508
+    let did_c_syn_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  HiLink mlirType Type
+  HiLink mlirOps Statement
+  HiLink mlirNumber Number
+  HiLink mlirComment Comment
+  HiLink mlirString String
+  HiLink mlirLabel Label
+  HiLink mlirKeyword Keyword
+  HiLink mlirBoolean Boolean
+  HiLink mlirFloat Float
+  HiLink mlirConstant Constant
+  HiLink mlirSpecialComment SpecialComment
+  HiLink mlirIdentifier Identifier
+  HiLink mlirBlockIdentifier Label
+  HiLink mlirTypeIdentifier Type
+  HiLink mlirAttrIdentifier PreProc
+
+  HiLink cirType Type
+  HiLink cirOps Statement
+  HiLink cirKeyword Keyword
+  delcommand HiLink
+endif
+
+let b:current_syntax = "cir"


### PR DESCRIPTION
Hi there, I'm opening the PR to add syntax highlighting support for vim and neovim users.

The PR borrows a lot from MLIR but also add
- Dedicated CIR types like bytes
- Dedicated CIR keywords(?!) like coroutine, resume, suspend, etc etc.
- Blanket operation highlighting for CIR operations (No need to edit syntax/cir.vim again for new operations)

Below is the before and after of applying syntax highlighting. 


Before:
<img width="1532" height="1003" alt="Screenshot 2025-08-22 at 3 30 44 PM" src="https://github.com/user-attachments/assets/b94f8965-99db-41b0-a3e2-c004b4dfd6b8" />


After:
<img width="1532" height="1003" alt="Screenshot 2025-08-22 at 3 30 21 PM" src="https://github.com/user-attachments/assets/e25448de-8dc3-4df3-88e3-35143a06c53a" />

