### PR TITLE
[CIR][NFC] Using types explicitly for `pslldqi` construct

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -161,9 +161,9 @@ static mlir::Value emitX86SExtMask(CIRGenFunction &cgf, mlir::Value op,
 static mlir::Value emitX86PSLLDQIByteShift(CIRGenFunction &cgf,
                                            const CallExpr *E,
                                            ArrayRef<mlir::Value> Ops) {
-  auto &builder = cgf.getBuilder();
+  CIRGenBuilderTy &builder = cgf.getBuilder();
   unsigned shiftVal = getIntValueFromConstOp(Ops[1]) & 0xff;
-  auto loc = cgf.getLoc(E->getExprLoc());
+  mlir::Location loc = cgf.getLoc(E->getExprLoc());
   auto resultType = cast<cir::VectorType>(Ops[0].getType());
 
   // If pslldq is shifting the vector more than 15 bytes, emit zero.


### PR DESCRIPTION
A simple clean up, just some small changes for the use explicitly types instead of `auto`. In the case of `BI__builtin_ia32_pslldqi*_byteshift`.

Following the suggestion of this comment: https://github.com/llvm/clangir/pull/1886#discussion_r2475276156