### PR TITLE
[CIR][WIP] Add BlockAddressOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6062,6 +6062,28 @@ def CIR_LinkerOptionsOp : CIR_Op<"linker_options", [
 }
 
 //===----------------------------------------------------------------------===//
+// BlockAddressOp
+//===----------------------------------------------------------------------===//
+
+def CIR_BlockAddressOp : CIR_Op<"blockaddress"> {
+  let summary = " TODO";
+  let description = [{
+    TODO
+  }];
+
+  let arguments = (ins StrAttr:$label, StrAttr:$func);
+  let results = (outs CIR_PointerType:$addr);
+  let assemblyFormat = [{
+    `(` $label `,` $func `)` `->` qualified(type($addr)) attr-dict
+  }];
+  let extraClassDeclaration = [{
+    /// Search for the matching `cir.label` operation.
+    void findLabel(cir::LabelOp &label);
+  }];
+
+}
+
+//===----------------------------------------------------------------------===//
 // Standard library function calls
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -225,8 +225,11 @@ public:
   }
 
   mlir::Value VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *E);
-  mlir::Value VisitAddrLabelExpr(const AddrLabelExpr *E) {
-    llvm_unreachable("NYI");
+  mlir::Value VisitAddrLabelExpr(const AddrLabelExpr *e) {
+    auto func = cast<cir::FuncOp>(CGF.CurFn);
+    return cir::BlockAddressOp::create(
+        Builder, CGF.getLoc(e->getSourceRange()), CGF.convertType(e->getType()),
+        e->getLabel()->getName(), func.getSymName());
   }
   mlir::Value VisitSizeOfPackExpr(SizeOfPackExpr *E) {
     llvm_unreachable("NYI");

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1843,6 +1843,20 @@ Block *cir::BrCondOp::getSuccessorForOperands(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// BlockAddressOp
+//===----------------------------------------------------------------------===//
+
+void cir::BlockAddressOp::findLabel(cir::LabelOp &label) {
+  getOperation()->getParentOp()->walk(([&](mlir::Operation *op) {
+    if (auto labelOp = dyn_cast<cir::LabelOp>(op))
+      if (labelOp.getLabel() == getLabel()) {
+        label = labelOp;
+        return;
+      }
+  }));
+}
+
+//===----------------------------------------------------------------------===//
 // CaseOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4457,6 +4457,29 @@ mlir::LogicalResult CIRToLLVMLinkerOptionsOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
+mlir::LogicalResult CIRToLLVMBlockAddressOpLowering::matchAndRewrite(
+    cir::BlockAddressOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  cir::LabelOp labelOp;
+  mlir::MLIRContext *ctx = rewriter.getContext();
+
+  op.findLabel(labelOp);
+
+  auto tagAttr = mlir::LLVM::BlockTagAttr::get(ctx, 0);
+  rewriter.setInsertionPoint(labelOp);
+  mlir::LLVM::BlockTagOp::create(rewriter, labelOp->getLoc(), tagAttr);
+  rewriter.eraseOp(labelOp);
+
+  auto fnSym = mlir::FlatSymbolRefAttr::get(ctx, op.getFunc());
+  auto blkAddr =
+      mlir::LLVM::BlockAddressAttr::get(rewriter.getContext(), fnSym, tagAttr);
+  rewriter.setInsertionPoint(op);
+  mlir::LLVM::BlockAddressOp::create(
+      rewriter, op.getLoc(), mlir::LLVM::LLVMPointerType::get(ctx), blkAddr);
+  rewriter.eraseOp(op);
+  return mlir::success();
+}
+
 void populateCIRToLLVMConversionPatterns(
     mlir::RewritePatternSet &patterns, mlir::TypeConverter &converter,
     mlir::DataLayout &dataLayout, cir::LowerModule *lowerModule,
@@ -4515,6 +4538,7 @@ void populateCIRToLLVMConversionPatterns(
       CIRToLLVMBitFfsOpLowering,
       CIRToLLVMBitParityOpLowering,
       CIRToLLVMBitPopcountOpLowering,
+      CIRToLLVMBlockAddressOpLowering,
       CIRToLLVMBrCondOpLowering,
       CIRToLLVMBrOpLowering,
       CIRToLLVMByteswapOpLowering,

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -1319,6 +1319,16 @@ public:
                   mlir::ConversionPatternRewriter &rewriter) const override;
 };
 
+class CIRToLLVMBlockAddressOpLowering
+    : public mlir::OpConversionPattern<cir::BlockAddressOp> {
+public:
+  using mlir::OpConversionPattern<cir::BlockAddressOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::BlockAddressOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
 mlir::ArrayAttr lowerCIRTBAAAttr(mlir::Attribute tbaa,
                                  mlir::ConversionPatternRewriter &rewriter,
                                  cir::LowerModule *lowerMod);


### PR DESCRIPTION
This PR adds support for the new `BlockAddressOp`, used for GCC labels as values.