### PR TITLE
[CIR][NFC] Add `getBreakTarget` method to `cir::BreakOp`

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1053,6 +1053,10 @@ def CIR_BreakOp : CIR_Op<"break", [Terminator]> {
   }];
   let assemblyFormat = "attr-dict";
   let hasVerifier = 1;
+  let extraClassDeclaration = [{
+    /// Find the parent operation corresponding to this break.
+    mlir::Operation *getBreakTarget();
+    }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -324,6 +324,15 @@ void cir::AllocaOp::build(::mlir::OpBuilder &odsBuilder,
 // BreakOp
 //===----------------------------------------------------------------------===//
 
+mlir::Operation *cir::BreakOp::getBreakTarget() {
+  // Find the innermost loop or switch parent operation.
+  mlir::Operation *parentOp = getOperation()->getParentOp();
+  while (::mlir::isa_and_present<cir::LoopOpInterface, cir::SwitchOp>(parentOp))
+    parentOp = parentOp->getParentOp();
+
+  return parentOp;
+}
+
 LogicalResult cir::BreakOp::verify() {
   if (!getOperation()->getParentOfType<LoopOpInterface>() &&
       !getOperation()->getParentOfType<SwitchOp>())


### PR DESCRIPTION
`cir::BreakOp::getBreakTarget` gets the innermost `cir::LoopOpInterface` or `cir::SwitchOp` containing this `break`.

For example:
```
A: for (...) {
B:   for(...) {
       break; // target = B
C:     switch (...) {
         default: break; // target = C
       }
     break; // target = A
   }     
```

NOTE: This is a part of a broader effort I am working on to make querying CIR control flow facts more easily. If folks have any design notes or ideas, please share them.