### PR TITLE
[CIR] Backport auto var constant init fix

### DIFF
--- a/clang/test/CIR/CallConvLowering/AArch64/struct.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/struct.c
@@ -68,7 +68,7 @@ void foo1() {
 // CIR: %[[#V1:]] = cir.cast bitcast %[[#V0]] : !cir.ptr<!rec_S> -> !cir.ptr<!u64i>
 // CIR: cir.store{{.*}} %arg0, %[[#V1]] : !u64i, !cir.ptr<!u64i>
 // CIR: %[[#V2:]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["__retval"] {alignment = 4 : i64}
-// CIR: %[[#V3:]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s2"]
+// CIR: %[[#V3:]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s2", init]
 // CIR: %[[#V4:]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["tmp"] {alignment = 4 : i64}
 // CIR: %[[#V5:]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !rec_S
 // CIR: cir.store{{.*}} %[[#V5]], %[[#V3]] : !rec_S, !cir.ptr<!rec_S>

--- a/clang/test/CIR/CodeGen/agg-init.cpp
+++ b/clang/test/CIR/CodeGen/agg-init.cpp
@@ -47,7 +47,7 @@ void yo() {
 }
 
 // CHECK: cir.func dso_local @_Z2yov()
-// CHECK:   %0 = cir.alloca !rec_Yo, !cir.ptr<!rec_Yo>, ["ext"] {alignment = 8 : i64}
+// CHECK:   %0 = cir.alloca !rec_Yo, !cir.ptr<!rec_Yo>, ["ext", init] {alignment = 8 : i64}
 // CHECK:   %1 = cir.alloca !rec_Yo, !cir.ptr<!rec_Yo>, ["ext2", init] {alignment = 8 : i64}
 // CHECK:   %2 = cir.const #cir.const_record<{#cir.int<1000070000> : !u32i, #cir.ptr<null> : !cir.ptr<!void>, #cir.int<0> : !u64i}> : !rec_Yo
 // CHECK:   cir.store{{.*}} %2, %0 : !rec_Yo, !cir.ptr<!rec_Yo>

--- a/clang/test/CIR/CodeGen/agg-init2.cpp
+++ b/clang/test/CIR/CodeGen/agg-init2.cpp
@@ -13,8 +13,13 @@ void f() {
   Zero z1 = Zero{};
 }
 
+// TODO: In this case, z1 gets "initialized" with an undef value. Should we
+//       treat that as uninitialized? Should it even be happening?
+
 // CHECK: cir.func dso_local @_Z1fv()
-// CHECK:     %0 = cir.alloca !rec_Zero, !cir.ptr<!rec_Zero>, ["z0", init]
-// CHECK:     %1 = cir.alloca !rec_Zero, !cir.ptr<!rec_Zero>, ["z1"]
-// CHECK:     cir.call @_ZN4ZeroC1Ev(%0) : (!cir.ptr<!rec_Zero>) -> ()
+// CHECK:     %[[Z0:.*]] = cir.alloca !rec_Zero, !cir.ptr<!rec_Zero>, ["z0", init]
+// CHECK:     %[[Z1:.*]] = cir.alloca !rec_Zero, !cir.ptr<!rec_Zero>, ["z1", init]
+// CHECK:     cir.call @_ZN4ZeroC1Ev(%[[Z0]]) : (!cir.ptr<!rec_Zero>) -> ()
+// CHECK:     %[[UNDEF:.*]] = cir.const #cir.undef : !rec_Zero
+// CHECK:     cir.store{{.*}} %[[UNDEF]], %[[Z1]] : !rec_Zero, !cir.ptr<!rec_Zero>
 // CHECK:     cir.return

--- a/clang/test/CIR/CodeGen/array-init.c
+++ b/clang/test/CIR/CodeGen/array-init.c
@@ -82,7 +82,7 @@ void foo() {
   double bar[] = {9,8,7};
 }
 // CIR-LABEL: @foo
-// CIR:  %[[DST:.*]] = cir.alloca !cir.array<!cir.double x 3>, !cir.ptr<!cir.array<!cir.double x 3>>, ["bar"]
+// CIR:  %[[DST:.*]] = cir.alloca !cir.array<!cir.double x 3>, !cir.ptr<!cir.array<!cir.double x 3>>, ["bar", init]
 // CIR:  %[[SRC:.*]] = cir.get_global @__const.foo.bar : !cir.ptr<!cir.array<!cir.double x 3>>
 // CIR:  cir.copy %[[SRC]] to %[[DST]] : !cir.ptr<!cir.array<!cir.double x 3>>
 

--- a/clang/test/CIR/CodeGen/complex-cast.cpp
+++ b/clang/test/CIR/CodeGen/complex-cast.cpp
@@ -31,7 +31,7 @@ void complex_user_defined_cast() {
   int _Complex c = p;
 }
 
-// CIR-AFTER: %[[P_ADDR:.*]] = cir.alloca !rec_Point, !cir.ptr<!rec_Point>, ["p"]
+// CIR-AFTER: %[[P_ADDR:.*]] = cir.alloca !rec_Point, !cir.ptr<!rec_Point>, ["p", init]
 // CIR-AFTER: %[[C_ADDR:.*]] = cir.alloca !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>, ["c", init]
 // CIR-AFTER: %[[P_CONST:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !rec_Point
 // CIR-AFTER: cir.store{{.*}} %[[P_CONST]], %[[P_ADDR]] : !rec_Point, !cir.ptr<!rec_Point>

--- a/clang/test/CIR/CodeGen/const-array.c
+++ b/clang/test/CIR/CodeGen/const-array.c
@@ -13,6 +13,6 @@ void foo() {
 }
 
 // CHECK-LABEL: @foo()
-// CHECK: %[[ADDR:.*]] = cir.alloca !cir.array<!s32i x 10>, !cir.ptr<!cir.array<!s32i x 10>>, ["a"]
+// CHECK: %[[ADDR:.*]] = cir.alloca !cir.array<!s32i x 10>, !cir.ptr<!cir.array<!s32i x 10>>, ["a", init]
 // CHECK: %[[SRC:.*]] = cir.get_global @__const.foo.a : !cir.ptr<!cir.array<!s32i x 10>>
 // CHECK: cir.copy %[[SRC]] to %[[ADDR]] : !cir.ptr<!cir.array<!s32i x 10>>

--- a/clang/test/CIR/CodeGen/packed-structs.c
+++ b/clang/test/CIR/CodeGen/packed-structs.c
@@ -71,7 +71,9 @@ typedef struct {
 } E;
 
 // CIR: cir.func {{.*@f1()}}
-// CIR:  {{.*}} = cir.alloca !rec_E, !cir.ptr<!rec_E>, ["a"] {alignment = 2 : i64}
+// CIR:  %[[E:.*]] = cir.alloca !rec_E, !cir.ptr<!rec_E>, ["a", init] {alignment = 2 : i64}
+// CIR:  %[[ZERO:.*]] = cir.const #cir.zero : !rec_E
+// CIR:  cir.store{{.*}} %[[ZERO]], %[[E]] : !rec_E, !cir.ptr<!rec_E>
 
 // LLVM: {{.*}} = alloca %struct.E, i64 1, align 2
 void f1() {
@@ -91,7 +93,7 @@ typedef struct {
 } G;
 
 // CIR: cir.func {{.*@f2()}}
-// CIR:  {{.*}} = cir.alloca !rec_G, !cir.ptr<!rec_G>, ["a"] {alignment = 1 : i64}
+// CIR:  {{.*}} = cir.alloca !rec_G, !cir.ptr<!rec_G>, ["a", init] {alignment = 1 : i64}
 
 // LLVM: {{.*}} = alloca %struct.G, i64 1, align 1
 void f2() {
@@ -123,7 +125,7 @@ typedef struct {
 } J;
 
 // CIR: cir.func {{.*@f3()}}
-// CIR:  {{.*}} = cir.alloca !rec_J, !cir.ptr<!rec_J>, ["a"] {alignment = 1 : i64}
+// CIR:  {{.*}} = cir.alloca !rec_J, !cir.ptr<!rec_J>, ["a", init] {alignment = 1 : i64}
 
 // LLVM: {{.*}} = alloca %struct.J, i64 1, align 1
 void f3() {

--- a/clang/test/CIR/CodeGen/std-find.cpp
+++ b/clang/test/CIR/CodeGen/std-find.cpp
@@ -10,7 +10,7 @@ int test_find(unsigned char n = 3)
     // CHECK: cir.func dso_local @_Z9test_findh(%arg0: !u8i
     unsigned num_found = 0;
     std::array<unsigned char, 9> v = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-    // CHECK: %[[array_addr:.*]] = cir.alloca ![[array]], !cir.ptr<![[array]]>, ["v"]
+    // CHECK: %[[array_addr:.*]] = cir.alloca ![[array]], !cir.ptr<![[array]]>, ["v", init]
 
     auto f = std::find(v.begin(), v.end(), n);
     // CHECK: {{.*}} cir.call @_ZNSt5arrayIhLj9EE5beginEv(%[[array_addr]])

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -134,7 +134,7 @@ struct NonTrivialConstexprConstructor {
 // Should locally copy struct members.
 void shouldLocallyCopyStructAssignments(void) {
   struct A a = { 3 };
-  // CHECK: %[[#SA:]] = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["a"] {alignment = 4 : i64}
+  // CHECK: %[[#SA:]] = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["a", init] {alignment = 4 : i64}
   struct A b = a;
   // CHECK: %[[#SB:]] = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["b", init] {alignment = 4 : i64}
   // cir.copy %[[#SA]] to %[[SB]] : !cir.ptr<!rec_A>
@@ -200,7 +200,7 @@ void unary_extension() {
   CompleteS a = __extension__ CompleteS();
 }
 
-// CHECK: %[[A_ADDR:.*]] = cir.alloca !rec_CompleteS, !cir.ptr<!rec_CompleteS>, ["a"]
+// CHECK: %[[A_ADDR:.*]] = cir.alloca !rec_CompleteS, !cir.ptr<!rec_CompleteS>, ["a", init]
 // CHECK: %[[ZERO_INIT:.*]] = cir.const #cir.zero : !rec_CompleteS
 // CHECK: cir.store{{.*}} %[[ZERO_INIT]], %[[A_ADDR]] : !rec_CompleteS, !cir.ptr<!rec_CompleteS>
 

--- a/clang/test/CIR/CodeGen/try-catch.cpp
+++ b/clang/test/CIR/CodeGen/try-catch.cpp
@@ -183,7 +183,7 @@ void tc8() {
 }
 
 // CHECK: cir.scope {
-// CHECK:   %[[V0:.*]] = cir.alloca !rec_S2, !cir.ptr<!rec_S2>, ["s"] {alignment = 4 : i64}
+// CHECK:   %[[V0:.*]] = cir.alloca !rec_S2, !cir.ptr<!rec_S2>, ["s", init] {alignment = 4 : i64}
 // CHECK:   cir.try {
 // CHECK:     %[[V1:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !rec_S2
 // CHECK:     cir.store align(4) %[[V1]], %[[V0]] : !rec_S2, !cir.ptr<!rec_S2>
@@ -192,7 +192,7 @@ void tc8() {
 // CHECK: }
 
 // FLAT: cir.func dso_local @_Z3tc8v()
-// FLAT:   %[[V0:.*]] = cir.alloca !rec_S2, !cir.ptr<!rec_S2>, ["s"] {alignment = 4 : i64}
+// FLAT:   %[[V0:.*]] = cir.alloca !rec_S2, !cir.ptr<!rec_S2>, ["s", init] {alignment = 4 : i64}
 // FLAT:   cir.br ^bb[[#B1:]]
 // FLAT: ^bb[[#B1]]:
 // FLAT:   cir.br ^bb[[#B2:]]

--- a/clang/test/CIR/CodeGen/vectype-ext.cpp
+++ b/clang/test/CIR/CodeGen/vectype-ext.cpp
@@ -524,7 +524,7 @@ void test_build_lvalue() {
 // LLVM: define dso_local void {{@.*test_vec3.*}}
 void test_vec3() {
   vi3 v = {};
-  // CIR-NEXT: %[[#PV:]] = cir.alloca !cir.vector<!s32i x 3>, !cir.ptr<!cir.vector<!s32i x 3>>, ["v"] {alignment = 16 : i64}
+  // CIR-NEXT: %[[#PV:]] = cir.alloca !cir.vector<!s32i x 3>, !cir.ptr<!cir.vector<!s32i x 3>>, ["v", init] {alignment = 16 : i64}
   // CIR-NEXT: %[[#VVAL:]] = cir.const #cir.const_vector<[#cir.int<0> : !s32i, #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<!s32i x 3>
   // CIR-NEXT: cir.store{{.*}} %[[#VVAL]], %[[#PV]] : !cir.vector<!s32i x 3>, !cir.ptr<!cir.vector<!s32i x 3>>
 
@@ -572,7 +572,7 @@ void vector_shuffle_dynamic_mask_test() {
 // LLVM: define dso_local void {{@.*test_vec3_array.*}}
 void test_vec3_array() {
   vi3 arr[4] = {};
-  // CIR: cir.alloca !cir.array<!cir.vector<!s32i x 3> x 4>, !cir.ptr<!cir.array<!cir.vector<!s32i x 3> x 4>>, ["arr"]
+  // CIR: cir.alloca !cir.array<!cir.vector<!s32i x 3> x 4>, !cir.ptr<!cir.array<!cir.vector<!s32i x 3> x 4>>, ["arr", init]
   // LLVM: alloca [4 x <3 x i32>], i64 1, align 16
 
   vi3 *ptr = &arr[0];

--- a/clang/test/CIR/Lowering/store-memcpy.cpp
+++ b/clang/test/CIR/Lowering/store-memcpy.cpp
@@ -7,7 +7,7 @@ void foo() {
 }
 // AFTER-DAG:  cir.global "private" constant cir_private @__const._Z3foov.s1 = #cir.const_array<"Hello\00" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6>
 // AFTER: @_Z3foov
-// AFTER:    %[[S1:.*]] = cir.alloca !cir.array<!s8i x 6>, !cir.ptr<!cir.array<!s8i x 6>>, ["s1"]
+// AFTER:    %[[S1:.*]] = cir.alloca !cir.array<!s8i x 6>, !cir.ptr<!cir.array<!s8i x 6>>, ["s1", init]
 // AFTER:    %[[HELLO:.*]] = cir.get_global @__const._Z3foov.s1 : !cir.ptr<!cir.array<!s8i x 6>>
 // AFTER:    cir.copy %[[HELLO]] to %[[S1]] : !cir.ptr<!cir.array<!s8i x 6>>
 // AFTER:    cir.return


### PR DESCRIPTION
This backports a problem I noticed while upstreaming constant initialization of automatic aggregate variables. Even though the aggregate is being initialized, we weren't setting the `init` attribute.

There is one odd case where the constant being used to initialize a class is an undef. OGCG does the same thing. In this patch I'm not attempting to detect that case, and I'm not sure if we should.