### PR TITLE
[CIR] Backport TypeInfo record element type constraints

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrConstraints.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrConstraints.td
@@ -39,11 +39,27 @@ def CIR_AnyIntOrFloatAttr : AnyAttrOf<[CIR_AnyIntAttr, CIR_AnyFPAttr],
 }
 
 //===----------------------------------------------------------------------===//
+// GlobalViewAttr constraints
+//===----------------------------------------------------------------------===//
+
+def CIR_AnyGlobalViewAttr : CIR_AttrConstraint<"::cir::GlobalViewAttr", "GlobalView attribute">;
+
+def CIR_AnyIntOrGlobalViewAttr : AnyAttrOf<[CIR_AnyIntAttr, CIR_AnyGlobalViewAttr],
+    "integer or global view attribute"> {
+  string cppType = "::mlir::TypedAttr";
+}
+
+//===----------------------------------------------------------------------===//
 // ArrayAttr constraints
 //===----------------------------------------------------------------------===//
 
 def CIR_IntArrayAttr : TypedArrayAttrBase<CIR_AnyIntAttr,
    "integer array attribute">;
+
+def CIR_IntOrGlobalViewArrayAttr : TypedArrayAttrBase<CIR_AnyIntOrGlobalViewAttr,
+   "integer or global view array attribute">{
+  string cppType = "::mlir::ArrayAttr";
+}
 
 //===----------------------------------------------------------------------===//
 // TBAAAttr constraints

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -849,8 +849,10 @@ def CIR_TypeInfoAttr : CIR_Attr<"TypeInfo", "typeinfo", [TypedAttrInterface]> {
     ```
   }];
 
-  let parameters = (ins AttributeSelfTypeParameter<"">:$type,
-                        "mlir::ArrayAttr":$data);
+  let parameters = (ins
+    AttributeSelfTypeParameter<"">:$type,
+    CIR_IntOrGlobalViewArrayAttr:$data
+  );
 
   let builders = [
     AttrBuilderWithInferredContext<(ins "mlir::Type":$type,

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -3671,11 +3671,6 @@ LogicalResult cir::TypeInfoAttr::verify(
   if (cir::ConstRecordAttr::verify(emitError, type, typeinfoData).failed())
     return failure();
 
-  for (auto &member : typeinfoData) {
-    if (llvm::isa<GlobalViewAttr, IntAttr>(member))
-      continue;
-    return emitError() << "expected GlobalViewAttr or IntAttr attribute";
-  }
   return success();
 }
 

--- a/clang/test/CIR/IR/invalid-type-info.cir
+++ b/clang/test/CIR/IR/invalid-type-info.cir
@@ -1,0 +1,17 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+!u8i = !cir.int<u, 8>
+
+!rec_anon_struct = !cir.record<struct  {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+
+// expected-error @below {{expected !cir.record type}}
+cir.global constant external @type_info = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS1B> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1A> : !cir.ptr<!u8i>}> : !u8i
+
+// -----
+
+!u8i = !cir.int<u, 8>
+
+!rec_anon_struct = !cir.record<struct  {!u8i, !u8i, !u8i}>
+
+// expected-error @below {{integer or global view array attribute}}
+cir.global constant external @type_info = #cir.typeinfo<{ #cir.undef : !u8i, #cir.int<1> : !u8i, #cir.int<1> : !u8i}> : !rec_anon_struct


### PR DESCRIPTION
Backport using ArrayOf constraints from the upstream and the test file for invalid type info