### PR TITLE
[CIR] Fix parsing of #cir.unwind and cir.resume for catch regions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1095,9 +1095,8 @@ def CIR_ResumeOp : CIR_Op<"resume", [
                        Optional<CIR_UInt32>:$type_id,
                        UnitAttr:$rethrow);
   let assemblyFormat = [{
-    ($rethrow^)?
-    ($exception_ptr^)?
-    (`,` $type_id^)?
+    (`rethrow` $rethrow^)?
+    ($exception_ptr^ (`,` $type_id^)?)?
     attr-dict
   }];
 }

--- a/clang/test/CIR/IR/resume-location-parsing.cir
+++ b/clang/test/CIR/IR/resume-location-parsing.cir
@@ -1,0 +1,62 @@
+// RUN: cir-opt %s | FileCheck %s
+
+// Test ClangIR exception handling parsing fix
+// This demonstrates the syntax that was failing before the fix:
+// 1. #cir.unwind attributes in catch blocks
+// 2. cir.resume operations with location information
+
+!void = !cir.void
+
+#loc1 = loc("simple.cpp":10:5)
+#loc2 = loc("simple.cpp":15:8)
+
+module {
+  // This represents C++ code like:
+  //   void function() {
+  //     RAII_Object obj;  // needs cleanup on exception
+  //   }
+
+  // CHECK-LABEL: @simple_cleanup_example
+  cir.func @simple_cleanup_example() -> !void {
+    cir.try {
+      // Normal execution path
+      cir.return
+    } catch [#cir.unwind {
+      // Cleanup/unwind region - not a real exception handler
+      // Before the fix: "undefined symbol alias id 'loc1'"
+      // CHECK: cir.resume
+      cir.resume loc(#loc1)
+    }]
+    cir.return
+  }
+
+  // This represents C++ code like:
+  //   void function() {
+  //     try { /* some code */ }
+  //     catch (...) { throw; }  // rethrow
+  //   }
+
+  // CHECK-LABEL: @rethrow_example
+  cir.func @rethrow_example() -> !void {
+    cir.try {
+      cir.return
+    } catch [#cir.unwind {
+      // Rethrow - continue unwinding to find real handler
+      // CHECK: cir.resume rethrow
+      cir.resume rethrow loc(#loc2)
+    }]
+    cir.return
+  }
+
+  // CHECK-LABEL: @test_unwind_catch_parsing
+  cir.func @test_unwind_catch_parsing() -> !void {
+    cir.try {
+      cir.return
+    } catch [#cir.unwind {
+      // CHECK: cir.resume
+      cir.resume
+    }]
+    // CHECK: cir.return
+    cir.return
+  }
+}


### PR DESCRIPTION
1. **Catch Entry Parsing**: `parseCatchEntry` in `CIRDialect.cpp` now properly handles `#cir.unwind` attributes

2. **Resume Operation**: Fix record definition of `cir.resume` in order to handle locations correctly

## Issue:
- `error: expected '{' to begin a region` when parsing `catch [#cir.unwind {`
- `error: undefined symbol alias id` when parsing `cir.resume loc(#loc)`