### PR TITLE
[CIR] Fix assertion failure in applyReplacements when operation is not in block

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3990,7 +3990,13 @@ void CIRGenModule::applyReplacements() {
     if (oldF.replaceAllSymbolUses(newF.getSymNameAttr(), theModule).failed())
       llvm_unreachable("internal error, cannot RAUW symbol");
     if (newF) {
-      newF->moveBefore(oldF);
+      // Only move newF before oldF if newF is already in a block.
+      // If newF is not in a block, it means it was created but not yet
+      // inserted into the module, which can happen with certain alias
+      // scenarios. In such cases, the symbol replacement above is sufficient.
+      if (newF->getBlock()) {
+        newF->moveBefore(oldF);
+      }
       oldF->erase();
     }
   }

--- a/clang/test/CIR/CodeGen/ctor-alias-complex.cpp
+++ b/clang/test/CIR/CodeGen/ctor-alias-complex.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-cir -O2 %s -o - | FileCheck %s
+
+// Test case for issue #1938: ensure that alias replacements work correctly
+// when operations are not yet in a block during applyReplacements().
+
+class Base {
+public:
+    Base() {}
+    virtual ~Base() {}
+};
+
+class Derived : public Base {
+public:
+    Derived() : Base() {}
+    ~Derived() {}
+};
+
+void test() {
+    Derived d;
+}
+
+// CHECK: cir.func @_ZN7DerivedC2Ev
+// CHECK: cir.func @_ZN7DerivedD2Ev
+// This test primarily checks that compilation succeeds without assertion failures


### PR DESCRIPTION
This PR fixes an assertion failure that occurs in applyReplacements when an operation is not in a block.

## Changes
- Modified CIRGenModule.cpp to handle the case when operation is not in block
- Added test case ctor-alias-complex.cpp to verify the fix