### PR TITLE
 [CIR] Add BlockAddrInfoAttr for LabelOp and BlockAddressOp 

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5897,7 +5897,7 @@ def CIR_LabelOp : CIR_Op<"label", [AlwaysSpeculatable]> {
   let description = [{
     An identifier which may be referred by cir.goto operation
   }];
-  let arguments = (ins CIR_BlockAddrInfoAttr:$label);
+  let arguments = (ins StrAttr:$label);
   let assemblyFormat = [{ $label attr-dict }];
   let hasVerifier = 1;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -652,11 +652,7 @@ mlir::LogicalResult CIRGenFunction::emitLabel(const LabelDecl *D) {
   }
 
   builder.setInsertionPointToEnd(labelBlock);
-
-  auto func = cast<cir::FuncOp>(CurFn);
-  auto blockAddrAttr = cir::BlockAddrInfoAttr::get(
-      builder.getContext(), func.getSymName(), D->getName());
-  cir::LabelOp::create(builder, getLoc(D->getSourceRange()), blockAddrAttr);
+  builder.create<cir::LabelOp>(getLoc(D->getSourceRange()), D->getName());
   builder.setInsertionPointToEnd(labelBlock);
 
   //  FIXME: emit debug info for labels, incrementProfileCounter

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2935,7 +2935,7 @@ LogicalResult cir::FuncOp::verify() {
   bool invalidBlockAddress = false;
   getOperation()->walk([&](mlir::Operation *op) {
     if (auto lab = dyn_cast<cir::LabelOp>(op)) {
-      labels.insert(lab.getLabel().getLabel());
+      labels.insert(lab.getLabel());
     } else if (auto goTo = dyn_cast<cir::GotoOp>(op)) {
       gotos.insert(goTo.getLabel());
     } else if (auto blkAdd = dyn_cast<cir::BlockAddressOp>(op)) {

--- a/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
@@ -29,7 +29,7 @@ static void process(cir::FuncOp func) {
 
   func.getBody().walk([&](mlir::Operation *op) {
     if (auto lab = dyn_cast<cir::LabelOp>(op)) {
-      labels.try_emplace(lab.getLabel().getLabel(), lab->getBlock());
+      labels.try_emplace(lab.getLabel(), lab->getBlock());
     } else if (auto goTo = dyn_cast<cir::GotoOp>(op)) {
       gotos.push_back(goTo);
     } else if (auto blockAddr = dyn_cast<cir::BlockAddressOp>(op)) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4518,8 +4518,8 @@ mlir::LogicalResult CIRToLLVMLabelOpLowering::matchAndRewrite(
   auto blockTagOp =
       mlir::LLVM::BlockTagOp::create(rewriter, op->getLoc(), tagAttr);
   auto func = op->getParentOfType<mlir::LLVM::LLVMFuncOp>();
-  auto blockInfoAttr = cir::BlockAddrInfoAttr::get(ctx, func.getSymName(),
-                                                   op.getLabel().getLabel());
+  auto blockInfoAttr =
+      cir::BlockAddrInfoAttr::get(ctx, func.getSymName(), op.getLabel());
   blockInfoAddr.mapBlockTag(blockInfoAttr, blockTagOp);
   rewriter.eraseOp(op);
 

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -84,7 +84,7 @@ err:
 // NOFLAT:    %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
 // NOFLAT:    cir.return %3 : !s32i
 // NOFLAT:  ^bb2:  // no predecessors
-// NOFLAT:    cir.label <@_Z21shouldNotGenBranchReti, "err">
+// NOFLAT:    cir.label "err"
 
 int shouldGenBranch(int x) {
   if (x > 5)
@@ -99,7 +99,7 @@ err:
 // NOFLAT:    }
 // NOFLAT:    cir.br ^bb1
 // NOFLAT:  ^bb1:
-// NOFLAT:    cir.label <@_Z15shouldGenBranchi, "err">
+// NOFLAT:    cir.label "err"
 
 void severalLabelsInARow(int a) {
   int b = a;
@@ -112,10 +112,10 @@ end2:
 }
 // NOFLAT:  cir.func dso_local @_Z19severalLabelsInARowi
 // NOFLAT:  ^bb[[#BLK1:]]:
-// NOFLAT:    cir.label <@_Z19severalLabelsInARowi, "end1">
+// NOFLAT:    cir.label "end1"
 // NOFLAT:    cir.br ^bb[[#BLK2:]]
 // NOFLAT:  ^bb[[#BLK2]]:
-// NOFLAT:    cir.label <@_Z19severalLabelsInARowi, "end2">
+// NOFLAT:    cir.label "end2"
 
 void severalGotosInARow(int a) {
   int b = a;
@@ -129,7 +129,7 @@ end:
 // NOFLAT:  ^bb[[#BLK1:]]:
 // NOFLAT:    cir.goto "end"
 // NOFLAT:  ^bb[[#BLK2:]]:
-// NOFLAT:    cir.label <@_Z18severalGotosInARowi, "end">
+// NOFLAT:    cir.label "end"
 
 
 void labelWithoutMatch() {
@@ -137,7 +137,7 @@ end:
   return;
 }
 // NOFLAT:  cir.func dso_local @_Z17labelWithoutMatchv()
-// NOFLAT:    cir.label <@_Z17labelWithoutMatchv, "end">
+// NOFLAT:    cir.label "end"
 // NOFLAT:    cir.return
 // NOFLAT:  }
 
@@ -290,7 +290,7 @@ void foo() {
 
 // NOFLAT: cir.func dso_local @_Z3foov()
 // NOFLAT:   cir.scope {
-// NOFLAT:     cir.label <@_Z3foov, "label">
+// NOFLAT:     cir.label "label"
 // NOFLAT:     %0 = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["agg.tmp0"]
 
 extern "C" void action1();
@@ -331,7 +331,7 @@ extern "C" void case_follow_label(int v) {
 // NOFLAT: cir.func dso_local @case_follow_label
 // NOFLAT: cir.switch
 // NOFLAT: cir.case(equal, [#cir.int<1> : !s32i]) {
-// NOFLAT: cir.label <@case_follow_label, "label">
+// NOFLAT: cir.label "label"
 // NOFLAT: cir.case(equal, [#cir.int<2> : !s32i]) {
 // NOFLAT: cir.call @action1()
 // NOFLAT: cir.break
@@ -357,7 +357,7 @@ extern "C" void default_follow_label(int v) {
 // NOFLAT: cir.case(anyof, [#cir.int<1> : !s32i, #cir.int<2> : !s32i]) {
 // NOFLAT: cir.call @action1()
 // NOFLAT: cir.break
-// NOFLAT: cir.label <@default_follow_label, "label">
+// NOFLAT: cir.label "label"
 // NOFLAT: cir.case(default, []) {
 // NOFLAT: cir.call @action2()
 // NOFLAT: cir.goto "label"

--- a/clang/test/CIR/CodeGen/label-values.c
+++ b/clang/test/CIR/CodeGen/label-values.c
@@ -16,7 +16,7 @@ A:
 // CIR:    cir.store align(8) [[BLOCK]], [[PTR]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CIR:    cir.br ^bb1
 // CIR:  ^bb1:  // pred: ^bb0
-// CIR:    cir.label <@A, "A">
+// CIR:    cir.label "A"
 // CIR:    cir.return
 //
 // LLVM: define dso_local void @A()
@@ -41,7 +41,7 @@ B:
 }
 
 // CIR:  cir.func dso_local @B()
-// CIR:    cir.label <@B, "B">
+// CIR:    cir.label "B"
 // CIR:    [[PTR:%.*]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr", init] {alignment = 8 : i64}
 // CIR:    [[BLOCK:%.*]] = cir.blockaddress <@B, "B"> -> !cir.ptr<!void>
 // CIR:    cir.store align(8) [[BLOCK]], [[PTR]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
@@ -80,10 +80,10 @@ B:
 // CIR:  ^bb1:  // 2 preds: ^bb2, ^bb3
 // CIR:    cir.return
 // CIR:  ^bb2:  // pred: ^bb0
-// CIR:    cir.label <@C, "A">
+// CIR:    cir.label "A"
 // CIR:    cir.br ^bb1
 // CIR:  ^bb3:  // no predecessors
-// CIR:    cir.label <@C, "B">
+// CIR:    cir.label "B"
 // CIR:    cir.br ^bb1
 
 // LLVM: define dso_local void @C(i32 %0)
@@ -128,7 +128,7 @@ A:
 // CIR:    cir.store align(8) %[[BLK2]], %[[PTR2]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CIR:    cir.br ^bb1
 // CIR:  ^bb1:  // pred: ^bb0
-// CIR:    cir.label <@D, "A">
+// CIR:    cir.label "A"
 // CIR:    %[[BLK3:.*]] = cir.blockaddress <@D, "A"> -> !cir.ptr<!void>
 // CIR:    cir.store align(8) %[[BLK3]], %[[PTR3]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CIR:    cir.return

--- a/clang/test/CIR/IR/block-adress.cir
+++ b/clang/test/CIR/IR/block-adress.cir
@@ -7,14 +7,14 @@ module {
     %0 = cir.blockaddress <@block_address, "label"> -> !cir.ptr<!void>
     cir.br ^bb1
   ^bb1:
-    cir.label <@block_address, "label">
+    cir.label "label"
     cir.return
   }
 // CHECK: cir.func @block_address
 // CHECK: %0 = cir.blockaddress <@block_address, "label"> -> !cir.ptr<!void>
 // CHECK:   cir.br ^bb1
 // CHECK: ^bb1:
-// CHECK:   cir.label <@block_address, "label">
+// CHECK:   cir.label "label"
 // CHECK:   cir.return
 
 cir.func @block_address_inside_scope() -> () {
@@ -23,12 +23,12 @@ cir.func @block_address_inside_scope() -> () {
   }
   cir.br ^bb1
 ^bb1:
-  cir.label <@block_address_inside_scope, "label">
+  cir.label "label"
   cir.return
 }
 // CHECK: cir.func @block_address_inside_scope
 // CHECK: cir.scope
 // CHECK:  %0 = cir.blockaddress <@block_address_inside_scope, "label"> -> !cir.ptr<!void>
-// CHECK:  cir.label <@block_address_inside_scope, "label">
+// CHECK:  cir.label "label"
 // CHECK: cir.return
 }

--- a/clang/test/CIR/IR/invalid-block-address.cir
+++ b/clang/test/CIR/IR/invalid-block-address.cir
@@ -7,7 +7,7 @@ cir.func @bad_block_address() -> () {
     %0 = cir.blockaddress <@bad_block_address, "label"> -> !cir.ptr<!void>
     cir.br ^bb1
   ^bb1:
-    cir.label <@bad_block_address, "wrong_label">
+    cir.label "wrong_label"
     cir.return
 }
 
@@ -16,6 +16,6 @@ cir.func @bad_block_func() -> () {
     %0 = cir.blockaddress <@mismatch_func, "label"> -> !cir.ptr<!void>
     cir.br ^bb1
   ^bb1:
-    cir.label <@bad_block_func, "label">
+    cir.label "label"
     cir.return
 }

--- a/clang/test/CIR/IR/invalid.cir
+++ b/clang/test/CIR/IR/invalid.cir
@@ -1225,7 +1225,7 @@ module {
 cir.func @bad_goto() -> () {
   cir.goto "somewhere"
 ^bb1:
-  cir.label <@bad_goto, "label">
+  cir.label "label"
   cir.return
 }
 

--- a/clang/test/CIR/Lowering/goto.cir
+++ b/clang/test/CIR/Lowering/goto.cir
@@ -23,7 +23,7 @@ module {
     %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
     cir.return %3 : !s32i
   ^bb2:
-    cir.label <@gotoFromIf, "err">
+    cir.label "err"
     %4 = cir.const #cir.int<1> : !s32i
     %5 = cir.unary(minus, %4) : !s32i, !s32i
     cir.store %5, %1 : !s32i, !cir.ptr<!s32i>

--- a/clang/test/CIR/Transforms/goto_solver.cir
+++ b/clang/test/CIR/Transforms/goto_solver.cir
@@ -8,18 +8,18 @@ cir.func @a(){
   cir.store align(8) %1, %0 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
   cir.br ^bb1
 ^bb1:
-  cir.label <@a, "label1">
+  cir.label "label1"
   cir.br ^bb2
 ^bb2:
   // This label is not referenced by any blockaddressOp, so it should be removed
-  cir.label <@a, "label2">
+  cir.label "label2"
   cir.return
 }
 
 // CHECK:  cir.func @a()
 // CHECK:   %1 = cir.blockaddress <@a, "label1"> -> !cir.ptr<!void>
 // CHECK: ^bb1:
-// CHECK:   cir.label <@a, "label1">
+// CHECK:   cir.label "label1"
 // CHECK:   cir.br ^bb2
 // CHECK: ^bb2:
 // CHECK-NOT: cir.label "label2"
@@ -30,11 +30,11 @@ cir.func @b(){
   cir.store align(8) %1, %0 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
   cir.goto "label2"
 ^bb1:
-  cir.label <@b, "label1">
+  cir.label "label1"
   cir.br ^bb2
 ^bb2: 
   // This label is not referenced by any blockaddressOp, so it should be removed
-  cir.label <@b, "label2">
+  cir.label "label2"
   cir.return
 }
 
@@ -43,13 +43,13 @@ cir.func @b(){
 // CHECK:   cir.store align(8) %1, {{.*}} : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CHECK:   cir.br ^bb2
 // CHECK: ^bb1:
-// CHECK:   cir.label <@b, "label1">
+// CHECK:   cir.label "label1"
 // CHECK:   cir.br ^bb2
 // CHECK: ^bb2:
 // CHECK-NOT: cir.label "label2"
 
 cir.func @c() {
-  cir.label <@c, "label1">
+  cir.label "label1"
   %0 = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr", init] {alignment = 8 : i64}
   %1 = cir.blockaddress <@c, "label1"> -> !cir.ptr<!void>
   cir.store align(8) %1, %0 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
@@ -57,7 +57,7 @@ cir.func @c() {
 }
 
 // CHECK: cir.func @c
-// CHECK:   cir.label <@c, "label1">
+// CHECK:   cir.label "label1"
 // CHECK:   %1 = cir.blockaddress <@c, "label1"> -> !cir.ptr<!void>
 // CHECK:   cir.store align(8) %1, {{.*}} : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 


### PR DESCRIPTION
This PR adds the new attribute `CIR_BlockAddrInfoAttr`, requested in [#1909](https://github.com/llvm/clangir/pull/1909), which is used in `BlockAddressOp` and `LabelOp`. I also created a custom builder to simplify construction so that we don’t have to call `mlir::FlatSymbolRefAttr::get` and `mlir::StringAttr::get` every time.
