### PR TITLE
Change to new theme: Just the docs

### DIFF
--- a/Development/README.md
+++ b/Development/README.md
@@ -1,5 +1,7 @@
 ---
-sort : 2
+title: Development
+nav_order: 2
+has_children: true
 ---
 
 # Development

--- a/Development/benchmark.md
+++ b/Development/benchmark.md
@@ -1,5 +1,6 @@
 ---
-sort : 5
+parent: Development
+nav_order: 5
 ---
 
 ## Benchmarks

--- a/Development/compile-time.md
+++ b/Development/compile-time.md
@@ -1,5 +1,6 @@
 ---
-sort : 6
+parent: Development
+nav_order: 6
 ---
 
 ## Compile time

--- a/Development/motivation.md
+++ b/Development/motivation.md
@@ -1,5 +1,6 @@
 ---
-sort : 1
+parent: Development
+nav_order: 1
 ---
 # Project Motivation
 

--- a/Development/pipeline.md
+++ b/Development/pipeline.md
@@ -1,5 +1,6 @@
 ---
-sort : 2
+parent: Development
+nav_order: 2
 ---
 # ClangIR in practice
 

--- a/Development/status.md
+++ b/Development/status.md
@@ -1,5 +1,6 @@
 ---
-sort : 3
+parent: Development
+nav_order: 3
 ---
 # Current Status
 

--- a/Development/upstreaming-progress.md
+++ b/Development/upstreaming-progress.md
@@ -1,5 +1,6 @@
 ---
-sort : 4
+parent: Development
+nav_order: 4
 ---
 # Upstreaming Progress
 

--- a/Dialect/README.md
+++ b/Dialect/README.md
@@ -1,5 +1,7 @@
 ---
-sort : 2
+title: CIR Dialect
+nav_order: 3
+has_children: true
 ---
 
 # CIR Dialect

--- a/Dialect/attrs.md
+++ b/Dialect/attrs.md
@@ -1,5 +1,6 @@
 ---
-sort : 3
+parent: CIR Dialect
+nav_order: 3
 ---
 
 # Attributes

--- a/Dialect/cir-style-guide.md
+++ b/Dialect/cir-style-guide.md
@@ -1,5 +1,6 @@
 ---
-sort : 5
+parent: CIR Dialect
+nav_order: 5
 ---
 
 # ASM Style Guide

--- a/Dialect/ops.md
+++ b/Dialect/ops.md
@@ -1,5 +1,6 @@
 ---
-sort : 1
+parent: CIR Dialect
+nav_order: 1
 ---
 
 # Operations

--- a/Dialect/passes.md
+++ b/Dialect/passes.md
@@ -1,5 +1,6 @@
 ---
-sort : 4
+parent: CIR Dialect
+nav_order: 4
 ---
 
 # Passes

--- a/Dialect/types.md
+++ b/Dialect/types.md
@@ -1,5 +1,6 @@
 ---
-sort : 2
+parent: CIR Dialect
+nav_order: 2
 ---
 
 # Types

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/GettingStarted/README.md
+++ b/GettingStarted/README.md
@@ -1,5 +1,7 @@
 ---
-sort: 1
+title: Getting started
+nav_order: 1
+has_children: true
 ---
 
 # Getting started

--- a/GettingStarted/build-install.md
+++ b/GettingStarted/build-install.md
@@ -1,5 +1,6 @@
 ---
-sort : 2
+parent: Getting started
+nav_order: 2
 ---
 
 # Build and install

--- a/GettingStarted/coding-guideline.md
+++ b/GettingStarted/coding-guideline.md
@@ -1,5 +1,6 @@
 ---
-sort : 5
+parent: Getting started
+nav_order: 5
 ---
 
 # Coding Guideline

--- a/GettingStarted/contrib.md
+++ b/GettingStarted/contrib.md
@@ -1,5 +1,6 @@
 ---
-sort : 4
+parent: Getting started
+nav_order: 4
 ---
 
 # How to contribute

--- a/GettingStarted/examples.md
+++ b/GettingStarted/examples.md
@@ -1,5 +1,6 @@
 ---
-sort : 6
+parent: Getting started
+nav_order: 6
 ---
 
 # Examples

--- a/GettingStarted/gitrepo.md
+++ b/GettingStarted/gitrepo.md
@@ -1,5 +1,6 @@
 ---
-sort : 1
+parent: Getting started
+nav_order: 1
 ---
 
 # Cloning repo

--- a/GettingStarted/testing.md
+++ b/GettingStarted/testing.md
@@ -1,5 +1,6 @@
 ---
-sort : 3
+parent: Getting started
+nav_order: 3
 ---
 
 # Testing

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+nav_exclude: true
+---
+
 # ClangIR (CIR)
 
 ClangIR is a high-level representation in Clang that reflects aspects of the C/C++

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-remote_theme: clearpathrobotics/jekyll-rtd-theme
+theme: just-the-docs
 title: ClangIR
 description: A new high-level IR for clang.
 


### PR DESCRIPTION
Current theming of the CIR homepage's been broken for a week now. I'm proposing we change to a new theme "Just The Docs".

The theme has 8.6k starts on github and seems to replicate a lot of what the old theme do aesthetically.

Screenshot for visualization
Pic 1
<img width="1171" height="971" alt="Screenshot 2025-09-22 at 5 14 08 PM" src="https://github.com/user-attachments/assets/e2ba838e-893a-4b7b-9498-c8d7fc8441ae" />

--

Pic 2

<img width="1171" height="971" alt="Screenshot 2025-09-22 at 5 19 32 PM" src="https://github.com/user-attachments/assets/cc567db7-127b-4ba2-a58e-c3ed28845745" />
