### PR TITLE
[CIR] Use free op create functions (NFC)

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRAsm.cpp
@@ -620,9 +620,9 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &S) {
   operands.push_back(InArgs);
   operands.push_back(InOutArgs);
 
-  auto IA = builder.create<cir::InlineAsmOp>(
-      getLoc(S.getAsmLoc()), ResultType, operands, AsmString, Constraints,
-      HasSideEffect, inferFlavor(CGM, S), mlir::ArrayAttr());
+  auto IA = cir::InlineAsmOp::create(
+      builder, getLoc(S.getAsmLoc()), ResultType, operands, AsmString,
+      Constraints, HasSideEffect, inferFlavor(CGM, S), mlir::ArrayAttr());
 
   if (false /*IsGCCAsmGoto*/) {
     assert(!cir::MissingFeatures::asmGoto());

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinNVPTX.cpp
@@ -35,9 +35,8 @@ mlir::Value CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId,
                                                  const CallExpr *expr) {
   [[maybe_unused]] auto getIntrinsic = [&](const char *name) {
     mlir::Type intTy = cir::IntType::get(&getMLIRContext(), 32, false);
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(getLoc(expr->getExprLoc()),
-                                          builder.getStringAttr(name), intTy)
+    return cir::LLVMIntrinsicCallOp::create(builder, getLoc(expr->getExprLoc()),
+                                            builder.getStringAttr(name), intTy)
         .getResult();
   };
   switch (builtinId) {
@@ -552,66 +551,58 @@ mlir::Value CIRGenFunction::emitNVPTXBuiltinExpr(unsigned builtinId,
   case NVPTX::BI__nvvm_getctarank_shared_cluster:
     llvm_unreachable("getctarank_shared_cluster NYI");
   case NVPTX::BI__nvvm_barrier_cluster_arrive:
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(
-            getLoc(expr->getExprLoc()),
-            builder.getStringAttr("nvvm.barrier.cluster.arrive"),
-            builder.getVoidTy())
+    return cir::LLVMIntrinsicCallOp::create(
+               builder, getLoc(expr->getExprLoc()),
+               builder.getStringAttr("nvvm.barrier.cluster.arrive"),
+               builder.getVoidTy())
         .getResult();
   case NVPTX::BI__nvvm_barrier_cluster_arrive_relaxed:
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(
-            getLoc(expr->getExprLoc()),
-            builder.getStringAttr("nvvm.barrier.cluster.arrive.relaxed"),
-            builder.getVoidTy())
+    return cir::LLVMIntrinsicCallOp::create(
+               builder, getLoc(expr->getExprLoc()),
+               builder.getStringAttr("nvvm.barrier.cluster.arrive.relaxed"),
+               builder.getVoidTy())
         .getResult();
   case NVPTX::BI__nvvm_barrier_cluster_wait:
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(
-            getLoc(expr->getExprLoc()),
-            builder.getStringAttr("nvvm.barrier.cluster.wait"),
-            builder.getVoidTy())
+    return cir::LLVMIntrinsicCallOp::create(
+               builder, getLoc(expr->getExprLoc()),
+               builder.getStringAttr("nvvm.barrier.cluster.wait"),
+               builder.getVoidTy())
         .getResult();
   case NVPTX::BI__nvvm_fence_sc_cluster:
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(
-            getLoc(expr->getExprLoc()),
-            builder.getStringAttr("nvvm.fence.sc.cluster"), builder.getVoidTy(),
-            mlir::ValueRange{})
+    return cir::LLVMIntrinsicCallOp::create(
+               builder, getLoc(expr->getExprLoc()),
+               builder.getStringAttr("nvvm.fence.sc.cluster"),
+               builder.getVoidTy(), mlir::ValueRange{})
         .getResult();
   case NVPTX::BI__nvvm_bar_sync:
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(
-            getLoc(expr->getExprLoc()),
-            builder.getStringAttr("nvvm.barrier.cta.sync.aligned.all"),
-            builder.getVoidTy(),
-            mlir::ValueRange{emitScalarExpr(expr->getArg(0))})
+    return cir::LLVMIntrinsicCallOp::create(
+               builder, getLoc(expr->getExprLoc()),
+               builder.getStringAttr("nvvm.barrier.cta.sync.aligned.all"),
+               builder.getVoidTy(),
+               mlir::ValueRange{emitScalarExpr(expr->getArg(0))})
         .getResult();
   case NVPTX::BI__syncthreads:
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(
-            getLoc(expr->getExprLoc()),
-            builder.getStringAttr("nvvm.barrier.cta.sync.aligned.all"),
-            builder.getVoidTy(),
-            mlir::ValueRange{
-                builder.getConstInt(getLoc(expr->getExprLoc()), SInt32Ty, 0)})
+    return cir::LLVMIntrinsicCallOp::create(
+               builder, getLoc(expr->getExprLoc()),
+               builder.getStringAttr("nvvm.barrier.cta.sync.aligned.all"),
+               builder.getVoidTy(),
+               mlir::ValueRange{builder.getConstInt(getLoc(expr->getExprLoc()),
+                                                    SInt32Ty, 0)})
         .getResult();
   case NVPTX::BI__nvvm_barrier_sync:
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(
-            getLoc(expr->getExprLoc()),
-            builder.getStringAttr("nvvm.barrier.cta.sync.all"),
-            builder.getVoidTy(),
-            mlir::ValueRange{emitScalarExpr(expr->getArg(0))})
+    return cir::LLVMIntrinsicCallOp::create(
+               builder, getLoc(expr->getExprLoc()),
+               builder.getStringAttr("nvvm.barrier.cta.sync.all"),
+               builder.getVoidTy(),
+               mlir::ValueRange{emitScalarExpr(expr->getArg(0))})
         .getResult();
   case NVPTX::BI__nvvm_barrier_sync_cnt:
-    return builder
-        .create<cir::LLVMIntrinsicCallOp>(
-            getLoc(expr->getExprLoc()),
-            builder.getStringAttr("nvvm.barrier.cta.sync.count"),
-            builder.getVoidTy(),
-            mlir::ValueRange{emitScalarExpr(expr->getArg(0)),
-                             emitScalarExpr(expr->getArg(1))})
+    return cir::LLVMIntrinsicCallOp::create(
+               builder, getLoc(expr->getExprLoc()),
+               builder.getStringAttr("nvvm.barrier.cta.sync.count"),
+               builder.getVoidTy(),
+               mlir::ValueRange{emitScalarExpr(expr->getArg(0)),
+                                emitScalarExpr(expr->getArg(1))})
         .getResult();
   default:
     return nullptr;

--- a/clang/lib/CIR/CodeGen/CIRGenCUDANV.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCUDANV.cpp
@@ -223,15 +223,15 @@ void CIRGenNVCUDARuntime::emitDeviceStubBodyNew(CIRGenFunction &cgf,
     if (auto globalOp = llvm::dyn_cast_or_null<cir::GlobalOp>(
             KernelHandles[fn.getSymName()])) {
       auto kernelTy = cir::PointerType::get(globalOp.getSymType());
-      mlir::Value kernel = builder.create<cir::GetGlobalOp>(
-          loc, kernelTy, globalOp.getSymName());
+      mlir::Value kernel = cir::GetGlobalOp::create(builder, loc, kernelTy,
+                                                    globalOp.getSymName());
       return kernel;
     }
     if (auto funcOp = llvm::dyn_cast_or_null<cir::FuncOp>(
             KernelHandles[fn.getSymName()])) {
       auto kernelTy = cir::PointerType::get(funcOp.getFunctionType());
       mlir::Value kernel =
-          builder.create<cir::GetGlobalOp>(loc, kernelTy, funcOp.getSymName());
+          cir::GetGlobalOp::create(builder, loc, kernelTy, funcOp.getSymName());
       mlir::Value func = builder.createBitcast(kernel, cgm.VoidPtrTy);
       return func;
     }

--- a/clang/lib/CIR/CodeGen/CIRGenCUDARuntime.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCUDARuntime.cpp
@@ -31,13 +31,13 @@ RValue CIRGenCUDARuntime::emitCUDAKernelCallExpr(CIRGenFunction &cgf,
   cgf.emitIfOnBoolExpr(
       expr->getConfig(),
       [&](mlir::OpBuilder &b, mlir::Location l) {
-        b.create<cir::YieldOp>(loc);
+        cir::YieldOp::create(b, loc);
       },
       loc,
       [&](mlir::OpBuilder &b, mlir::Location l) {
         CIRGenCallee callee = cgf.emitCallee(expr->getCallee());
         cgf.emitCall(expr->getCallee()->getType(), callee, expr, retValue);
-        b.create<cir::YieldOp>(loc);
+        cir::YieldOp::create(b, loc);
       },
       loc);
 

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -372,7 +372,7 @@ void CIRGenModule::emitCXXGlobalVarDeclInit(const VarDecl *varDecl,
                        getASTContext().getDeclAlign(varDecl));
       emitDeclInit(cgf, varDecl, declAddr);
       builder.setInsertionPointToEnd(block);
-      builder.create<cir::YieldOp>(addr->getLoc());
+      cir::YieldOp::create(builder, addr->getLoc());
     }
 
     if (varDecl->getType().isConstantStorage(getASTContext(), true,
@@ -396,7 +396,7 @@ void CIRGenModule::emitCXXGlobalVarDeclInit(const VarDecl *varDecl,
         // Don't confuse lexical cleanup.
         builder.clearInsertionPoint();
       } else
-        builder.create<cir::YieldOp>(addr->getLoc());
+        cir::YieldOp::create(builder, addr->getLoc());
     }
     return;
   }
@@ -428,5 +428,5 @@ void CIRGenModule::emitCXXGlobalVarDeclInit(const VarDecl *varDecl,
     cgf.emitStoreOfScalar(rv.getScalarVal(), declAddr, false, ty);
   }
   builder.setInsertionPointToEnd(block);
-  builder.create<cir::YieldOp>(addr->getLoc());
+  cir::YieldOp::create(builder, addr->getLoc());
 }

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -335,8 +335,8 @@ emitCallLikeOp(CIRGenFunction &CGF, mlir::Location callLoc,
     if (op)
       return op;
 
-    op = builder.create<cir::TryOp>(
-        *CGF.currSrcLoc, /*scopeBuilder=*/
+    op = cir::TryOp::create(
+        builder, *CGF.currSrcLoc, /*scopeBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {},
         // Don't emit the code right away for catch clauses, for
         // now create the regions and consume the try scope result.
@@ -348,7 +348,7 @@ emitCallLikeOp(CIRGenFunction &CGF, mlir::Location callLoc,
           // handler: unwind.
           auto *r = result.addRegion();
           builder.createBlock(r);
-          builder.create<cir::ResumeOp>(loc, mlir::Value{}, mlir::Value{});
+          cir::ResumeOp::create(builder, loc, mlir::Value{}, mlir::Value{});
         });
     op.setSynthetic(true);
     return op;
@@ -391,7 +391,7 @@ emitCallLikeOp(CIRGenFunction &CGF, mlir::Location callLoc,
     CGF.callWithExceptionCtx = nullptr;
 
     if (tryOp.getSynthetic()) {
-      builder.create<cir::YieldOp>(tryOp.getLoc());
+      cir::YieldOp::create(builder, tryOp.getLoc());
       builder.restoreInsertionPoint(ip);
     }
     return callOpWithExceptions;
@@ -1432,7 +1432,7 @@ mlir::Value CIRGenFunction::emitVAArg(VAArgExpr *VE, Address &VAListAddr) {
   auto loc = CGM.getLoc(VE->getExprLoc());
   auto type = convertType(VE->getType());
   auto vaList = emitVAListRef(VE->getSubExpr()).getPointer();
-  return builder.create<cir::VAArgOp>(loc, type, vaList);
+  return cir::VAArgOp::create(builder, loc, type, vaList);
 }
 
 static void getTrivialDefaultFunctionAttributes(

--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -42,7 +42,7 @@ cir::BrOp CIRGenFunction::emitBranchThroughCleanup(mlir::Location Loc,
   // Insert a branch: to the cleanup block (unsolved) or to the already
   // materialized label. Keep track of unsolved goto's.
   assert(Dest.getBlock() && "assumes incoming valid dest");
-  auto brOp = builder.create<BrOp>(Loc, Dest.getBlock());
+  auto brOp = BrOp::create(builder, Loc, Dest.getBlock());
 
   // Calculate the innermost active normal cleanup.
   EHScopeStack::stable_iterator TopCleanup =
@@ -319,11 +319,11 @@ static void emitCleanup(CIRGenFunction &CGF, EHScopeStack::Cleanup *Fn,
 
   if (ActiveFlag.isValid()) {
     mlir::Value isActive = builder.createLoad(loc, ActiveFlag);
-    builder.create<cir::IfOp>(loc, isActive, false,
-                              [&](mlir::OpBuilder &b, mlir::Location) {
-                                emitCleanup();
-                                builder.createYield(loc);
-                              });
+    cir::IfOp::create(builder, loc, isActive, false,
+                      [&](mlir::OpBuilder &b, mlir::Location) {
+                        emitCleanup();
+                        builder.createYield(loc);
+                      });
   } else {
     emitCleanup();
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1319,8 +1319,8 @@ void CIRGenFunction::emitCXXDeleteExpr(const CXXDeleteExpr *E) {
   assert(convertTypeForMem(DeleteTy) == Ptr.getElementType());
 
   if (E->isArrayForm()) {
-    builder.create<cir::DeleteArrayOp>(Ptr.getPointer().getLoc(),
-                                       Ptr.getPointer());
+    cir::DeleteArrayOp::create(builder, Ptr.getPointer().getLoc(),
+                               Ptr.getPointer());
   } else {
     (void)EmitObjectDelete(*this, E, Ptr, DeleteTy);
   }
@@ -1449,11 +1449,11 @@ mlir::Value CIRGenFunction::emitCXXNewExpr(const CXXNewExpr *E) {
     nullCmpResult = builder.createCompare(loc, cir::CmpOpKind::ne,
                                           allocation.getPointer(), nullPtr);
     preIfBody = builder.saveInsertionPoint();
-    builder.create<cir::IfOp>(loc, nullCmpResult,
-                              /*withElseRegion=*/false,
-                              [&](mlir::OpBuilder &, mlir::Location) {
-                                ifBody = builder.saveInsertionPoint();
-                              });
+    cir::IfOp::create(builder, loc, nullCmpResult,
+                      /*withElseRegion=*/false,
+                      [&](mlir::OpBuilder &, mlir::Location) {
+                        ifBody = builder.saveInsertionPoint();
+                      });
     postIfBody = builder.saveInsertionPoint();
   }
 
@@ -1483,7 +1483,7 @@ mlir::Value CIRGenFunction::emitCXXNewExpr(const CXXNewExpr *E) {
                           allocatorArgs);
     operatorDeleteCleanup = EHStack.stable_begin();
     cleanupDominator =
-        builder.create<cir::UnreachableOp>(getLoc(E->getSourceRange()))
+        cir::UnreachableOp::create(builder, getLoc(E->getSourceRange()))
             .getOperation();
   }
 
@@ -1554,7 +1554,7 @@ mlir::Value CIRGenFunction::emitCXXNewExpr(const CXXNewExpr *E) {
 
     // Reset insertion point to resume back to post ifOp.
     if (postIfBody.isSet()) {
-      builder.create<cir::YieldOp>(loc);
+      cir::YieldOp::create(builder, loc);
       builder.restoreInsertionPoint(postIfBody);
     }
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
@@ -342,23 +342,22 @@ public:
     Expr *cond = E->getCond()->IgnoreParens();
     mlir::Value condValue = CGF.evaluateExprAsBool(cond);
 
-    return Builder
-        .create<cir::TernaryOp>(
-            loc, condValue,
-            /*thenBuilder=*/
-            [&](mlir::OpBuilder &b, mlir::Location loc) {
-              eval.begin(CGF);
-              mlir::Value trueValue = Visit(E->getTrueExpr());
-              b.create<cir::YieldOp>(loc, trueValue);
-              eval.end(CGF);
-            },
-            /*elseBuilder=*/
-            [&](mlir::OpBuilder &b, mlir::Location loc) {
-              eval.begin(CGF);
-              mlir::Value falseValue = Visit(E->getFalseExpr());
-              b.create<cir::YieldOp>(loc, falseValue);
-              eval.end(CGF);
-            })
+    return cir::TernaryOp::create(
+               Builder, loc, condValue,
+               /*thenBuilder=*/
+               [&](mlir::OpBuilder &b, mlir::Location loc) {
+                 eval.begin(CGF);
+                 mlir::Value trueValue = Visit(E->getTrueExpr());
+                 cir::YieldOp::create(b, loc, trueValue);
+                 eval.end(CGF);
+               },
+               /*elseBuilder=*/
+               [&](mlir::OpBuilder &b, mlir::Location loc) {
+                 eval.begin(CGF);
+                 mlir::Value falseValue = Visit(E->getFalseExpr());
+                 cir::YieldOp::create(b, loc, falseValue);
+                 eval.end(CGF);
+               })
         .getResult();
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConst.cpp
@@ -1991,7 +1991,8 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &Value,
       if (!C)
         return {};
 
-      assert(mlir::isa<mlir::TypedAttr>(C) && "This should always be a TypedAttr.");
+      assert(mlir::isa<mlir::TypedAttr>(C) &&
+             "This should always be a TypedAttr.");
       auto CTyped = mlir::cast<mlir::TypedAttr>(C);
 
       if (I == 0)
@@ -2115,20 +2116,20 @@ mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *E) {
   if (const auto *methodDecl = dyn_cast<CXXMethodDecl>(decl)) {
     auto ty = mlir::cast<cir::MethodType>(convertType(E->getType()));
     if (methodDecl->isVirtual())
-      return builder.create<cir::ConstantOp>(
-          loc, getCXXABI().buildVirtualMethodAttr(ty, methodDecl));
+      return cir::ConstantOp::create(
+          builder, loc, getCXXABI().buildVirtualMethodAttr(ty, methodDecl));
 
     auto methodFuncOp = GetAddrOfFunction(methodDecl);
-    return builder.create<cir::ConstantOp>(
-        loc, builder.getMethodAttr(ty, methodFuncOp));
+    return cir::ConstantOp::create(builder, loc,
+                                   builder.getMethodAttr(ty, methodFuncOp));
   }
 
   auto ty = mlir::cast<cir::DataMemberType>(convertType(E->getType()));
 
   // Otherwise, a member data pointer.
   const auto *fieldDecl = cast<FieldDecl>(decl);
-  return builder.create<cir::ConstantOp>(
-      loc, builder.getDataMemberAttr(ty, fieldDecl->getFieldIndex()));
+  return cir::ConstantOp::create(
+      builder, loc, builder.getDataMemberAttr(ty, fieldDecl->getFieldIndex()));
 }
 
 mlir::Attribute ConstantEmitter::emitAbstract(const Expr *E,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1869,8 +1869,9 @@ public:
     for (uint32_t i = 0; i < N; ++i) {
       args.push_back(emitScalarExpr(E->getArg(i)));
     }
-    const auto call = builder.create<cir::LLVMIntrinsicCallOp>(
-        getLoc(E->getExprLoc()), builder.getStringAttr(Name), cirTy, args);
+    const auto call = cir::LLVMIntrinsicCallOp::create(
+        builder, getLoc(E->getExprLoc()), builder.getStringAttr(Name), cirTy,
+        args);
     return RValue::get(call->getResult(0));
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -838,8 +838,8 @@ cir::GlobalOp CIRGenModule::createGlobalOp(CIRGenModule &cgm,
     if (curCGF)
       builder.setInsertionPoint(curCGF->CurFn);
 
-    g = builder.create<cir::GlobalOp>(loc, name, t, isConstant, linkage,
-                                      addrSpace);
+    g = cir::GlobalOp::create(builder, loc, name, t, isConstant, linkage,
+                              addrSpace);
     if (!curCGF) {
       if (insertPoint)
         cgm.getModule().insert(insertPoint, g);
@@ -1040,7 +1040,7 @@ void CIRGenModule::replaceGlobal(cir::GlobalOp oldSym, cir::GlobalOp newSym) {
           auto ar = cast<ConstArrayAttr>(init);
           mlir::OpBuilder::InsertionGuard guard(builder);
           builder.setInsertionPointAfter(c);
-          auto newUser = builder.create<cir::ConstantOp>(c.getLoc(), ar);
+          auto newUser = cir::ConstantOp::create(builder, c.getLoc(), ar);
           c.replaceAllUsesWith(newUser.getOperation());
         }
       }
@@ -1282,8 +1282,8 @@ mlir::Value CIRGenModule::getAddrOfGlobalVar(const VarDecl *d, mlir::Type ty,
   bool tlsAccess = d->getTLSKind() != VarDecl::TLS_None;
   auto g = getOrCreateCIRGlobal(d, ty, isForDefinition);
   auto ptrTy = builder.getPointerTo(g.getSymType(), g.getAddrSpace());
-  return builder.create<cir::GetGlobalOp>(getLoc(d->getSourceRange()), ptrTy,
-                                          g.getSymName(), tlsAccess);
+  return cir::GetGlobalOp::create(builder, getLoc(d->getSourceRange()), ptrTy,
+                                  g.getSymName(), tlsAccess);
 }
 
 cir::GlobalViewAttr
@@ -2715,7 +2715,7 @@ cir::FuncOp CIRGenModule::createCIRFunction(mlir::Location loc, StringRef name,
     if (curCGF)
       builder.setInsertionPoint(curCGF->CurFn);
 
-    f = builder.create<cir::FuncOp>(loc, name, ty);
+    f = cir::FuncOp::create(builder, loc, name, ty);
 
     if (fd)
       f.setAstAttr(makeFuncDeclAttr(fd, &getMLIRContext()));

--- a/clang/lib/CIR/CodeGen/CIRGenOpenMPRuntime.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenMPRuntime.cpp
@@ -66,7 +66,7 @@ void CIRGenOpenMPRuntime::emitTaskWaitCall(CIRGenBuilderTy &builder,
     // TODO(cir): This could change in the near future when OpenMP 5.0 gets
     // supported by MLIR
     llvm_unreachable("NYI");
-    // builder.create<mlir::omp::TaskwaitOp>(Loc);
+    // mlir::omp::TaskwaitOp::create(builder, Loc);
   } else {
     llvm_unreachable("NYI");
   }
@@ -80,7 +80,7 @@ void CIRGenOpenMPRuntime::emitBarrierCall(CIRGenBuilderTy &builder,
   assert(!cir::MissingFeatures::openMPRegionInfo());
 
   if (CGF.CGM.getLangOpts().OpenMPIRBuilder) {
-    builder.create<mlir::omp::BarrierOp>(Loc);
+    mlir::omp::BarrierOp::create(builder, Loc);
     return;
   }
 
@@ -98,7 +98,7 @@ void CIRGenOpenMPRuntime::emitTaskyieldCall(CIRGenBuilderTy &builder,
     return;
 
   if (CGF.CGM.getLangOpts().OpenMPIRBuilder) {
-    builder.create<mlir::omp::TaskyieldOp>(Loc);
+    mlir::omp::TaskyieldOp::create(builder, Loc);
   } else {
     llvm_unreachable("NYI");
   }

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -71,13 +71,13 @@ CIRGenFunction::emitOMPParallelDirective(const OMPParallelDirective &S) {
   mlir::LogicalResult res = mlir::success();
   auto scopeLoc = getLoc(S.getSourceRange());
   // Create a `omp.parallel` op.
-  auto parallelOp = builder.create<ParallelOp>(scopeLoc);
+  auto parallelOp = ParallelOp::create(builder, scopeLoc);
   mlir::Block &block = parallelOp.getRegion().emplaceBlock();
   mlir::OpBuilder::InsertionGuard guardCase(builder);
   builder.setInsertionPointToEnd(&block);
   // Create a scope for the OpenMP region.
-  builder.create<cir::ScopeOp>(
-      scopeLoc, /*scopeBuilder=*/
+  cir::ScopeOp::create(
+      builder, scopeLoc, /*scopeBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
         LexicalScope lexScope{*this, scopeLoc, builder.getInsertionBlock()};
         // Emit the body of the region.
@@ -88,7 +88,7 @@ CIRGenFunction::emitOMPParallelDirective(const OMPParallelDirective &S) {
           res = mlir::failure();
       });
   // Add the terminator for `omp.parallel`.
-  builder.create<TerminatorOp>(getLoc(S.getSourceRange().getEnd()));
+  TerminatorOp::create(builder, getLoc(S.getSourceRange().getEnd()));
   return res;
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRMemorySlot.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRMemorySlot.cpp
@@ -43,8 +43,8 @@ llvm::SmallVector<MemorySlot> cir::AllocaOp::getPromotableSlots() {
 
 Value cir::AllocaOp::getDefaultValue(const MemorySlot &slot,
                                      OpBuilder &builder) {
-  return builder.create<cir::ConstantOp>(getLoc(), slot.elemType,
-                                         cir::UndefAttr::get(slot.elemType));
+  return cir::ConstantOp::create(builder, getLoc(), slot.elemType,
+                                 cir::UndefAttr::get(slot.elemType));
 }
 
 void cir::AllocaOp::handleBlockArgument(const MemorySlot &slot,
@@ -141,7 +141,7 @@ bool cir::CopyOp::storesTo(const MemorySlot &slot) {
 
 Value cir::CopyOp::getStored(const MemorySlot &slot, OpBuilder &builder,
                              Value reachingDef, const DataLayout &dataLayout) {
-  return builder.create<cir::LoadOp>(getLoc(), slot.elemType, getSrc());
+  return cir::LoadOp::create(builder, getLoc(), slot.elemType, getSrc());
 }
 
 DeletionKind cir::CopyOp::removeBlockingUses(
@@ -149,10 +149,10 @@ DeletionKind cir::CopyOp::removeBlockingUses(
     OpBuilder &builder, Value reachingDefinition,
     const DataLayout &dataLayout) {
   if (loadsFrom(slot))
-    builder.create<cir::StoreOp>(getLoc(), reachingDefinition, getDst(),
-                                 /*is_volatile=*/false,
-                                 /*is_nontemporal=*/false, mlir::IntegerAttr{},
-                                 cir::MemOrderAttr(), cir::TBAAAttr{});
+    cir::StoreOp::create(builder, getLoc(), reachingDefinition, getDst(),
+                         /*is_volatile=*/false,
+                         /*is_nontemporal=*/false, mlir::IntegerAttr{},
+                         cir::MemOrderAttr(), cir::TBAAAttr{});
   return DeletionKind::Delete;
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -160,8 +160,8 @@ struct SimplifyPtrStrideOp : public OpRewritePattern<PtrStrideOp> {
         return mlir::failure();
 
       base = getElemOp.getBase();
-      index = rewriter.create<cir::BinOp>(op->getLoc(), cir::BinOpKind::Add,
-                                          elemIndex, index);
+      index = cir::BinOp::create(rewriter, op->getLoc(), cir::BinOpKind::Add,
+                                 elemIndex, index);
 
     } else {
       return mlir::failure();
@@ -202,7 +202,7 @@ struct SimplifyCastOp : public OpRewritePattern<cir::CastOp> {
     auto intType = cast<cir::IntType>(dataLayout.getIntType(context));
     auto zeroAttr = rewriter.getAttr<cir::IntAttr>(
         intType, llvm::APInt(intType.getWidth(), 0));
-    auto index = rewriter.create<cir::ConstantOp>(op->getLoc(), zeroAttr);
+    auto index = cir::ConstantOp::create(rewriter, op->getLoc(), zeroAttr);
 
     rewriter.replaceOpWithNewOp<cir::GetElementOp>(op, op.getType(),
                                                    op.getOperand(), index);

--- a/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CallConvLowering.cpp
@@ -76,7 +76,7 @@ private:
   void bitcast(mlir::Value src, mlir::Type newTy) {
     if (src.getType() != newTy) {
       auto cast =
-          rewriter.create<CastOp>(src.getLoc(), newTy, CastKind::bitcast, src);
+          CastOp::create(rewriter, src.getLoc(), newTy, CastKind::bitcast, src);
       rewriter.replaceAllUsesExcept(src, cast, cast);
     }
   }

--- a/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/GotoSolver.cpp
@@ -52,7 +52,7 @@ static void process(cir::FuncOp func) {
     mlir::OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(goTo);
     Block *dest = labels[goTo.getLabel()];
-    rewriter.create<cir::BrOp>(goTo.getLoc(), dest);
+    cir::BrOp::create(rewriter, goTo.getLoc(), dest);
     goTo.erase();
   }
 }

--- a/clang/lib/CIR/Dialect/Transforms/HoistAllocas.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/HoistAllocas.cpp
@@ -142,7 +142,7 @@ static void processConstAlloca(cir::AllocaOp alloca) {
     // operation.
     mlir::OpBuilder builder(alloca);
     auto invariantGroupOp =
-        builder.create<cir::InvariantGroupOp>(alloca.getLoc(), alloca);
+        cir::InvariantGroupOp::create(builder, alloca.getLoc(), alloca);
 
     // And replace all uses of the original alloca-ed pointer with the marked
     // pointer (which carries invariant group information).

--- a/clang/lib/CIR/Dialect/Transforms/IdiomRecognizer.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/IdiomRecognizer.cpp
@@ -42,9 +42,8 @@ private:
   template <size_t... Indices>
   static TargetOp buildCall(CIRBaseBuilderTy &builder, CallOp call,
                             std::index_sequence<Indices...>) {
-    return builder.create<TargetOp>(call.getLoc(), call.getResult().getType(),
-                                    call.getCalleeAttr(),
-                                    call.getOperand(Indices)...);
+    return TargetOp::create(builder, call.getLoc(), call.getResult().getType(),
+                            call.getCalleeAttr(), call.getOperand(Indices)...);
   }
 
 public:
@@ -170,15 +169,15 @@ bool IdiomRecognizerPass::raiseIteratorBeginEnd(CallOp call) {
   if (callExprAttr.isIteratorBeginCall()) {
     if (opts.emitRemarkFoundCalls())
       emitRemark(call.getLoc()) << "found call to begin() iterator";
-    iterOp = builder.create<cir::IterBeginOp>(
-        call.getLoc(), call.getResult().getType(), call.getCalleeAttr(),
-        call.getOperand(0));
+    iterOp = cir::IterBeginOp::create(builder, call.getLoc(),
+                                      call.getResult().getType(),
+                                      call.getCalleeAttr(), call.getOperand(0));
   } else if (callExprAttr.isIteratorEndCall()) {
     if (opts.emitRemarkFoundCalls())
       emitRemark(call.getLoc()) << "found call to end() iterator";
-    iterOp = builder.create<cir::IterEndOp>(
-        call.getLoc(), call.getResult().getType(), call.getCalleeAttr(),
-        call.getOperand(0));
+    iterOp = cir::IterEndOp::create(builder, call.getLoc(),
+                                    call.getResult().getType(),
+                                    call.getCalleeAttr(), call.getOperand(0));
   } else {
     return false;
   }

--- a/clang/lib/CIR/Dialect/Transforms/SCFPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/SCFPrepare.cpp
@@ -76,8 +76,8 @@ struct canonicalizeIVtoCmpLHS : public OpRewritePattern<ForOp> {
   void replaceWithNewCmpOp(CmpOp oldCmp, CmpOpKind newKind, Value lhs,
                            Value rhs, PatternRewriter &rewriter) const {
     rewriter.setInsertionPointAfter(oldCmp.getOperation());
-    auto newCmp = rewriter.create<cir::CmpOp>(oldCmp.getLoc(), oldCmp.getType(),
-                                              newKind, lhs, rhs);
+    auto newCmp = cir::CmpOp::create(rewriter, oldCmp.getLoc(),
+                                     oldCmp.getType(), newKind, lhs, rhs);
     oldCmp->replaceAllUsesWith(newCmp);
     oldCmp->erase();
   }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/ABIInfoImpl.cpp
@@ -44,8 +44,8 @@ mlir::Value emitRoundPointerUpToAlignment(cir::CIRBaseBuilderTy &builder,
       loc, builder.createPtrBitcast(ptr, builder.getUIntNTy(8)),
       builder.getUnsignedInt(loc, alignment - 1, /*width=*/32));
   auto dataLayout = mlir::DataLayout::closest(roundUp.getDefiningOp());
-  return builder.create<cir::PtrMaskOp>(
-      loc, roundUp.getType(), roundUp,
+  return cir::PtrMaskOp::create(
+      builder, loc, roundUp.getType(), roundUp,
       builder.getSignedInt(loc, -(signed)alignment,
                            dataLayout.getTypeSizeInBits(roundUp.getType())));
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareX86CXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/Targets/LoweringPrepareX86CXXABI.cpp
@@ -130,8 +130,8 @@ mlir::Value LoweringPrepareX86CXXABI::lowerVAArgX86_64(
                                       ty));
 
   mlir::OpBuilder::InsertPoint scopeIP;
-  auto scopeOp = builder.create<cir::ScopeOp>(
-      loc,
+  auto scopeOp = cir::ScopeOp::create(
+      builder, loc,
       [&](mlir::OpBuilder &opBuilder, mlir::Type &yieldTy, mlir::Location loc) {
         scopeIP = opBuilder.saveInsertionPoint();
         yieldTy = op.getType();
@@ -177,7 +177,7 @@ mlir::Value LoweringPrepareX86CXXABI::lowerVAArgX86_64(
   mlir::Block *inRegBlock = builder.createBlock(contBlock);
   mlir::Block *inMemBlock = builder.createBlock(contBlock);
   builder.setInsertionPointToEnd(currentBlock);
-  builder.create<BrCondOp>(loc, inRegs, inRegBlock, inMemBlock);
+  BrCondOp::create(builder, loc, inRegs, inRegBlock, inMemBlock);
 
   // Emit code to load the value if it was passed in registers.
   builder.setInsertionPointToStart(inRegBlock);
@@ -340,13 +340,13 @@ mlir::Value LoweringPrepareX86CXXABI::lowerVAArgX86_64(
     builder.createStore(loc, builder.createAdd(fp_offset, offset), fp_offset_p);
   }
 
-  builder.create<BrOp>(loc, mlir::ValueRange{regAddr}, contBlock);
+  BrOp::create(builder, loc, mlir::ValueRange{regAddr}, contBlock);
 
   // Emit code to load the value if it was passed in memory.
   builder.setInsertionPointToStart(inMemBlock);
   mlir::Value memAddr =
       buildX86_64VAArgFromMemory(builder, datalayout, valist, ty, loc);
-  builder.create<BrOp>(loc, mlir::ValueRange{memAddr}, contBlock);
+  BrOp::create(builder, loc, mlir::ValueRange{memAddr}, contBlock);
 
   // Yield the appropriate result.
   builder.setInsertionPointToStart(contBlock);
@@ -358,7 +358,7 @@ mlir::Value LoweringPrepareX86CXXABI::lowerVAArgX86_64(
                 loc, builder.createPtrBitcast(res_addr, ty), alignment)
           : builder.createLoad(loc, builder.createPtrBitcast(res_addr, ty));
 
-  builder.create<cir::YieldOp>(loc, result);
+  cir::YieldOp::create(builder, loc, result);
 
   return scopeOp.getResult(0);
 }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LoweringHelpers.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LoweringHelpers.h
@@ -23,50 +23,50 @@ mlir::Value createIntCast(mlir::OpBuilder &bld, mlir::Value src,
   auto loc = src.getLoc();
 
   if (dstWidth > srcWidth && isSigned)
-    return bld.create<mlir::LLVM::SExtOp>(loc, dstTy, src);
+    return mlir::LLVM::SExtOp::create(bld, loc, dstTy, src);
   else if (dstWidth > srcWidth)
-    return bld.create<mlir::LLVM::ZExtOp>(loc, dstTy, src);
+    return mlir::LLVM::ZExtOp::create(bld, loc, dstTy, src);
   else if (dstWidth < srcWidth)
-    return bld.create<mlir::LLVM::TruncOp>(loc, dstTy, src);
+    return mlir::LLVM::TruncOp::create(bld, loc, dstTy, src);
   else
-    return bld.create<mlir::LLVM::BitcastOp>(loc, dstTy, src);
+    return mlir::LLVM::BitcastOp::create(bld, loc, dstTy, src);
 }
 
 mlir::Value getConstAPInt(mlir::OpBuilder &bld, mlir::Location loc,
                           mlir::Type typ, const llvm::APInt &val) {
-  return bld.create<mlir::LLVM::ConstantOp>(loc, typ, val);
+  return mlir::LLVM::ConstantOp::create(bld, loc, typ, val);
 }
 
 mlir::Value getConst(mlir::OpBuilder &bld, mlir::Location loc, mlir::Type typ,
                      unsigned val) {
-  return bld.create<mlir::LLVM::ConstantOp>(loc, typ, val);
+  return mlir::LLVM::ConstantOp::create(bld, loc, typ, val);
 }
 
 mlir::Value createShL(mlir::OpBuilder &bld, mlir::Value lhs, unsigned rhs) {
   if (!rhs)
     return lhs;
   auto rhsVal = getConst(bld, lhs.getLoc(), lhs.getType(), rhs);
-  return bld.create<mlir::LLVM::ShlOp>(lhs.getLoc(), lhs, rhsVal);
+  return mlir::LLVM::ShlOp::create(bld, lhs.getLoc(), lhs, rhsVal);
 }
 
 mlir::Value createLShR(mlir::OpBuilder &bld, mlir::Value lhs, unsigned rhs) {
   if (!rhs)
     return lhs;
   auto rhsVal = getConst(bld, lhs.getLoc(), lhs.getType(), rhs);
-  return bld.create<mlir::LLVM::LShrOp>(lhs.getLoc(), lhs, rhsVal);
+  return mlir::LLVM::LShrOp::create(bld, lhs.getLoc(), lhs, rhsVal);
 }
 
 mlir::Value createAShR(mlir::OpBuilder &bld, mlir::Value lhs, unsigned rhs) {
   if (!rhs)
     return lhs;
   auto rhsVal = getConst(bld, lhs.getLoc(), lhs.getType(), rhs);
-  return bld.create<mlir::LLVM::AShrOp>(lhs.getLoc(), lhs, rhsVal);
+  return mlir::LLVM::AShrOp::create(bld, lhs.getLoc(), lhs, rhsVal);
 }
 
 mlir::Value createAnd(mlir::OpBuilder &bld, mlir::Value lhs,
                       const llvm::APInt &rhs) {
   auto rhsVal = getConstAPInt(bld, lhs.getLoc(), lhs.getType(), rhs);
-  return bld.create<mlir::LLVM::AndOp>(lhs.getLoc(), lhs, rhsVal);
+  return mlir::LLVM::AndOp::create(bld, lhs.getLoc(), lhs, rhsVal);
 }
 
 #endif // LLVM_CLANG_LIB_LOWERINGHELPERS_H

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerToMLIRHelpers.h
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerToMLIRHelpers.h
@@ -11,10 +11,10 @@ mlir::Value getConst(mlir::ConversionPatternRewriter &rewriter,
                      mlir::Location loc, mlir::Type ty, T value) {
   assert(mlir::isa<mlir::IntegerType>(ty) || mlir::isa<mlir::FloatType>(ty));
   if (mlir::isa<mlir::IntegerType>(ty))
-    return rewriter.create<mlir::arith::ConstantOp>(
-        loc, ty, mlir::IntegerAttr::get(ty, value));
-  return rewriter.create<mlir::arith::ConstantOp>(
-      loc, ty, mlir::FloatAttr::get(ty, value));
+    return mlir::arith::ConstantOp::create(rewriter, loc, ty,
+                                           mlir::IntegerAttr::get(ty, value));
+  return mlir::arith::ConstantOp::create(rewriter, loc, ty,
+                                         mlir::FloatAttr::get(ty, value));
 }
 
 mlir::Value createIntCast(mlir::ConversionPatternRewriter &rewriter,
@@ -29,13 +29,13 @@ mlir::Value createIntCast(mlir::ConversionPatternRewriter &rewriter,
   auto loc = src.getLoc();
 
   if (dstWidth > srcWidth && isSigned)
-    return rewriter.create<mlir::arith::ExtSIOp>(loc, dstTy, src);
+    return mlir::arith::ExtSIOp::create(rewriter, loc, dstTy, src);
   else if (dstWidth > srcWidth)
-    return rewriter.create<mlir::arith::ExtUIOp>(loc, dstTy, src);
+    return mlir::arith::ExtUIOp::create(rewriter, loc, dstTy, src);
   else if (dstWidth < srcWidth)
-    return rewriter.create<mlir::arith::TruncIOp>(loc, dstTy, src);
+    return mlir::arith::TruncIOp::create(rewriter, loc, dstTy, src);
   else
-    return rewriter.create<mlir::arith::BitcastOp>(loc, dstTy, src);
+    return mlir::arith::BitcastOp::create(rewriter, loc, dstTy, src);
 }
 
 mlir::arith::CmpIPredicate convertCmpKindToCmpIPredicate(cir::CmpOpKind kind,


### PR DESCRIPTION
The builder create methods are deprecated:
https://mlir.llvm.org/deprecation/. See
https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339.