### PR TITLE
[CIR][NFC] Backport changes to use QualType::isStorageConstant

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2264,7 +2264,8 @@ static Address createReferenceTemporary(CIRGenFunction &CGF,
     QualType Ty = Inner->getType();
     if (CGF.CGM.getCodeGenOpts().MergeAllConstants &&
         (Ty->isArrayType() || Ty->isRecordType()) &&
-        CGF.CGM.isTypeConstant(Ty, /*ExcludeCtor=*/true, /*ExcludeDtor=*/false))
+        Ty.isConstantStorage(CGF.CGM.getASTContext(), /*ExcludeCtor=*/true,
+                             /*ExcludeDtor=*/false))
       assert(0 && "NYI");
 
     // The temporary memory should be created in the same scope as the extending

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -535,17 +535,6 @@ public:
   /// optimization.
   bool HasHiddenLTOVisibility(const CXXRecordDecl *RD);
 
-  /// Determine whether an object of this type can be emitted
-  /// as a constant.
-  ///
-  /// If ExcludeCtor is true, the duration when the object's constructor runs
-  /// will not be considered. The caller will need to verify that the object is
-  /// not written to during its construction.
-  /// FIXME: in LLVM codegen path this is part of CGM, which doesn't seem
-  /// like necessary, since (1) it doesn't use CGM at all and (2) is AST type
-  /// query specific.
-  bool isTypeConstant(clang::QualType Ty, bool ExcludeCtor, bool ExcludeDtor);
-
   /// FIXME: this could likely be a common helper and not necessarily related
   /// with codegen.
   /// Return the best known alignment for an unknown pointer to a


### PR DESCRIPTION
We had a comment in the code suggesting that CIRGenModule::isTypeConstant could be shared with OGCG. The code there was moved into QualType::isConstantStorage quite a while ago, but the incubator code never got updated to use it. This change does that.