### PR TITLE
[CIR] Fix element type for lowering vtt.address_point

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1197,8 +1197,7 @@ mlir::LogicalResult CIRToLLVMVTTAddrPointOpLowering::matchAndRewrite(
     }
 
     offsets.push_back(adaptor.getOffset());
-    eltType = mlir::IntegerType::get(resultType.getContext(), 8,
-                                     mlir::IntegerType::Signless);
+    eltType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
   } else {
     llvmAddr = getValueForVTableSymbol(op, rewriter, getTypeConverter(),
                                        op.getNameAttr(), eltType);

--- a/clang/test/CIR/CodeGen/vtt.cpp
+++ b/clang/test/CIR/CodeGen/vtt.cpp
@@ -78,7 +78,7 @@ int f() {
 // LLVM:   %[[VTT:.*]] = load ptr, ptr %[[VTT_ADDR]], align 8
 // LLVM:   %[[V:.*]] = load ptr, ptr %[[VTT]], align 8
 // LLVM:   store ptr %[[V]], ptr %[[THIS]], align 8
-// LLVM:   getelementptr inbounds i8, ptr %[[VTT]], i32 1
+// LLVM:   getelementptr inbounds ptr, ptr %[[VTT]], i32 1
 // LLVM:   ret void
 // LLVM: }
 


### PR DESCRIPTION
While upstreaming vtt.address_point lowering, I noticed an important difference in the LLVM IR generated between the CIR path and the OGCG path. We were incorrectly using i8 as the element type for the GEP generated when vtt.address_point is lowered with a value argument. This patch fixes that.