### PR TITLE
[CIR] Add support for __atomic_test_and_set and __atomic_clear

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6063,6 +6063,68 @@ def CIR_AtomicCmpXchg : CIR_Op<"atomic.cmp_xchg", [
   let hasVerifier = 1;
 }
 
+def CIR_AtomicTestAndSetOp : CIR_Op<"atomic.test_and_set"> {
+  let summary = "Atomic test and set";
+  let description = [{
+    C/C++ atomic test and set operation. Implements the builtin function
+    `__atomic_test_and_set`.
+
+    The operation takes as its only operand a pointer to an 8-bit signed
+    integer. The operation atomically set the integer to an implementation-
+    defined non-zero "set" value. The result of the operation is a boolean value
+    indicating whether the previous value of the integer was the "set" value.
+
+    Example:
+    ```mlir
+      %res = cir.atomic.test_and_set seq_cst %ptr : !cir.ptr<!s8i> -> !cir.bool
+    ```
+  }];
+
+  let arguments = (ins
+    Arg<CIR_PtrToType<CIR_SInt8>, "", [MemRead, MemWrite]>:$ptr,
+    Arg<CIR_MemOrder, "memory order">:$mem_order,
+    OptionalAttr<CIR_MemScopeKind>:$syncscope,
+    OptionalAttr<I64Attr>:$alignment,
+    UnitAttr:$is_volatile);
+
+  let results = (outs CIR_BoolType:$result);
+
+  let assemblyFormat = [{
+    $mem_order $ptr
+    (`volatile` $is_volatile^)?
+    `:` qualified(type($ptr)) `->` qualified(type($result)) attr-dict
+  }];
+}
+
+def CIR_AtomicClearOp : CIR_Op<"atomic.clear"> {
+  let summary = "Atomic clear";
+  let description = [{
+    C/C++ atomic clear operation. Implements the builtin function
+    `__atomic_clear`.
+
+    The operation takes as its only operand a pointer to an 8-bit signed
+    integer. The operation atomically sets the integer to zero.
+
+    Example:
+    ```mlir
+      cir.atomic.clear seq_cst %ptr : !cir.ptr<!s8i>
+    ```
+  }];
+
+  let arguments = (ins
+    Arg<CIR_PtrToType<CIR_SInt8>, "", [MemRead, MemWrite]>:$ptr,
+    Arg<CIR_MemOrder, "memory order">:$mem_order,
+    OptionalAttr<CIR_MemScopeKind>:$syncscope,
+    OptionalAttr<I64Attr>:$alignment,
+    UnitAttr:$is_volatile);
+
+  let assemblyFormat = [{
+    $mem_order $ptr
+    (`volatile` $is_volatile^)?
+    `:` qualified(type($ptr)) attr-dict
+  }];
+}
+
 def CIR_AtomicFence : CIR_Op<"atomic.fence"> {
   let summary = "Atomic thread fence";
   let description = [{

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -746,11 +746,22 @@ static void emitAtomicOp(CIRGenFunction &CGF, AtomicExpr *E, Address Dest,
                                               cir::AtomicFetchKind::Nand);
     break;
   case AtomicExpr::AO__atomic_test_and_set: {
-    llvm_unreachable("NYI");
+    auto op = cir::AtomicTestAndSetOp::create(
+        builder, loc, Ptr.getPointer(), Order,
+        cir::MemScopeKindAttr::get(&CGF.getMLIRContext(), Scope),
+        builder.getI64IntegerAttr(Ptr.getAlignment().getQuantity()),
+        E->isVolatile());
+    builder.createStore(loc, op, Dest);
+    return;
   }
 
   case AtomicExpr::AO__atomic_clear: {
-    llvm_unreachable("NYI");
+    cir::AtomicClearOp::create(
+        builder, loc, Ptr.getPointer(), Order,
+        cir::MemScopeKindAttr::get(&CGF.getMLIRContext(), Scope),
+        builder.getI64IntegerAttr(Ptr.getAlignment().getQuantity()),
+        E->isVolatile());
+    return;
   }
   }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -936,6 +936,26 @@ public:
                   mlir::ConversionPatternRewriter &) const override;
 };
 
+class CIRToLLVMAtomicTestAndSetOpLowering
+    : public mlir::OpConversionPattern<cir::AtomicTestAndSetOp> {
+public:
+  using mlir::OpConversionPattern<cir::AtomicTestAndSetOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::AtomicTestAndSetOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
+class CIRToLLVMAtomicClearOpLowering
+    : public mlir::OpConversionPattern<cir::AtomicClearOp> {
+public:
+  using mlir::OpConversionPattern<cir::AtomicClearOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::AtomicClearOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
 class CIRToLLVMAtomicFenceLowering
     : public mlir::OpConversionPattern<cir::AtomicFence> {
 public:


### PR DESCRIPTION
This patch adds support for the builtin functions `__atomic_test_and_set` and `__atomic_clear`.