### PR TITLE
[CIR] Add support for AliasOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3762,6 +3762,67 @@ def CIR_OptionalPriorityAttr : OptionalAttr<
   >
 >;
 
+def CIR_AliasOp : CIR_Op<"alias", [AutomaticAllocationScope, CallableOpInterface,
+                       FunctionOpInterface, IsolatedFromAbove]> {
+  let arguments = (ins 
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<CIR_FuncType>:$function_type, FlatSymbolRefAttr:$aliasee,
+    CIR_VisibilityAttr:$global_visibility,
+    DefaultValuedAttr<CIR_GlobalLinkageKind,
+                      "GlobalLinkageKind::ExternalLinkage">:$linkage,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs,
+    DefaultValuedAttr<CIR_CallingConv, "CallingConv::C">:$calling_conv
+   );
+
+  let regions = (region AnyRegion:$body);
+  let extraClassDeclaration = [{
+    /// Returns the region on the current operation that is callable. This may
+    /// return null in the case of an external callable object, e.g. an external
+    /// function.
+    ::mlir::Region *getCallableRegion() {
+      return nullptr;
+    }
+
+    /// Returns the results types that the callable region produces when
+    /// executed.
+    llvm::ArrayRef<mlir::Type> getCallableResults() {
+      return getFunctionType().getReturnTypes();
+    }
+
+    /// Returns the argument attributes for all callable region arguments or
+    /// null if there are none.
+    ::mlir::ArrayAttr getCallableArgAttrs() {
+      return getArgAttrs().value_or(nullptr);
+    }
+
+    /// Returns the result attributes for all callable region results or null if
+    /// there are none.
+    ::mlir::ArrayAttr getCallableResAttrs() {
+      return getResAttrs().value_or(nullptr);
+    }
+
+    /// Returns the argument types of this function.
+    llvm::ArrayRef<mlir::Type> getArgumentTypes() {
+       return getFunctionType().getInputs();
+    }
+
+    /// Returns 0 or 1 result type of this function (0 in the case of a function
+    /// returing void)
+    llvm::ArrayRef<mlir::Type> getResultTypes() {
+       return getFunctionType().getReturnTypes();
+    }
+
+    //===------------------------------------------------------------------===//
+    // SymbolOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    bool isDeclaration() {
+      return true;
+    }
+  }];
+}
+
 def FuncOp : CIR_Op<"func", [
   AutomaticAllocationScope, CallableOpInterface, FunctionOpInterface,
   DeclareOpInterfaceMethods<CIRGlobalValueInterface>,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -855,6 +855,10 @@ public:
 
   void ReplaceUsesOfNonProtoTypeWithRealFunction(mlir::Operation *Old,
                                                  cir::FuncOp NewFn);
+  cir::AliasOp createCIRAliasFunction(mlir::Location loc, llvm::StringRef name,
+                                      cir::FuncType Ty, StringRef aliasee,
+                                      cir::GlobalLinkageKind linkage,
+                                      const clang::FunctionDecl *FD);
 
   // TODO: CodeGen also passes an AttributeList here. We'll have to match that
   // in CIR

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2952,55 +2952,67 @@ verifyCallCommInSymbolUses(Operation *op, SymbolTableCollection &symbolTable) {
     return success();
 
   cir::FuncOp fn = symbolTable.lookupNearestSymbolFrom<cir::FuncOp>(op, fnAttr);
-  if (!fn)
-    return op->emitOpError() << "'" << fnAttr.getValue()
-                             << "' does not reference a valid function";
+  cir::AliasOp alias =
+      symbolTable.lookupNearestSymbolFrom<cir::AliasOp>(op, fnAttr);
+  if (!fn && !alias)
+    return op->emitOpError()
+           << "'" << fnAttr.getValue()
+           << "' does not reference a valid function or alias";
   auto callIf = dyn_cast<cir::CIRCallOpInterface>(op);
   assert(callIf && "expected CIR call interface to be always available");
-
   // Verify that the operand and result types match the callee. Note that
   // argument-checking is disabled for functions without a prototype.
-  auto fnType = fn.getFunctionType();
-  if (!fn.getNoProto()) {
-    unsigned numCallOperands = callIf.getNumArgOperands();
-    unsigned numFnOpOperands = fnType.getNumInputs();
 
-    if (!fnType.isVarArg() && numCallOperands != numFnOpOperands)
-      return op->emitOpError("incorrect number of operands for callee");
+  auto verify = [&op, &callIf](bool getNoProto, cir::FuncType fnType,
+                               cir::CallingConv cc) -> LogicalResult {
+    if (!getNoProto) {
+      unsigned numCallOperands = callIf.getNumArgOperands();
+      unsigned numFnOpOperands = fnType.getNumInputs();
 
-    if (fnType.isVarArg() && numCallOperands < numFnOpOperands)
-      return op->emitOpError("too few operands for callee");
+      if (!fnType.isVarArg() && numCallOperands != numFnOpOperands)
+        return op->emitOpError("incorrect number of operands for callee");
 
-    for (unsigned i = 0, e = numFnOpOperands; i != e; ++i)
-      if (callIf.getArgOperand(i).getType() != fnType.getInput(i))
-        return op->emitOpError("operand type mismatch: expected operand type ")
-               << fnType.getInput(i) << ", but provided "
-               << op->getOperand(i).getType() << " for operand number " << i;
-  }
+      if (fnType.isVarArg() && numCallOperands < numFnOpOperands)
+        return op->emitOpError("too few operands for callee");
 
-  // Calling convention must match.
-  if (callIf.getCallingConv() != fn.getCallingConv())
-    return op->emitOpError("calling convention mismatch: expected ")
-           << stringifyCallingConv(fn.getCallingConv()) << ", but provided "
-           << stringifyCallingConv(callIf.getCallingConv());
+      for (unsigned i = 0, e = numFnOpOperands; i != e; ++i)
+        if (callIf.getArgOperand(i).getType() != fnType.getInput(i))
+          return op->emitOpError(
+                     "operand type mismatch: expected operand type ")
+                 << fnType.getInput(i) << ", but provided "
+                 << op->getOperand(i).getType() << " for operand number " << i;
+    }
+    // Calling convention must match.
+    if (callIf.getCallingConv() != cc)
+      return op->emitOpError("calling convention mismatch: expected ")
+             << stringifyCallingConv(cc) << ", but provided "
+             << stringifyCallingConv(callIf.getCallingConv());
 
-  // Void function must not return any results.
-  if (fnType.hasVoidReturn() && op->getNumResults() != 0)
-    return op->emitOpError("callee returns void but call has results");
+    // Void function must not return any results.
+    if (fnType.hasVoidReturn() && op->getNumResults() != 0)
+      return op->emitOpError("callee returns void but call has results");
 
-  // Non-void function calls must return exactly one result.
-  if (!fnType.hasVoidReturn() && op->getNumResults() != 1)
-    return op->emitOpError("incorrect number of results for callee");
+    // Non-void function calls must return exactly one result.
+    if (!fnType.hasVoidReturn() && op->getNumResults() != 1)
+      return op->emitOpError("incorrect number of results for callee");
 
-  // Parent function and return value types must match.
-  if (!fnType.hasVoidReturn() &&
-      op->getResultTypes().front() != fnType.getReturnType()) {
-    return op->emitOpError("result type mismatch: expected ")
-           << fnType.getReturnType() << ", but provided "
-           << op->getResult(0).getType();
-  }
+    // Parent function and return value types must match.
+    if (!fnType.hasVoidReturn() &&
+        op->getResultTypes().front() != fnType.getReturnType()) {
+      return op->emitOpError("result type mismatch: expected ")
+             << fnType.getReturnType() << ", but provided "
+             << op->getResult(0).getType();
+    }
 
-  return success();
+    return success();
+  };
+
+  if (fn)
+    return verify(fn.getNoProto(), fn.getFunctionType(), fn.getCallingConv());
+  if (alias)
+    return verify(/*getNoProto=*/true, alias.getFunctionType(),
+                  alias.getCallingConv());
+  llvm_unreachable("unreachable");
 }
 
 static mlir::ParseResult


### PR DESCRIPTION
Related to #1913.

Added alias op and verifier for call op. Failing two tests related to constructor and destructor aliases
```
Clang :: CIR/CodeGen/ctor-alias.cpp
Clang :: CIR/CodeGen/virtual-destructor-calls.cpp
```

Right now `cir::FuncOp CIRGenModule::GetOrCreateCIRFunction` is being used in a lot of place where if we switch to using Alias in emitAliasForGlobal, we'll hit cast type error. I'm not quite sure if i should change the function result type to be mlir::Operation* or something that encompasses both function and alias or not