### PR TITLE
[CIR] Fix cir.linker_options description in tablegen

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6109,6 +6109,7 @@ def CIR_LinkerOptionsOp : CIR_Op<"linker_options", [
 
     // Link against aarch64 compiler-rt builtins
     cir.linker_options ["-l", "clang_rt.builtins-aarch64"]
+    ```
   }];
 
   let arguments = (ins StrArrayAttr:$options);


### PR DESCRIPTION
PR for #1919 