### PR TITLE
[CMake] Add CIR to mlir-headers dependencies

### DIFF
--- a/clang/include/clang/CIR/Dialect/CMakeLists.txt
+++ b/clang/include/clang/CIR/Dialect/CMakeLists.txt
@@ -24,5 +24,5 @@ mlir_tablegen(Passes.h.inc -gen-pass-decls -name CIR)
 mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix CIR)
 mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix CIR)
 add_public_tablegen_target(MLIRCIRPassIncGen)
-
+add_dependencies(mlir-headers MLIRCIRPassIncGen)
 add_clang_mlir_doc(Passes CIRPasses ./ -gen-pass-doc)

--- a/clang/include/clang/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/include/clang/CIR/Dialect/IR/CMakeLists.txt
@@ -27,6 +27,7 @@ mlir_tablegen(CIROpsStructs.cpp.inc -gen-attrdef-defs)
 mlir_tablegen(CIROpsAttributes.h.inc -gen-attrdef-decls)
 mlir_tablegen(CIROpsAttributes.cpp.inc -gen-attrdef-defs)
 add_public_tablegen_target(MLIRCIREnumsGen)
+add_dependencies(mlir-headers MLIRCIREnumsGen)
 
 clang_tablegen(CIRBuiltinsLowering.inc -gen-cir-builtins-lowering
                SOURCE CIROps.td


### PR DESCRIPTION
This allows generation of the CIR tablegen targets without going through 
```
$(ninja -C build_pilot -t targets all | grep IncGen | sed 's/:.*//')
```