### PR TITLE
[CIR] Fix error in cir.label when using cir.br in entry block

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -643,7 +643,7 @@ mlir::LogicalResult CIRGenFunction::emitLabel(const LabelDecl *D) {
   // to this label.
   mlir::Block *currBlock = builder.getBlock();
   mlir::Block *labelBlock = currBlock;
-  if (!currBlock->empty()) {
+  if (!currBlock->empty() || currBlock->isEntryBlock()) {
     {
       mlir::OpBuilder::InsertionGuard guard(builder);
       labelBlock = builder.createBlock(builder.getBlock()->getParent());

--- a/clang/test/CIR/CodeGen/label-values.c
+++ b/clang/test/CIR/CodeGen/label-values.c
@@ -41,16 +41,18 @@ B:
 }
 
 // CIR:  cir.func dso_local @B()
-// CIR:    cir.label "B"
 // CIR:    [[PTR:%.*]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr", init] {alignment = 8 : i64}
+// CIR:    cir.br ^bb1
+// CIR:   ^bb1:  // pred: ^bb0
+// CIR:    cir.label "B"
 // CIR:    [[BLOCK:%.*]] = cir.blockaddress <@B, "B"> -> !cir.ptr<!void>
 // CIR:    cir.store align(8) [[BLOCK]], [[PTR]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CIR:    cir.return
 
 // LLVM: define dso_local void @B
+// LLVM:   %[[PTR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:   br label %[[B:.*]]
 // LLVM: [[B]]:
-// LLVM:   %[[PTR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:   store ptr blockaddress(@B, %[[B]]), ptr %[[PTR]], align 8
 // LLVM:   ret void
 


### PR DESCRIPTION

This PR fixes an error I found while working on `cir.indirectbr`. The issue occurs when a branching operator points to the entry block LLVM’s verifier does not allow this https://github.com/llvm/clangir/blob/10f2ee11fa61bb1550819ed54a5b0e111d9243aa/mlir/lib/IR/Verifier.cpp#L205-L208
Previously, in `cir.label`, when building a block, we only checked if the current block was not empty. Now, we also check if we are in the entry block. If we are, a new block is created instead.
This change also helps emit IR that is closer to the classic code behavior.