### PR TITLE
[MLIR] [Backport] Backport cmake from upstream to add missing mlir-headers dependencies

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -203,6 +203,12 @@ function(add_mlir_interface interface)
   add_dependencies(mlir-generic-headers MLIR${interface}IncGen)
 endfunction()
 
+# Add a dialect-specific tablegen target that generates headers in the include directory.
+# In most cases, this is what should be used after invoking `mlir_tablegen`.
+macro(add_mlir_dialect_tablegen_target target)
+  add_public_tablegen_target(${target})
+  add_dependencies(mlir-headers ${target})
+endmacro()
 
 # Generate Documentation
 function(add_mlir_doc doc_filename output_file output_directory command)

--- a/mlir/include/mlir/Dialect/Func/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Func/IR/CMakeLists.txt
@@ -3,6 +3,6 @@ mlir_tablegen(FuncOps.h.inc -gen-op-decls)
 mlir_tablegen(FuncOps.cpp.inc -gen-op-defs)
 mlir_tablegen(FuncOpsDialect.h.inc -gen-dialect-decls)
 mlir_tablegen(FuncOpsDialect.cpp.inc -gen-dialect-defs)
-add_public_tablegen_target(MLIRFuncOpsIncGen)
+add_mlir_dialect_tablegen_target(MLIRFuncOpsIncGen)
 
 add_mlir_doc(FuncOps FuncOps Dialects/ -gen-op-doc)

--- a/mlir/include/mlir/Dialect/LLVMIR/Transforms/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/LLVMIR/Transforms/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name LLVM)
-add_public_tablegen_target(MLIRLLVMPassIncGen)
+add_mlir_dialect_tablegen_target(MLIRLLVMPassIncGen)
 
 add_mlir_doc(Passes LLVMPasses ./ -gen-pass-doc)

--- a/mlir/include/mlir/Transforms/CMakeLists.txt
+++ b/mlir/include/mlir/Transforms/CMakeLists.txt
@@ -3,6 +3,6 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name Transforms)
 mlir_tablegen(Transforms.capi.h.inc -gen-pass-capi-header --prefix Transforms)
 mlir_tablegen(Transforms.capi.cpp.inc -gen-pass-capi-impl --prefix Transforms)
-add_public_tablegen_target(MLIRTransformsPassIncGen)
+add_mlir_dialect_tablegen_target(MLIRTransformsPassIncGen)
 
 add_mlir_doc(Passes GeneralPasses ./ -gen-pass-doc)


### PR DESCRIPTION
Similar to #1927 , this allows generation of the missing mlir tablegen targets without going through
```
$(ninja -C build_pilot -t targets all | grep IncGen | sed 's/:.*//')
```

Helpful to #1917